### PR TITLE
Updates release workflow with environment variables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -41,14 +45,14 @@ jobs:
             ${{ runner.os }}-n8n-cache-
 
       - name: Setup npm authentication
-        if: ${{ secrets.NPM_TOKEN }}
+        if: env.NPM_TOKEN != ''
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=${{ env.NPM_TOKEN }}" > ~/.npmrc
           echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
           echo "always-auth=true" >> ~/.npmrc
           echo "@n8n-as-code:registry=https://registry.npmjs.org/" >> ~/.npmrc
           # Also create project-level .npmrc for tools that look in current directory
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+          echo "//registry.npmjs.org/:_authToken=${{ env.NPM_TOKEN }}" > .npmrc
           echo "registry=https://registry.npmjs.org/" >> .npmrc
           echo "@n8n-as-code:registry=https://registry.npmjs.org/" >> .npmrc
 
@@ -59,12 +63,12 @@ jobs:
           publish: npm run release
           version: npm run version-packages
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ env.NPM_TOKEN }}
 
       - name: Publish VS Code Extension
         if: steps.changesets.outputs.published == 'true'
         run: |
           npm run build:extension
           cd packages/vscode-extension
-          npx @vscode/vsce publish --no-dependencies -t ${{ secrets.VSCE_TOKEN }}
+          npx @vscode/vsce publish --no-dependencies -t ${{ env.VSCE_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,6 @@ package-lock.json
 ehthumbs.db
 Thumbs.db
 
-# Exclude workflows directory (managed as independent repo)
-./workflows/
 
 # --- Packages build artifacts ---
 packages/*/dist/


### PR DESCRIPTION
Refactors the release workflow to use environment variables instead of directly accessing secrets, improving security and maintainability. Also removes the excluded workflows directory from .gitignore as it's now managed as an independent repository.