### PR TITLE
Updates dependency installation command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           version: 10
 
       - name: Install Dependencies
-        run: npm ci
+        run: npm install
 
       - name: Cache n8n repository
         uses: actions/cache@v4


### PR DESCRIPTION
Switches from `npm ci` to `npm install` to ensure consistent dependency installation across environments, particularly for development workflows where exact version matching isn't strictly required.