### PR TITLE
Ignores n8n-as-code in changeset configuration

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["n8n-as-code"]
 }


### PR DESCRIPTION
Updates the changeset configuration to exclude the n8n-as-code package from version updates, likely to prevent unintended version bumps in this specific dependency.