### PR TITLE
build: update workspace configuration and changeset ignore list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["n8n-as-code-monorepo", "n8n-as-code"]
+  "ignore": ["n8n-as-code"]
 }

--- a/package.json
+++ b/package.json
@@ -8,11 +8,10 @@
     "n8n-as-code": "./packages/cli/dist/index.js"
   },
   "workspaces": [
-    ".",
     "packages/*"
   ],
   "scripts": {
-    "build": "npm run generate:nodes && tsc -b --force && npm run build --workspaces --if-present",
+    "build": "npm run generate:nodes && tsc -b --force && npm run build --workspace=packages/agent-cli --workspace=packages/cli --workspace=packages/core --workspace=packages/vscode-extension",
     "build:core": "cd packages/core && npm run build",
     "build:cli": "cd packages/cli && npm run build",
     "build:extension": "cd packages/vscode-extension && npm run build",


### PR DESCRIPTION
Remove root workspace from package.json and simplify changeset ignore list to only exclude 'n8n-as-code'. Update build script to explicitly specify workspaces for targeted builds.

BREAKING CHANGE: Root workspace removed from package.json configuration