### PR TITLE
build: exclude n8n-as-code from release process

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "clean": "npm run clean --workspaces --if-present && rm -rf packages/*/dist packages/*/out packages/**/tsconfig.tsbuildinfo .n8n-cache/ node_modules/.cache",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "npm run build && changeset publish"
+    "release": "npm run build && changeset publish --filter \"!n8n-as-code\""
   },
   "author": "",
   "license": "ISC",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,6 +3,7 @@
     "displayName": "n8n as code",
     "description": "Edit your n8n workflows directly in VS Code with AI assistance.",
     "version": "0.2.0",
+    "private": true,
     "publisher": "etienne-lescot",
     "files": [
         "out",


### PR DESCRIPTION
Adds --filter flag to changeset publish command to exclude n8n-as-code package Marks vscode-extension package as private to prevent accidental publishing