### PR TITLE
Updates VS Code extension publish command to use patch version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,8 @@ jobs:
           NPM_TOKEN: ${{ env.NPM_TOKEN }}
 
       - name: Publish VS Code Extension
-        if: steps.changesets.outputs.published == 'true'
+        if: env.VSCE_TOKEN != ''
         run: |
           npm run build:extension
           cd packages/vscode-extension
-          npx @vscode/vsce publish --no-dependencies -t ${{ env.VSCE_TOKEN }}
+          npx @vscode/vsce publish patch --no-dependencies -t ${{ env.VSCE_TOKEN }}


### PR DESCRIPTION
Changes the publish command to use 'patch' version instead of default, ensuring version increments follow semantic versioning conventions. This ensures proper version updates when publishing the extension.