### PR TITLE
ci: update VS Code extension publish command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,4 +84,4 @@ jobs:
         run: |
           npm run build:extension
           cd packages/vscode-extension
-          npx @vscode/vsce publish patch --no-dependencies -t ${{ env.VSCE_TOKEN }}
+          npx @vscode/vsce publish patch --no-dependencies --pat ${{ env.VSCE_TOKEN }}


### PR DESCRIPTION
The publish command now uses the `--pat` flag instead of `-t` for the VS Code extension publishing token. This aligns with the current VS Code extension publishing tool requirements.