### PR TITLE
Updates site URL and base URL for GitHub Pages deployment

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -15,10 +15,10 @@ const config: Config = {
   },
 
   // Set the production url of your site here
-  url: 'https://n8n-as-code.dev',
+  url: 'https://EtienneLescot.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
+  baseUrl: '/n8n-as-code/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
Changes the production URL from n8n-as-code.dev to EtienneLescot.github.io and updates the base URL to /n8n-as-code/ to align with the GitHub Pages deployment configuration.