### PR TITLE
docs(config): update site URL and add trailing slash

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -9,13 +9,9 @@ const config: Config = {
   tagline: 'Manage n8n workflows as code with version control and AI assistance',
   favicon: 'img/favicon.ico',
 
-  // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
-  future: {
-    v4: true, // Improve compatibility with the upcoming Docusaurus v4
-  },
 
   // Set the production url of your site here
-  url: 'https://EtienneLescot.github.io',
+  url: 'https://etiennelescot.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/n8n-as-code/',
@@ -24,6 +20,7 @@ const config: Config = {
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'EtienneLescot',
   projectName: 'n8n-as-code',
+  trailingSlash: true,
 
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
- Change site URL from 'https://EtienneLescot.github.io' to 'https://etiennelescot.github.io'
- Remove future flags for Docusaurus v4 compatibility
- Add trailingSlash configuration for better URL handling