### PR TITLE
Update directory-utils.ts

### DIFF
--- a/packages/sync/src/services/directory-utils.ts
+++ b/packages/sync/src/services/directory-utils.ts
@@ -26,9 +26,9 @@ export function createHostSlug(host: string): string {
         .replace(/\.net$/, '')
         .replace(/\.org$/, '');
     
-    // Replace remaining dots and hyphens with underscores
+    // Replace remaining dots, hyphens, and colons with underscores
     return cleanHost
-        .replace(/[.-]/g, '_')
+        .replace(/[.\-:]/g, '_')
         .toLowerCase();
 }
 


### PR DESCRIPTION
Some of us use n8n on a non standard port.

e.g. http://servcies.local:85 the : was causing an issue with the validity of the directory name, this fixes that.