### PR TITLE
fix: bundle prettier to prevent activation failure when installed fro…

### DIFF
--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # n8n-as-code
 
+## 0.13.1
+
+### Patch Changes
+
+- fix: bundle prettier instead of externalizing it to prevent activation failure when installed from store
+
 ## 0.13.0
 
 ### Minor Changes

--- a/packages/vscode-extension/esbuild.config.js
+++ b/packages/vscode-extension/esbuild.config.js
@@ -49,7 +49,7 @@ const extensionBuild = esbuild.build({
     entryPoints: ['./src/extension.ts'],
     bundle: true,
     outfile: 'out/extension.js',
-    external: ['vscode', 'prettier'],
+    external: ['vscode'],
     format: 'cjs',
     platform: 'node',
     logOverride: {
@@ -71,7 +71,7 @@ const skillsCliBuild = fs.existsSync(finalSkillsCliEntry) ? esbuild.build({
     entryPoints: [finalSkillsCliEntry],
     bundle: true,
     outfile: 'out/skills/cli.js',
-    external: ['vscode', 'prettier'],
+    external: ['vscode'],
     format: 'cjs',
     platform: 'node',
     logOverride: {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "n8n-as-code",
   "displayName": "n8n as code",
   "description": "Edit your n8n workflows directly in VS Code with AI assistance.",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "publisher": "etienne-lescot",
   "files": [


### PR DESCRIPTION
This pull request addresses an activation failure for the VS Code extension when installed from the store by bundling `prettier` instead of externalizing it. The change ensures that all necessary dependencies are included within the extension bundle, improving reliability for users.

Dependency bundling and build configuration:

* Updated `esbuild.config.js` to bundle `prettier` for both the main extension and the skills CLI, removing it from the list of external dependencies. [[1]](diffhunk://#diff-b14228534e7668ed2994ec5104ff2cb6cc1a787911ba2aba757b82ea5f4a1097L52-R52) [[2]](diffhunk://#diff-b14228534e7668ed2994ec5104ff2cb6cc1a787911ba2aba757b82ea5f4a1097L74-R74)

Release and versioning:

* Bumped the extension version to `0.13.1` in `package.json` and documented the patch change in `CHANGELOG.md`. [[1]](diffhunk://#diff-41ef0db31db6ae1a96349d902b1f423d33e2b104ad20d0b25f5eae835bc5d5c5L5-R5) [[2]](diffhunk://#diff-9e1f2e7877092e1179b4d0412082925e1937d2cdff0568584657b9ed44b1112bR3-R8)…m store