### PR TITLE
fix(transformer): replace eval with AST-based value extraction

### DIFF
--- a/packages/transformer/src/compiler/typescript-parser.ts
+++ b/packages/transformer/src/compiler/typescript-parser.ts
@@ -5,7 +5,7 @@
  * Extracts metadata from decorators and class structure
  */
 
-import { Project, SourceFile, SyntaxKind, ClassDeclaration, PropertyDeclaration, MethodDeclaration } from 'ts-morph';
+import { Project, SourceFile, SyntaxKind, ClassDeclaration, PropertyDeclaration, MethodDeclaration, Node } from 'ts-morph';
 import { WorkflowAST, NodeAST, ConnectionAST, WorkflowMetadata } from '../types.js';
 
 /**
@@ -106,13 +106,8 @@ export class TypeScriptParser {
             throw new Error('@workflow decorator missing metadata argument');
         }
         
-        // Parse object literal argument
-        const metadataArg = args[0];
-        const metadataText = metadataArg.getText();
-        
-        // Use eval in a safe context to parse the object literal
-        // This is safe because we're only parsing our own generated code
-        const metadata = this.parseObjectLiteral(metadataText);
+        // Extract metadata directly from the AST node — no eval needed
+        const metadata = this.extractValueFromASTNode(args[0], workflowClass.getSourceFile());
         
         return metadata as WorkflowMetadata;
     }
@@ -137,15 +132,15 @@ export class TypeScriptParser {
                 continue;
             }
             
-            const metadataText = args[0].getText();
-            const metadata = this.parseObjectLiteral(metadataText);
+            const sourceFile = prop.getSourceFile();
+            const metadata = this.extractValueFromASTNode(args[0], sourceFile);
             
             // Extract property name
             const propertyName = prop.getName();
             
             // Extract parameters from property initializer
             const initializer = prop.getInitializer();
-            const parameters = initializer ? this.parseObjectLiteral(initializer.getText()) : {};
+            const parameters = initializer ? this.extractValueFromASTNode(initializer, sourceFile) : {};
             
             nodes.push({
                 propertyName,
@@ -430,19 +425,159 @@ export class TypeScriptParser {
     }
     
     /**
-     * Parse object literal string to object
-     * 
-     * Uses Function constructor for safe eval of object literals
-     * This is safe because we only parse our own generated code
+     * Extract a JavaScript value by walking a ts-morph AST node.
+     *
+     * Supported: string/number/boolean literals, null, undefined, plain object
+     * literals, array literals, no-substitution template literals, negative
+     * number literals, and top-level `const` identifiers whose initializers
+     * are themselves statically resolvable.
+     *
+     * For truly dynamic expressions (function calls, imports, template
+     * expressions with substitutions, etc.) a helpful error is thrown
+     * explaining what IS supported and how to work around the limitation.
+     *
+     * @param node - The AST node to evaluate.
+     * @param sourceFile - The containing SourceFile, used to resolve
+     *   top-level `const` identifier references.
      */
-    private parseObjectLiteral(text: string): any {
-        try {
-            // Wrap in parentheses and use Function constructor
-            const func = new Function(`return (${text})`);
-            return func();
-        } catch (error) {
-            console.error('Failed to parse object literal:', text);
-            throw new Error(`Failed to parse object literal: ${error}`);
+    private extractValueFromASTNode(node: Node, sourceFile?: SourceFile): any {
+        switch (node.getKind()) {
+
+            // ── Primitive literals ───────────────────────────────────────
+            case SyntaxKind.StringLiteral:
+            case SyntaxKind.NoSubstitutionTemplateLiteral:
+                return (node as any).getLiteralValue() as string;
+
+            case SyntaxKind.NumericLiteral:
+                return Number((node as any).getLiteralValue());
+
+            case SyntaxKind.TrueKeyword:
+                return true;
+
+            case SyntaxKind.FalseKeyword:
+                return false;
+
+            case SyntaxKind.NullKeyword:
+                return null;
+
+            case SyntaxKind.UndefinedKeyword:
+                return undefined;
+
+            // ── Negative numbers  (-42, -3.14) ───────────────────────────
+            case SyntaxKind.PrefixUnaryExpression: {
+                const prefix = node as any;
+                if (prefix.getOperatorToken() === SyntaxKind.MinusToken) {
+                    const operand = this.extractValueFromASTNode(prefix.getOperand(), sourceFile);
+                    if (typeof operand === 'number') return -operand;
+                }
+                throw new Error(
+                    `[n8n-as-code] Cannot statically evaluate prefix expression ` +
+                    `"${node.getText()}" in a node parameter. ` +
+                    `Only literal values are supported.`
+                );
+            }
+
+            // ── Plain object literals ─────────────────────────────────────
+            case SyntaxKind.ObjectLiteralExpression: {
+                const result: Record<string, any> = {};
+                const objLit = node as any;
+                for (const prop of objLit.getProperties()) {
+                    if (prop.getKind() === SyntaxKind.PropertyAssignment) {
+                        const key: string = prop.getName();
+                        const valueNode: Node | undefined = prop.getInitializer();
+                        result[key] = valueNode !== undefined
+                            ? this.extractValueFromASTNode(valueNode, sourceFile)
+                            : undefined;
+                    } else if (prop.getKind() === SyntaxKind.ShorthandPropertyAssignment) {
+                        // { name }  →  try to resolve `name` as a top-level const
+                        const key: string = prop.getName();
+                        result[key] = this.resolveIdentifier(key, sourceFile);
+                    }
+                    // SpreadAssignment / MethodDeclaration inside object literals
+                    // are intentionally not handled here.
+                }
+                return result;
+            }
+
+            // ── Array literals ────────────────────────────────────────────
+            case SyntaxKind.ArrayLiteralExpression: {
+                const arrLit = node as any;
+                return (arrLit.getElements() as Node[]).map(
+                    (elem) => this.extractValueFromASTNode(elem, sourceFile)
+                );
+            }
+
+            // ── Identifier reference (e.g. a top-level const) ─────────────
+            case SyntaxKind.Identifier: {
+                const name = node.getText();
+                if (name === 'undefined') return undefined;
+                return this.resolveIdentifier(name, sourceFile);
+            }
+
+            // ── Dynamic / unsupported expressions ────────────────────────
+            case SyntaxKind.CallExpression: {
+                const preview = node.getText().substring(0, 80);
+                throw new Error(
+                    `[n8n-as-code] Dynamic expression not supported in node parameters:\n` +
+                    `  ${preview}\n\n` +
+                    `Only static literal values (strings, numbers, booleans, null, plain objects,\n` +
+                    `arrays) and references to top-level \`const\` literals are supported.\n\n` +
+                    `Workaround – move the computation to a top-level const BEFORE the class:\n` +
+                    `  import { readFileSync } from 'fs';\n` +
+                    `  const jsCode = readFileSync('code/example.js', 'utf-8');  // still a call — not yet supported\n` +
+                    `  // For now use a string literal directly, or open an issue to request\n` +
+                    `  // dynamic evaluation support.`
+                );
+            }
+
+            default: {
+                const kindName = node.getKindName();
+                const preview = node.getText().substring(0, 80);
+                throw new Error(
+                    `[n8n-as-code] Cannot statically evaluate ` +
+                    `${kindName} expression "${preview}" in a node parameter.\n` +
+                    `Only literal values are supported.`
+                );
+            }
         }
+    }
+
+    /**
+     * Try to resolve an identifier name to its value by looking at top-level
+     * `const` variable declarations in the given source file.
+     *
+     * Only plain `const` declarations with a statically-resolvable initializer
+     * are supported. `let` / `var` and destructuring are not resolved.
+     */
+    private resolveIdentifier(name: string, sourceFile?: SourceFile): any {
+        if (!sourceFile) {
+            throw new Error(
+                `[n8n-as-code] Cannot resolve identifier "${name}": no source file context available.`
+            );
+        }
+
+        const varDecl = sourceFile.getVariableDeclaration(name);
+        if (varDecl) {
+            const stmt = varDecl.getVariableStatement();
+            const isConst = stmt?.getDeclarationKind() === 'const' ||
+                (stmt as any)?.getDeclarationKind?.() === 0; // VariableDeclarationKind.Const
+            if (!isConst) {
+                throw new Error(
+                    `[n8n-as-code] Identifier "${name}" is declared with \`let\` or \`var\`. ` +
+                    `Only \`const\` top-level declarations can be referenced in node parameters.`
+                );
+            }
+            const init = varDecl.getInitializer();
+            if (init) {
+                return this.extractValueFromASTNode(init, sourceFile);
+            }
+        }
+
+        throw new Error(
+            `[n8n-as-code] Cannot resolve identifier "${name}" in node parameters.\n` +
+            `Only static literal values and references to top-level \`const\` literals are supported.\n` +
+            `If "${name}" is a function, calling it dynamically is not yet supported.\n` +
+            `Workaround: use a string or object literal directly in the node parameter.`
+        );
     }
 }

--- a/packages/transformer/tests/typescript-parser-ast-extraction.test.ts
+++ b/packages/transformer/tests/typescript-parser-ast-extraction.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for TypeScriptParser's AST-based value extraction.
+ *
+ * Covers the bug reported in:
+ *   "Failed to parse object literal: ReferenceError: foo is not defined"
+ *
+ * The parser must correctly handle:
+ *  - All literal value types (strings, numbers, booleans, null, arrays, objects)
+ *  - Top-level `const` identifier references
+ *  - Helpful errors for dynamic / un-resolvable expressions (function calls, etc.)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { TypeScriptParser } from '../src/compiler/typescript-parser.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal workflow scaffold that wraps the given node body. */
+function makeWorkflow(nodeBody: string, preamble = ''): string {
+    return `
+import { workflow, node, links } from '@n8n-as-code/core';
+${preamble}
+
+@workflow({ name: 'Test', active: false })
+export class TestWorkflow {
+    @node({
+        name: 'Test Node',
+        type: 'n8n-nodes-base.code',
+        version: 2,
+        position: [0, 0],
+    })
+    TestNode = ${nodeBody};
+
+    @links()
+    defineRouting() {}
+}
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TypeScriptParser – AST value extraction', () => {
+
+    describe('literal values', () => {
+        it('parses string literals', async () => {
+            const parser = new TypeScriptParser();
+            const ast = await parser.parseCode(makeWorkflow(`{ jsCode: "console.log('hi')" }`));
+            expect(ast.nodes[0].parameters.jsCode).toBe("console.log('hi')");
+        });
+
+        it('parses number literals', async () => {
+            const parser = new TypeScriptParser();
+            const ast = await parser.parseCode(makeWorkflow(`{ retryOnFail: 3 }`));
+            expect(ast.nodes[0].parameters.retryOnFail).toBe(3);
+        });
+
+        it('parses negative number literals', async () => {
+            const parser = new TypeScriptParser();
+            const ast = await parser.parseCode(makeWorkflow(`{ offset: -10 }`));
+            expect(ast.nodes[0].parameters.offset).toBe(-10);
+        });
+
+        it('parses boolean literals', async () => {
+            const parser = new TypeScriptParser();
+            const ast = await parser.parseCode(makeWorkflow(`{ continueOnFail: true }`));
+            expect(ast.nodes[0].parameters.continueOnFail).toBe(true);
+        });
+
+        it('parses null', async () => {
+            const parser = new TypeScriptParser();
+            const ast = await parser.parseCode(makeWorkflow(`{ value: null }`));
+            expect(ast.nodes[0].parameters.value).toBeNull();
+        });
+
+        it('parses array literals', async () => {
+            const parser = new TypeScriptParser();
+            const ast = await parser.parseCode(makeWorkflow(`{ values: [1, 2, 3] }`));
+            expect(ast.nodes[0].parameters.values).toEqual([1, 2, 3]);
+        });
+
+        it('parses nested object literals', async () => {
+            const parser = new TypeScriptParser();
+            const ast = await parser.parseCode(makeWorkflow(`{ options: { timeout: 5000, retries: 3 } }`));
+            expect(ast.nodes[0].parameters.options).toEqual({ timeout: 5000, retries: 3 });
+        });
+
+        it('parses no-substitution template literals', async () => {
+            const parser = new TypeScriptParser();
+            const ast = await parser.parseCode(makeWorkflow('{ jsCode: `const x = 1;` }'));
+            expect(ast.nodes[0].parameters.jsCode).toBe('const x = 1;');
+        });
+    });
+
+    describe('top-level const identifier resolution', () => {
+        it('resolves a string const declared before the class', async () => {
+            const parser = new TypeScriptParser();
+            const preamble = `const myCode = "return items;";`;
+            const ast = await parser.parseCode(makeWorkflow(`{ jsCode: myCode }`, preamble));
+            expect(ast.nodes[0].parameters.jsCode).toBe('return items;');
+        });
+
+        it('resolves a number const', async () => {
+            const parser = new TypeScriptParser();
+            const preamble = `const TIMEOUT = 30000;`;
+            const ast = await parser.parseCode(makeWorkflow(`{ timeout: TIMEOUT }`, preamble));
+            expect(ast.nodes[0].parameters.timeout).toBe(30000);
+        });
+
+        it('resolves a nested-object const', async () => {
+            const parser = new TypeScriptParser();
+            const preamble = `const opts = { batchSize: 50, parallel: true };`;
+            const ast = await parser.parseCode(makeWorkflow(`{ options: opts }`, preamble));
+            expect(ast.nodes[0].parameters.options).toEqual({ batchSize: 50, parallel: true });
+        });
+
+        it('resolves a template-literal const', async () => {
+            const parser = new TypeScriptParser();
+            const preamble = 'const script = `return $input.all();`;';
+            const ast = await parser.parseCode(makeWorkflow('{ jsCode: script }', preamble));
+            expect(ast.nodes[0].parameters.jsCode).toBe('return $input.all();');
+        });
+    });
+
+    describe('dynamic / unsupported expressions', () => {
+        it('throws a helpful error for a bare function call  (original bug report)', async () => {
+            const parser = new TypeScriptParser();
+            const code = makeWorkflow(
+                `{ jsCode: foo() }`,
+                `function foo() { return "code"; }`
+            );
+            await expect(parser.parseCode(code)).rejects.toThrow(
+                /Dynamic expression not supported/
+            );
+        });
+
+        it('throws a helpful error for require().readFileSync call', async () => {
+            const parser = new TypeScriptParser();
+            const code = makeWorkflow(
+                `{ jsCode: require('fs').readFileSync("code/example.js") }`
+            );
+            await expect(parser.parseCode(code)).rejects.toThrow(
+                /Dynamic expression not supported/
+            );
+        });
+
+        it('error message mentions workaround', async () => {
+            const parser = new TypeScriptParser();
+            const code = makeWorkflow(`{ jsCode: foo() }`, `function foo() { return "x"; }`);
+            await expect(parser.parseCode(code)).rejects.toThrow(/static literal values/);
+        });
+
+        it('throws a helpful error for an unresolvable identifier', async () => {
+            const parser = new TypeScriptParser();
+            const code = makeWorkflow(`{ jsCode: unknownVar }`);
+            await expect(parser.parseCode(code)).rejects.toThrow(
+                /Cannot resolve identifier "unknownVar"/
+            );
+        });
+    });
+});


### PR DESCRIPTION
- Replace new Function() / eval approach in parseObjectLiteral with a proper ts-morph AST node walker (extractValueFromASTNode) that handles string/number/boolean/null literals, arrays, nested objects:and no-substitution template literals without any eval scope issues
- Add resolveIdentifier() to resolve top-level `const` declarations from the same source file — `const code = '...'; node = { jsCode: code }` now works
- Throw clear, actionable errors for unsupported dynamic expressions (CallExpression etc.) with explicit workaround guidance instead of the cryptic 'ReferenceError: foo is not defined'
- Add 16 tests covering all literal types, const resolution, and the exact patterns from the bug report