### PR TITLE
Feat/simplify watcher UI only

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -632,9 +632,11 @@ async function initializeSyncManager(context: vscode.ExtensionContext) {
 
     // ── Lightweight UI watchers (replaces the heavy chokidar-based WorkflowStateTracker watcher) ──
     //
-    // 1. VS Code native FS watcher: detects new/deleted .workflow.ts files and refreshes the list.
+    // 1. VS Code native FS watcher on *.workflow.ts: detects new/deleted files → refreshes list.
     //    We deliberately ignore 'change' events — 'modified locally' is no longer a tracked status.
-    // 2. Remote polling every 60s: discovers workflows created/deleted on the n8n instance.
+    // 2. State file watcher on .n8n-state.json: written by CLI after every push/pull/resolve →
+    //    refreshes list and reloads the open webview (handles agent-driven CLI operations).
+    // 3. Remote polling every 60s: discovers workflows created/deleted on the n8n instance.
     if (vscode.workspace.workspaceFolders?.length) {
         const syncFolder = config.get<string>('syncFolder') || 'workflows';
         const pattern = new vscode.RelativePattern(
@@ -656,6 +658,32 @@ async function initializeSyncManager(context: vscode.ExtensionContext) {
         context.subscriptions.push(fileWatcher);
     }
 
+    // 3. State file watcher: .n8n-state.json is written by the CLI after every push/pull/resolve.
+    //    Watching it lets the UI react to CLI operations (agent-driven workflow).
+    //    IMPORTANT: cli.list() here has NO fetchRemote option → purely local (readdirSync +
+    //    in-memory remoteIds populated at init). No network call on every state change.
+    if (vscode.workspace.workspaceFolders?.length) {
+        const syncFolder = config.get<string>('syncFolder') || 'workflows';
+        const statePattern = new vscode.RelativePattern(
+            vscode.workspace.workspaceFolders[0],
+            `${syncFolder}/**/.n8n-state.json`
+        );
+        // ignoreCreate=true, ignoreChange=false, ignoreDelete=true — only react to writes
+        const stateWatcher = vscode.workspace.createFileSystemWatcher(statePattern, true, false, true);
+        stateWatcher.onDidChange(async () => {
+            if (!cli) return;
+            try {
+                store.dispatch(setWorkflows(await cli.list()));
+                enhancedTreeProvider.refresh();
+                // Reload the open webview — the CLI may have pushed a new version
+                WorkflowWebview.reloadCurrent(outputChannel);
+            } catch (err) {
+                console.error('[n8n] State watcher: failed to refresh after CLI operation', err);
+            }
+        });
+        context.subscriptions.push(stateWatcher);
+    }
+
     // Remote polling — lightweight `list` every 60 seconds to surface new/deleted remote workflows.
     const pollingInterval = setInterval(async () => {
         if (!cli) return;
@@ -670,7 +698,7 @@ async function initializeSyncManager(context: vscode.ExtensionContext) {
 
     statusBar.setWatchMode(false);
     // NOTE: syncManager.startWatch() is intentionally NOT called.
-    // The heavy chokidar-based watcher is replaced by the two lightweight UI watchers above.
+    // The heavy chokidar-based watcher is replaced by the three lightweight UI watchers above.
 
     // Initial list — uses cli.list(fetchRemote: true) which mirrors `n8nac list`
     outputChannel.appendLine('[n8n] Loading workflow list...');


### PR DESCRIPTION
This pull request refines the workflow sync status logic and updates the CLI and extension documentation to reflect a simplified status model. The main change is the removal of the `MODIFIED_LOCALLY` status from the global workflow list, making workflow status reporting more consistent and easier to understand. Additionally, the internal `Watcher` class has been renamed to `WorkflowStateTracker` across the codebase for clarity.

**Workflow Status Model Simplification**
* The `MODIFIED_LOCALLY` status is no longer returned by the global `list` command, and related documentation, CLI output, and sorting logic have been updated to remove references to this status. Now, only `TRACKED`, `CONFLICT`, `EXIST_ONLY_LOCALLY`, and `EXIST_ONLY_REMOTELY` are shown in workflow listings. (`[[1]](diffhunk://#diff-06680ff905686c7a8b6c183e2060a4ca614fbc83c0f4dedd47f7c42adbb848ffL23)`, `[[2]](diffhunk://#diff-06680ff905686c7a8b6c183e2060a4ca614fbc83c0f4dedd47f7c42adbb848ffL64-R66)`, `[[3]](diffhunk://#diff-06680ff905686c7a8b6c183e2060a4ca614fbc83c0f4dedd47f7c42adbb848ffL103)`, `[[4]](diffhunk://#diff-06680ff905686c7a8b6c183e2060a4ca614fbc83c0f4dedd47f7c42adbb848ffL119-L120)`, `[[5]](diffhunk://#diff-06680ff905686c7a8b6c183e2060a4ca614fbc83c0f4dedd47f7c42adbb848ffL135)`, `[[6]](diffhunk://#diff-df94062193d3fc9bc158bf366e6e194009afb043c8b697dd337689203ad44cf7L35-R36)`, `[[7]](diffhunk://#diff-78677a0e7f3fe015f3ae03f7890214c7fc8e68d41b90f9d19e71f5fe8011cb76L95-R95)`, `[[8]](diffhunk://#diff-78677a0e7f3fe015f3ae03f7890214c7fc8e68d41b90f9d19e71f5fe8011cb76L108-R113)`, `[[9]](diffhunk://#diff-65a28b51d4bbfe0d62ce58f6f4cea24041436ad5484394658288cea42116c5fdL23-R26)`)
* Documentation for CLI commands and the VS Code extension has been updated to reflect the new status model and clarify sync behaviors, including the automatic use of `fetch` within `push` and `pull`. (`[[1]](diffhunk://#diff-78677a0e7f3fe015f3ae03f7890214c7fc8e68d41b90f9d19e71f5fe8011cb76L135-R135)`, `[[2]](diffhunk://#diff-78677a0e7f3fe015f3ae03f7890214c7fc8e68d41b90f9d19e71f5fe8011cb76L165-R167)`, `[[3]](diffhunk://#diff-78677a0e7f3fe015f3ae03f7890214c7fc8e68d41b90f9d19e71f5fe8011cb76L175-L179)`, `[[4]](diffhunk://#diff-78677a0e7f3fe015f3ae03f7890214c7fc8e68d41b90f9d19e71f5fe8011cb76L281-R304)`, `[[5]](diffhunk://#diff-65a28b51d4bbfe0d62ce58f6f4cea24041436ad5484394658288cea42116c5fdL14-R14)`, `[[6]](diffhunk://#diff-65a28b51d4bbfe0d62ce58f6f4cea24041436ad5484394658288cea42116c5fdL23-R26)`)

**Internal Refactoring: Watcher → WorkflowStateTracker**
* The `Watcher` class has been renamed to `WorkflowStateTracker` throughout the codebase, including all imports, constructor parameters, and log messages, to better reflect its responsibility for tracking workflow state changes. (`[[1]](diffhunk://#diff-acc4a1e4ba4712bfb6650d1a701b31de4638c07ff9fc1b2907fa5a1b32e01bd5L23-R23)`, `[[2]](diffhunk://#diff-acc4a1e4ba4712bfb6650d1a701b31de4638c07ff9fc1b2907fa5a1b32e01bd5L200-R218)`, `[[3]](diffhunk://#diff-70bada1c98bd3d527d0048f95948ffa000eed6d2ad2b7b456960a64c6f297ef2L7-R7)`, `[[4]](diffhunk://#diff-b7b3350ad199e54c57f4150d4afb04b1a84e977c578b39423e8792fb126de643L4-R4)`, `[[5]](diffhunk://#diff-b7b3350ad199e54c57f4150d4afb04b1a84e977c578b39423e8792fb126de643L21-R25)`, `[[6]](diffhunk://#diff-849839e981ec73eded51a1c07c7349041d8f1959c3351349cb12bdf41917a784L22-R22)`, `[[7]](diffhunk://#diff-849839e981ec73eded51a1c07c7349041d8f1959c3351349cb12bdf41917a784L77-R77)`, `[[8]](diffhunk://#diff-b34aef34407c7a2b5788d2bd06dc801571f381e39b959b03473ade79b2d18cc9L6-R6)`, `[[9]](diffhunk://#diff-b34aef34407c7a2b5788d2bd06dc801571f381e39b959b03473ade79b2d18cc9L21-R26)`, `[[10]](diffhunk://#diff-bc1b13d4727730e0cec6483605bd55c6c4f7154a4ebff422df7ecc1ea75a9b37L6-R6)`, `[[11]](diffhunk://#diff-bc1b13d4727730e0cec6483605bd55c6c4f7154a4ebff422df7ecc1ea75a9b37L17-R17)`, `[[12]](diffhunk://#diff-bc1b13d4727730e0cec6483605bd55c6c4f7154a4ebff422df7ecc1ea75a9b37L55-R55)`)

**Documentation and Usage Pattern Updates**
* CLI usage patterns and quickstart examples have been updated to remove unnecessary manual `fetch` steps and clarify the recommended workflow for listing, pulling, and pushing workflows. (`[docs/docs/usage/cli.mdL281-R304](diffhunk://#diff-78677a0e7f3fe015f3ae03f7890214c7fc8e68d41b90f9d19e71f5fe8011cb76L281-R304)`)
* VS Code extension documentation now describes the new polling and automatic refresh behavior for workflow status. (`[docs/docs/usage/vscode-extension.mdL14-R14](diffhunk://#diff-65a28b51d4bbfe0d62ce58f6f4cea24041436ad5484394658288cea42116c5fdL14-R14)`)

Let me know if you want a deeper dive into any of these changes!