### PR TITLE
Refine release process for version bumps and direct publishing

### DIFF
--- a/docs/docs/contribution/index.md
+++ b/docs/docs/contribution/index.md
@@ -111,7 +111,8 @@ The project uses a custom commit-driven release flow.
 #### Push to `main`
 
 - Stable release creation is only allowed when `next` is not ahead of `main`.
-- A push to `main` creates or updates a single release PR when commit history requires version bumps.
+- If any package version in `package.json` is already ahead of its latest stable tag, `main` publishes that version directly instead of opening a new release PR.
+- A push to `main` creates or updates a single release PR only when no package is already ahead of its latest stable tag and commit history requires version bumps.
 - The release PR updates package versions and internal dependency versions together.
 
 #### Merge the release PR


### PR DESCRIPTION
This pull request updates the documentation for the project's commit-driven release flow to clarify how pushes to `main` interact with package versions and release PRs. The main change is a more precise description of when a release PR is created or updated versus when a package is published directly.

Release flow documentation improvements:

* Clarified that if any package version in `package.json` is already ahead of its latest stable tag, pushing to `main` publishes that version directly, instead of opening a new release PR.
* Updated the conditions for creating or updating a release PR: it now only happens when no package is already ahead of its latest stable tag and commit history requires version bumps.…hing