### PR TITLE
Fix README configuration file name for project switching

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -48,7 +48,7 @@ If no project selector is provided, `init --yes` will auto-select the only avail
 ---
 
 ### `switch`
-Switch the active n8n project (updates `projectId` / `projectName` in `n8nac.json`).
+Switch the active n8n project (updates `projectId` / `projectName` in `n8nac-config.json`).
 
 ```bash
 n8nac switch


### PR DESCRIPTION
This pull request makes a minor documentation update to clarify the file name used by the project switching command in the CLI. The change ensures that users reference the correct configuration file when switching projects.

* Updated the description of the `switch` command in `packages/cli/README.md` to reference `n8nac-config.json` instead of the outdated `n8nac.json` file.…tching