### PR TITLE
Enhance release workflow and VSCode version handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,7 +282,7 @@ jobs:
 
   publish-prerelease:
     name: Publish Prerelease
-    if: github.ref == 'refs/heads/next'
+    if: github.ref == 'refs/heads/next' && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     environment: next
     steps:
@@ -324,6 +324,10 @@ jobs:
           node scripts/release/workspace-release.mjs prerelease --apply > prerelease-plan.json
           CHANGED=$(node -e "const fs=require('fs'); process.stdout.write(JSON.parse(fs.readFileSync('prerelease-plan.json','utf8')).changed ? 'true' : 'false');")
           echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"
+
+      - name: Refresh lockfile
+        if: steps.prerelease-plan.outputs.changed == 'true'
+        run: npm install --package-lock-only
 
       - name: Build all packages
         if: steps.prerelease-plan.outputs.changed == 'true'
@@ -397,3 +401,34 @@ jobs:
           echo "ℹ️ Skipping Open VSX publish for next builds."
           echo "ℹ️ Open VSX exposes preview metadata, but downstream clients can still resolve the highest version by default."
           echo "ℹ️ Only stable releases from main are published to Open VSX."
+
+      - name: Persist prerelease versions on next
+        if: steps.prerelease-plan.outputs.changed == 'true'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add package-lock.json packages/cli/package.json packages/skills/package.json packages/transformer/package.json packages/vscode-extension/package.json
+          if git diff --cached --quiet; then
+            echo "ℹ️ No prerelease version changes to persist."
+            exit 0
+          fi
+          git commit -m 'chore: persist prerelease versions [skip ci]'
+
+          node <<'NODE'
+          const fs = require('fs');
+          const { execFileSync } = require('child_process');
+          const plan = JSON.parse(fs.readFileSync('prerelease-plan.json', 'utf8'));
+          const extension = plan.packages.find(pkg => pkg.name === 'n8n-as-code');
+          if (!extension?.changed || !extension.prereleaseVersion) {
+            process.exit(0);
+          }
+          const tag = `n8n-as-code@next-v${extension.prereleaseVersion}`;
+          try {
+            execFileSync('git', ['rev-parse', '-q', '--verify', `refs/tags/${tag}`], { stdio: 'ignore' });
+          } catch {
+            execFileSync('git', ['tag', tag], { stdio: 'inherit' });
+          }
+          NODE
+
+          git push origin HEAD:refs/heads/next
+          git push origin --tags

--- a/scripts/release/workspace-release.mjs
+++ b/scripts/release/workspace-release.mjs
@@ -49,6 +49,7 @@ const PACKAGES = [
 const PATCH_TYPES = new Set(['fix', 'perf', 'refactor', 'revert', 'deps', 'build']);
 const BUMP_PRIORITY = { none: 0, patch: 1, minor: 2, major: 3 };
 const extensionPackage = PACKAGES.find(pkg => pkg.name === 'n8n-as-code');
+const VSCODE_PRERELEASE_TAG_PREFIX = 'n8n-as-code@next-v';
 
 const CROSS_PACKAGE_RULES = [
   {
@@ -241,6 +242,31 @@ function getLatestStableTag(pkg) {
 
   for (const tag of tags) {
     const version = parseTagVersion(tag, pkg.tagPrefix);
+    if (!version) {
+      continue;
+    }
+
+    if (!latest || compareVersions(version, latest.version) > 0) {
+      latest = { tag, version };
+    }
+  }
+
+  return latest;
+}
+
+function getLatestPublishedVscodeVersion() {
+  const tags = gitLines(['tag', '--list', 'n8n-as-code@*']);
+  let latest = null;
+
+  for (const tag of tags) {
+    let version = null;
+
+    if (tag.startsWith(VSCODE_PRERELEASE_TAG_PREFIX)) {
+      version = parseVersion(tag.slice(VSCODE_PRERELEASE_TAG_PREFIX.length));
+    } else {
+      version = parseTagVersion(tag, extensionPackage.tagPrefix);
+    }
+
     if (!version) {
       continue;
     }
@@ -569,11 +595,16 @@ function computeStablePlan() {
     const directInfo = directBumps.get(pkg.name) || { bump: null, commits: [] };
     const currentStableString = currentVersion.replace(/-.*$/, '');
     const versionAheadOfTag = latestTag ? compareVersions(currentStableVersion, latestTag.version) > 0 : false;
-    const targetVersion = bumpInfo.bump ? formatVersion(incrementVersion(currentStableVersion, bumpInfo.bump)) : currentStableString;
     const changed = Boolean(bumpInfo.bump) || versionAheadOfTag;
+    const targetVersion = pkg.publishTarget === 'vscode'
+      ? (changed ? formatVersion(incrementVersion(currentStableVersion, 'patch')) : currentStableString)
+      : (bumpInfo.bump ? formatVersion(incrementVersion(currentStableVersion, bumpInfo.bump)) : currentStableString);
     const reasons = [...bumpInfo.reasons];
     if (versionAheadOfTag && !reasons.includes('version-ahead-of-tag')) {
       reasons.push('version-ahead-of-tag');
+    }
+    if (pkg.publishTarget === 'vscode' && changed && !reasons.includes('sequential-vscode-version')) {
+      reasons.push('sequential-vscode-version');
     }
 
     return {
@@ -621,7 +652,7 @@ function computePrereleasePlan() {
     return {
       ...pkg,
       prereleaseVersion: pkg.publishTarget === 'vscode'
-        ? buildVscodePrereleaseVersion(parseVersion(pkg.targetVersion), sequence)
+        ? pkg.targetVersion
         : `${pkg.targetVersion}-next.${sequence}`,
     };
   });
@@ -645,13 +676,17 @@ function computePendingStablePlan() {
 
     const latestTag = getLatestStableTag(pkg);
     const latestStableVersion = latestTag ? formatVersion(latestTag.version) : null;
-    const changed = latestTag ? compareVersions(currentStableVersion, latestTag.version) > 0 : false;
+    const latestPublishedVersion = pkg.publishTarget === 'vscode'
+      ? getLatestPublishedVscodeVersion()
+      : latestTag;
+    const changed = latestPublishedVersion ? compareVersions(currentStableVersion, latestPublishedVersion.version) > 0 : false;
 
     return {
       ...pkg,
       currentVersion,
       latestStableTag: latestTag?.tag ?? null,
       latestStableVersion,
+      latestPublishedVersion: latestPublishedVersion ? formatVersion(latestPublishedVersion.version) : null,
       targetVersion: formatVersion(currentStableVersion),
       changed,
     };
@@ -719,7 +754,7 @@ function applyPlan(plan, versionKey) {
   return plan;
 }
 
-function main() {
+async function main() {
   const args = parseArgs(process.argv);
   const command = args._[0];
   const apply = Boolean(args.apply);
@@ -745,4 +780,7 @@ function main() {
   process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
 }
 
-main();
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
This pull request introduces improvements to the release workflow and the workspace release script, focusing on more robust handling of prerelease versions, especially for the VSCode extension package. The changes enhance version tracking, ensure sequential prerelease versioning, and automate the persistence of version changes during prerelease publication.

**Release workflow enhancements:**

* Added a step to refresh the `package-lock.json` file before building packages when prerelease changes are detected, ensuring dependency consistency.
* Automated the persistence of prerelease version changes by committing and pushing updated version files and tags when changes are detected, including special handling for the VSCode extension.
* Updated the condition for publishing prereleases to exclude runs triggered by the `github-actions[bot]` user, preventing unnecessary workflow executions.

**Workspace release script improvements:**

* Introduced the `VSCODE_PRERELEASE_TAG_PREFIX` constant and a new `getLatestPublishedVscodeVersion()` function to accurately track and compare published VSCode extension versions, ensuring sequential versioning and correct detection of changes. [[1]](diffhunk://#diff-89ce93394e1c68ef5a1e874aa990ca9103ae81903343639b8d73a49519478ddaR52) [[2]](diffhunk://#diff-89ce93394e1c68ef5a1e874aa990ca9103ae81903343639b8d73a49519478ddaR257-R281)
* Modified version computation logic for the VSCode extension to always increment patch versions for stable releases and to use the target version directly for prereleases, improving version management and preventing duplicate or skipped versions. [[1]](diffhunk://#diff-89ce93394e1c68ef5a1e874aa990ca9103ae81903343639b8d73a49519478ddaL572-R608) [[2]](diffhunk://#diff-89ce93394e1c68ef5a1e874aa990ca9103ae81903343639b8d73a49519478ddaL624-R655) [[3]](diffhunk://#diff-89ce93394e1c68ef5a1e874aa990ca9103ae81903343639b8d73a49519478ddaL648-R689)

**Script reliability improvements:**

* Converted the main function to async and added error handling to ensure failures are reported clearly and the script exits with a non-zero status on error. [[1]](diffhunk://#diff-89ce93394e1c68ef5a1e874aa990ca9103ae81903343639b8d73a49519478ddaL722-R757) [[2]](diffhunk://#diff-89ce93394e1c68ef5a1e874aa990ca9103ae81903343639b8d73a49519478ddaL748-R786)…g on its own commits and enhance VSCode version handling