### PR TITLE
Improve alignment checks in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,9 @@ jobs:
 
       - name: Enforce next alignment
         run: |
-          git fetch origin main next || true
-          if git show-ref --verify --quiet refs/remotes/origin/next; then
+          git fetch origin main
+          if git ls-remote --exit-code --heads origin next >/dev/null 2>&1; then
+            git fetch origin next:refs/remotes/origin/next
             if ! git merge-base --is-ancestor origin/next HEAD; then
               echo "❌ next is ahead of main. Stable release is blocked until main includes every next commit."
               exit 1
@@ -186,7 +187,7 @@ jobs:
       - name: Sync next to main
         if: steps.pending.outputs.pending == 'true'
         run: |
-          git fetch origin main next || true
+          git fetch origin main
           git push origin HEAD:refs/heads/next --force
 
   create-release-pr:
@@ -207,8 +208,9 @@ jobs:
       - name: Enforce next alignment
         if: needs.publish-stable.outputs.pending != 'true'
         run: |
-          git fetch origin main next || true
-          if git show-ref --verify --quiet refs/remotes/origin/next; then
+          git fetch origin main
+          if git ls-remote --exit-code --heads origin next >/dev/null 2>&1; then
+            git fetch origin next:refs/remotes/origin/next
             if ! git merge-base --is-ancestor origin/next HEAD; then
               echo "❌ next is ahead of main. Release PR creation is blocked until main includes every next commit."
               exit 1


### PR DESCRIPTION
This pull request updates the `release.yml` GitHub Actions workflow to improve the reliability and correctness of fetching and aligning branches during the release process. The main focus is on making sure the `next` branch is properly fetched and aligned with `main` before proceeding with stable releases or creating release PRs.

Branch alignment and fetch improvements:

* Changed the logic for fetching the `next` branch to use `git ls-remote` to check for its existence and fetch it explicitly, reducing errors when the branch is missing or not up-to-date. (`.github/workflows/release.yml`) [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L30-R32) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L210-R213)
* Removed the use of `|| true` in `git fetch` commands to avoid masking fetch errors and ensure the workflow fails when branch alignment is not possible. (`.github/workflows/release.yml`) [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L30-R32) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L189-R190) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L210-R213)
* Updated the "Sync next to main" step to fetch only the `main` branch, simplifying the fetch command and ensuring correct push behavior. (`.github/workflows/release.yml`)