### PR TITLE
Improve clarity of conflict protection in README

### DIFF
--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -22,7 +22,7 @@ The extension follows a git-like model: **List**, **Pull**, and **Push**. You ha
 
 ### 🛡️ Conflict Management
 The system intelligently detects conflicts to prevent data loss:
-- **Protection**: If a workflow is modified simultaneously on n8n and locally, synchronization stops.
+- **Protection**: If a workflow is edited simultaneously on n8n and locally, synchronization stops.
 - **Resolution**: An interface allows you to compare versions (Diff View) and choose which one to keep (Force Push/Pull).
 
 ### 🗂️ Multi-Instance Support


### PR DESCRIPTION
This pull request makes a minor wording adjustment to the `README.md` for the VSCode extension, clarifying the description of conflict management. The change improves clarity by using "edited" instead of "modified" to describe simultaneous workflow changes.

* Updated the conflict management section in `packages/vscode-extension/README.md` to clarify that synchronization stops when a workflow is "edited" simultaneously on n8n and locally, rather than "modified".