### PR TITLE
Simplify VSCode release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,17 +25,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Enforce next alignment
-        run: |
-          git fetch origin main
-          if git ls-remote --exit-code --heads origin next >/dev/null 2>&1; then
-            git fetch origin next:refs/remotes/origin/next
-            if ! git merge-base --is-ancestor origin/next HEAD; then
-              echo "❌ next is ahead of main. Stable release is blocked until main includes every next commit."
-              exit 1
-            fi
-          fi
-
       - name: Detect pending stable publish
         id: pending
         run: |
@@ -204,18 +193,6 @@ jobs:
       - name: Skip when a stable publish is pending
         if: needs.publish-stable.outputs.pending == 'true'
         run: echo "Stable versions are already ahead of tags on main; skipping release PR creation."
-
-      - name: Enforce next alignment
-        if: needs.publish-stable.outputs.pending != 'true'
-        run: |
-          git fetch origin main
-          if git ls-remote --exit-code --heads origin next >/dev/null 2>&1; then
-            git fetch origin next:refs/remotes/origin/next
-            if ! git merge-base --is-ancestor origin/next HEAD; then
-              echo "❌ next is ahead of main. Release PR creation is blocked until main includes every next commit."
-              exit 1
-            fi
-          fi
 
       - name: Setup Node.js
         if: needs.publish-stable.outputs.pending != 'true'
@@ -403,34 +380,3 @@ jobs:
           echo "ℹ️ Skipping Open VSX publish for next builds."
           echo "ℹ️ Open VSX exposes preview metadata, but downstream clients can still resolve the highest version by default."
           echo "ℹ️ Only stable releases from main are published to Open VSX."
-
-      - name: Persist prerelease versions on next
-        if: steps.prerelease-plan.outputs.changed == 'true'
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add package-lock.json packages/cli/package.json packages/skills/package.json packages/transformer/package.json packages/vscode-extension/package.json
-          if git diff --cached --quiet; then
-            echo "ℹ️ No prerelease version changes to persist."
-            exit 0
-          fi
-          git commit -m 'chore: persist prerelease versions [skip ci]'
-
-          node <<'NODE'
-          const fs = require('fs');
-          const { execFileSync } = require('child_process');
-          const plan = JSON.parse(fs.readFileSync('prerelease-plan.json', 'utf8'));
-          const extension = plan.packages.find(pkg => pkg.name === 'n8n-as-code');
-          if (!extension?.changed || !extension.prereleaseVersion) {
-            process.exit(0);
-          }
-          const tag = `n8n-as-code@next-v${extension.prereleaseVersion}`;
-          try {
-            execFileSync('git', ['rev-parse', '-q', '--verify', `refs/tags/${tag}`], { stdio: 'ignore' });
-          } catch {
-            execFileSync('git', ['tag', tag], { stdio: 'inherit' });
-          }
-          NODE
-
-          git push origin HEAD:refs/heads/next
-          git push origin --tags

--- a/docs/docs/contribution/index.md
+++ b/docs/docs/contribution/index.md
@@ -78,9 +78,10 @@ n8n-as-code uses a custom commit-driven release flow with independent package ve
 ### Current Package Versions
 
 Packages evolve **independently** with their own version numbers:
-- **n8nac**: `0.11.3` (embeds sync engine, exposes `n8nac skills`)
+- **@n8n-as-code/transformer**: `0.2.9`
+- **n8nac**: `0.11.4` (embeds sync engine, exposes `n8nac skills`)
 - **@n8n-as-code/skills**: `0.16.16` (internal library, consumed by `n8nac` and the VS Code extension)
-- **VS Code Extension**: `0.20.0`
+- **VS Code Extension**: `0.20.1`
 
 > **Note**: Each package has its own version number. The release workflow updates internal dependency pins automatically whenever an upstream package version changes.
 
@@ -93,7 +94,7 @@ The project uses a custom commit-driven release flow.
 | `@n8n-as-code/transformer` | NPM Registry | Conventional commits + dependency propagation |
 | `@n8n-as-code/skills` | NPM Registry | Conventional commits + dependency propagation |
 | `n8nac` | NPM Registry | Conventional commits + dependency propagation |
-| `n8n-as-code` (VS Code Extension) | VS Code Marketplace / Open VSX | `packages/vscode-extension/package.json` + commit-driven bump |
+| `n8n-as-code` (VS Code Extension) | VS Code Marketplace / Open VSX | `packages/vscode-extension/package.json` with stable `x.y.0` releases and prerelease `x.y.z` patch increments |
 | Claude adapter artifacts | GitHub repository / plugin distribution flow | Built from `packages/skills/scripts/build-claude-adapter.js` |
 | `n8n-as-code-monorepo` (root) | Not published | Not released |
 | `docs` | Not published | Not released |
@@ -105,15 +106,17 @@ The project uses a custom commit-driven release flow.
 - Every push to `next` computes prerelease bumps from commit messages.
 - Internal dependency versions are re-pinned automatically.
 - Changed public packages are published to npm with the `next` dist-tag.
-- The VS Code extension is published to the Marketplace as a prerelease.
+- The VS Code extension is published to the Marketplace as a prerelease on the current stable line, using patch increments greater than `0`.
+- Example: if the current stable extension is `0.20.0`, prereleases on `next` become `0.20.1`, `0.20.2`, `0.20.3`, and so on.
 - Open VSX prereleases remain disabled.
 
 #### Push to `main`
 
-- Stable release creation is only allowed when `next` is not ahead of `main`.
 - If any package version in `package.json` is already ahead of its latest stable tag, `main` publishes that version directly instead of opening a new release PR.
 - A push to `main` creates or updates a single release PR only when no package is already ahead of its latest stable tag and commit history requires version bumps.
 - The release PR updates package versions and internal dependency versions together.
+- For the VS Code extension, stable releases always land on patch `0` of the next stable line.
+- Example: after a `0.20.x` prerelease cycle, the next stable extension release becomes `0.21.0`.
 
 #### Merge the release PR
 
@@ -136,11 +139,11 @@ git commit -m "fix(cli): handle sync edge case"
 ```
 
 **Result:**
-- `n8nac`: `0.11.3` → `0.11.4` ✅
+- `n8nac`: `0.11.4` → `0.11.5` ✅
 - `@n8n-as-code/skills`: (unchanged, no dependency on n8nac) ✅
-- `VS Code Extension`: `0.20.0` → `0.20.1` (auto-bumped because it depends on n8nac) ✅
+- `VS Code Extension`: `0.20.1` → `0.21.0` (next stable line, patch reset to `0`) ✅
 
-All packages that depend on `n8nac` will have their `package.json` updated to reference `"n8nac": "0.9.4"`.
+All packages that depend on `n8nac` will have their `package.json` updated to reference the newly released stable version.
 
 ### Workflow Summary Diagram
 
@@ -165,6 +168,7 @@ CI automatically:
 ### Key Rules
 - **Never manually edit release versions in PRs by hand** unless you are intentionally repairing the release flow
 - **Use conventional commits** so the CI can derive `major`, `minor`, or `patch` automatically
+- **The VS Code extension uses `stable = patch 0` and `prerelease = patch > 0`**
 - **The VS Code extension version line is driven from `packages/vscode-extension/package.json`**
 - **Internal dependencies are automatically re-pinned** whenever an upstream package is bumped
 - **Private packages remain safe** - they can participate in version orchestration without npm publication

--- a/scripts/release/workspace-release.mjs
+++ b/scripts/release/workspace-release.mjs
@@ -49,7 +49,6 @@ const PACKAGES = [
 const PATCH_TYPES = new Set(['fix', 'perf', 'refactor', 'revert', 'deps', 'build']);
 const BUMP_PRIORITY = { none: 0, patch: 1, minor: 2, major: 3 };
 const extensionPackage = PACKAGES.find(pkg => pkg.name === 'n8n-as-code');
-const VSCODE_PRERELEASE_TAG_PREFIX = 'n8n-as-code@next-v';
 
 const CROSS_PACKAGE_RULES = [
   {
@@ -242,31 +241,6 @@ function getLatestStableTag(pkg) {
 
   for (const tag of tags) {
     const version = parseTagVersion(tag, pkg.tagPrefix);
-    if (!version) {
-      continue;
-    }
-
-    if (!latest || compareVersions(version, latest.version) > 0) {
-      latest = { tag, version };
-    }
-  }
-
-  return latest;
-}
-
-function getLatestPublishedVscodeVersion() {
-  const tags = gitLines(['tag', '--list', 'n8n-as-code@*']);
-  let latest = null;
-
-  for (const tag of tags) {
-    let version = null;
-
-    if (tag.startsWith(VSCODE_PRERELEASE_TAG_PREFIX)) {
-      version = parseVersion(tag.slice(VSCODE_PRERELEASE_TAG_PREFIX.length));
-    } else {
-      version = parseTagVersion(tag, extensionPackage.tagPrefix);
-    }
-
     if (!version) {
       continue;
     }
@@ -597,14 +571,20 @@ function computeStablePlan() {
     const versionAheadOfTag = latestTag ? compareVersions(currentStableVersion, latestTag.version) > 0 : false;
     const changed = Boolean(bumpInfo.bump) || versionAheadOfTag;
     const targetVersion = pkg.publishTarget === 'vscode'
-      ? (changed ? formatVersion(incrementVersion(currentStableVersion, 'patch')) : currentStableString)
+      ? (
+          versionAheadOfTag
+            ? currentStableString
+            : changed
+              ? formatVersion(incrementVersion(currentStableVersion, bumpInfo.bump === 'major' ? 'major' : 'minor'))
+              : currentStableString
+        )
       : (bumpInfo.bump ? formatVersion(incrementVersion(currentStableVersion, bumpInfo.bump)) : currentStableString);
     const reasons = [...bumpInfo.reasons];
     if (versionAheadOfTag && !reasons.includes('version-ahead-of-tag')) {
       reasons.push('version-ahead-of-tag');
     }
-    if (pkg.publishTarget === 'vscode' && changed && !reasons.includes('sequential-vscode-version')) {
-      reasons.push('sequential-vscode-version');
+    if (pkg.publishTarget === 'vscode' && changed && !versionAheadOfTag && !reasons.includes('stable-vscode-minor-line')) {
+      reasons.push('stable-vscode-minor-line');
     }
 
     return {
@@ -652,7 +632,7 @@ function computePrereleasePlan() {
     return {
       ...pkg,
       prereleaseVersion: pkg.publishTarget === 'vscode'
-        ? pkg.targetVersion
+        ? buildVscodePrereleaseVersion(parseVersion(pkg.currentVersion), sequence)
         : `${pkg.targetVersion}-next.${sequence}`,
     };
   });
@@ -676,17 +656,13 @@ function computePendingStablePlan() {
 
     const latestTag = getLatestStableTag(pkg);
     const latestStableVersion = latestTag ? formatVersion(latestTag.version) : null;
-    const latestPublishedVersion = pkg.publishTarget === 'vscode'
-      ? getLatestPublishedVscodeVersion()
-      : latestTag;
-    const changed = latestPublishedVersion ? compareVersions(currentStableVersion, latestPublishedVersion.version) > 0 : false;
+    const changed = latestTag ? compareVersions(currentStableVersion, latestTag.version) > 0 : false;
 
     return {
       ...pkg,
       currentVersion,
       latestStableTag: latestTag?.tag ?? null,
       latestStableVersion,
-      latestPublishedVersion: latestPublishedVersion ? formatVersion(latestPublishedVersion.version) : null,
       targetVersion: formatVersion(currentStableVersion),
       changed,
     };


### PR DESCRIPTION
This pull request refines the release workflow and documentation to clarify and enforce versioning rules for the VS Code extension, and removes obsolete logic related to prerelease version persistence and tag handling. The changes ensure that stable releases for the extension always land on patch `0` of a new minor line, while prereleases increment the patch version above `0` on the current stable line. Documentation is updated to reflect these rules, and the release scripts are simplified accordingly.

**Release workflow and versioning rules for VS Code extension:**

* Removed enforcement steps in `.github/workflows/release.yml` that previously blocked stable releases and release PR creation if the `next` branch was ahead of `main`. This streamlines the release process and removes unnecessary checks. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L28-L38) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L208-L219)
* Updated release scripts (`scripts/release/workspace-release.mjs`) to ensure stable VS Code extension releases always use patch `0` of the next minor line, and prereleases increment patch above `0` on the current stable line. Also removed obsolete prerelease tag logic and related helper functions. [[1]](diffhunk://#diff-89ce93394e1c68ef5a1e874aa990ca9103ae81903343639b8d73a49519478ddaL52) [[2]](diffhunk://#diff-89ce93394e1c68ef5a1e874aa990ca9103ae81903343639b8d73a49519478ddaL257-L281) [[3]](diffhunk://#diff-89ce93394e1c68ef5a1e874aa990ca9103ae81903343639b8d73a49519478ddaL600-R587) [[4]](diffhunk://#diff-89ce93394e1c68ef5a1e874aa990ca9103ae81903343639b8d73a49519478ddaL655-R635) [[5]](diffhunk://#diff-89ce93394e1c68ef5a1e874aa990ca9103ae81903343639b8d73a49519478ddaL679-L689)

**Documentation updates:**

* Clarified versioning rules in `docs/docs/contribution/index.md`, including examples and workflow diagrams for VS Code extension releases, and updated package version numbers to reflect new release logic. [[1]](diffhunk://#diff-b340b958bf486626bb7122639f6ef2217f1e0b70e7b1d4d763b8cf95629f9e5bL81-R84) [[2]](diffhunk://#diff-b340b958bf486626bb7122639f6ef2217f1e0b70e7b1d4d763b8cf95629f9e5bL96-R97) [[3]](diffhunk://#diff-b340b958bf486626bb7122639f6ef2217f1e0b70e7b1d4d763b8cf95629f9e5bL108-R119) [[4]](diffhunk://#diff-b340b958bf486626bb7122639f6ef2217f1e0b70e7b1d4d763b8cf95629f9e5bL139-R146) [[5]](diffhunk://#diff-b340b958bf486626bb7122639f6ef2217f1e0b70e7b1d4d763b8cf95629f9e5bR171)

**Removal of obsolete prerelease persistence:**

* Removed steps in `.github/workflows/release.yml` that persisted prerelease versions and tags for the VS Code extension on the `next` branch, since prerelease tags are no longer needed.