### PR TITLE
Add note on using npx --yes for CI and automation

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -12,6 +12,12 @@ No installation required — run directly with npx:
 npx n8nac <command>
 ```
 
+For CI, scripts, and AI agents, prefer `npx --yes` to avoid interactive install prompts:
+
+```bash
+npx --yes n8nac <command>
+```
+
 Or install globally if you prefer:
 
 ```bash


### PR DESCRIPTION
This pull request updates the documentation to clarify how to run the CLI tool non-interactively, which is especially useful for CI environments, scripts, and AI agents.

Documentation improvements:

* Added a recommendation to use `npx --yes n8nac <command>` for CI, scripts, and AI agents to avoid interactive install prompts in `packages/cli/README.md`.