### PR TITLE
Update version to 0.21.0 and reset stable line in CHANGELOG

### DIFF
--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # n8n-as-code
 
+## [0.21.0](https://github.com/EtienneLescot/n8n-as-code/compare/n8n-as-code@v0.20.2...n8n-as-code@v0.21.0) (2026-03-09)
+
+### Bug Fixes
+
+* reset the VS Code extension stable line to `0.21.0` after the `0.20.2` prerelease and stable publish collided in the Marketplace
+
 ## [0.20.2](https://github.com/EtienneLescot/n8n-as-code/compare/n8n-as-code@v0.20.1...n8n-as-code@v0.20.2) (2026-03-09)
 
 ### Bug Fixes

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "n8n-as-code",
   "displayName": "n8n as code",
   "description": "Edit your n8n workflows directly in VS Code with AI assistance.",
-  "version": "0.20.2",
+  "version": "0.21.0",
   "private": true,
   "publisher": "etienne-lescot",
   "files": [


### PR DESCRIPTION
This pull request resets the VS Code extension stable version line to `0.21.0` following a collision between prerelease and stable publishes on the Marketplace. No code changes were made; only versioning and changelog updates.

* Version update:
  * Updated the extension version in `package.json` from `0.20.2` to `0.21.0` to resolve publishing issues.

* Changelog update:
  * Added a new entry in `CHANGELOG.md` documenting the version reset and the reason for the change.