### PR TITLE
Add note on pinning package versions for automation

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,6 +18,12 @@ For CI, scripts, and AI agents, prefer `npx --yes` to avoid interactive install 
 npx --yes n8nac <command>
 ```
 
+If you need fully repeatable automation, pin an explicit package version instead of relying on whatever `npx` resolves that day:
+
+```bash
+npx --yes n8nac@0.11.4 <command>
+```
+
 Or install globally if you prefer:
 
 ```bash


### PR DESCRIPTION
This pull request adds documentation to clarify best practices for using `npx` with the `n8nac` package, specifically for automation scenarios. The most important change is an added recommendation on how to ensure repeatable automation by pinning the package version.

Documentation improvements:

* Updated `packages/cli/README.md` to recommend pinning an explicit package version with `npx --yes n8nac@<version>` for fully repeatable automation, instead of relying on the latest version.