### PR TITLE
Clarify package-scoped documentation commits as patch releases

### DIFF
--- a/docs/docs/contribution/index.md
+++ b/docs/docs/contribution/index.md
@@ -168,6 +168,7 @@ CI automatically:
 ### Key Rules
 - **Never manually edit release versions in PRs by hand** unless you are intentionally repairing the release flow
 - **Use conventional commits** so the CI can derive `major`, `minor`, or `patch` automatically
+- **Package-scoped `docs(...)` commits also count as patch releases** when they touch files inside a released package
 - **The VS Code extension uses `stable = patch 0` and `prerelease = patch > 0`**
 - **The VS Code extension version line is driven from `packages/vscode-extension/package.json`**
 - **Internal dependencies are automatically re-pinned** whenever an upstream package is bumped

--- a/scripts/release/workspace-release.mjs
+++ b/scripts/release/workspace-release.mjs
@@ -46,7 +46,7 @@ const PACKAGES = [
   },
 ];
 
-const PATCH_TYPES = new Set(['fix', 'perf', 'refactor', 'revert', 'deps', 'build']);
+const PATCH_TYPES = new Set(['fix', 'perf', 'refactor', 'revert', 'deps', 'build', 'docs']);
 const BUMP_PRIORITY = { none: 0, patch: 1, minor: 2, major: 3 };
 const extensionPackage = PACKAGES.find(pkg => pkg.name === 'n8n-as-code');
 


### PR DESCRIPTION
This pull request clarifies and improves the release automation rules for package-scoped documentation changes. The most important changes ensure that commits affecting documentation within released packages trigger a patch release, and update the release script logic accordingly.

Release rules documentation update:

* Updated `docs/docs/contribution/index.md` to specify that package-scoped `docs(...)` commits count as patch releases when they modify files inside a released package.

Release script logic update:

* Added `'docs'` to the set of conventional commit types that trigger a patch bump in `scripts/release/workspace-release.mjs`, ensuring documentation changes within packages are included in patch releases.