### PR TITLE
Update pinned npx example version in CLI documentation

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@ npx --yes n8nac <command>
 If you need fully repeatable automation, pin an explicit package version instead of relying on whatever `npx` resolves that day:
 
 ```bash
-npx --yes n8nac@0.11.4 <command>
+npx --yes n8nac@0.11.5 <command>
 ```
 
 Or install globally if you prefer:


### PR DESCRIPTION
This pull request updates the documentation to reference the latest package version for `n8nac` in the `packages/cli/README.md` file.

Documentation update:

* Updated the example command to use `n8nac@0.11.5` instead of `n8nac@0.11.4` to ensure users are directed to the newest version.