### PR TITLE
Clarify connection instructions in README

### DIFF
--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -10,7 +10,7 @@
 
 1.  **Installation**: Install the extension from the Marketplace.
 2.  **Workspace**: Open a folder or a `.code-workspace` in VS Code before initialization. The extension requires an active workspace to index files and settings.
-3.  **Connection**: Click the **n8n** icon in the Activity Bar, then click the **Gear (⚙️)** to configure your `Host` and `API Key`. Your projects load automatically, with the Personal project pre-selected by default.
+3.  **Connection**: Click the **n8n** icon in the Activity Bar, then click the **Gear (⚙️)** or the configure button to configure your `Host` and `API Key`. Your projects load automatically, with the Personal project pre-selected by default.
 4.  **Import**: Use the refresh button (**Refresh**) to see your existing workflows.
 
 ---


### PR DESCRIPTION
This pull request makes a small update to the instructions in the `README.md` for the VS Code extension. The change clarifies that users can configure their `Host` and `API Key` using either the Gear icon or the configure button.

([packages/vscode-extension/README.mdL13-R13](diffhunk://#diff-68fae9b9adeb34aacaa83ee8f7e3798aad18f8fac8d2df7696bf265f54788861L13-R13))