### PR TITLE
Improve workspace initialization and reset state on missing config

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -37,7 +37,6 @@ let syncManager: SyncManager | undefined;
  *  list, fetch, pull, push. This is the only object the command handlers touch. */
 let cli: CliApi | undefined;
 let initializingPromise: Promise<void> | undefined;
-let configRefreshTimeout: NodeJS.Timeout | undefined;
 let lastConfigRefreshSignature: string | undefined;
 let runtimeDisposables: vscode.Disposable[] = [];
 
@@ -405,13 +404,11 @@ export async function activate(context: vscode.ExtensionContext) {
                     enhancedTreeProvider.setExtensionState(ExtensionState.SETTINGS_CHANGED);
                     statusBar.showSettingsChanged();
                 } else {
-                    const valid = validateN8nConfig().isValid;
                     const root = getWorkspaceRoot();
-                    const wasInit = root ? isFolderPreviouslyInitialized(root) : false;
-                    if (valid && wasInit) {
-                        enhancedTreeProvider.setExtensionState(ExtensionState.UNINITIALIZED);
-                        statusBar.showNotInitialized();
-                    } else if (!valid) {
+                    const hasUnifiedConfig = root ? fs.existsSync(path.join(root, 'n8nac-config.json')) : false;
+                    const valid = validateN8nConfig().isValid;
+                    if (!hasUnifiedConfig || !valid) {
+                        resetExtensionRuntimeState();
                         enhancedTreeProvider.setExtensionState(ExtensionState.CONFIGURING);
                         statusBar.showConfiguring();
                     } else {
@@ -433,15 +430,8 @@ export async function activate(context: vscode.ExtensionContext) {
         );
 
         const refreshFromConfigFile = async () => {
-            if (configRefreshTimeout) {
-                clearTimeout(configRefreshTimeout);
-            }
-
-            configRefreshTimeout = setTimeout(async () => {
-                outputChannel.appendLine('[n8n] Workspace config changed. Refreshing extension state...');
-                await refreshStateFromWorkspaceConfig(context);
-                configRefreshTimeout = undefined;
-            }, 150);
+            outputChannel.appendLine('[n8n] Workspace config changed. Refreshing extension state...');
+            await refreshStateFromWorkspaceConfig(context);
         };
 
         configWatcher.onDidCreate(refreshFromConfigFile);
@@ -539,8 +529,18 @@ async function determineInitialState(context: vscode.ExtensionContext) {
     lastConfigRefreshSignature = getConfigRefreshSignature(workspaceRoot);
 
     if (!workspaceRoot) {
+        resetExtensionRuntimeState();
         enhancedTreeProvider.setExtensionState(ExtensionState.UNINITIALIZED);
         statusBar.hide();
+        updateContextKeys();
+        return;
+    }
+
+    const hasUnifiedConfig = fs.existsSync(path.join(workspaceRoot, 'n8nac-config.json'));
+    if (!hasUnifiedConfig) {
+        resetExtensionRuntimeState();
+        enhancedTreeProvider.setExtensionState(ExtensionState.CONFIGURING);
+        statusBar.showConfiguring();
         updateContextKeys();
         return;
     }
@@ -893,10 +893,6 @@ async function reinitializeSyncManager(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {
-    if (configRefreshTimeout) {
-        clearTimeout(configRefreshTimeout);
-        configRefreshTimeout = undefined;
-    }
     disposeRuntimeDisposables();
     proxyService.stop();
 }

--- a/packages/vscode-extension/src/utils/state-detection.ts
+++ b/packages/vscode-extension/src/utils/state-detection.ts
@@ -150,6 +150,14 @@ export function determineInitialState(workspaceRoot?: string): {
     };
   }
 
+  if (!fs.existsSync(path.join(workspaceRoot, 'n8nac-config.json'))) {
+    return {
+      state: 'configuring',
+      hasValidConfig: false,
+      isPreviouslyInitialized: false
+    };
+  }
+
   const isPreviouslyInitialized = isFolderPreviouslyInitialized(workspaceRoot);
 
   if (isPreviouslyInitialized && hasValidConfig) {


### PR DESCRIPTION
This pull request improves the extension's handling of workspace configuration, especially around initialization and state detection. The most important changes focus on ensuring the presence of the unified config file (`n8nac-config.json`) before proceeding, and simplifying how configuration refreshes are managed.

Configuration validation and initialization:

* Added explicit checks for the existence of `n8nac-config.json` in both the `activate` and `determineInitialState` functions, ensuring the extension transitions to the `CONFIGURING` state and resets runtime state if the config file is missing. [[1]](diffhunk://#diff-4c90b03b52f52f0b353937581a6f678abab846759e4ebe0fc8064e3004ff0164L408-R411) [[2]](diffhunk://#diff-4c90b03b52f52f0b353937581a6f678abab846759e4ebe0fc8064e3004ff0164R532-R547) [[3]](diffhunk://#diff-b4b9ca875f2be369f7c93bd3ab7c9dd2016f08d4f3131d396dfec6617f85a552R153-R160)
* Updated the logic in `determineInitialState` to reset runtime state and set extension state appropriately when the workspace root is missing or not properly configured.

Configuration refresh handling:

* Removed the debounced timeout mechanism for config refreshes, simplifying the refresh logic to trigger immediately on config changes.
* Removed the now-unused `configRefreshTimeout` variable and its cleanup logic from the extension lifecycle. [[1]](diffhunk://#diff-4c90b03b52f52f0b353937581a6f678abab846759e4ebe0fc8064e3004ff0164L40) [[2]](diffhunk://#diff-4c90b03b52f52f0b353937581a6f678abab846759e4ebe0fc8064e3004ff0164L896-L899)… file is missing