### PR TITLE
chore: stop publishing raw skills source assets

### DIFF
--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -32,8 +32,7 @@
         "typescript": "^5.3.3"
     },
     "files": [
-        "dist/",
-        "src/assets/"
+        "dist/"
     ],
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Summary

Stops publishing raw `@n8n-as-code/skills` source assets in the npm package by limiting the published files to `dist/` only.

## Why

The raw docs cache under `src/assets/n8n-docs-cache/**` is a build-time source cache and is not used by agents at runtime. Removing it from the published package reduces redistributed third-party content without affecting runtime search or workflow generation behavior.

## Validation

- Verified `npm pack --dry-run` no longer includes `src/assets/n8n-docs-cache/**`
- Verified runtime assets remain published in `dist/assets/*.json`
