### PR TITLE
fix(cli): handle inaccessible community projects API

### DIFF
--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -94,8 +94,6 @@ export class N8nApiClient {
             id: projectId,
             name,
             type,
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString()
         };
     }
 

--- a/packages/cli/tests/unit/n8n-api-client.test.ts
+++ b/packages/cli/tests/unit/n8n-api-client.test.ts
@@ -184,11 +184,6 @@ describe('N8nApiClient test workflow support', () => {
                     data: { message: 'unavailable' },
                 },
                 message: 'Request failed with status code 403',
-            })
-            .mockResolvedValueOnce({
-                data: {
-                    data: [],
-                },
             });
 
         const workflows = await client.getAllWorkflows('personal');
@@ -198,6 +193,9 @@ describe('N8nApiClient test workflow support', () => {
             id: 'wf-1',
             projectId: 'actual-project-id',
         });
+        expect(mockAxiosGet).toHaveBeenCalledTimes(2);
+        expect(mockAxiosGet).toHaveBeenNthCalledWith(1, '/api/v1/workflows');
+        expect(mockAxiosGet).toHaveBeenNthCalledWith(2, '/api/v1/projects');
     });
 
     it('normalizes webhook paths with leading slashes and special characters', () => {


### PR DESCRIPTION
## Summary

Fixes the CLI init/project flow when `/api/v1/projects` is inaccessible on some Community Edition instances.

## What changed

- use a stable placeholder `Personal` project when the projects API returns `403` or `404`
- stop trying to infer a real remote project id from workflows in that fallback path
- treat the placeholder id as a local sentinel so workflow listing is not incorrectly filtered out
- add regression tests for the fallback behavior and mock isolation in the API client test file

## Why

Issue #255 reports a Community Edition instance on a recent n8n version where `get projects` is unavailable, causing init to fail with `No projects found`.

The previous fallback logic relied on error-message matching and attempted to infer a real project id from workflows. This change simplifies the model:

- if projects are accessible, use them normally
- if they are not accessible, force a synthetic `Personal` project for bootstrap/sync configuration

That matches the intended UX for Community Edition and avoids brittle inference.

Closes #255
