### PR TITLE
Fix CLI issues with community projects API and review feedback

### DIFF
--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -94,8 +94,6 @@ export class N8nApiClient {
             id: projectId,
             name,
             type,
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString()
         };
     }
 

--- a/packages/cli/tests/unit/n8n-api-client.test.ts
+++ b/packages/cli/tests/unit/n8n-api-client.test.ts
@@ -184,11 +184,6 @@ describe('N8nApiClient test workflow support', () => {
                     data: { message: 'unavailable' },
                 },
                 message: 'Request failed with status code 403',
-            })
-            .mockResolvedValueOnce({
-                data: {
-                    data: [],
-                },
             });
 
         const workflows = await client.getAllWorkflows('personal');
@@ -198,6 +193,9 @@ describe('N8nApiClient test workflow support', () => {
             id: 'wf-1',
             projectId: 'actual-project-id',
         });
+        expect(mockAxiosGet).toHaveBeenCalledTimes(2);
+        expect(mockAxiosGet).toHaveBeenNthCalledWith(1, '/api/v1/workflows');
+        expect(mockAxiosGet).toHaveBeenNthCalledWith(2, '/api/v1/projects');
     });
 
     it('normalizes webhook paths with leading slashes and special characters', () => {


### PR DESCRIPTION
This pull request refactors and simplifies how the `N8nApiClient` handles cases where the projects API is unavailable or restricted (such as due to license limitations), and improves test coverage for these scenarios. The main improvements include centralizing fallback logic for "Personal" projects, reducing code duplication, and ensuring workflows are not incorrectly filtered when using a placeholder project ID.

**Project fallback and error handling improvements:**

* Centralized the logic for falling back to a placeholder "Personal" project when the projects API returns 403/404 errors, using new helper methods (`shouldUsePersonalProjectFallback`, `createPersonalProject`, etc.), and removed redundant attempts to discover project IDs from workflows. This makes the fallback behavior more consistent and easier to maintain. [[1]](diffhunk://#diff-5b836fd115f5a6c3a7ccec8818bb4ada619e8b85785d96df02da82a584f0651eR87-R107) [[2]](diffhunk://#diff-5b836fd115f5a6c3a7ccec8818bb4ada619e8b85785d96df02da82a584f0651eL104-R128) [[3]](diffhunk://#diff-5b836fd115f5a6c3a7ccec8818bb4ada619e8b85785d96df02da82a584f0651eL198-R193)
* Added a static constant for the placeholder personal project ID to avoid magic strings and improve code clarity.

**Workflow filtering logic:**

* Updated workflow filtering so that when the placeholder personal project ID is used, no filtering is applied, preventing workflows from being excluded incorrectly. [[1]](diffhunk://#diff-5b836fd115f5a6c3a7ccec8818bb4ada619e8b85785d96df02da82a584f0651eL295-R242) [[2]](diffhunk://#diff-5b836fd115f5a6c3a7ccec8818bb4ada619e8b85785d96df02da82a584f0651eL391-R340)

**Testing enhancements:**

* Expanded unit tests to cover the fallback to the placeholder personal project and to verify that workflows are not filtered out when using the placeholder project ID. This ensures correct behavior in restricted environments.
* Improved test setup by resetting and re-mocking Axios methods in the test suite to ensure isolated and reliable tests.