### PR TITLE
Fixed: node10 is deprecated in TypeScript 7

### DIFF
--- a/packages/cli/src/core/services/workspace-setup-service.ts
+++ b/packages/cli/src/core/services/workspace-setup-service.ts
@@ -55,8 +55,8 @@ const TSCONFIG_CONTENT = JSON.stringify(
     {
         compilerOptions: {
             target: 'ES2022',
-            module: 'Node16',
-            moduleResolution: 'node16',
+            module: 'NodeNext',
+            moduleResolution: 'NodeNext',
             experimentalDecorators: true,
             emitDecoratorMetadata: false,
             strict: false,

--- a/packages/cli/tests/unit/workspace-setup-service.test.ts
+++ b/packages/cli/tests/unit/workspace-setup-service.test.ts
@@ -26,6 +26,8 @@ describe('WorkspaceSetupService', () => {
         const tsconfig = JSON.parse(fs.readFileSync(tsconfigPath, 'utf-8'));
         expect(tsconfig.compilerOptions.baseUrl).toBeUndefined();
         expect(tsconfig.compilerOptions.paths).toBeUndefined();
+        expect(tsconfig.compilerOptions.module).toBe('NodeNext');
+        expect(tsconfig.compilerOptions.moduleResolution).toBe('NodeNext');
     });
 
     it('writes declaration file with ambient module for @n8n-as-code/transformer', () => {


### PR DESCRIPTION
- Fixes: `node: Deprecated, use "node10" in TypeScript 5.0+ instead`
- Fixes: `node10: It’s recommended to use "node16" instead`

https://www.typescriptlang.org/tsconfig/#moduleResolution