### PR TITLE
fix(types): add webhookId to NodeDecoratorOptions interface

### DIFF
--- a/packages/cli/src/core/assets/n8n-workflows.d.ts
+++ b/packages/cli/src/core/assets/n8n-workflows.d.ts
@@ -74,6 +74,8 @@ export interface WorkflowDecoratorOptions {
 export interface NodeDecoratorOptions {
     /** Unique identifier of the node (matches workflow JSON) */
     id?: string;
+    /** Stable webhook ID assigned by n8n to webhook nodes */
+    webhookId?: string;
     /** Display name shown in n8n UI */
     name: string;
     /** Node type identifier (e.g. "n8n-nodes-base.httpRequest") */
@@ -204,6 +206,8 @@ declare module '@n8n-as-code/transformer' {
     export interface NodeDecoratorOptions {
         /** Unique identifier of the node (matches workflow JSON) */
         id?: string;
+        /** Stable webhook ID assigned by n8n to webhook nodes */
+        webhookId?: string;
         /** Display name shown in n8n UI */
         name: string;
         /** Node type identifier (e.g. "n8n-nodes-base.httpRequest") */


### PR DESCRIPTION
## Fix: Add `webhookId` to `NodeDecoratorOptions` in generated type stubs

Fixes #317

### Problem

The auto-generated `n8n-workflows.d.ts` was missing the `webhookId` property in `NodeDecoratorOptions`. When pulling a workflow from n8n that contains a Webhook node, the generated `.workflow.ts` file includes `webhookId` in the `@node(...)` decorator, causing a TypeScript compile error:

```ts
No overload matches this call.
  Overload 1 of 2, '(options: NodeDecoratorOptions): PropertyDecorator', gave the following error.
    Object literal may only specify known properties, and 'webhookId' does not exist in type 'NodeDecoratorOptions'.
```

### Change

Added `webhookId?: string` to `NodeDecoratorOptions` in both locations of `n8n-workflows.d.ts`:

- Global export block
- `declare module '@n8n-as-code/transformer'` block

This matches the existing `webhookId?: string` field in `NodeDecoratorMetadata` from the `@n8n-as-code/transformer` package.