### PR TITLE
fix/add-graceful-websocket-close

### DIFF
--- a/packages/vscode-extension/src/services/proxy-service.ts
+++ b/packages/vscode-extension/src/services/proxy-service.ts
@@ -28,8 +28,8 @@ export class ProxyService {
 
     /**
      * Check whether a WebSocket close code is valid for sending in a close frame.
-     * Codes 1005, 1006, and 1015 are reserved and MUST NOT be set as a status
-     * code in a Close control frame (RFC 6455 §7.4.1).
+     * Codes 1004, 1005, 1006, and 1015 are reserved and MUST NOT be set as a
+     * status code in a Close control frame (RFC 6455 §7.4.1).
      */
     private isSendableCloseCode(code: number): boolean {
         if (code >= 3000 && code <= 4999) { return true; }

--- a/packages/vscode-extension/src/services/proxy-service.ts
+++ b/packages/vscode-extension/src/services/proxy-service.ts
@@ -26,6 +26,18 @@ export class ProxyService {
         this.outputChannel = channel;
     }
 
+    /**
+     * Check whether a WebSocket close code is valid for sending in a close frame.
+     * Codes 1005, 1006, and 1015 are reserved and MUST NOT be set as a status
+     * code in a Close control frame (RFC 6455 §7.4.1).
+     */
+    private isSendableCloseCode(code: number): boolean {
+        if (code >= 3000 && code <= 4999) { return true; }
+        if (code >= 1000 && code <= 1003) { return true; }
+        if (code >= 1007 && code <= 1014) { return true; }
+        return false;
+    }
+
     private log(message: string) {
         if (this.outputChannel) {
             this.outputChannel.appendLine(message);
@@ -375,7 +387,11 @@ export class ProxyService {
                             clearPing();
                             this.log(`[Proxy] WS Connection Closed (Upstream): ${code}${reason.length > 0 ? ` ${reason.toString()}` : ''}`);
                             if (clientWs.readyState === WebSocket.OPEN) {
-                                clientWs.close(code, reason);
+                                if (this.isSendableCloseCode(code)) {
+                                    clientWs.close(code, reason);
+                                } else {
+                                    clientWs.close();
+                                }
                             } else {
                                 clientWs.terminate();
                             }
@@ -384,7 +400,11 @@ export class ProxyService {
                         clientWs.on('close', (code, reason) => {
                             clearPing();
                             if (upstreamWs.readyState === WebSocket.OPEN || upstreamWs.readyState === WebSocket.CONNECTING) {
-                                upstreamWs.close(code, reason);
+                                if (this.isSendableCloseCode(code)) {
+                                    upstreamWs.close(code, reason);
+                                } else {
+                                    upstreamWs.close();
+                                }
                             }
                         });
 


### PR DESCRIPTION
**What does this PR do?**

Fixes a crash in the WebSocket proxy when the upstream (or client) closes with reserved close codes 1005 or 1006. Per RFC 6455 §7.4.1, codes 1004, 1005, 1006, and 1015 are reserved and MUST NOT be sent in a Close control frame, but the proxy was forwarding them directly to `ws.close(code, reason)`, causing a `TypeError: First argument must be a valid error code number`.

This PR adds an `isSendableCloseCode()` helper method that validates close codes before forwarding. When a non-sendable code is received, `close()` is called without arguments instead of crashing.

Fixes #318