### PR TITLE
fix(extension): WebSocket proxy — sanitize non-sendable close codes

### DIFF
--- a/packages/vscode-extension/src/services/proxy-service.ts
+++ b/packages/vscode-extension/src/services/proxy-service.ts
@@ -375,7 +375,11 @@ export class ProxyService {
                             clearPing();
                             this.log(`[Proxy] WS Connection Closed (Upstream): ${code}${reason.length > 0 ? ` ${reason.toString()}` : ''}`);
                             if (clientWs.readyState === WebSocket.OPEN) {
-                                clientWs.close(code, reason);
+                                if (ProxyService.isSendableCloseCode(code)) {
+                                    clientWs.close(code, reason);
+                                } else {
+                                    clientWs.close();
+                                }
                             } else {
                                 clientWs.terminate();
                             }
@@ -384,7 +388,11 @@ export class ProxyService {
                         clientWs.on('close', (code, reason) => {
                             clearPing();
                             if (upstreamWs.readyState === WebSocket.OPEN || upstreamWs.readyState === WebSocket.CONNECTING) {
-                                upstreamWs.close(code, reason);
+                                if (ProxyService.isSendableCloseCode(code)) {
+                                    upstreamWs.close(code, reason);
+                                } else {
+                                    upstreamWs.close();
+                                }
                             }
                         });
 
@@ -411,6 +419,18 @@ export class ProxyService {
 
             this.server.on('error', reject);
         });
+    }
+
+    /** True if `code` is allowed in an outgoing Close frame (same rules as `ws` `isValidStatusCode`, RFC 6455). */
+    private static isSendableCloseCode(code: number): boolean {
+        return (
+            (code >= 1000 &&
+                code <= 1014 &&
+                code !== 1004 &&
+                code !== 1005 &&
+                code !== 1006) ||
+            (code >= 3000 && code <= 4999)
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
Fixes #318.

When the upstream n8n WebSocket closes with codes **1005** or **1006**, those values are valid as *reported* close reasons in Node/`ws`, but they **must not** be sent in an outgoing Close frame (RFC 6455). The proxy called `clientWs.close(code, reason)` verbatim, which triggers `TypeError: First argument must be a valid error code number`.

## Changes
- Add `isSendableCloseCode` aligned with `ws` `isValidStatusCode` (1000–1014 except 1004/1005/1006, or 3000–4999).
- **Upstream → client:** use `close()` without code when the code is not sendable.
- **Client → upstream:** same sanitization for symmetry.

## Testing
- `npm run build` in `packages/vscode-extension` (tsc + bundle) passes locally.

Made with [Cursor](https://cursor.com)