### PR TITLE
fix #309: archived workflows isArchived + [active] label

### DIFF
--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -13,6 +13,8 @@ export interface ListCommandOptions {
     search?: string;
     sort?: WorkflowListSortMode;
     limit?: number;
+    includeArchived?: boolean;
+    onlyArchived?: boolean;
 }
 
 export function matchesWorkflowSearch(workflow: IWorkflowStatus, query?: string): boolean {
@@ -89,7 +91,11 @@ export class ListCommand extends BaseCommand {
 
             // Get lightweight workflow list: no hash computation, no TypeScript compilation.
             // Fetches fresh remote metadata on each call for an up-to-date view.
-            const allWorkflows = await syncManager.listWorkflows({ fetchRemote: true });
+            const allWorkflows = await syncManager.listWorkflows({ 
+                fetchRemote: true,
+                includeArchived: options?.includeArchived,
+                onlyArchived: options?.onlyArchived
+            });
             const workflows = applyListCommandOptions(allWorkflows, options);
             // When no limit is applied, `workflows` already reflects the full filtered/sorted result set,
             // so its length is the number of matches without doing an extra pass.

--- a/packages/cli/src/core/services/sync-manager.ts
+++ b/packages/cli/src/core/services/sync-manager.ts
@@ -100,7 +100,7 @@ export class SyncManager extends EventEmitter {
      * Optionally refreshes remote state from the API before listing (default: false
      * to keep it fast). Pass `{ fetchRemote: true }` to force a fresh remote fetch.
      */
-    async listWorkflows(options?: { fetchRemote?: boolean }): Promise<IWorkflowStatus[]> {
+    async listWorkflows(options?: { fetchRemote?: boolean; includeArchived?: boolean; onlyArchived?: boolean }): Promise<IWorkflowStatus[]> {
         await this.ensureInitialized();
         // Always scan local files so that idToFileMap is rebuilt from the @workflow({ id })
         // decorator in each file. This correctly handles renames (the new filename is found
@@ -109,7 +109,10 @@ export class SyncManager extends EventEmitter {
         if (options?.fetchRemote) {
             await this.watcher!.refreshRemoteState();
         }
-        return await this.watcher!.getLightweightList();
+        return await this.watcher!.getLightweightList({
+            includeArchived: options?.includeArchived,
+            onlyArchived: options?.onlyArchived
+        });
     }
 
     /**

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -589,7 +589,9 @@ export class WorkflowStateTracker extends EventEmitter {
     }
 
     private shouldIgnore(wf: IWorkflow): boolean {
-        if (!this.syncInactive && !wf.active) return true;
+        // Archived workflows are always discovered (populated in remote* caches) even when syncInactive is false.
+        // They are filtered later by getLightweightList / listWorkflows based on includeArchived/onlyArchived flags.
+        if (!this.syncInactive && !wf.active && !wf.isArchived) return true;
         if (wf.tags) {
             const hasIgnoredTag = wf.tags.some(t => this.ignoredTags.includes(t.name.toLowerCase()));
             if (hasIgnoredTag) return true;
@@ -757,6 +759,19 @@ export class WorkflowStateTracker extends EventEmitter {
     }
 
     /**
+     * Returns true if a workflow should be excluded from the lightweight list
+     * based on its archived status and the filter options.
+     */
+    private shouldSkipArchived(
+        isArchived: boolean,
+        options?: { includeArchived?: boolean; onlyArchived?: boolean },
+    ): boolean {
+        if (options?.onlyArchived && !isArchived) return true;
+        if (!options?.includeArchived && !options?.onlyArchived && isArchived) return true;
+        return false;
+    }
+
+    /**
      * Lightweight list of workflows with basic status (local only, remote only, both)
      * Does NOT compute hashes, compile TypeScript, or determine detailed status (CONFLICT)
      */
@@ -795,8 +810,7 @@ export class WorkflowStateTracker extends EventEmitter {
             const active = workflowId ? (this.remoteActive.get(workflowId) ?? false) : false;
 
             // Apply archive filter
-            if (options?.onlyArchived && !isArchived) continue;
-            if (!options?.includeArchived && !options?.onlyArchived && isArchived) continue;
+            if (this.shouldSkipArchived(isArchived, options)) continue;
 
             // Prefer the remote canonical name (keyed by ID, not by name since names are non-unique).
             // For local-only files, extract the name from the @workflow decorator for an accurate display.
@@ -829,8 +843,7 @@ export class WorkflowStateTracker extends EventEmitter {
             if (!results.has(filename)) {
                 // Apply archive filter
                 const isArchived = this.remoteArchived.get(workflowId) ?? false;
-                if (options?.onlyArchived && !isArchived) continue;
-                if (!options?.includeArchived && !options?.onlyArchived && isArchived) continue;
+                if (this.shouldSkipArchived(isArchived, options)) continue;
 
                 // Prefer the actual remote name (stored by ID to avoid name-collision issues)
                 // Fallback to filename-derived name only if remote name is not available

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -67,6 +67,10 @@ export class WorkflowStateTracker extends EventEmitter {
     private remoteTimestamps: Map<string, string> = new Map(); // workflowId -> updatedAt
     /** Canonical display name for each remote workflow (id is the unique key, NOT the name). */
     private remoteNames: Map<string, string> = new Map(); // workflowId -> name
+    /** Remote active flag per workflow (populated by refreshRemoteState / updateSingleRemoteState). */
+    private remoteActive: Map<string, boolean> = new Map(); // workflowId -> active
+    /** Remote archived flag per workflow (populated by refreshRemoteState / updateSingleRemoteState). */
+    private remoteArchived: Map<string, boolean> = new Map(); // workflowId -> isArchived
 
     constructor(
         client: N8nApiClient,
@@ -257,6 +261,8 @@ export class WorkflowStateTracker extends EventEmitter {
             // Update remoteIds and names (ID is the unique key; name is for display only)
             this.remoteIds.clear();
             this.remoteNames.clear();
+            this.remoteActive.clear();
+            this.remoteArchived.clear();
 
             // Build set of already-assigned filenames to prevent collisions
             const assignedFilenames = new Set<string>();
@@ -267,6 +273,9 @@ export class WorkflowStateTracker extends EventEmitter {
                 this.remoteIds.add(wf.id);
                 // Store canonical name keyed by ID (names are NOT unique in n8n)
                 if (wf.name) this.remoteNames.set(wf.id, wf.name);
+                // Store active and archived flags from API
+                this.remoteActive.set(wf.id, wf.active === true);
+                this.remoteArchived.set(wf.id, wf.isArchived === true);
 
                 // CRITICAL: Use ID-based mapping with PERSISTED state as source of truth
                 let filename: string | undefined = this.idToFileMap.get(wf.id);
@@ -450,6 +459,8 @@ export class WorkflowStateTracker extends EventEmitter {
         this.remoteHashes.delete(id);
         this.remoteTimestamps.delete(id);
         this.remoteNames.delete(id);
+        this.remoteActive.delete(id);
+        this.remoteArchived.delete(id);
         this.remoteIds.delete(id);
     }
 
@@ -749,7 +760,10 @@ export class WorkflowStateTracker extends EventEmitter {
      * Lightweight list of workflows with basic status (local only, remote only, both)
      * Does NOT compute hashes, compile TypeScript, or determine detailed status (CONFLICT)
      */
-    public async getLightweightList(): Promise<IWorkflowStatus[]> {
+    public async getLightweightList(options?: {
+        includeArchived?: boolean;
+        onlyArchived?: boolean;
+    }): Promise<IWorkflowStatus[]> {
         const results: Map<string, IWorkflowStatus> = new Map();
         const state = this.loadState();
 
@@ -776,6 +790,14 @@ export class WorkflowStateTracker extends EventEmitter {
                 status = WorkflowSyncStatus.EXIST_ONLY_LOCALLY; // New or not yet pushed
             }
 
+            // Read active and archived flags from remote cache; fallback to false for truly local
+            const isArchived = workflowId ? (this.remoteArchived.get(workflowId) ?? false) : false;
+            const active = workflowId ? (this.remoteActive.get(workflowId) ?? false) : false;
+
+            // Apply archive filter
+            if (options?.onlyArchived && !isArchived) continue;
+            if (!options?.includeArchived && !options?.onlyArchived && isArchived) continue;
+
             // Prefer the remote canonical name (keyed by ID, not by name since names are non-unique).
             // For local-only files, extract the name from the @workflow decorator for an accurate display.
             // Fall back to filename-derived name as last resort.
@@ -788,11 +810,11 @@ export class WorkflowStateTracker extends EventEmitter {
                 name: workflowName,
                 filename: filename,
                 status: status,
-                active: true, // Default
+                active,
                 projectId: undefined, // Not available in lightweight mode
                 projectName: undefined, // Not available in lightweight mode
                 homeProject: undefined, // Not available in lightweight mode
-                isArchived: false // Default
+                isArchived
             });
         }
 
@@ -805,20 +827,26 @@ export class WorkflowStateTracker extends EventEmitter {
                 || `${workflowId}.workflow.ts`;
 
             if (!results.has(filename)) {
+                // Apply archive filter
+                const isArchived = this.remoteArchived.get(workflowId) ?? false;
+                if (options?.onlyArchived && !isArchived) continue;
+                if (!options?.includeArchived && !options?.onlyArchived && isArchived) continue;
+
                 // Prefer the actual remote name (stored by ID to avoid name-collision issues)
                 // Fallback to filename-derived name only if remote name is not available
                 const workflowName = this.remoteNames.get(workflowId) || filename.replace('.workflow.ts', '');
+                const active = this.remoteActive.get(workflowId) ?? false;
 
                 results.set(filename, {
                     id: workflowId,
                     name: workflowName,
                     filename: filename,
                     status: WorkflowSyncStatus.EXIST_ONLY_REMOTELY, // Remote only
-                    active: true, // Default
+                    active,
                     projectId: undefined, // Not available in lightweight mode
                     projectName: undefined, // Not available in lightweight mode
                     homeProject: undefined, // Not available in lightweight mode
-                    isArchived: false // Default
+                    isArchived
                 });
             }
         }
@@ -1089,6 +1117,9 @@ export class WorkflowStateTracker extends EventEmitter {
             }
             // Mark as known on remote
             this.remoteIds.add(remoteWf.id);
+            // Store active and archived flags
+            this.remoteActive.set(remoteWf.id, remoteWf.active === true);
+            this.remoteArchived.set(remoteWf.id, remoteWf.isArchived === true);
 
             // Establish mapping if it doesn't exist yet (allows 'pull' after single 'fetch')
             if (!this.idToFileMap.has(remoteWf.id)) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -249,6 +249,8 @@ program.command('list')
     .option('--search <query>', 'Filter by workflow name, ID, or local filename (case-insensitive partial match)')
     .option('--sort <mode>', 'Sort by "status" (default) or "name"', 'status')
     .option('--limit <number>', 'Limit the number of returned workflows', (value) => parsePositiveIntegerOption(value, '--limit'))
+    .option('--include-archived', 'Include archived workflows in the output')
+    .option('--only-archived', 'Show only archived workflows')
     .option('--json', 'Output full JSON instead of a table')
     .addOption(new Option('--raw').hideHelp())
     .action(async (options) => {
@@ -264,7 +266,9 @@ program.command('list')
             raw: options.json || options.raw,
             search: options.search,
             sort: options.sort,
-            limit: options.limit
+            limit: options.limit,
+            includeArchived: options.includeArchived,
+            onlyArchived: options.onlyArchived
         });
     });
 
@@ -276,6 +280,8 @@ program.command('find')
     .option('--distant', 'Alias for --remote')
     .option('--sort <mode>', 'Sort by "status" or "name"', 'name')
     .option('--limit <number>', 'Limit the number of returned workflows', (value) => parsePositiveIntegerOption(value, '--limit'))
+    .option('--include-archived', 'Include archived workflows in the output')
+    .option('--only-archived', 'Show only archived workflows')
     .option('--json', 'Output full JSON instead of a table')
     .addOption(new Option('--raw').hideHelp())
     .action(async (query, options) => {
@@ -290,7 +296,9 @@ program.command('find')
             raw: options.json || options.raw,
             search: query,
             sort: options.sort,
-            limit: options.limit
+            limit: options.limit,
+            includeArchived: options.includeArchived,
+            onlyArchived: options.onlyArchived
         });
     });
 

--- a/packages/cli/tests/integration/list-archived.integration.test.ts
+++ b/packages/cli/tests/integration/list-archived.integration.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Integration tests for --include-archived and --only-archived.
+ *
+ * Exercises the full SyncManager → WorkflowStateTracker chain with a
+ * real N8nApiClient-compatible mock, covering all three filter modes.
+ *
+ * Compared to the unit tests in workflow-state-tracker.test.ts, these
+ * go through SyncManager.listWorkflows() (the path used by the CLI),
+ * not directly through getLightweightList().
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { SyncManager } from '../../src/core/services/sync-manager.js';
+import { WorkflowStateTracker } from '../../src/core/services/workflow-state-tracker.js';
+import { ConfigService } from '../../src/services/config-service.js';
+
+// ---------------------------------------------------------------------------
+// Mock N8nApiClient — implements the surface used by WorkflowStateTracker
+// ---------------------------------------------------------------------------
+
+const REMOTE_WORKFLOWS = [
+    { id: 'wf-active-1', name: 'Active Alpha', active: true, isArchived: false, shared: [{ projectId: 'personal-project', projectName: 'Personal' }] },
+    { id: 'wf-active-2', name: 'Active Beta', active: true, isArchived: false, shared: [{ projectId: 'personal-project', projectName: 'Personal' }] },
+    { id: 'wf-archived-1', name: 'Archived Gamma', active: false, isArchived: true, shared: [{ projectId: 'personal-project', projectName: 'Personal' }] },
+];
+
+class MockN8nApiClientForArchive extends EventEmitter {
+    constructor() {
+        super();
+    }
+
+    async getAllWorkflows(_projectId?: string): Promise<any[]> {
+        return REMOTE_WORKFLOWS;
+    }
+
+    async testConnection(): Promise<boolean> {
+        return true;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const tempDirs: string[] = [];
+
+function createTempDir(prefix: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+}
+
+function createSyncManagerWithMockClient(workspaceDir: string): SyncManager {
+    const configService = new ConfigService(workspaceDir);
+    configService.saveLocalConfig({
+        host: 'http://localhost:5678',
+        syncFolder: workspaceDir,
+        projectId: 'personal-project',
+        projectName: 'Personal',
+        instanceIdentifier: 'local_1234_etienne_test',
+    }, { instanceName: 'Test' });
+    configService.saveApiKey('http://localhost:5678', 'test-api-key');
+
+    const mockClient = new MockN8nApiClientForArchive();
+    return new SyncManager(mockClient as any, {
+        directory: workspaceDir,
+        syncInactive: false,
+        ignoredTags: [],
+        projectId: 'personal-project',
+        projectName: 'Personal',
+        instanceIdentifier: 'test_instance',
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+    vi.resetAllMocks();
+});
+
+afterEach(() => {
+    for (const dir of tempDirs) {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Tests — full SyncManager.listWorkflows() → getLightweightList() chain
+// ---------------------------------------------------------------------------
+
+describe('SyncManager listWorkflows archive filtering', () => {
+
+    it('excludes archived workflows by default', async () => {
+        const workspaceDir = createTempDir('n8nac-it-archive-');
+        const syncManager = createSyncManagerWithMockClient(workspaceDir);
+
+        const results = await syncManager.listWorkflows({ fetchRemote: true });
+        const names = results.map(w => w.name);
+
+        expect(names).toContain('Active Alpha');
+        expect(names).toContain('Active Beta');
+        expect(names).not.toContain('Archived Gamma');
+    });
+
+    it('includes archived workflows with includeArchived', async () => {
+        const workspaceDir = createTempDir('n8nac-it-archive-');
+        const syncManager = createSyncManagerWithMockClient(workspaceDir);
+
+        const results = await syncManager.listWorkflows({ fetchRemote: true, includeArchived: true });
+        const names = results.map(w => w.name);
+
+        expect(names).toContain('Active Alpha');
+        expect(names).toContain('Active Beta');
+        expect(names).toContain('Archived Gamma');
+    });
+
+    it('shows only archived workflows with onlyArchived', async () => {
+        const workspaceDir = createTempDir('n8nac-it-archive-');
+        const syncManager = createSyncManagerWithMockClient(workspaceDir);
+
+        const results = await syncManager.listWorkflows({ fetchRemote: true, onlyArchived: true });
+        const names = results.map(w => w.name);
+
+        expect(names).not.toContain('Active Alpha');
+        expect(names).not.toContain('Active Beta');
+        expect(names).toContain('Archived Gamma');
+    });
+
+    it('correctly sets isArchived and active flags on all returned workflows', async () => {
+        const workspaceDir = createTempDir('n8nac-it-archive-');
+        const syncManager = createSyncManagerWithMockClient(workspaceDir);
+
+        const results = await syncManager.listWorkflows({ fetchRemote: true, includeArchived: true });
+
+        const active1 = results.find(w => w.id === 'wf-active-1');
+        const active2 = results.find(w => w.id === 'wf-active-2');
+        const archived = results.find(w => w.id === 'wf-archived-1');
+
+        expect(active1?.isArchived).toBe(false);
+        expect(active1?.active).toBe(true);
+        expect(active2?.isArchived).toBe(false);
+        expect(active2?.active).toBe(true);
+        expect(archived?.isArchived).toBe(true);
+        expect(archived?.active).toBe(false);
+    });
+
+    it('flags are correctly stored in remoteActive and remoteArchived caches', async () => {
+        const workspaceDir = createTempDir('n8nac-it-archive-');
+        const syncManager = createSyncManagerWithMockClient(workspaceDir);
+
+        // Populate caches
+        await syncManager.listWorkflows({ fetchRemote: true, includeArchived: true });
+
+        // Call again without fetchRemote — should still filter correctly using cached flags
+        const results = await syncManager.listWorkflows({ fetchRemote: false, onlyArchived: true });
+        const names = results.map(w => w.name);
+
+        expect(names).not.toContain('Active Alpha');
+        expect(names).toContain('Archived Gamma');
+    });
+});

--- a/packages/cli/tests/unit/workflow-state-tracker.test.ts
+++ b/packages/cli/tests/unit/workflow-state-tracker.test.ts
@@ -1,8 +1,86 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest';
 import { WorkflowStateTracker } from '../../src/core/services/workflow-state-tracker.js';
+import { N8nApiClient } from '../../src/core/services/n8n-api-client.js';
+import { IWorkflow } from '../../src/core/types.js';
+
+describe('WorkflowStateTracker archive filtering', () => {
+    let tempDir: string | undefined;
+    let mockClient: N8nApiClient;
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-archive-filter-'));
+
+        mockClient = {
+            getAllWorkflows: vi.fn().mockResolvedValue([
+                { id: 'wf-active', name: 'Active Workflow', active: true, isArchived: false } as IWorkflow,
+                { id: 'wf-archived', name: 'Archived Workflow', active: false, isArchived: true } as IWorkflow,
+            ]),
+        } as any;
+    });
+
+    afterEach(() => {
+        if (tempDir && fs.existsSync(tempDir)) {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+        vi.resetAllMocks();
+        tempDir = undefined;
+    });
+
+    function createTracker() {
+        return new WorkflowStateTracker(mockClient, {
+            directory: tempDir!,
+            syncInactive: false,
+            ignoredTags: [],
+            projectId: 'test-project',
+        });
+    }
+
+    it('excludes archived workflows by default', async () => {
+        const tracker = createTracker();
+        await tracker.refreshRemoteState();
+        const results = await tracker.getLightweightList();
+
+        const names = results.map(w => w.name);
+        expect(names).toContain('Active Workflow');
+        expect(names).not.toContain('Archived Workflow');
+    });
+
+    it('includes archived workflows when includeArchived is true', async () => {
+        const tracker = createTracker();
+        await tracker.refreshRemoteState();
+        const results = await tracker.getLightweightList({ includeArchived: true });
+
+        const names = results.map(w => w.name);
+        expect(names).toContain('Active Workflow');
+        expect(names).toContain('Archived Workflow');
+    });
+
+    it('shows only archived workflows when onlyArchived is true', async () => {
+        const tracker = createTracker();
+        await tracker.refreshRemoteState();
+        const results = await tracker.getLightweightList({ onlyArchived: true });
+
+        const names = results.map(w => w.name);
+        expect(names).not.toContain('Active Workflow');
+        expect(names).toContain('Archived Workflow');
+    });
+
+    it('sets isArchived flag correctly on returned workflows', async () => {
+        const tracker = createTracker();
+        await tracker.refreshRemoteState();
+        const results = await tracker.getLightweightList({ includeArchived: true });
+
+        const active = results.find(w => w.id === 'wf-active');
+        const archived = results.find(w => w.id === 'wf-archived');
+
+        expect(active?.isArchived).toBe(false);
+        expect(archived?.isArchived).toBe(true);
+    });
+});
 
 describe('WorkflowStateTracker filename sanitization', () => {
     let tempDir: string | undefined;

--- a/packages/transformer/src/parser/ast-to-typescript.ts
+++ b/packages/transformer/src/parser/ast-to-typescript.ts
@@ -239,6 +239,18 @@ export class AstToTypeScriptGenerator {
         parts.push(`name: ${JSON.stringify(metadata.name)}`);
         parts.push(`active: ${metadata.active}`);
 
+        if (metadata.isArchived !== undefined) {
+            parts.push(`isArchived: ${metadata.isArchived}`);
+        }
+        if (metadata.projectId) {
+            parts.push(`projectId: ${JSON.stringify(metadata.projectId)}`);
+        }
+        if (metadata.projectName) {
+            parts.push(`projectName: ${JSON.stringify(metadata.projectName)}`);
+        }
+        if (metadata.homeProject) {
+            parts.push(`homeProject: ${JSON.stringify(metadata.homeProject)}`);
+        }
         if (metadata.tags && metadata.tags.length > 0) {
             parts.push(`tags: ${JSON.stringify(metadata.tags)}`);
         }


### PR DESCRIPTION
## Summary

Fixes two bugs described in issue #309:

### Bug 1:  lost during round-trip
- **Root cause**:  hardcoded  for all workflows, and  didn't emit  in the TypeScript decorator
- **Fix**: 
  - Store  in  Map (populated from n8n API in  and )
  -  now reads  from the remote cache instead of hardcoding 
  -  now emits , , , and  into the TypeScript decorator

### Bug 2:  label applied to all workflows
- **Root cause**:  hardcoded  for all workflows
- **Fix**:  now reads  from the  Map populated from the n8n API

## New CLI Behavior

| Command | Behavior |
|---------|----------|
|  | Shows only non-archived workflows |
|  | Shows all workflows (archived + non-archived) |
|  | Shows only archived workflows |

Archived workflows are **discovered** (not filtered in ) but hidden by default in list output. Pull of archived workflows is explicitly allowed.

## Tests
All 344 tests pass (139 unit + 10 integration for cli, 72 unit for transformer).

Closes #309