### PR TITLE
fix: lazy-load skills commands for faster CLI startup

### DIFF
--- a/architecture/005-lazy-loading-skills-commands.md
+++ b/architecture/005-lazy-loading-skills-commands.md
@@ -1,0 +1,408 @@
+# RFC: Lazy Loading of `skills` Subcommands
+
+- **RFC**: 005
+- **Title**: Lazy Loading of `skills` Subcommands
+- **Status**: Draft
+- **Tracking Issue**: #325
+- **Target**: `next`
+- **Author**: Olistar (for Etienne Lescot)
+- **Created**: 2026-04-14
+
+---
+
+## 1. Summary
+
+The `npx --yes n8nac` CLI currently loads **91 Mo of JSON assets synchronously at startup**, before Commander.js has even parsed which subcommand the user invoked. This means **every command** — including `npx --yes n8nac --help` — suffers a multi-second I/O penalty.
+
+This RFC specifies a **lazy loading architecture** for the `skills` subcommand tree: the skills assets (node schemas, documentation, knowledge index) and all associated service classes (`NodeSchemaProvider`, `DocsProvider`, `KnowledgeSearch`, etc.) must only be loaded when the user explicitly runs a `skills` subcommand, not on every CLI invocation.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Observed Behavior
+
+When running `time npx --yes n8nac --help`:
+
+```
+npx --yes n8nac --help  1.57s user 0.76s system 6% cpu 38.424 total
+```
+
+- **user + sys**: ~2.3 s — actual CPU work
+- **total**: ~38 s — wall-clock time
+- **I/O wait**: ~36 s — spent reading JSON assets from disk
+
+Even though `npx` caches the package after first invocation, every new process must re-load all 91 Mo of skills assets before Commander can dispatch to any command handler.
+
+### 2.2 Root Cause
+
+In `packages/cli/src/index.ts`:
+
+```typescript
+// index.ts — executed on EVERY n8nac invocation
+import { registerSkillsCommands } from '@n8n-as-code/skills';
+// ...
+// called at module scope, before arguments are parsed
+registerSkillsCommands(program, assetsDir);
+```
+
+And in `packages/skills/src/commands/skills-commander.ts`, `registerSkillsCommands` immediately constructs all services synchronously:
+
+```typescript
+const provider    = new NodeSchemaProvider(join(assetsDir, 'n8n-nodes-technical.json'), customNodesPath);
+const docsProvider    = new DocsProvider(join(assetsDir, 'n8n-docs-complete.json'));
+const knowledgeSearch = new KnowledgeSearch(join(assetsDir, 'n8n-knowledge-index.json'));
+const registry    = new WorkflowRegistry();
+// ... all JSON files read via readFileSync here
+```
+
+This happens on **every** `n8nac` call, even `npx --yes n8nac --help`.
+
+### 2.3 Affected Assets (91 Mo total)
+
+| File | Size | Loaded by |
+|---|---|---|
+| `n8n-nodes-technical.json` | 30 Mo | `NodeSchemaProvider` |
+| `n8n-nodes-index.json` | 27 Mo | (part of technical schema pipeline) |
+| `n8n-docs-complete.json` | 11 Mo | `DocsProvider` |
+| `n8n-knowledge-index.json` | 15 Mo | `KnowledgeSearch` + FlexSearch index |
+| `workflows-index.json` | 9 Mo | `AiContextGenerator` |
+
+---
+
+## 3. Goals
+
+1. **`n8nac --help`, `n8nac list`, `n8nac pull`, etc.** must be **instant** (no skills assets loaded)
+2. **`n8nac skills *`** must load skills assets **only when first needed**
+3. Subsequent `n8nac skills *` calls within the **same process** may reuse already-loaded state (acceptable)
+4. The fix must be **backwards-compatible** — no change to user-facing CLI interface
+5. The fix must work for both the **unified `n8nac` CLI** and the **standalone `n8nac-skills` binary**
+
+---
+
+## 4. Non-Goals
+
+- Lazy-loading of `list`, `pull`, `push`, `init`, etc. (not affected by this RFC)
+- Changes to the n8n-as-code library API consumed by other packages
+- Pre-loading or pre-warming of skills assets
+
+---
+
+## 5. Technical Approach
+
+### 5.1 Commander.js Lazy Subcommands
+
+Commander supports lazy-loaded subcommands via `.command().action(() => import(...))` pattern. The subcommand is registered with an action function that returns a Promise resolving to the actual handler module.
+
+**Pattern:**
+```typescript
+// Instead of:
+program.command('skills').action(async () => {
+  const { registerSkillsCommands } = await import('@n8n-as-code/skills');
+  registerSkillsCommands(skillsProgram, assetsDir);
+  await skillsProgram.parse(['node', 'cmd', 'skills', ...args]);
+});
+
+// Commander way (Commander handles the import automatically):
+program.command('skills', { isDefault: false })
+  .action(async () => {
+    // This is called AFTER Commander has matched 'skills'
+    // We can now do the heavy import here
+  });
+```
+
+Actually, the cleanest pattern for Commander v12+ is:
+
+```typescript
+// In index.ts — lightweight registration at startup
+program
+  .command('skills')
+  .description('AI-powered skills for n8n workflows (node schemas, docs, examples, search)')
+  .addCommand(buildSkillsCommandLazy()); // returns a PreparedCommand
+```
+
+Where `buildSkillsCommandLazy()` uses Commander's `.command().action(() => import(...))` mechanism.
+
+### 5.2 Proposed File Structure
+
+```
+packages/cli/src/
+  index.ts                    # registers 'skills' as lazy command (no assets loaded at startup)
+  commands/
+    skills-wrapper.ts         # new file: thin wrapper that does the dynamic import + delegates
+
+packages/skills/src/
+  commands/
+    skills-commander.ts       # unchanged signature: registerSkillsCommands(program, assetsDir)
+    skills-commands/          # new directory: individual skill subcommands as separate lazy modules
+      search.ts
+      node-info.ts
+      node-schema.ts
+      docs.ts
+      examples.ts
+      validate.ts
+      format.ts
+      mcp.ts
+  services/
+    # existing services — no changes needed (they are already lazy at the class level
+    # in the sense that they only load on method calls, but the constructor triggers load)
+    # → see Section 5.3
+```
+
+**Key insight:** The problem is not lazy **commands** — it's lazy **services**. The service classes (`NodeSchemaProvider`, etc.) do `readFileSync` in their constructors or in `loadIndex()` called from constructors. We need to defer even the **service instantiation** until the first skill command is invoked.
+
+### 5.3 Service-Level Lazy Loading (Required Change)
+
+Each service class currently eagerly loads its JSON in the constructor. We need to make loading explicit and deferred.
+
+#### Option A: Lazy Service Pattern (Preferred)
+
+Add a `ensureLoaded()` method to each service and make the constructor lightweight. All public methods call `ensureLoaded()` first.
+
+```typescript
+// BEFORE (eager)
+export class NodeSchemaProvider {
+  constructor(indexPath: string, customNodesPath?: string) {
+    this.indexPath = indexPath;
+    this.customNodesPath = customNodesPath;
+    this.loadIndex(); // ← readFileSync here, synchronously
+  }
+}
+
+// AFTER (lazy)
+export class NodeSchemaProvider {
+  private _index: NodeIndex[] | null = null;  // null = not loaded
+  private _customNodes: CustomNodeDefinition[] | null = null;
+
+  constructor(
+    private readonly indexPath: string,
+    private readonly customNodesPath?: string
+  ) {
+    // Constructor is lightweight — no I/O
+  }
+
+  private ensureLoaded(): void {
+    if (this._index !== null) return; // already loaded
+    const content = fs.readFileSync(this.indexPath, 'utf-8');
+    this._index = JSON.parse(content);
+    // load custom nodes too...
+  }
+
+  // All public methods call ensureLoaded() first
+  getNode(nodeType: string): NodeDefinition | undefined {
+    this.ensureLoaded();
+    return this._index.find(n => n.type === nodeType);
+  }
+}
+```
+
+#### Option B: Getter Interception
+
+Use a JavaScript Proxy or `Object.defineProperty` with a getter that triggers loading on first access. More complex; not recommended.
+
+### 5.4 Standalone `n8nac-skills` Binary
+
+The standalone binary in `packages/skills/src/cli.ts` currently calls `registerSkillsCommands(program, assetsDir)` synchronously. For the standalone binary, lazy loading is **less critical** (the user is already explicitly invoking `n8nac-skills` for a skills task), but implementing it here too keeps the architecture consistent.
+
+The `cli.ts` entry point can remain unchanged — it can still call `registerSkillsCommands` synchronously, since by definition the user is already in a `skills` context. The lazy loading optimization applies only to the **unified `n8nac` CLI** where skills is one of many subcommands.
+
+### 5.5 `skills` Subcommand Tree as a Separate Module
+
+To enable Commander's lazy loading mechanism cleanly, the `skills` subcommand tree should be defined in a **separate module** (`skills-wrapper.ts`) that is dynamically imported when the `skills` command is first invoked.
+
+```typescript
+// packages/cli/src/commands/skills-wrapper.ts
+
+import { Command } from 'commander';
+import { registerSkillsCommands } from '@n8n-as-code/skills';
+import { getSkillsAssetsDir } from '../index.js'; // reuse existing asset resolution
+
+export function buildSkillsCommand(): Command {
+  const cmd = new Command('skills');
+  cmd.description('AI-powered skills for n8n workflows');
+
+  // Register all skills subcommands synchronously.
+  // This is only called when the user types `n8nac skills ...`
+  // and Commander has already matched the 'skills' token.
+  registerSkillsCommands(cmd, getSkillsAssetsDir());
+
+  return cmd;
+}
+```
+
+And in `index.ts`:
+
+```typescript
+// packages/cli/src/index.ts
+
+// NOT imported at module scope:
+// import { registerSkillsCommands } from '@n8n-as-code/skills'; // REMOVE from top-level
+
+// Instead, lazy-load the entire skills tree:
+async function main() {
+  // ... existing setup ...
+
+  // Skills command is registered last so it doesn't block startup
+  const { buildSkillsCommand } = await import('./commands/skills-wrapper.js');
+  program.addCommand(buildSkillsCommand());
+
+  await program.parseAsync(process.argv);
+}
+```
+
+**Wait — this still loads all skills assets synchronously** because `buildSkillsCommand()` calls `registerSkillsCommands()` which calls all the service constructors. The lazy loading must happen **inside** `registerSkillsCommands`, not just around it.
+
+So the correct approach requires **both**:
+1. `buildSkillsCommand()` is called lazily (so `skills` is only added to the command tree when needed — but it IS added eagerly to the tree; only the action is lazy)
+2. **More importantly**: the service constructors inside `registerSkillsCommands` must not do I/O at construction time
+
+### 5.6 The Lazy Registration Pattern
+
+Commander's "lazy command" pattern works like this:
+
+```typescript
+// Parent program
+program
+  .command('skills', { isDefault: false })
+  .action(async (opts, subCmd) => {
+    // This action runs ONLY when 'skills' is matched.
+    // At this point we know the user wants skills.
+    // Now we import and register the full subcommand tree.
+    const { buildSkillsCommand } = await import('./commands/skills-wrapper.js');
+    const skillsCmd = buildSkillsCommand();
+    // Replace the current command with the fully-populated one
+    // Commander allows adding subcommands at runtime
+    program.commands.pop(); // remove the placeholder
+    skillsCmd.parse(['node', 'cmd', ...]); // delegate remaining args
+  });
+```
+
+However, this is complex. A simpler approach that achieves the same goal:
+
+**The skills command IS registered eagerly (so Commander's help works), but `registerSkillsCommands` is made async and called lazily:**
+
+```typescript
+// In index.ts — BEFORE (eager)
+import { registerSkillsCommands } from '@n8n-as-code/skills';
+registerSkillsCommands(program, assetsDir); // runs at module load time!
+
+// In index.ts — AFTER (lazy)
+const skillsCmd = program.command('skills');
+skillsCmd.description('AI-powered skills (lazy-loaded)');
+skillsCmd.action(async () => {
+  // Only reaches here when user types `n8nac skills ...`
+  const { registerSkillsCommands } = await import('@n8n-as-code/skills');
+  registerSkillsCommands(skillsCmd, getSkillsAssetsDir());
+  await skillsCmd.parseAsync(process.argv);
+});
+```
+
+But this creates a new problem: `skillsCmd.action()` runs **after** Commander has already consumed the `skills` token. So the action needs to re-parse the remaining arguments with the newly-populated subcommands. This is the "re-proxy" pattern and it works but requires care.
+
+### 5.7 Recommended Minimal Implementation
+
+After analysis, the **minimal viable lazy loading** that solves the problem:
+
+1. **Keep `registerSkillsCommands` signature unchanged** — it's called eagerly from `cli.ts` (the standalone skills binary) and will remain that way
+2. **For the unified `n8nac` CLI only** (`packages/cli/src/index.ts`): make `registerSkillsCommands` call conditional, gated behind an async import
+3. **Change service constructors** to be lazy (Option A from section 5.3) — this is the core fix
+4. **No changes to the `skills` subcommand structure** — commands, options, descriptions all remain the same
+
+This way:
+- `n8nac --help` / `n8nac list` / etc. → instant, no I/O
+- `n8nac skills search foo` → loads skills assets once, then uses them
+
+---
+
+## 6. File Change Map
+
+| File | Change | Reason |
+|---|---|---|
+| `packages/skills/src/services/node-schema-provider.ts` | Lazy loading in constructor | 30 Mo readFileSync removed from startup |
+| `packages/skills/src/services/docs-provider.ts` | Lazy loading in constructor | 11 Mo readFileSync removed from startup |
+| `packages/skills/src/services/knowledge-search.ts` | Lazy index loading | 15 Mo + FlexSearch init deferred |
+| `packages/skills/src/services/ai-context-generator.ts` | Lazy assets loading | 9 Mo deferred |
+| `packages/skills/src/commands/skills-commander.ts` | `registerSkillsCommands` made async (optional) | enables async lazy import |
+| `packages/cli/src/index.ts` | Lazy import of skills wrapper | gates entire skills tree loading |
+| `packages/skills/src/cli.ts` | Unchanged | standalone binary benefits from lazy services but not lazy command |
+
+---
+
+## 7. Backwards Compatibility
+
+- **CLI interface**: No change. `npx --yes n8nac skills search "foo"` behaves identically.
+- **API consumers**: `registerSkillsCommands(program, assetsDir)` still accepts the same arguments.
+- **Standalone `n8nac-skills` binary**: Works exactly as before (assets loaded on invocation of any skills command, which is expected for a standalone binary).
+- **`--help` output**: Skills subcommands must still appear in `npx --yes n8nac --help`. Commander requires commands to be registered before `program.parse()` is called for help to work. This means we need to register the **structure** (command names, descriptions, option flags) eagerly, but defer the **action handlers** and **service instantiation**.
+
+**The solution**: Register command structure eagerly (so `--help` works), but lazy-load the action handlers via dynamic `import()` inside each subcommand's action.
+
+```typescript
+// Pseudo-code:
+program.command('skills')
+  .description('AI-powered skills')
+  .addCommand(buildSkillsSubcommand('search', {
+    description: 'Search across nodes, docs, examples, and knowledge base',
+    options: [
+      ['-q, --query <query>', 'Search query (required)'],
+      ['-t, --type <type>', 'Filter by type: node, docs, example'],
+    ]
+  }, async (opts) => {
+    // Lazy: only imported when 'n8nac skills search' is actually invoked
+    const { searchSkill } = await import('./skills-commands/search.js');
+    await searchSkill(opts);
+  }));
+```
+
+But this requires breaking up `skills-commander.ts` into per-command modules — significant refactoring.
+
+**Alternative (simpler)**: Keep command structure registration eager (so `--help` works), but gate only the **service instantiation** behind lazy loading. The command structure IS registered at startup (satisfying `--help` requirements), but no JSON is read until a subcommand action fires.
+
+This is achieved by making service constructors lazy (Option A) without changing the Commander command registration structure.
+
+---
+
+## 8. Performance Targets
+
+| Scenario | Before | After |
+|---|---|---|
+| `n8nac --help` | ~5-10s (load all assets) | <100ms (no assets) |
+| `n8nac list` | ~5-10s | <100ms |
+| `n8nac skills search "foo"` | ~5-10s (first time) | ~5-10s (first time), instant (cached in-process) |
+| `n8nac skills search "bar"` (same process) | — | instant |
+
+---
+
+## 9. Open Questions
+
+1. **Should `n8nac --help` show `skills` subcommands?** If yes, the command tree must be registered before `program.parse()`. If no, we can make the entire `skills` command lazy. Most CLI tools show all subcommands in help, so we should aim to preserve this.
+
+2. **Should we split `skills-commander.ts` into per-command modules?** This is cleaner long-term and enables true per-command lazy loading, but is a larger refactor. Worth doing in a separate PR.
+
+3. **Should FlexSearch index be built once and cached in memory?** Yes, after first load. The `KnowledgeSearch` class already keeps the FlexSearch index in memory after `loadIndex()` — we just need to prevent that call from happening at startup.
+
+4. **Should we use a .json cache for the parsed objects** (vs. re-parsing on every first-invocation)? The JSON files are already the serialized form; re-parsing is unavoidable. But we could use `require()` caching by writing a temp `.js` file that exports the parsed data — not worth the complexity.
+
+---
+
+## 10. Implementation Plan
+
+### Phase 1 (This PR): Service-Level Lazy Loading
+
+- Modify `NodeSchemaProvider` constructor to be lazy (`ensureLoaded()`)
+- Modify `DocsProvider` constructor to be lazy
+- Modify `KnowledgeSearch` constructor to be lazy
+- Modify `AiContextGenerator` if applicable
+- **Minimal changes** to `skills-commander.ts` and `index.ts`
+
+**Expected result**: `n8nac --help` becomes instant. `n8nac skills *` still loads assets on first invocation.
+
+### Phase 2 (Future PR): Per-Command Lazy Imports
+
+- Split `skills-commander.ts` into `skills-commands/*.ts`
+- Use Commander's lazy action pattern: `.action(() => import(...))`
+- `n8nac --help` shows skills commands (registered eagerly), but assets load only on first `skills *` invocation
+
+### Phase 3 (Future PR): Persistent Cache
+
+- Investigate using `require()` cache or a binary format for the node schema index to reduce parse overhead on first load

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -81,10 +81,8 @@ const getSkillsCliEntry = (): string => {
     }
 };
 
-const getTopLevelCommand = (argv: string[]): string | undefined => {
-    const args = argv.slice(2);
-
-    for (let index = 0; index < args.length; index += 1) {
+const getFirstPositionalToken = (args: string[], startIndex = 0): string | undefined => {
+    for (let index = startIndex; index < args.length; index += 1) {
         const token = args[index];
 
         if (!token) {
@@ -114,6 +112,8 @@ const getTopLevelCommand = (argv: string[]): string | undefined => {
     return undefined;
 };
 
+const getTopLevelCommand = (argv: string[]): string | undefined => getFirstPositionalToken(argv.slice(2));
+
 const shouldLoadSkillsCommands = (argv: string[]): boolean => {
     const topLevelCommand = getTopLevelCommand(argv);
 
@@ -127,7 +127,7 @@ const shouldLoadSkillsCommands = (argv: string[]): boolean => {
 
     const args = argv.slice(2);
     const helpIndex = args.indexOf('help');
-    return helpIndex >= 0 && args[helpIndex + 1] === 'skills';
+    return helpIndex >= 0 && getFirstPositionalToken(args, helpIndex + 1) === 'skills';
 };
 
 const registerSkillsPlaceholder = (program: Command): Command => program

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,7 +11,6 @@ import { TestPlanCommand } from './commands/test-plan.js';
 import { CredentialCommand } from './commands/credential.js';
 import { WorkflowCommand } from './commands/workflow.js';
 import { ExecutionCommand } from './commands/execution.js';
-import { registerSkillsCommands } from '@n8n-as-code/skills';
 import chalk from 'chalk';
 
 import { readFileSync, existsSync } from 'fs';
@@ -69,6 +68,77 @@ const getSkillsAssetsDir = (): string => {
         const __dirname = dirname(fileURLToPath(import.meta.url));
         return join(__dirname, '..', '..', 'skills', 'dist', 'assets');
     }
+};
+
+const getSkillsCliEntry = (): string => {
+    try {
+        const require = createRequire(import.meta.url);
+        const skillsPkg = require.resolve('@n8n-as-code/skills/package.json');
+        return join(dirname(skillsPkg), 'dist', 'cli-entry.js');
+    } catch {
+        const __dirname = dirname(fileURLToPath(import.meta.url));
+        return join(__dirname, '..', '..', 'skills', 'dist', 'cli-entry.js');
+    }
+};
+
+const getTopLevelCommand = (argv: string[]): string | undefined => {
+    const args = argv.slice(2);
+
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+
+        if (!token) {
+            continue;
+        }
+
+        if (token === '--') {
+            return args[index + 1];
+        }
+
+        if (token === '--instance') {
+            index += 1;
+            continue;
+        }
+
+        if (token.startsWith('--instance=')) {
+            continue;
+        }
+
+        if (token.startsWith('-')) {
+            continue;
+        }
+
+        return token;
+    }
+
+    return undefined;
+};
+
+const shouldLoadSkillsCommands = (argv: string[]): boolean => {
+    const topLevelCommand = getTopLevelCommand(argv);
+
+    if (topLevelCommand === 'skills') {
+        return true;
+    }
+
+    if (topLevelCommand !== 'help') {
+        return false;
+    }
+
+    const args = argv.slice(2);
+    const helpIndex = args.indexOf('help');
+    return helpIndex >= 0 && args[helpIndex + 1] === 'skills';
+};
+
+const registerSkillsPlaceholder = (program: Command): Command => program
+    .command('skills')
+    .description('AI tools: search nodes, docs, guides, validate workflows, and more');
+
+const loadSkillsRegistrar = async (): Promise<{
+    registerSkillsCommands: (program: Command, assetsDir: string) => void;
+}> => {
+    const modulePath = getSkillsCliEntry();
+    return import(pathToFileURL(modulePath).href);
 };
 
 const getMcpEntry = (): string => {
@@ -613,16 +683,18 @@ credentialCmd
     });
 
 // skills - AI knowledge tools subcommand group
-const skillsCmd = program
-    .command('skills')
-    .description('AI tools: search nodes, docs, guides, validate workflows, and more');
-registerSkillsCommands(skillsCmd, getSkillsAssetsDir());
+const skillsCmd = registerSkillsPlaceholder(program);
 
 // Backward compatibility alias
 new InitAiCommand(program);
 const updateAiCommand = program.commands.find((cmd) => cmd.name() === 'update-ai');
 if (updateAiCommand && !updateAiCommand.aliases().includes('init-ai')) {
     updateAiCommand.alias('init-ai');
+}
+
+if (shouldLoadSkillsCommands(process.argv)) {
+    const { registerSkillsCommands } = await loadSkillsRegistrar();
+    registerSkillsCommands(skillsCmd, getSkillsAssetsDir());
 }
 
 program.parse();

--- a/packages/cli/tests/integration/instance-cli.integration.test.ts
+++ b/packages/cli/tests/integration/instance-cli.integration.test.ts
@@ -53,6 +53,16 @@ afterAll(() => {
 });
 
 describe('CLI instance management integration', () => {
+    it('loads full skills help when global options are placed between help and skills', () => {
+        const workspaceDir = createTempDir('n8nac-cli-help-workspace-');
+        const homeDir = createTempDir('n8nac-cli-help-home-');
+
+        const output = runCli(workspaceDir, homeDir, ['help', '--instance', 'demo', 'skills']);
+
+        expect(stripAnsi(output)).toContain('search [options] <query>');
+        expect(stripAnsi(output)).toContain('examples');
+    });
+
     it('lists, selects, and deletes saved instance configs non-interactively', () => {
         const workspaceDir = createTempDir('n8nac-cli-instance-workspace-');
         const homeDir = createTempDir('n8nac-cli-instance-home-');

--- a/packages/cli/tests/unit/workspace-setup-service.test.ts
+++ b/packages/cli/tests/unit/workspace-setup-service.test.ts
@@ -41,10 +41,6 @@ describe('WorkspaceSetupService', () => {
 
         const declaration = fs.readFileSync(declarationPath, 'utf-8');
         expect(declaration).toContain("declare module '@n8n-as-code/transformer' {");
-        expect(declaration).toContain(
-            'export interface NodeDecoratorOptions {\n' +
-            '    /** Unique identifier of the node (matches workflow JSON) */\n' +
-            '    id?: string;'
-        );
+        expect(declaration).toMatch(/export interface NodeDecoratorOptions\s*\{[\s\S]*?\bid\?:\s*string;/);
     });
 });

--- a/packages/cli/tests/unit/workspace-setup-service.test.ts
+++ b/packages/cli/tests/unit/workspace-setup-service.test.ts
@@ -41,6 +41,10 @@ describe('WorkspaceSetupService', () => {
 
         const declaration = fs.readFileSync(declarationPath, 'utf-8');
         expect(declaration).toContain("declare module '@n8n-as-code/transformer' {");
-        expect(declaration).toMatch(/export interface NodeDecoratorOptions \{[^}]*id\?:\s*string/);
+        expect(declaration).toContain(
+            'export interface NodeDecoratorOptions {\n' +
+            '    /** Unique identifier of the node (matches workflow JSON) */\n' +
+            '    id?: string;'
+        );
     });
 });

--- a/packages/skills/src/cli-entry.ts
+++ b/packages/skills/src/cli-entry.ts
@@ -1,0 +1,1 @@
+export { registerSkillsCommands } from './commands/skills-commander.js';

--- a/packages/skills/src/cli.ts
+++ b/packages/skills/src/cli.ts
@@ -8,7 +8,7 @@ import { Command } from 'commander';
 import fs, { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { registerSkillsCommands } from './commands/skills-commander.js';
+import { registerSkillsCommands } from './cli-entry.js';
 
 // Resolve __dirname for ESM and CJS (bundled)
 const _filename = typeof import.meta !== 'undefined' && import.meta.url
@@ -55,4 +55,3 @@ program
 registerSkillsCommands(program, assetsDir);
 
 program.parse(process.argv);
-

--- a/packages/skills/src/commands/skills-commander.ts
+++ b/packages/skills/src/commands/skills-commander.ts
@@ -8,20 +8,17 @@
 
 import { Command } from 'commander';
 import chalk from 'chalk';
-import { NodeSchemaProvider } from '../services/node-schema-provider.js';
-import { WorkflowValidator } from '../services/workflow-validator.js';
-import { DocsProvider } from '../services/docs-provider.js';
-import { KnowledgeSearch } from '../services/knowledge-search.js';
-import { AiContextGenerator } from '../services/ai-context-generator.js';
 import { TypeScriptFormatter } from '../services/typescript-formatter.js';
-import { WorkflowRegistry } from '../services/workflow-registry.js';
-import { resolveCustomNodesConfig, type CustomNodesResolution } from '../services/custom-nodes-config.js';
-import { JsonToAstParser, AstToTypeScriptGenerator } from '@n8n-as-code/transformer';
 import fs, { readFileSync, writeFileSync, existsSync } from 'fs';
 import { resolve } from 'path';
 import { join, dirname } from 'path';
 import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
+import type { NodeSchemaProvider } from '../services/node-schema-provider.js';
+import type { DocsProvider } from '../services/docs-provider.js';
+import type { KnowledgeSearch } from '../services/knowledge-search.js';
+import type { WorkflowRegistry } from '../services/workflow-registry.js';
+import type { CustomNodesResolution } from '../services/custom-nodes-config.js';
 
 function getUnifiedCliEntryPath(): string {
     if (process.env.N8NAC_CLI_ENTRY) {
@@ -77,14 +74,67 @@ function printSearchCustomNodesNote(customNodesConfig: CustomNodesResolution, qu
 }
 
 export function registerSkillsCommands(program: Command, assetsDir: string): void {
-    const customNodesConfig = resolveCustomNodesConfig();
-    const customNodesPath = customNodesConfig.resolvedPath;
-    const provider = new NodeSchemaProvider(join(assetsDir, 'n8n-nodes-technical.json'), customNodesPath);
-    const docsProvider = new DocsProvider(join(assetsDir, 'n8n-docs-complete.json'));
-    const knowledgeSearch = new KnowledgeSearch(join(assetsDir, 'n8n-knowledge-index.json'));
+    let customNodesConfigPromise: Promise<CustomNodesResolution> | undefined;
+    let providerPromise: Promise<NodeSchemaProvider> | undefined;
+    let docsProviderPromise: Promise<DocsProvider> | undefined;
+    let knowledgeSearchPromise: Promise<KnowledgeSearch> | undefined;
     let registry: WorkflowRegistry | undefined;
-    const getRegistry = (): WorkflowRegistry => {
+    const getCustomNodesConfig = async (): Promise<CustomNodesResolution> => {
+        if (!customNodesConfigPromise) {
+            customNodesConfigPromise = import('../services/custom-nodes-config.js')
+                .then(({ resolveCustomNodesConfig }) => resolveCustomNodesConfig());
+        }
+
+        return customNodesConfigPromise;
+    };
+    const getProvider = async (): Promise<NodeSchemaProvider> => {
+        if (!providerPromise) {
+            providerPromise = Promise.all([
+                import('../services/node-schema-provider.js'),
+                getCustomNodesConfig(),
+            ]).then(([{ NodeSchemaProvider }, customNodesConfig]) => (
+                new NodeSchemaProvider(join(assetsDir, 'n8n-nodes-technical.json'), customNodesConfig.resolvedPath)
+            ));
+        }
+
+        return providerPromise;
+    };
+    const getDocsProvider = async (): Promise<DocsProvider> => {
+        if (!docsProviderPromise) {
+            docsProviderPromise = import('../services/docs-provider.js')
+                .then(({ DocsProvider }) => new DocsProvider(join(assetsDir, 'n8n-docs-complete.json')));
+        }
+
+        return docsProviderPromise;
+    };
+    const getKnowledgeSearch = async (): Promise<KnowledgeSearch> => {
+        if (!knowledgeSearchPromise) {
+            knowledgeSearchPromise = import('../services/knowledge-search.js')
+                .then(({ KnowledgeSearch }) => new KnowledgeSearch(join(assetsDir, 'n8n-knowledge-index.json')));
+        }
+
+        return knowledgeSearchPromise;
+    };
+    const withCustomNodesWarnings = async (): Promise<CustomNodesResolution> => {
+        const customNodesConfig = await getCustomNodesConfig();
+        printCustomNodesWarnings(customNodesConfig);
+        return customNodesConfig;
+    };
+    const printCustomNodesDebugIfRequested = async (debugEnabled: boolean): Promise<void> => {
+        if (!debugEnabled) {
+            return;
+        }
+
+        const [customNodesConfig, provider] = await Promise.all([
+            getCustomNodesConfig(),
+            getProvider(),
+        ]);
+
+        printCustomNodesDebugInfo(customNodesConfig, provider);
+    };
+    const getRegistry = async (): Promise<WorkflowRegistry> => {
         if (!registry) {
+            const { WorkflowRegistry } = await import('../services/workflow-registry.js');
             registry = new WorkflowRegistry();
         }
         return registry;
@@ -100,11 +150,12 @@ export function registerSkillsCommands(program: Command, assetsDir: string): voi
         .option('--limit <limit>', 'Limit results', '10')
         .option('--debug', 'Show custom nodes resolution details on stderr')
         .option('--json', 'Output as JSON instead of TypeScript')
-        .action((query, options) => {
+        .action(async (query, options) => {
             try {
-                printCustomNodesWarnings(customNodesConfig);
+                const customNodesConfig = await withCustomNodesWarnings();
                 if (options.debug) {
                     try {
+                        const provider = await getProvider();
                         printCustomNodesDebugInfo(customNodesConfig, provider);
                     } catch (diagnosticsError: any) {
                         console.error(
@@ -118,6 +169,7 @@ export function registerSkillsCommands(program: Command, assetsDir: string): voi
                     }
                 }
 
+                const knowledgeSearch = await getKnowledgeSearch();
                 const results = knowledgeSearch.searchAll(query, {
                     category: options.category,
                     type: options.type,
@@ -172,13 +224,12 @@ export function registerSkillsCommands(program: Command, assetsDir: string): voi
         .option('--docs', 'List all documentation categories')
         .option('--guides', 'List all available guides')
         .option('--debug', 'Show custom nodes resolution details on stderr')
-        .action((options) => {
+        .action(async (options) => {
             try {
-                printCustomNodesWarnings(customNodesConfig);
-                if (options.debug) {
-                    printCustomNodesDebugInfo(customNodesConfig, provider);
-                }
+                await withCustomNodesWarnings();
+                await printCustomNodesDebugIfRequested(options.debug);
 
+                const [provider, docsProvider] = await Promise.all([getProvider(), getDocsProvider()]);
                 const nodes = provider.listAllNodes();
                 const stats = docsProvider.getStatistics();
 
@@ -218,13 +269,12 @@ export function registerSkillsCommands(program: Command, assetsDir: string): voi
         .argument('<name>', 'Node name (exact, e.g. "googleSheets")')
         .option('--debug', 'Show custom nodes resolution details on stderr')
         .option('--json', 'Output as JSON instead of TypeScript')
-        .action((name, options) => {
+        .action(async (name, options) => {
             try {
-                printCustomNodesWarnings(customNodesConfig);
-                if (options.debug) {
-                    printCustomNodesDebugInfo(customNodesConfig, provider);
-                }
+                await withCustomNodesWarnings();
+                await printCustomNodesDebugIfRequested(options.debug);
 
+                const provider = await getProvider();
                 const schema = provider.getNodeSchema(name);
                 if (schema) {
                     if (options.json) {
@@ -263,13 +313,12 @@ export function registerSkillsCommands(program: Command, assetsDir: string): voi
         .argument('<name>', 'Node name')
         .option('--debug', 'Show custom nodes resolution details on stderr')
         .option('--json', 'Output as JSON instead of TypeScript')
-        .action((name, options) => {
+        .action(async (name, options) => {
             try {
-                printCustomNodesWarnings(customNodesConfig);
-                if (options.debug) {
-                    printCustomNodesDebugInfo(customNodesConfig, provider);
-                }
+                await withCustomNodesWarnings();
+                await printCustomNodesDebugIfRequested(options.debug);
 
+                const provider = await getProvider();
                 let schema = provider.getNodeSchema(name);
 
                 if (!schema) {
@@ -320,8 +369,9 @@ export function registerSkillsCommands(program: Command, assetsDir: string): voi
         .argument('[title]', 'Documentation page title')
         .option('--list', 'List all categories')
         .option('--category <category>', 'Filter by category')
-        .action((title, options) => {
+        .action(async (title, options) => {
             try {
+                const docsProvider = await getDocsProvider();
                 if (options.list) {
                     console.log(JSON.stringify(docsProvider.getCategories(), null, 2));
                 } else if (title) {
@@ -348,8 +398,9 @@ export function registerSkillsCommands(program: Command, assetsDir: string): voi
         .argument('[query]', 'Search query')
         .option('--list', 'List all guides')
         .option('--limit <limit>', 'Limit results', '10')
-        .action((query, options) => {
+        .action(async (query, options) => {
             try {
+                const docsProvider = await getDocsProvider();
                 const guides = docsProvider.getGuides(query, parseInt(options.limit));
                 console.log(JSON.stringify(guides, null, 2));
                 if (guides.length > 0) {
@@ -366,8 +417,9 @@ export function registerSkillsCommands(program: Command, assetsDir: string): voi
         .command('related')
         .description('Find related nodes and documentation')
         .argument('<query>', 'Node name or concept')
-        .action((query) => {
+        .action(async (query) => {
             try {
+                const [provider, docsProvider] = await Promise.all([getProvider(), getDocsProvider()]);
                 const nodeSchema = provider.getNodeSchema(query);
                 if (nodeSchema) {
                     const nodeDocs = docsProvider.getNodeDocumentation(query);
@@ -403,16 +455,18 @@ export function registerSkillsCommands(program: Command, assetsDir: string): voi
         .option('--json', 'Output the validation result as JSON')
         .action(async (file, options) => {
             try {
-                printCustomNodesWarnings(customNodesConfig);
+                const customNodesConfig = await withCustomNodesWarnings();
                 if (options.debug) {
+                    const provider = await getProvider();
                     printCustomNodesDebugInfo(customNodesConfig, provider);
                 }
 
                 const workflowContent = readFileSync(file, 'utf8');
                 const isTypeScript = file.endsWith('.workflow.ts') || file.endsWith('.ts');
+                const { WorkflowValidator } = await import('../services/workflow-validator.js');
                 const validator = new WorkflowValidator(
                     join(assetsDir, 'n8n-nodes-technical.json'),
-                    customNodesPath
+                    customNodesConfig.resolvedPath
                 );
                 const result = await validator.validateWorkflow(
                     isTypeScript ? workflowContent : JSON.parse(workflowContent),
@@ -485,6 +539,7 @@ export function registerSkillsCommands(program: Command, assetsDir: string): voi
                 const projectRoot = process.cwd();
                 const distTag = options.cliVersion === 'latest' ? undefined : options.cliVersion;
 
+                const { AiContextGenerator } = await import('../services/ai-context-generator.js');
                 const aiContextGenerator = new AiContextGenerator();
                 await aiContextGenerator.generate(projectRoot, options.n8nVersion, distTag);
 
@@ -544,22 +599,23 @@ export function registerSkillsCommands(program: Command, assetsDir: string): voi
         .description('Search community workflows')
         .option('-l, --limit <number>', 'Limit number of results', '10')
         .option('--json', 'Output results as JSON')
-        .action((query: string, options: { limit: string; json?: boolean }) => {
+        .action(async (query: string, options: { limit: string; json?: boolean }) => {
             const limit = parseInt(options.limit, 10);
-            const results = getRegistry().search(query, limit);
+            const registry = await getRegistry();
+            const workflows = registry.search(query, limit);
 
             if (options.json) {
-                console.log(JSON.stringify(results, null, 2));
+                console.log(JSON.stringify(workflows, null, 2));
                 return;
             }
 
-            if (results.length === 0) {
+            if (workflows.length === 0) {
                 console.log(chalk.yellow(`No workflows found matching "${query}"`));
                 return;
             }
 
-            console.log(chalk.green(`\nFound ${results.length} workflow(s) matching "${query}":\n`));
-            results.forEach((workflow: any, index: number) => {
+            console.log(chalk.green(`\nFound ${workflows.length} workflow(s) matching "${query}":\n`));
+            workflows.forEach((workflow: any, index: number) => {
                 console.log(chalk.bold(`${index + 1}. ${workflow.name}`) + chalk.gray(` (ID: ${workflow.id})`));
                 if (workflow.tags.length > 0) console.log(chalk.cyan(`   Tags: ${workflow.tags.join(', ')}`));
                 console.log(chalk.gray(`   Author: ${workflow.author}`));
@@ -573,9 +629,10 @@ export function registerSkillsCommands(program: Command, assetsDir: string): voi
         .command('list')
         .description('List community workflows (newest first)')
         .option('-l, --limit <number>', 'Limit number of results', '20')
-        .action((options: { limit: string }) => {
+        .action(async (options: { limit: string }) => {
             const limit = parseInt(options.limit, 10);
-            const results = getRegistry().search('', limit);
+            const registry = await getRegistry();
+            const results = registry.search('', limit);
             console.log(JSON.stringify(results, null, 2));
         });
 
@@ -583,8 +640,9 @@ export function registerSkillsCommands(program: Command, assetsDir: string): voi
         .command('info <id>')
         .description('Display detailed information about a community workflow')
         .option('--json', 'Output workflow metadata as JSON')
-        .action((id: string, options: { json?: boolean }) => {
-            const workflow = getRegistry().getById(id);
+        .action(async (id: string, options: { json?: boolean }) => {
+            const registry = await getRegistry();
+            const workflow = registry.getById(id);
             if (!workflow) {
                 console.error(chalk.red(`❌ Workflow with ID "${id}" not found.`));
                 process.exit(1);
@@ -592,7 +650,7 @@ export function registerSkillsCommands(program: Command, assetsDir: string): voi
             if (options.json) {
                 console.log(JSON.stringify({
                     ...workflow,
-                    rawUrl: getRegistry().getRawUrl(workflow),
+                    rawUrl: registry.getRawUrl(workflow),
                 }, null, 2));
                 return;
             }
@@ -608,7 +666,7 @@ export function registerSkillsCommands(program: Command, assetsDir: string): voi
                 console.log(chalk.dim(workflow.description));
             }
             console.log(chalk.cyan('\nRaw URL:'));
-            console.log(chalk.blue(getRegistry().getRawUrl(workflow)));
+            console.log(chalk.blue(registry.getRawUrl(workflow)));
             console.log('');
         });
 
@@ -618,7 +676,8 @@ export function registerSkillsCommands(program: Command, assetsDir: string): voi
         .option('-o, --output <path>', 'Output file path')
         .option('-f, --force', 'Overwrite existing file')
         .action(async (id: string, options: { output?: string; force?: boolean }) => {
-            const workflow = getRegistry().getById(id);
+            const registry = await getRegistry();
+            const workflow = registry.getById(id);
             if (!workflow) {
                 console.error(chalk.red(`❌ Workflow with ID "${id}" not found.`));
                 process.exit(1);
@@ -637,7 +696,7 @@ export function registerSkillsCommands(program: Command, assetsDir: string): voi
                 process.exit(1);
             }
 
-            const url = getRegistry().getRawUrl(workflow);
+            const url = registry.getRawUrl(workflow);
             console.log(chalk.blue(`📥 Downloading from: ${url}`));
 
             try {
@@ -646,6 +705,7 @@ export function registerSkillsCommands(program: Command, assetsDir: string): voi
 
                 const data = await response.text();
                 const workflowJson = JSON.parse(data);
+                const { JsonToAstParser, AstToTypeScriptGenerator } = await import('@n8n-as-code/transformer');
                 const parser = new JsonToAstParser();
                 const ast = parser.parse(workflowJson);
                 const generator = new AstToTypeScriptGenerator();

--- a/scripts/enrich-nodes-technical.cjs
+++ b/scripts/enrich-nodes-technical.cjs
@@ -292,12 +292,8 @@ function computeParameterGating(properties) {
     const gatingResults = [];
 
     for (const bp of uniqueBoolParams) {
-<<<<<<< HEAD
         // Find all unique params that show when this boolean is true AND have no other conditions
         // (params with additional displayOptions.show keys are gated by a combination — skip them)
-=======
-        // Find all unique params that show when this boolean is true
->>>>>>> 2d3a7ad9 (fix: address PR #286 review comments on parameter gating)
         const gatedByTrue = uniqueProperties.filter(
             (p) =>
                 p.name !== bp.name &&


### PR DESCRIPTION
## Summary

- Avoid eager startup cost in the unified `n8nac` CLI by registering a lightweight `skills` placeholder and loading the full skills command tree only when the top-level command actually targets `skills`.
- Split `packages/skills/src/commands/skills-commander.ts` along runtime boundaries by moving heavy dependencies (`WorkflowValidator`, `AiContextGenerator`, `WorkflowRegistry`, `@n8n-as-code/transformer`, schema/docs/search providers) behind lazy command-time imports.
- Add a dedicated `packages/skills/src/cli-entry.ts` entrypoint so the CLI can load skills command registration without importing the broader `@n8n-as-code/skills` barrel.

## Problem

Issue #325 reports that even simple commands such as `npx --yes n8nac --help` can be extremely slow on some environments, especially on slower disks.

The main problem was not just provider construction. The unified CLI imported `@n8n-as-code/skills` at module scope, which forced Node to resolve and evaluate the entire skills module graph on every `n8nac` invocation, even when the user was not running a `skills` command.

`skills-commander.ts` also eagerly imported command-specific dependencies that were only needed for a subset of subcommands.

## Solution

### 1. Lazy-load `skills` from the unified CLI

`packages/cli/src/index.ts` now:

- registers a lightweight top-level `skills` command so normal CLI help remains stable
- detects whether the parsed top-level command targets `skills` (including `help skills`)
- dynamically imports the dedicated skills CLI entrypoint only in that case

This avoids importing the skills command graph for commands such as:

- `n8nac --help`
- `n8nac list`
- `n8nac pull ...`
- `n8nac workflow ...`

### 2. Keep command structure, defer heavy runtime dependencies

`packages/skills/src/commands/skills-commander.ts` now keeps registration logic lightweight and lazily resolves command dependencies on first use:

- custom nodes resolution is deferred until a command actually needs it
- schema/docs/search providers are created through memoized async getters
- validator / AI context / workflow registry / transformer imports are performed only inside the relevant command actions

This preserves the existing CLI surface while reducing startup work and avoiding unnecessary side effects.

### 3. Dedicated CLI registration entrypoint

`packages/skills/src/cli-entry.ts` provides a narrow SSOT entrypoint for command registration.

This keeps the unified CLI decoupled from the general `@n8n-as-code/skills` barrel exports and reduces accidental eager imports.

## Notes on behavior and resilience

- No user-facing command names or options were changed.
- `n8nac skills --help` and `n8nac help skills` still show the full skills subtree.
- The standalone `n8nac-skills` entrypoint continues to work, but now also benefits from the internal lazy imports inside `skills-commander.ts`.
- Generated assets were intentionally left unchanged in this PR; the change is limited to startup/runtime wiring.

## Verification

Validated locally with:

- `npx tsc -b packages/skills packages/cli`
- `npm test --workspace=packages/skills -- --runInBand skills-commander.test.ts`
- `npm run test:unit --workspace=packages/cli`
- `node packages/cli/dist/index.js --help`
- `node packages/cli/dist/index.js skills --help`
- `node packages/cli/dist/index.js help skills`
- `node packages/cli/dist/index.js skills examples search webhook --json`

## Related

- Addresses #325