### PR TITLE
feat: add description property to WorkflowDecoratorOptions (fixes #298)

### DIFF
--- a/packages/cli/src/core/assets/n8n-workflows.d.ts
+++ b/packages/cli/src/core/assets/n8n-workflows.d.ts
@@ -59,6 +59,8 @@ export interface WorkflowDecoratorOptions {
     id: string;
     /** Human-readable name */
     name: string;
+    /** Workflow description */
+    description?: string;
     /** Whether the workflow is active */
     active: boolean;
     /** Workflow execution settings */

--- a/packages/transformer/src/compiler/workflow-builder.ts
+++ b/packages/transformer/src/compiler/workflow-builder.ts
@@ -48,6 +48,11 @@ export class WorkflowBuilder {
             tags: ast.metadata.tags || []
         };
         
+        // Add optional description
+        if (ast.metadata.description) {
+            workflow.description = ast.metadata.description;
+        }
+        
         // Add optional organization metadata
         if (ast.metadata.projectId) {
             workflow.projectId = ast.metadata.projectId;

--- a/packages/transformer/src/decorators/types.ts
+++ b/packages/transformer/src/decorators/types.ts
@@ -14,6 +14,7 @@ import { WorkflowSettings, CredentialReference } from '../types.js';
 export interface WorkflowDecoratorMetadata {
     id: string;
     name: string;
+    description?: string;
     active: boolean;
     tags?: string[];
     settings?: WorkflowSettings;

--- a/packages/transformer/src/parser/ast-to-typescript.ts
+++ b/packages/transformer/src/parser/ast-to-typescript.ts
@@ -239,6 +239,10 @@ export class AstToTypeScriptGenerator {
         parts.push(`name: ${JSON.stringify(metadata.name)}`);
         parts.push(`active: ${metadata.active}`);
 
+        if (metadata.description) {
+            parts.push(`description: ${JSON.stringify(metadata.description)}`);
+        }
+
         if (metadata.tags && metadata.tags.length > 0) {
             parts.push(`tags: ${JSON.stringify(metadata.tags)}`);
         }

--- a/packages/transformer/src/parser/json-to-ast.ts
+++ b/packages/transformer/src/parser/json-to-ast.ts
@@ -46,6 +46,7 @@ export class JsonToAstParser {
             metadata: {
                 id: workflow.id,
                 name: workflow.name,
+                description: workflow.description,
                 active: workflow.active,
                 tags: this.parseTags(workflow.tags),
                 settings: workflow.settings,

--- a/packages/transformer/src/types.ts
+++ b/packages/transformer/src/types.ts
@@ -24,6 +24,7 @@ export interface WorkflowAST {
 export interface WorkflowMetadata {
     id: string;
     name: string;
+    description?: string;
     active: boolean;
     tags?: string[];
     settings?: WorkflowSettings;
@@ -138,6 +139,7 @@ export interface ConnectionAST {
 export interface N8nWorkflow {
     id: string;
     name: string;
+    description?: string;
     active: boolean;
     nodes: N8nNode[];
     connections: N8nConnections;


### PR DESCRIPTION
## Background

n8n 2.16.0 introduced the `description` field on workflows (n8n-io/n8n#25778). Currently, the `@workflow` decorator in n8n-as-code does not support this field, so workflow descriptions are lost during round-trip conversion (JSON → TypeScript → JSON).

## Solution

Add `description?: string` to the `WorkflowDecoratorOptions` interface and propagate it through the entire transformation pipeline.

## Changes

- `packages/cli/src/core/assets/n8n-workflows.d.ts`: Add `description?: string` to `WorkflowDecoratorOptions`
- `packages/transformer/src/decorators/types.ts`: Add `description?: string` to `WorkflowDecoratorMetadata`
- `packages/transformer/src/types.ts`: Add `description?: string` to both `WorkflowMetadata` and `N8nWorkflow`
- `packages/transformer/src/compiler/workflow-builder.ts`: Include `description` in the built workflow JSON output
- `packages/transformer/src/parser/json-to-ast.ts`: Parse `description` from incoming workflow JSON into AST metadata
- `packages/transformer/src/parser/ast-to-typescript.ts`: Emit `description` in the generated `@workflow` decorator

## Verification

1. Define a workflow with `description` in the decorator and verify it appears in the output JSON
2. Pull a workflow with description from n8n and verify it appears in the generated `.workflow.ts`

Closes #298