### PR TITLE
fix(types): reconcile top-level NodeDecoratorOptions with declare module copy

### DIFF
--- a/packages/cli/src/core/assets/n8n-workflows.d.ts
+++ b/packages/cli/src/core/assets/n8n-workflows.d.ts
@@ -71,6 +71,8 @@ export interface WorkflowDecoratorOptions {
     isArchived?: boolean;
 }
 
+// Must stay in lockstep with the NodeDecoratorOptions inside
+// `declare module '@n8n-as-code/transformer'` below.
 export interface NodeDecoratorOptions {
     /** Unique identifier of the node (matches workflow JSON) */
     id?: string;
@@ -88,6 +90,16 @@ export interface NodeDecoratorOptions {
     credentials?: Record<string, { id: string; name: string }>;
     /** Error handling mode */
     onError?: 'continueErrorOutput' | 'continueRegularOutput' | 'stopWorkflow';
+    /** Always output data even when the node has no results */
+    alwaysOutputData?: boolean;
+    /** Execute this node only once, for the first item */
+    executeOnce?: boolean;
+    /** Retry on failure */
+    retryOnFail?: boolean;
+    /** Maximum number of retry attempts (used with retryOnFail) */
+    maxTries?: number;
+    /** Milliseconds to wait between retries (used with retryOnFail) */
+    waitBetweenTries?: number;
 }
 
 // =========================================================================


### PR DESCRIPTION
## Summary

The top-level `NodeDecoratorOptions` export in `packages/cli/src/core/assets/n8n-workflows.d.ts` is missing 5 fields that exist on its `declare module '@n8n-as-code/transformer'` counterpart:

- `alwaysOutputData?: boolean`
- `executeOnce?: boolean`
- `retryOnFail?: boolean`
- `maxTries?: number`
- `waitBetweenTries?: number`

This is invisible in practice because `.workflow.ts` files import via the ambient module path, which resolves against the `declare module` copy. But a developer using `import type { NodeDecoratorOptions } from './n8n-workflows';` directly would see a narrower type than the runtime permits, and regenerations do not reconcile the two.

## Evidence

In production workflows that use the n8nac-generated stubs, the 5 fields are actively used — e.g., `retryOnFail` / `maxTries` / `waitBetweenTries` on HTTP request nodes that wrap external API calls. These compile because the `@node({...})` decorator call is typed via the ambient module, but the type assertion divergence can bite in any code path that references `NodeDecoratorOptions` directly.

## Change

Mirrors the 5 fields into the top-level export with identical JSDoc comments and adds a lockstep comment above the declaration so future additions update both copies.

## Test plan

- TypeScript compilation of existing `.workflow.ts` files: unchanged (they resolve via the ambient module)
- Direct `import type` now exposes the full field set — no runtime implications