### PR TITLE
docs(types): clarify webhookId is user-assigned, not n8n-assigned

### DIFF
--- a/packages/cli/src/core/assets/n8n-workflows.d.ts
+++ b/packages/cli/src/core/assets/n8n-workflows.d.ts
@@ -74,7 +74,7 @@ export interface WorkflowDecoratorOptions {
 export interface NodeDecoratorOptions {
     /** Unique identifier of the node (matches workflow JSON) */
     id?: string;
-    /** Stable webhook ID assigned by n8n to webhook nodes */
+    /** User-assigned slug that pins the webhook path in n8n; must match the webhookId in the workflow JSON to keep the webhook URL stable across pushes */
     webhookId?: string;
     /** Display name shown in n8n UI */
     name: string;
@@ -206,7 +206,7 @@ declare module '@n8n-as-code/transformer' {
     export interface NodeDecoratorOptions {
         /** Unique identifier of the node (matches workflow JSON) */
         id?: string;
-        /** Stable webhook ID assigned by n8n to webhook nodes */
+        /** User-assigned slug that pins the webhook path in n8n; must match the webhookId in the workflow JSON to keep the webhook URL stable across pushes */
         webhookId?: string;
         /** Display name shown in n8n UI */
         name: string;


### PR DESCRIPTION
## Summary

The doc comment on `NodeDecoratorOptions.webhookId` (both top-level and `declare module` copies) currently reads:

> `/** Stable webhook ID assigned by n8n to webhook nodes */`

This is inverted. In every n8nac workflow I've inspected (5 webhook nodes across 5 production workflows in my own repo), `webhookId` values are user-chosen semantic slugs like `audit-approve`, `li-review-final-2`, `signal-v6`. n8n does generate a UUID when the field is absent, but the declared-in-code value is what the developer chose — and that's the value that survives push/pull roundtrips.

A reader trusting "assigned by n8n" may incorrectly treat the field as read-only metadata and omit it when creating a new webhook node. That causes n8n to generate a random UUID on push, which silently breaks any externally-registered webhook URL (rate-limit gates, payment receivers, callback integrations).

## Change

Replaces the comment in both declarations with:

> `/** User-assigned slug that pins the webhook path in n8n; must match the webhookId in the workflow JSON to keep the webhook URL stable across pushes */`

## Test plan

Pure docs — no behavior change. Stubs emitted via `n8nac update-ai` / VS Code extension should regenerate with the corrected wording.