### PR TITLE
fix: preserve unknown workflow settings (e.g. availableInMCP) on push

### DIFF
--- a/packages/transformer/src/types.ts
+++ b/packages/transformer/src/types.ts
@@ -43,6 +43,7 @@ export interface WorkflowMetadata {
  * Workflow settings
  */
 export interface WorkflowSettings {
+    [key: string]: unknown;
     executionOrder?: 'v0' | 'v1' | 'v2';
     timeSavedMode?: 'fixed' | 'calculated';
     errorWorkflow?: string;


### PR DESCRIPTION
### Problem

`n8nac push` silently drops any workflow setting not in the hardcoded `WorkflowSettings` allowlist. This causes `settings.availableInMCP` (and any future n8n settings) to reset to `false` on every push, even when the local `.workflow.ts` file has the correct value.

### Reproduction

1. Enable MCP access on a workflow via the n8n GUI (Settings → Available in MCP → On)
2. `npx n8nac pull <workflowId>` — local file correctly has `availableInMCP: true`
3. Make any edit to the local file
4. `npx n8nac push <file.workflow.ts>`
5. Check n8n GUI — MCP access is now **disabled**

### Root Cause

`WorkflowSettings` in `packages/transformer/src/types.ts` is a closed interface with only 7 known keys. The pipeline (parser → generator → compiler) passes settings through by direct assignment, but the TypeScript type constraint silently strips any key not in the interface. When n8n receives settings without `availableInMCP`, it defaults to `false`.

This is a general problem — not specific to `availableInMCP`. Any setting n8n adds in the future that isn't in this allowlist will also be dropped.

### Fix

Added an index signature `[key: string]: unknown` to `WorkflowSettings`, making it an open interface that preserves unrecognized settings through the full round-trip.

This matches the existing pattern in the codebase — `parameters` uses `Record<string, any>`, `N8nConnections` uses index signatures, `credentials` uses `Record<string, CredentialReference>`. `WorkflowSettings` was the only closed interface for n8n API data.

No other code changes needed — the parser, generator, and compiler already use direct assignment (`settings: workflow.settings`) rather than field picking, so the data flows through once the type allows it.

### Testing

- All 72 existing tests pass (7 test files)
- TypeScript compilation clean with zero errors
