### PR TITLE
docs: enforce 'next' as PR base branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
 **What does this PR do?**
 
 **Related issue (if any):** #
+
+> ⚠️ All PRs must target the `next` branch as base.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, next ]
 
 jobs:
   build-and-test:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ on:
       - 'scripts/sync-brand-assets.mjs'
       - '.github/workflows/docs.yml'
   pull_request:
-    branches: [ main ]
+    branches: [ main, next ]
     paths:
       - 'docs/**'
       - 'res/**'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,5 +22,6 @@ npm run build
 - Keep PRs focused — one thing at a time
 - Write tests if you're adding new behavior
 - Don't worry too much about formatting, CI will catch style issues
+- All pull requests must target the `next` branch as base
 
 That's it. No CLA, no bureaucracy.

--- a/docs/docs/contribution/index.md
+++ b/docs/docs/contribution/index.md
@@ -171,10 +171,10 @@ CI automatically:
 - Write comprehensive tests for new features
 
 ### Pull Request Process
-1. Create a feature branch from `main`
+1. Create a feature branch from `next`
 2. Make your changes with tests
 3. Ensure all tests pass
-4. Submit a pull request with clear description
+4. Submit a pull request with clear description targeting `next`
 
 ### Documentation
 - Update relevant documentation when adding features


### PR DESCRIPTION
## Summary
- Add contribution rule requiring all PRs to target `next` branch
- Update contribution docs to branch from `next` instead of `main`

## Testing
- `npm run lint` ✅
- `npm run typecheck` ✅