### PR TITLE
Follow-up: enable CI checks for PRs targeting `next`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, next ]
 
 jobs:
   build-and-test:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ on:
       - 'scripts/sync-brand-assets.mjs'
       - '.github/workflows/docs.yml'
   pull_request:
-    branches: [ main ]
+    branches: [ main, next ]
     paths:
       - 'docs/**'
       - 'res/**'


### PR DESCRIPTION
### Motivation
- The repository contribution guidance was changed to target `next` as the PR base but CI workflows only ran for PRs targeting `main`, which could leave PRs unvalidated or miss required checks.

### Description
- Updated `.github/workflows/ci.yml` so the `pull_request` trigger runs for both `main` and `next` by adding `next` to the `branches` list.
- Updated `.github/workflows/docs.yml` so documentation validation on `pull_request` also runs for `next` by adding `next` to the `branches` list.
- Changes were committed on the current branch as `5b9c753` with message `ci: run PR workflows on next branch`.

### Testing
- Ran `git diff --check` and it returned no issues.
- Validated the modified workflow YAML with `ruby -e "require 'yaml'; ['.github/workflows/ci.yml','.github/workflows/docs.yml'].each{|p| YAML.load_file(p)}; puts 'yaml ok'"` which succeeded.
- A pre-commit hook (lefthook) ran during the commit and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e77d5973948331ab270ca131475d07)