### PR TITLE
[codex] fix config-root workflow path resolution

### DIFF
--- a/packages/cli/src/commands/base.ts
+++ b/packages/cli/src/commands/base.ts
@@ -48,7 +48,7 @@ export class BaseCommand {
                 process.exit(1);
             }
             this.activeInstanceId = match.id;
-            directory = match.syncFolder || './workflows';
+            directory = this.configService.resolveWorkspacePath(match.syncFolder || './workflows');
             folderSync = match.folderSync ?? false;
         } else {
             const localConfig = this.configService.getLocalConfig();
@@ -76,7 +76,7 @@ export class BaseCommand {
                 process.exit(1);
             }
 
-            directory = localConfig.syncFolder || './workflows';
+            directory = this.configService.resolveWorkspacePath(localConfig.syncFolder || './workflows');
             folderSync = localConfig.folderSync ?? false;
         }
 
@@ -142,6 +142,9 @@ export class BaseCommand {
 
         return {
             directory: this.config.directory,
+            workflowDir: localConfig.workflowDir
+                ? this.configService.resolveWorkspacePath(localConfig.workflowDir)
+                : undefined,
             syncInactive: true,
             ignoredTags: [],
             instanceIdentifier: instanceIdentifier,

--- a/packages/cli/src/core/services/sync-manager.ts
+++ b/packages/cli/src/core/services/sync-manager.ts
@@ -31,13 +31,13 @@ export class SyncManager extends EventEmitter {
     private async ensureInitialized() {
         if (this.watcher) return;
 
-        // Build project-scoped directory: baseDir/instanceId/projectSlug
-        const projectSlug = createProjectSlug(this.config.projectName);
-        const instanceDir = path.join(
-            this.config.directory, 
-            this.config.instanceIdentifier || 'default',
-            projectSlug
-        );
+        const instanceDir = this.config.workflowDir
+            ? path.normalize(this.config.workflowDir)
+            : path.join(
+                this.config.directory,
+                this.config.instanceIdentifier || 'default',
+                createProjectSlug(this.config.projectName),
+            );
         
         if (!fs.existsSync(instanceDir)) {
             fs.mkdirSync(instanceDir, { recursive: true });

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -56,6 +56,7 @@ export interface IWorkflowStatus {
 
 export interface ISyncConfig {
     directory: string;
+    workflowDir?: string;        // Optional explicit workflow directory override
     syncInactive: boolean; // internal default true
     ignoredTags: string[]; // internal default []
     instanceIdentifier?: string; // Optional: auto-generated if not provided

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -59,14 +59,16 @@ export type ISelectInstanceResult =
 export class ConfigService {
     private globalStore: Conf;
     private localConfigPath: string;
+    private workspaceRoot: string;
 
-    constructor(workspaceRoot = process.cwd()) {
+    constructor(workspaceRoot?: string) {
         this.globalStore = new Conf({
             projectName: 'n8nac',
             configName: 'credentials',
             configFileMode: 0o600
         });
-        this.localConfigPath = path.join(workspaceRoot, 'n8nac-config.json');
+        this.workspaceRoot = workspaceRoot ? path.resolve(workspaceRoot) : this.findConfigRoot(process.cwd());
+        this.localConfigPath = path.join(this.workspaceRoot, 'n8nac-config.json');
     }
 
     /**
@@ -280,9 +282,10 @@ export class ConfigService {
             persistedVerification = this.buildPersistedVerification(verifiedOrFailed, current?.verification);
         }
 
-        const profile = this.sanitizeInstanceProfile({
+        const profile = this.prepareInstanceProfile(current, {
             ...current,
             ...input,
+            workflowDir: input.workflowDir,
             id: current?.id || options.instanceId || this.createInstanceId(),
             name: this.resolveInstanceName({
                 current,
@@ -290,9 +293,9 @@ export class ConfigService {
                 requestedName: options.instanceName,
                 verification,
             }),
-            instanceIdentifier: verification
-                ? (verification.status === 'verified' ? verification.instanceIdentifier : undefined)
-                : (input.instanceIdentifier || current?.instanceIdentifier),
+            instanceIdentifier: input.instanceIdentifier
+                || current?.instanceIdentifier
+                || (verification?.status === 'verified' ? verification.instanceIdentifier : undefined),
             verification: persistedVerification,
         });
 
@@ -354,9 +357,10 @@ export class ConfigService {
             ? workspaceConfig.instances.find((instance) => instance.id === targetId)
             : undefined;
 
-        const profile = this.sanitizeInstanceProfile({
+        const profile = this.prepareInstanceProfile(current, {
             ...current,
             ...config,
+            workflowDir: config.workflowDir,
             id: current?.id || options.instanceId || this.createInstanceId(),
             name: options.instanceName?.trim() || current?.name || this.createDefaultInstanceName(config.host || current?.host),
         });
@@ -378,7 +382,7 @@ export class ConfigService {
     ): IInstanceProfile {
         const workspaceConfig = this.getWorkspaceConfig();
         const current = profile.id ? workspaceConfig.instances.find((instance) => instance.id === profile.id) : undefined;
-        const savedProfile = this.sanitizeInstanceProfile({
+        const savedProfile = this.prepareInstanceProfile(current, {
             ...current,
             ...profile,
             id: current?.id || profile.id || this.createInstanceId(),
@@ -478,14 +482,14 @@ export class ConfigService {
 
         const updated = this.saveInstanceProfile({
             ...instance,
+            workflowDir: undefined,
             name: this.resolveInstanceName({
                 current: instance,
                 host,
                 verification,
             }),
-            instanceIdentifier: verification.status === 'verified'
-                ? verification.instanceIdentifier
-                : undefined,
+            instanceIdentifier: instance.instanceIdentifier
+                || (verification.status === 'verified' ? verification.instanceIdentifier : undefined),
             verification: persistedVerification,
         }, {
             setActive: instance.id === this.getActiveInstanceId(),
@@ -587,6 +591,10 @@ export class ConfigService {
         const active = instanceId ? this.getInstance(instanceId) : this.getActiveInstance();
         const apiKey = this.getApiKey(host, instanceId || active?.id);
 
+        if (active?.instanceIdentifier) {
+            return active.instanceIdentifier;
+        }
+
         if (!apiKey) {
             throw new Error('API key not found');
         }
@@ -628,6 +636,32 @@ export class ConfigService {
      */
     getInstanceConfigPath(): string {
         return this.localConfigPath;
+    }
+
+    getWorkspaceRoot(): string {
+        return this.workspaceRoot;
+    }
+
+    resolveWorkspacePath(targetPath: string): string {
+        return path.isAbsolute(targetPath)
+            ? targetPath
+            : path.resolve(this.workspaceRoot, targetPath);
+    }
+
+    private findConfigRoot(startDir: string): string {
+        let currentDir = path.resolve(startDir);
+
+        while (true) {
+            if (fs.existsSync(path.join(currentDir, 'n8nac-config.json'))) {
+                return currentDir;
+            }
+
+            const parentDir = path.dirname(currentDir);
+            if (parentDir === currentDir) {
+                return path.resolve(startDir);
+            }
+            currentDir = parentDir;
+        }
     }
 
     private loadWorkspaceConfig(): { config: IWorkspaceConfig; shouldPersist: boolean } {
@@ -820,13 +854,9 @@ export class ConfigService {
             ? profile.name.trim()
             : this.createDefaultInstanceName(localConfig.host);
 
-        // Recompute workflowDir whenever all three deps are present, so the stored value stays in sync
-        if (localConfig.syncFolder && localConfig.instanceIdentifier && localConfig.projectName) {
-            localConfig.workflowDir = this.normalizeConfigPath(
-                localConfig.syncFolder,
-                localConfig.instanceIdentifier,
-                createProjectSlug(localConfig.projectName),
-            );
+        // Compute workflowDir when absent; preserve explicit/pinned paths from config.
+        if (!localConfig.workflowDir) {
+            localConfig.workflowDir = this.computeWorkflowDir(localConfig);
         }
 
         return {
@@ -835,6 +865,50 @@ export class ConfigService {
             ...localConfig,
             verification: this.sanitizeVerification((profile as Partial<IInstanceProfile>).verification),
         };
+    }
+
+    private prepareInstanceProfile(
+        current: IInstanceProfile | undefined,
+        profile: Record<string, unknown> | Partial<IInstanceProfile>
+    ): IInstanceProfile {
+        const next = { ...profile } as Partial<IInstanceProfile>;
+        const incomingWorkflowDir = typeof next.workflowDir === 'string' && next.workflowDir.trim() !== ''
+            ? next.workflowDir.trim()
+            : undefined;
+        const currentWorkflowDir = current?.workflowDir;
+        const currentWorkflowDirIsGenerated = !!current && this.isGeneratedWorkflowDir(current);
+        const workflowDirIsExplicit = !!incomingWorkflowDir && (
+            !current ||
+            incomingWorkflowDir !== currentWorkflowDir ||
+            !currentWorkflowDirIsGenerated
+        );
+
+        if (workflowDirIsExplicit) {
+            next.workflowDir = incomingWorkflowDir;
+        } else if (!incomingWorkflowDir && currentWorkflowDir && !currentWorkflowDirIsGenerated) {
+            next.workflowDir = currentWorkflowDir;
+        } else {
+            delete next.workflowDir;
+        }
+
+        return this.sanitizeInstanceProfile(next);
+    }
+
+    private computeWorkflowDir(config: Partial<ILocalConfig>): string | undefined {
+        if (!config.syncFolder || !config.instanceIdentifier || !config.projectName) {
+            return undefined;
+        }
+
+        return this.normalizeConfigPath(
+            config.syncFolder,
+            config.instanceIdentifier,
+            createProjectSlug(config.projectName),
+        );
+    }
+
+    private isGeneratedWorkflowDir(config: Partial<ILocalConfig>): boolean {
+        const expectedWorkflowDir = this.computeWorkflowDir(config);
+        return !!config.workflowDir && !!expectedWorkflowDir && config.workflowDir === expectedWorkflowDir;
     }
 
     private sanitizeVerification(verification: IInstanceVerification | undefined): IInstanceVerification | undefined {

--- a/packages/cli/tests/unit/config-service.test.ts
+++ b/packages/cli/tests/unit/config-service.test.ts
@@ -45,6 +45,37 @@ describe('ConfigService', () => {
         }));
     });
 
+    it('finds n8nac-config.json in a parent directory when no workspace root is provided', () => {
+        const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/tmp/workspace/backend');
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockImplementation((filePath: string) =>
+            filePath === '/tmp/workspace/n8nac-config.json'
+        );
+
+        try {
+            const discoveredConfigService = new ConfigService();
+
+            expect(discoveredConfigService.getWorkspaceRoot()).toBe('/tmp/workspace');
+            expect(discoveredConfigService.getInstanceConfigPath()).toBe('/tmp/workspace/n8nac-config.json');
+            expect(discoveredConfigService.resolveWorkspacePath('workflows')).toBe('/tmp/workspace/workflows');
+        } finally {
+            cwdSpy.mockRestore();
+        }
+    });
+
+    it('uses the current directory as workspace root when no config file is found', () => {
+        const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/tmp/workspace/backend');
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+        try {
+            const discoveredConfigService = new ConfigService();
+
+            expect(discoveredConfigService.getWorkspaceRoot()).toBe('/tmp/workspace/backend');
+            expect(discoveredConfigService.getInstanceConfigPath()).toBe('/tmp/workspace/backend/n8nac-config.json');
+        } finally {
+            cwdSpy.mockRestore();
+        }
+    });
+
     it('returns the active instance as the local config when the workspace config already contains a library', () => {
         const workspaceConfig: IWorkspaceConfig = {
             version: 2,
@@ -253,6 +284,69 @@ describe('ConfigService', () => {
         expect(persistedConfig.workflowDir).toBe('//server/share/workflows/unc_instance/production');
     });
 
+    it('preserves an explicit workflowDir instead of recomputing it', () => {
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+        const savedProfile = configService.saveLocalConfig({
+            host: 'https://prod.example.com',
+            syncFolder: 'workflows',
+            projectId: 'project-prod',
+            projectName: 'Production',
+            instanceIdentifier: 'prod_identifier',
+            workflowDir: 'shared/workflows/project',
+        }, {
+            instanceName: 'Production'
+        });
+
+        expect(savedProfile.workflowDir).toBe('shared/workflows/project');
+        const persistedConfig = JSON.parse((fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1]);
+        expect(persistedConfig.workflowDir).toBe('shared/workflows/project');
+    });
+
+    it('recomputes a generated workflowDir when project settings change', () => {
+        const workspaceConfig: IWorkspaceConfig = {
+            version: 2,
+            activeInstanceId: 'prod',
+            instances: [
+                {
+                    id: 'prod',
+                    name: 'Production',
+                    host: 'https://prod.example.com',
+                    syncFolder: 'workflows',
+                    projectId: 'project-old',
+                    projectName: 'Old Project',
+                    instanceIdentifier: 'prod_identifier',
+                    workflowDir: 'workflows/prod_identifier/old_project',
+                }
+            ],
+            host: 'https://prod.example.com',
+            syncFolder: 'workflows',
+            projectId: 'project-old',
+            projectName: 'Old Project',
+            instanceIdentifier: 'prod_identifier',
+            workflowDir: 'workflows/prod_identifier/old_project',
+        };
+
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+        (fs.readFileSync as any).mockReturnValue(JSON.stringify(workspaceConfig));
+
+        const updated = configService.updateInstanceConfig({
+            host: 'https://prod.example.com',
+            syncFolder: 'n8n-workflows',
+            projectId: 'project-new',
+            projectName: 'New Project',
+        }, {
+            instanceId: 'prod',
+            instanceName: 'Production',
+            setActive: true,
+        });
+
+        expect(updated.workflowDir).toBe('n8n-workflows/prod_identifier/new_project');
+        const persistedConfig = JSON.parse((fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1]);
+        expect(persistedConfig.workflowDir).toBe('n8n-workflows/prod_identifier/new_project');
+        expect(persistedConfig.instances[0].workflowDir).toBe('n8n-workflows/prod_identifier/new_project');
+    });
+
     it('rejects creating a duplicate verified instance config for the same host and authenticated user', async () => {
         (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
 
@@ -308,6 +402,67 @@ describe('ConfigService', () => {
         if (duplicate.status === 'duplicate') {
             expect(duplicate.duplicateInstance.name).toContain('prod.example.com');
         }
+    });
+
+    it('keeps pinned instanceIdentifier and workflowDir when verification resolves a different user', async () => {
+        const workspaceConfig: IWorkspaceConfig = {
+            version: 2,
+            activeInstanceId: 'prod',
+            instances: [
+                {
+                    id: 'prod',
+                    name: 'Production',
+                    host: 'https://prod.example.com',
+                    syncFolder: 'workflows',
+                    projectId: 'project-prod',
+                    projectName: 'Production',
+                    instanceIdentifier: 'shared_instance',
+                    workflowDir: 'workflows/shared/project',
+                }
+            ],
+            host: 'https://prod.example.com',
+            syncFolder: 'workflows',
+            projectId: 'project-prod',
+            projectName: 'Production',
+            instanceIdentifier: 'shared_instance',
+            workflowDir: 'workflows/shared/project',
+        };
+
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+        (fs.readFileSync as any).mockReturnValue(JSON.stringify(workspaceConfig));
+
+        const result = await configService.upsertInstanceConfigWithVerification({
+            host: 'https://prod.example.com',
+            apiKey: 'bob-key',
+            syncFolder: 'workflows',
+            projectId: 'project-prod',
+            projectName: 'Production',
+        }, {
+            createNew: false,
+            setActive: true,
+            client: {
+                async getCurrentUser() {
+                    return {
+                        id: 'bob',
+                        email: 'bob@example.com',
+                        firstName: 'Bob',
+                        lastName: 'Jones',
+                    };
+                }
+            }
+        });
+
+        expect(result.status).toBe('saved');
+        if (result.status === 'saved') {
+            expect(result.profile.instanceIdentifier).toBe('shared_instance');
+            expect(result.profile.workflowDir).toBe('workflows/shared/project');
+        }
+
+        const persistedConfig = JSON.parse((fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1]);
+        expect(persistedConfig.instanceIdentifier).toBe('shared_instance');
+        expect(persistedConfig.workflowDir).toBe('workflows/shared/project');
+        expect(persistedConfig.instances[0].instanceIdentifier).toBe('shared_instance');
+        expect(persistedConfig.instances[0].workflowDir).toBe('workflows/shared/project');
     });
 
     it('setActiveInstance rewrites the top-level active config cache', () => {
@@ -477,6 +632,39 @@ describe('ConfigService', () => {
         const persistedConfig = JSON.parse((fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1]);
         expect(persistedConfig.instanceIdentifier).toBe('recomputed-id');
         expect(persistedConfig.instances[0].instanceIdentifier).toBe('recomputed-id');
+    });
+
+    it('getOrCreateInstanceIdentifier returns the pinned identifier without re-verifying', async () => {
+        const workspaceConfig: IWorkspaceConfig = {
+            version: 2,
+            activeInstanceId: 'prod',
+            instances: [
+                {
+                    id: 'prod',
+                    name: 'Production',
+                    host: 'https://prod.example.com',
+                    syncFolder: 'workflows',
+                    projectId: 'project-prod',
+                    projectName: 'Production',
+                    instanceIdentifier: 'shared_instance'
+                }
+            ],
+            host: 'https://prod.example.com',
+            syncFolder: 'workflows',
+            projectId: 'project-prod',
+            projectName: 'Production',
+            instanceIdentifier: 'shared_instance'
+        };
+
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+        (fs.readFileSync as any).mockReturnValue(JSON.stringify(workspaceConfig));
+        mockConf.get.mockReturnValue({ prod: 'test-key' });
+
+        const result = await configService.getOrCreateInstanceIdentifier('https://prod.example.com', 'prod');
+
+        expect(result).toBe('shared_instance');
+        expect(mockResolveInstanceIdentifier).not.toHaveBeenCalled();
+        expect(fs.writeFileSync).not.toHaveBeenCalled();
     });
 
     it('selectInstanceConfigWithVerification switches to the already verified duplicate config', async () => {

--- a/packages/cli/tests/unit/sync-manager.test.ts
+++ b/packages/cli/tests/unit/sync-manager.test.ts
@@ -167,4 +167,24 @@ describe('SyncManager push filename contract', () => {
         expect(refreshLocalState.mock.invocationCallOrder[0]).toBeLessThan(getWorkflowIdForFilename.mock.invocationCallOrder[0]);
         expect(push).toHaveBeenCalledWith(workflowFilename, 'wf-123', expect.any(String));
     });
+
+    it('uses an explicit workflowDir as the active sync scope', async () => {
+        const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-sync-manager-'));
+        const workflowDir = path.join(workspaceDir, 'shared', 'project');
+        const manager = new SyncManager(new MockN8nApiClient() as any, {
+            directory: path.join(workspaceDir, 'generated-base'),
+            workflowDir,
+            syncInactive: true,
+            ignoredTags: [],
+            projectId: 'project-1',
+            projectName: 'Personal',
+            instanceIdentifier: 'generated_instance',
+        });
+
+        await (manager as any).ensureInitialized();
+
+        expect((manager as any).watcher.getDirectory()).toBe(workflowDir);
+        expect(fs.existsSync(path.join(workflowDir, 'n8n-workflows.d.ts'))).toBe(true);
+        expect(fs.existsSync(path.join(workspaceDir, 'generated-base', 'generated_instance', 'personal'))).toBe(false);
+    });
 });


### PR DESCRIPTION
## Summary

Fixes #347 by resolving `n8nac-config.json` from the nearest parent directory and anchoring relative workflow paths to that config root.

Also preserves pinned `instanceIdentifier` and `workflowDir` values for the shared workflow directory behavior discussed in #345.

## What changed

- Walk upward from the current working directory to find the nearest `n8nac-config.json` when `ConfigService` is created without an explicit root.
- Store the discovered workspace root and use it to resolve relative `syncFolder` paths before commands initialize sync state.
- Resolve explicit relative `workflowDir` values against the config root before passing them to `SyncManager`.
- Preserve existing or explicitly provided pinned `instanceIdentifier` and `workflowDir` values instead of recomputing them during verification/config normalization.
- Add regression coverage for parent config discovery, pinned workflow directories, and sync scope selection.

## Impact

Running `n8nac` from a subdirectory now uses the repo-level config and workflow directory instead of silently operating on `<cwd>/workflows`. Teams can also keep a shared committed workflow folder while each user keeps their own API key.

## Validation

- `npm run test:unit --workspace=n8nac -- tests/unit/config-service.test.ts`
- `npm run build --workspace=n8nac`