### PR TITLE
[codex] Fix skills validator nested parameters

### DIFF
--- a/packages/skills/src/services/workflow-validator.ts
+++ b/packages/skills/src/services/workflow-validator.ts
@@ -239,19 +239,50 @@ export class WorkflowValidator {
     };
   }
 
+  private isExpressionValue(value: any): boolean {
+    return typeof value === 'string' && value.includes('{{');
+  }
+
+  private getConditionParamValue(
+    condParamName: string,
+    nodeParams: Record<string, any>,
+    rootParams: Record<string, any>
+  ): any {
+    if (condParamName.startsWith('/')) {
+      return rootParams[condParamName.slice(1)];
+    }
+    return Object.prototype.hasOwnProperty.call(nodeParams, condParamName)
+      ? nodeParams[condParamName]
+      : rootParams[condParamName];
+  }
+
   /**
-   * Check whether a schema property's displayOptions.show conditions are satisfied
-   * by the current node parameters. If no displayOptions defined → always shown.
+   * Check whether a schema property's displayOptions conditions are satisfied
+   * by the current parameters. If no displayOptions defined -> always shown.
    */
-  private isPropertyDisplayed(prop: any, nodeParams: Record<string, any>): boolean {
+  private isPropertyDisplayed(
+    prop: any,
+    nodeParams: Record<string, any>,
+    rootParams: Record<string, any> = nodeParams
+  ): boolean {
+    const hide = prop.displayOptions?.hide;
+    if (hide && typeof hide === 'object') {
+      for (const [condParamName, hiddenValues] of Object.entries(hide)) {
+        if (!Array.isArray(hiddenValues)) continue;
+        const actualValue = this.getConditionParamValue(condParamName, nodeParams, rootParams);
+        if (this.isExpressionValue(actualValue)) continue;
+        if (hiddenValues.includes(actualValue)) return false;
+      }
+    }
+
     const show = prop.displayOptions?.show;
     if (!show || typeof show !== 'object') return true;
 
     for (const [condParamName, allowedValues] of Object.entries(show)) {
       if (!Array.isArray(allowedValues)) continue;
-      const actualValue = nodeParams[condParamName];
+      const actualValue = this.getConditionParamValue(condParamName, nodeParams, rootParams);
       // Skip expression values — can't evaluate at static validation time
-      if (typeof actualValue === 'string' && actualValue.includes('{{')) continue;
+      if (this.isExpressionValue(actualValue)) continue;
       if (!allowedValues.includes(actualValue)) return false;
     }
     return true;
@@ -267,84 +298,7 @@ export class WorkflowValidator {
     warnings: ValidationWarning[]
   ): void {
     const schemaProps = nodeSchema.schema?.properties || nodeSchema.properties || [];
-    // Only consider props whose display conditions are satisfied by the current params
-    const displayedProps = schemaProps.filter((p: any) => this.isPropertyDisplayed(p, node.parameters));
-    const requiredProps = displayedProps.filter((p: any) => p.required === true);
-
-    // Check required parameters
-    for (const prop of requiredProps) {
-      if (!(prop.name in node.parameters)) {
-        errors.push({
-          type: 'error',
-          nodeId: node.id,
-          nodeName: node.name,
-          message: `Missing required parameter: "${prop.name}"`,
-          path: `nodes[${node.name}].parameters.${prop.name}`,
-        });
-      }
-    }
-
-    // Check for unknown parameters (might be typos)
-    const knownParamNames = new Set(schemaProps.map((p: any) => p.name));
-    for (const paramName of Object.keys(node.parameters)) {
-      if (!knownParamNames.has(paramName)) {
-        warnings.push({
-          type: 'warning',
-          nodeId: node.id,
-          nodeName: node.name,
-          message: `Unknown parameter: "${paramName}". This might be a typo or deprecated parameter.`,
-          path: `nodes[${node.name}].parameters.${paramName}`,
-        });
-      }
-    }
-
-    // Validate 'options' type parameter values
-    // Collect all valid values for each options-type property across all display conditions
-    const optionValuesByPropName = new Map<string, Set<string | number>>();
-    for (const prop of schemaProps) {
-      if (prop.type === 'options' && Array.isArray(prop.options)) {
-        if (!optionValuesByPropName.has(prop.name)) {
-          optionValuesByPropName.set(prop.name, new Set());
-        }
-        const set = optionValuesByPropName.get(prop.name)!;
-        for (const opt of prop.options) {
-          if (opt.value !== undefined) set.add(opt.value);
-        }
-      }
-    }
-
-    for (const [propName, validValues] of optionValuesByPropName) {
-      if (!(propName in node.parameters)) continue;
-      const actualValue = node.parameters[propName];
-      // Skip expressions
-      if (typeof actualValue === 'string' && actualValue.includes('{{')) continue;
-      if (!validValues.has(actualValue)) {
-        // Try to find which resource this operation belongs to, for a helpful hint
-        let hint = '';
-        if (propName === 'operation') {
-          const resourceValue = node.parameters['resource'];
-          if (resourceValue) {
-            // Find operation props scoped to this resource
-            const scopedOps = schemaProps
-              .filter((p: any) => p.name === 'operation' && p.type === 'options' &&
-                Array.isArray(p.displayOptions?.show?.resource) &&
-                p.displayOptions.show.resource.includes(resourceValue))
-              .flatMap((p: any) => p.options?.map((o: any) => o.value) ?? []);
-            if (scopedOps.length > 0) {
-              hint = ` For resource "${resourceValue}", valid operations are: [${scopedOps.join(', ')}].`;
-            }
-          }
-        }
-        const validList = [...validValues].slice(0, 20).join(', ') + (validValues.size > 20 ? ', ...' : '');
-        errors.push({
-          type: 'error',
-          nodeId: node.id,
-          nodeName: node.name,
-          message: `Invalid value "${actualValue}" for parameter "${propName}". n8n will reject this with "Could not find property option".${hint} All known values: [${validList}].`,
-          path: `nodes[${node.name}].parameters.${propName}`,
-        });
-      }
-    }
+    this.validateParameterSet(node, schemaProps, node.parameters, node.parameters, `nodes[${node.name}].parameters`, errors, warnings, true);
 
     // Cross-check: when both 'resource' and 'operation' are set, verify the operation
     // is valid for the specific resource (some operations only exist for certain resources)
@@ -375,6 +329,247 @@ export class WorkflowValidator {
           });
         }
       }
+    }
+  }
+
+  private validateParameterSet(
+    node: any,
+    schemaProps: any[],
+    params: Record<string, any>,
+    rootParams: Record<string, any>,
+    path: string,
+    errors: ValidationError[],
+    warnings: ValidationWarning[],
+    warnUnknownParameters: boolean
+  ): void {
+    // Only consider props whose display conditions are satisfied by the current params
+    const displayedProps = schemaProps.filter((p: any) => this.isPropertyDisplayed(p, params, rootParams));
+    const requiredProps = displayedProps.filter((p: any) => p.required === true);
+
+    // Check required parameters
+    for (const prop of requiredProps) {
+      if (!(prop.name in params)) {
+        errors.push({
+          type: 'error',
+          nodeId: node.id,
+          nodeName: node.name,
+          message: `Missing required parameter: "${prop.name}"`,
+          path: `${path}.${prop.name}`,
+        });
+      }
+    }
+
+    // Check for unknown parameters (might be typos)
+    if (warnUnknownParameters) {
+      const knownParamNames = new Set(schemaProps.map((p: any) => p.name));
+      for (const paramName of Object.keys(params)) {
+        if (!knownParamNames.has(paramName)) {
+          warnings.push({
+            type: 'warning',
+            nodeId: node.id,
+            nodeName: node.name,
+            message: `Unknown parameter: "${paramName}". This might be a typo or deprecated parameter.`,
+            path: `${path}.${paramName}`,
+          });
+        }
+      }
+    }
+
+    // Validate 'options' type parameter values
+    // Collect all valid values for each options-type property across all display conditions
+    const optionValuesByPropName = new Map<string, Set<string | number>>();
+    for (const prop of schemaProps) {
+      if (prop.type === 'options' && Array.isArray(prop.options)) {
+        if (!optionValuesByPropName.has(prop.name)) {
+          optionValuesByPropName.set(prop.name, new Set());
+        }
+        const set = optionValuesByPropName.get(prop.name)!;
+        for (const opt of prop.options) {
+          if (opt.value !== undefined) set.add(opt.value);
+        }
+      }
+    }
+
+    for (const [propName, validValues] of optionValuesByPropName) {
+      if (!(propName in params)) continue;
+      const actualValue = params[propName];
+      // Skip expressions
+      if (this.isExpressionValue(actualValue)) continue;
+      if (!validValues.has(actualValue)) {
+        // Try to find which resource this operation belongs to, for a helpful hint
+        let hint = '';
+        if (propName === 'operation') {
+          const resourceValue = rootParams['resource'];
+          if (resourceValue) {
+            // Find operation props scoped to this resource
+            const scopedOps = schemaProps
+              .filter((p: any) => p.name === 'operation' && p.type === 'options' &&
+                Array.isArray(p.displayOptions?.show?.resource) &&
+                p.displayOptions.show.resource.includes(resourceValue))
+              .flatMap((p: any) => p.options?.map((o: any) => o.value) ?? []);
+            if (scopedOps.length > 0) {
+              hint = ` For resource "${resourceValue}", valid operations are: [${scopedOps.join(', ')}].`;
+            }
+          }
+        }
+        const validList = [...validValues].slice(0, 20).join(', ') + (validValues.size > 20 ? ', ...' : '');
+        errors.push({
+          type: 'error',
+          nodeId: node.id,
+          nodeName: node.name,
+          message: `Invalid value "${actualValue}" for parameter "${propName}". n8n will reject this with "Could not find property option".${hint} All known values: [${validList}].`,
+          path: `${path}.${propName}`,
+        });
+      }
+    }
+
+    for (const prop of displayedProps) {
+      if (prop.type !== 'filter' || !(prop.name in params)) continue;
+      this.validateFilterParameter(node, prop, params[prop.name], `${path}.${prop.name}`, errors);
+    }
+
+    for (const prop of displayedProps) {
+      if (prop.type !== 'fixedCollection' || !Array.isArray(prop.options)) continue;
+      if (!(prop.name in params)) continue;
+
+      const fixedCollectionValue = params[prop.name];
+      if (!fixedCollectionValue || typeof fixedCollectionValue !== 'object') continue;
+
+      this.validateFixedCollectionDefaultShape(node, prop, fixedCollectionValue, `${path}.${prop.name}`, errors);
+
+      for (const option of prop.options) {
+        if (!option?.name || !Array.isArray(option.values)) continue;
+        const optionValue = fixedCollectionValue[option.name];
+        if (Array.isArray(optionValue)) {
+          optionValue.forEach((item, index) => {
+            if (!item || typeof item !== 'object') return;
+            this.validateParameterSet(
+              node,
+              option.values,
+              item,
+              rootParams,
+              `${path}.${prop.name}.${option.name}[${index}]`,
+              errors,
+              warnings,
+              false
+            );
+          });
+        } else if (optionValue && typeof optionValue === 'object') {
+          this.validateParameterSet(
+            node,
+            option.values,
+            optionValue,
+            rootParams,
+            `${path}.${prop.name}.${option.name}`,
+            errors,
+            warnings,
+            false
+          );
+        }
+      }
+    }
+  }
+
+  private validateFixedCollectionDefaultShape(
+    node: any,
+    prop: any,
+    value: Record<string, any>,
+    path: string,
+    errors: ValidationError[]
+  ): void {
+    if (!prop.default || typeof prop.default !== 'object' || Array.isArray(prop.default)) return;
+
+    for (const option of prop.options || []) {
+      if (!option?.name || !(option.name in prop.default) || !(option.name in value)) continue;
+      this.validateDefaultShape(
+        node,
+        prop.default[option.name],
+        value[option.name],
+        `${path}.${option.name}`,
+        errors
+      );
+    }
+  }
+
+  private validateFilterParameter(
+    node: any,
+    prop: any,
+    value: any,
+    path: string,
+    errors: ValidationError[]
+  ): void {
+    if (!value || typeof value !== 'object') return;
+
+    const filterOptions = prop.typeOptions?.filter;
+    if (!filterOptions || typeof filterOptions !== 'object') return;
+
+    const requiredOptionNames = ['caseSensitive', 'typeValidation'].filter((name) => name in filterOptions);
+    if (requiredOptionNames.length === 0) return;
+
+    if (!value.options || typeof value.options !== 'object') {
+      errors.push({
+        type: 'error',
+        nodeId: node.id,
+        nodeName: node.name,
+        message: `Missing required parameter: "${path}.options"`,
+        path: `${path}.options`,
+      });
+      return;
+    }
+
+    for (const optionName of requiredOptionNames) {
+      if (!(optionName in value.options)) {
+        errors.push({
+          type: 'error',
+          nodeId: node.id,
+          nodeName: node.name,
+          message: `Missing required parameter: "${path}.options.${optionName}"`,
+          path: `${path}.options.${optionName}`,
+        });
+      }
+    }
+  }
+
+  private hasNestedDefaultShape(value: any): boolean {
+    if (Array.isArray(value)) return value.length > 0;
+    return Boolean(value && typeof value === 'object' && Object.keys(value).length > 0);
+  }
+
+  private validateDefaultShape(
+    node: any,
+    defaultValue: any,
+    actualValue: any,
+    path: string,
+    errors: ValidationError[]
+  ): void {
+    if (Array.isArray(defaultValue)) {
+      if (!Array.isArray(actualValue) || defaultValue.length === 0) return;
+      actualValue.forEach((item, index) => {
+        this.validateDefaultShape(node, defaultValue[0], item, `${path}[${index}]`, errors);
+      });
+      return;
+    }
+
+    if (!defaultValue || typeof defaultValue !== 'object' || !actualValue || typeof actualValue !== 'object') {
+      return;
+    }
+
+    for (const [key, nestedDefault] of Object.entries(defaultValue)) {
+      const nestedPath = `${path}.${key}`;
+      if (!(key in actualValue)) {
+        if (this.hasNestedDefaultShape(nestedDefault)) {
+          errors.push({
+            type: 'error',
+            nodeId: node.id,
+            nodeName: node.name,
+            message: `Missing required parameter: "${nestedPath}"`,
+            path: nestedPath,
+          });
+        }
+        continue;
+      }
+
+      this.validateDefaultShape(node, nestedDefault, actualValue[key], nestedPath, errors);
     }
   }
 

--- a/packages/skills/tests/workflow-validator.test.ts
+++ b/packages/skills/tests/workflow-validator.test.ts
@@ -262,3 +262,281 @@ describe('WorkflowValidator - custom nodes', () => {
         expect(result.errors.some(e => e.message.includes('endpoint'))).toBe(true);
     });
 });
+
+describe('WorkflowValidator - nested parameter validation', () => {
+    const createValidatorWithNodeSchema = (nodeSchema: any): WorkflowValidator => {
+        const indexPath = path.resolve(_dirname, 'fixtures/n8n-nodes-technical.json');
+        const validator = new WorkflowValidator(indexPath);
+        jest.spyOn(validator['provider'], 'getNodeSchema').mockReturnValue(nodeSchema);
+        return validator;
+    };
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('honors displayOptions.hide when checking required parameters', async () => {
+        const validator = createValidatorWithNodeSchema({
+            name: 'postgres',
+            type: 'n8n-nodes-base.postgres',
+            version: 1,
+            schema: {
+                properties: [
+                    {
+                        name: 'operation',
+                        type: 'options',
+                        options: [{ name: 'Execute Query', value: 'executeQuery' }],
+                        required: true,
+                    },
+                    {
+                        name: 'query',
+                        type: 'string',
+                        required: true,
+                        displayOptions: { show: { operation: ['executeQuery'] } },
+                    },
+                    {
+                        name: 'schema',
+                        type: 'string',
+                        required: true,
+                        displayOptions: { hide: { operation: ['executeQuery'] } },
+                    },
+                    {
+                        name: 'table',
+                        type: 'string',
+                        required: true,
+                        displayOptions: { hide: { operation: ['executeQuery'] } },
+                    },
+                ],
+            },
+        });
+
+        const result = await validator.validateWorkflow({
+            nodes: [
+                {
+                    id: '1',
+                    name: 'Postgres',
+                    type: 'n8n-nodes-base.postgres',
+                    typeVersion: 1,
+                    position: [0, 0],
+                    parameters: {
+                        operation: 'executeQuery',
+                        query: 'select 1',
+                    },
+                },
+            ],
+            connections: {},
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.errors.map(e => e.message)).not.toContain('Missing required parameter: "schema"');
+        expect(result.errors.map(e => e.message)).not.toContain('Missing required parameter: "table"');
+    });
+
+    it('recurses into fixedCollection items and catches missing Switch filter options', async () => {
+        const validator = createValidatorWithNodeSchema({
+            name: 'switch',
+            type: 'n8n-nodes-base.switch',
+            version: 3.2,
+            schema: {
+                properties: [
+                    {
+                        name: 'mode',
+                        type: 'options',
+                        options: [{ name: 'Rules', value: 'rules' }],
+                    },
+                    {
+                        name: 'rules',
+                        type: 'fixedCollection',
+                        displayOptions: { show: { mode: ['rules'] } },
+                        default: {
+                            values: [
+                                {
+                                    conditions: {
+                                        options: {
+                                            caseSensitive: true,
+                                            typeValidation: 'strict',
+                                        },
+                                        conditions: [
+                                            {
+                                                leftValue: '',
+                                                rightValue: '',
+                                                operator: {
+                                                    type: 'string',
+                                                    operation: 'equals',
+                                                },
+                                            },
+                                        ],
+                                        combinator: 'and',
+                                    },
+                                },
+                            ],
+                        },
+                        options: [
+                            {
+                                name: 'values',
+                                displayName: 'Routing Rule',
+                                values: [
+                                    {
+                                        name: 'conditions',
+                                        type: 'filter',
+                                        default: {},
+                                        typeOptions: {
+                                            filter: {
+                                                caseSensitive: '={{!$parameter.options.ignoreCase}}',
+                                                typeValidation: 'strict',
+                                            },
+                                        },
+                                    },
+                                    {
+                                        name: 'renameOutput',
+                                        type: 'boolean',
+                                        default: false,
+                                    },
+                                    {
+                                        name: 'outputKey',
+                                        type: 'string',
+                                        required: true,
+                                        displayOptions: { show: { renameOutput: [true] } },
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        });
+
+        const result = await validator.validateWorkflow({
+            nodes: [
+                {
+                    id: '1',
+                    name: 'Switch',
+                    type: 'n8n-nodes-base.switch',
+                    typeVersion: 3.2,
+                    position: [0, 0],
+                    parameters: {
+                        mode: 'rules',
+                        rules: {
+                            values: [
+                                {
+                                    conditions: {
+                                        conditions: [
+                                            {
+                                                leftValue: '={{ $json.state }}',
+                                                operator: { type: 'string', operation: 'equals' },
+                                                rightValue: 'planning',
+                                            },
+                                        ],
+                                        combinator: 'and',
+                                    },
+                                    outputIndex: 0,
+                                },
+                            ],
+                        },
+                    },
+                },
+            ],
+            connections: {},
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors.some(e => e.path?.endsWith('.rules.values[0].conditions.options'))).toBe(true);
+        expect(result.warnings.some(w => w.message.includes('outputIndex'))).toBe(false);
+
+        const validResult = await validator.validateWorkflow({
+            nodes: [
+                {
+                    id: '1',
+                    name: 'Switch',
+                    type: 'n8n-nodes-base.switch',
+                    typeVersion: 3.2,
+                    position: [0, 0],
+                    parameters: {
+                        mode: 'rules',
+                        rules: {
+                            values: [
+                                {
+                                    conditions: {
+                                        options: {
+                                            caseSensitive: true,
+                                            typeValidation: 'strict',
+                                        },
+                                        conditions: [
+                                            {
+                                                leftValue: '={{ $json.state }}',
+                                                operator: { type: 'string', operation: 'equals' },
+                                                rightValue: 'planning',
+                                            },
+                                        ],
+                                        combinator: 'and',
+                                    },
+                                    outputIndex: 0,
+                                },
+                            ],
+                        },
+                    },
+                },
+            ],
+            connections: {},
+        });
+
+        expect(validResult.valid).toBe(true);
+    });
+
+    it('applies nested fixedCollection displayOptions against item parameters', async () => {
+        const validator = createValidatorWithNodeSchema({
+            name: 'switch',
+            type: 'n8n-nodes-base.switch',
+            version: 3.2,
+            schema: {
+                properties: [
+                    {
+                        name: 'rules',
+                        type: 'fixedCollection',
+                        default: {},
+                        options: [
+                            {
+                                name: 'values',
+                                displayName: 'Routing Rule',
+                                values: [
+                                    { name: 'renameOutput', type: 'boolean', default: false },
+                                    {
+                                        name: 'outputKey',
+                                        type: 'string',
+                                        required: true,
+                                        displayOptions: { show: { renameOutput: [true] } },
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        });
+
+        const result = await validator.validateWorkflow({
+            nodes: [
+                {
+                    id: '1',
+                    name: 'Switch',
+                    type: 'n8n-nodes-base.switch',
+                    typeVersion: 3.2,
+                    position: [0, 0],
+                    parameters: {
+                        rules: {
+                            values: [
+                                { renameOutput: false },
+                                { renameOutput: true },
+                            ],
+                        },
+                    },
+                },
+            ],
+            connections: {},
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].path).toBe('nodes[Switch].parameters.rules.values[1].outputKey');
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #348 by extending skills workflow validation to inspect nested parameter structures instead of only top-level node parameters.

## What changed

- Honor `displayOptions.hide` when deciding whether required parameters are visible.
- Recurse into `fixedCollection` option entries and validate nested required fields/options there.
- Validate filter metadata options such as Switch `conditions.options.caseSensitive` and `typeValidation`.
- Avoid warning on nested fixedCollection fields that are accepted by n8n but not represented as top-level node parameters.

## Root cause

`validateNodeParameters()` only checked top-level schema properties and only considered `displayOptions.show`. That meant Switch v3 nested filter options were skipped, while hidden Postgres fields could still be treated as required.

## Validation

- `npx tsc -b packages/skills`
- `npm test -- --runTestsByPath packages/skills/tests/workflow-validator.test.ts`