### PR TITLE
[codex] Preserve workflow descriptions on create

### DIFF
--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -478,8 +478,51 @@ export class N8nApiClient {
     }
 
     async createWorkflow(payload: Partial<IWorkflow>): Promise<IWorkflow> {
-        const res = await this.client.post('/api/v1/workflows', payload);
-        return res.data;
+        const createPayload = this.cleanWorkflowCreatePayload(payload);
+        const res = await this.client.post('/api/v1/workflows', createPayload);
+        const createdWorkflow = res.data as IWorkflow;
+
+        if (
+            createdWorkflow?.id &&
+            typeof payload.description === 'string' &&
+            payload.description.length > 0
+        ) {
+            try {
+                return await this.updateWorkflow(createdWorkflow.id, {
+                    ...payload,
+                    name: createdWorkflow.name ?? payload.name,
+                    nodes: createdWorkflow.nodes ?? payload.nodes,
+                    connections: createdWorkflow.connections ?? payload.connections,
+                    settings: createdWorkflow.settings ?? payload.settings,
+                });
+            } catch (error: any) {
+                console.warn(
+                    `[N8nApiClient] Workflow ${createdWorkflow.id} was created, but setting its description failed: ${error.message}`
+                );
+            }
+        }
+
+        return createdWorkflow;
+    }
+
+    private cleanWorkflowCreatePayload(payload: Partial<IWorkflow>): Partial<IWorkflow> {
+        const allowedKeys = new Set([
+            'name',
+            'nodes',
+            'connections',
+            'settings',
+            'staticData',
+            'projectId',
+        ]);
+
+        const clean: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(payload as Record<string, unknown>)) {
+            if (allowedKeys.has(key) && value !== undefined) {
+                clean[key] = value;
+            }
+        }
+
+        return clean as Partial<IWorkflow>;
     }
 
     async getTags(): Promise<ITag[]> {

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -6,6 +6,7 @@ export interface IN8nCredentials {
 export interface IWorkflow {
     id: string;
     name: string;
+    description?: string;
     active: boolean;
     nodes: any[];
     connections: any;

--- a/packages/cli/tests/unit/n8n-api-client.test.ts
+++ b/packages/cli/tests/unit/n8n-api-client.test.ts
@@ -226,6 +226,87 @@ describe('N8nApiClient test workflow support', () => {
         expect(mockAxiosGet).toHaveBeenNthCalledWith(2, '/api/v1/projects');
     });
 
+    it('strips fields rejected by the workflow create endpoint and restores description via update', async () => {
+        const client = new N8nApiClient({ host: 'https://n8n.local', apiKey: 'secret' });
+        mockAxiosPost.mockResolvedValueOnce({
+            data: {
+                id: 'wf-1',
+                name: 'Created Workflow',
+                nodes: [],
+                connections: {},
+                settings: { executionOrder: 'v1' },
+            },
+        });
+        mockAxiosPut.mockResolvedValueOnce({
+            status: 200,
+            data: {
+                id: 'wf-1',
+                name: 'Created Workflow',
+                description: 'Local-only workflow description',
+                nodes: [],
+                connections: {},
+                settings: { executionOrder: 'v1' },
+            },
+        });
+
+        await client.createWorkflow({
+            id: 'local-id',
+            name: 'Created Workflow',
+            description: 'Local-only workflow description',
+            active: false,
+            tags: [{ id: 'tag-1', name: 'Tag 1' }],
+            nodes: [],
+            connections: {},
+            settings: { executionOrder: 'v1' },
+            projectId: 'project-1',
+        } as any);
+
+        expect(mockAxiosPost).toHaveBeenCalledWith('/api/v1/workflows', {
+            name: 'Created Workflow',
+            nodes: [],
+            connections: {},
+            settings: { executionOrder: 'v1' },
+            projectId: 'project-1',
+        });
+        expect(mockAxiosPut).toHaveBeenCalledWith('/api/v1/workflows/wf-1', {
+            name: 'Created Workflow',
+            description: 'Local-only workflow description',
+            nodes: [],
+            connections: {},
+            settings: { executionOrder: 'v1' },
+        });
+    });
+
+    it('still returns the created workflow when the follow-up description update fails', async () => {
+        const client = new N8nApiClient({ host: 'https://n8n.local', apiKey: 'secret' });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        mockAxiosPost.mockResolvedValueOnce({
+            data: {
+                id: 'wf-created',
+                name: 'Created Workflow',
+                nodes: [],
+                connections: {},
+                settings: { executionOrder: 'v1' },
+            },
+        });
+        mockAxiosPut.mockRejectedValueOnce(new Error('update failed'));
+
+        await expect(client.createWorkflow({
+            name: 'Created Workflow',
+            description: 'Description that may need update support',
+            nodes: [],
+            connections: {},
+            settings: { executionOrder: 'v1' },
+        } as any)).resolves.toMatchObject({
+            id: 'wf-created',
+            name: 'Created Workflow',
+        });
+
+        expect(mockAxiosPost).toHaveBeenCalledOnce();
+        expect(mockAxiosPut).toHaveBeenCalledOnce();
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Workflow wf-created was created'));
+    });
+
     it('normalizes webhook paths with leading slashes and special characters', () => {
         const client = new N8nApiClient({ host: 'https://n8n.local', apiKey: 'secret' });
 


### PR DESCRIPTION
## Summary

- Sanitizes workflow create payloads to match n8n's `workflowCreate` schema.
- Preserves `@workflow({ description })` on first push by creating the workflow first, then applying the description through the update endpoint.
- Keeps the create path resilient: if the follow-up description update fails, the created workflow is still returned so the n8n-generated ID can be written locally.
- Adds `description` to the CLI workflow type and covers success/failure behavior in API client tests.

## Root Cause

n8n 2.17.6 exposes different schemas for workflow creation and update. `POST /api/v1/workflows` uses `workflowCreate`, which rejects `description` as an additional property. `PUT /api/v1/workflows/{id}` uses the full `workflow` schema, which accepts `description`. Sending the local workflow payload directly to create caused first push of described workflows to fail with HTTP 400.

## Validation

- `npm run build --workspace=packages/cli`
- `npm run test:unit --workspace=packages/cli -- tests/unit/n8n-api-client.test.ts`
- Live smoke against local n8n 2.17.6: `N8nApiClient.createWorkflow()` created a workflow, applied description via update, returned the generated ID, and the probe workflow was deleted afterward.