### PR TITLE
fix(ci): prevent docs workflow failures off main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -93,9 +93,11 @@ jobs:
         run: npm run build
 
       - name: Setup Pages
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         uses: actions/configure-pages@v4
 
       - name: Upload artifact
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs/build


### PR DESCRIPTION
## Summary
- restrict GitHub Pages setup in the docs workflow to non-PR runs on `main`
- keep documentation build and validation running on other branches without Pages-specific steps
- avoid branch-specific CI failures while preserving the existing `main` deployment path