### PR TITLE
Preserve pinned workflow directories and descriptions

### DIFF
--- a/packages/cli/src/commands/base.ts
+++ b/packages/cli/src/commands/base.ts
@@ -48,7 +48,7 @@ export class BaseCommand {
                 process.exit(1);
             }
             this.activeInstanceId = match.id;
-            directory = match.syncFolder || './workflows';
+            directory = this.configService.resolveWorkspacePath(match.syncFolder || './workflows');
             folderSync = match.folderSync ?? false;
         } else {
             const localConfig = this.configService.getLocalConfig();
@@ -76,7 +76,7 @@ export class BaseCommand {
                 process.exit(1);
             }
 
-            directory = localConfig.syncFolder || './workflows';
+            directory = this.configService.resolveWorkspacePath(localConfig.syncFolder || './workflows');
             folderSync = localConfig.folderSync ?? false;
         }
 
@@ -142,6 +142,9 @@ export class BaseCommand {
 
         return {
             directory: this.config.directory,
+            workflowDir: localConfig.workflowDir
+                ? this.configService.resolveWorkspacePath(localConfig.workflowDir)
+                : undefined,
             syncInactive: true,
             ignoredTags: [],
             instanceIdentifier: instanceIdentifier,

--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -478,8 +478,51 @@ export class N8nApiClient {
     }
 
     async createWorkflow(payload: Partial<IWorkflow>): Promise<IWorkflow> {
-        const res = await this.client.post('/api/v1/workflows', payload);
-        return res.data;
+        const createPayload = this.cleanWorkflowCreatePayload(payload);
+        const res = await this.client.post('/api/v1/workflows', createPayload);
+        const createdWorkflow = res.data as IWorkflow;
+
+        if (
+            createdWorkflow?.id &&
+            typeof payload.description === 'string' &&
+            payload.description.length > 0
+        ) {
+            try {
+                return await this.updateWorkflow(createdWorkflow.id, {
+                    ...payload,
+                    name: createdWorkflow.name ?? payload.name,
+                    nodes: createdWorkflow.nodes ?? payload.nodes,
+                    connections: createdWorkflow.connections ?? payload.connections,
+                    settings: createdWorkflow.settings ?? payload.settings,
+                });
+            } catch (error: any) {
+                console.warn(
+                    `[N8nApiClient] Workflow ${createdWorkflow.id} was created, but setting its description failed: ${error.message}`
+                );
+            }
+        }
+
+        return createdWorkflow;
+    }
+
+    private cleanWorkflowCreatePayload(payload: Partial<IWorkflow>): Partial<IWorkflow> {
+        const allowedKeys = new Set([
+            'name',
+            'nodes',
+            'connections',
+            'settings',
+            'staticData',
+            'projectId',
+        ]);
+
+        const clean: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(payload as Record<string, unknown>)) {
+            if (allowedKeys.has(key) && value !== undefined) {
+                clean[key] = value;
+            }
+        }
+
+        return clean as Partial<IWorkflow>;
     }
 
     async getTags(): Promise<ITag[]> {

--- a/packages/cli/src/core/services/sync-manager.ts
+++ b/packages/cli/src/core/services/sync-manager.ts
@@ -31,13 +31,13 @@ export class SyncManager extends EventEmitter {
     private async ensureInitialized() {
         if (this.watcher) return;
 
-        // Build project-scoped directory: baseDir/instanceId/projectSlug
-        const projectSlug = createProjectSlug(this.config.projectName);
-        const instanceDir = path.join(
-            this.config.directory, 
-            this.config.instanceIdentifier || 'default',
-            projectSlug
-        );
+        const instanceDir = this.config.workflowDir
+            ? path.normalize(this.config.workflowDir)
+            : path.join(
+                this.config.directory,
+                this.config.instanceIdentifier || 'default',
+                createProjectSlug(this.config.projectName),
+            );
         
         if (!fs.existsSync(instanceDir)) {
             fs.mkdirSync(instanceDir, { recursive: true });

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -56,6 +56,7 @@ export interface IWorkflowStatus {
 
 export interface ISyncConfig {
     directory: string;
+    workflowDir?: string;        // Optional explicit workflow directory override
     syncInactive: boolean; // internal default true
     ignoredTags: string[]; // internal default []
     instanceIdentifier?: string; // Optional: auto-generated if not provided

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -6,6 +6,7 @@ export interface IN8nCredentials {
 export interface IWorkflow {
     id: string;
     name: string;
+    description?: string;
     active: boolean;
     nodes: any[];
     connections: any;

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -59,14 +59,16 @@ export type ISelectInstanceResult =
 export class ConfigService {
     private globalStore: Conf;
     private localConfigPath: string;
+    private workspaceRoot: string;
 
-    constructor(workspaceRoot = process.cwd()) {
+    constructor(workspaceRoot?: string) {
         this.globalStore = new Conf({
             projectName: 'n8nac',
             configName: 'credentials',
             configFileMode: 0o600
         });
-        this.localConfigPath = path.join(workspaceRoot, 'n8nac-config.json');
+        this.workspaceRoot = workspaceRoot ? path.resolve(workspaceRoot) : this.findConfigRoot(process.cwd());
+        this.localConfigPath = path.join(this.workspaceRoot, 'n8nac-config.json');
     }
 
     /**
@@ -280,9 +282,10 @@ export class ConfigService {
             persistedVerification = this.buildPersistedVerification(verifiedOrFailed, current?.verification);
         }
 
-        const profile = this.sanitizeInstanceProfile({
+        const profile = this.prepareInstanceProfile(current, {
             ...current,
             ...input,
+            workflowDir: input.workflowDir,
             id: current?.id || options.instanceId || this.createInstanceId(),
             name: this.resolveInstanceName({
                 current,
@@ -290,9 +293,9 @@ export class ConfigService {
                 requestedName: options.instanceName,
                 verification,
             }),
-            instanceIdentifier: verification
-                ? (verification.status === 'verified' ? verification.instanceIdentifier : undefined)
-                : (input.instanceIdentifier || current?.instanceIdentifier),
+            instanceIdentifier: input.instanceIdentifier
+                || current?.instanceIdentifier
+                || (verification?.status === 'verified' ? verification.instanceIdentifier : undefined),
             verification: persistedVerification,
         });
 
@@ -354,9 +357,10 @@ export class ConfigService {
             ? workspaceConfig.instances.find((instance) => instance.id === targetId)
             : undefined;
 
-        const profile = this.sanitizeInstanceProfile({
+        const profile = this.prepareInstanceProfile(current, {
             ...current,
             ...config,
+            workflowDir: config.workflowDir,
             id: current?.id || options.instanceId || this.createInstanceId(),
             name: options.instanceName?.trim() || current?.name || this.createDefaultInstanceName(config.host || current?.host),
         });
@@ -378,7 +382,7 @@ export class ConfigService {
     ): IInstanceProfile {
         const workspaceConfig = this.getWorkspaceConfig();
         const current = profile.id ? workspaceConfig.instances.find((instance) => instance.id === profile.id) : undefined;
-        const savedProfile = this.sanitizeInstanceProfile({
+        const savedProfile = this.prepareInstanceProfile(current, {
             ...current,
             ...profile,
             id: current?.id || profile.id || this.createInstanceId(),
@@ -478,14 +482,14 @@ export class ConfigService {
 
         const updated = this.saveInstanceProfile({
             ...instance,
+            workflowDir: undefined,
             name: this.resolveInstanceName({
                 current: instance,
                 host,
                 verification,
             }),
-            instanceIdentifier: verification.status === 'verified'
-                ? verification.instanceIdentifier
-                : undefined,
+            instanceIdentifier: instance.instanceIdentifier
+                || (verification.status === 'verified' ? verification.instanceIdentifier : undefined),
             verification: persistedVerification,
         }, {
             setActive: instance.id === this.getActiveInstanceId(),
@@ -587,6 +591,10 @@ export class ConfigService {
         const active = instanceId ? this.getInstance(instanceId) : this.getActiveInstance();
         const apiKey = this.getApiKey(host, instanceId || active?.id);
 
+        if (active?.instanceIdentifier) {
+            return active.instanceIdentifier;
+        }
+
         if (!apiKey) {
             throw new Error('API key not found');
         }
@@ -628,6 +636,32 @@ export class ConfigService {
      */
     getInstanceConfigPath(): string {
         return this.localConfigPath;
+    }
+
+    getWorkspaceRoot(): string {
+        return this.workspaceRoot;
+    }
+
+    resolveWorkspacePath(targetPath: string): string {
+        return path.isAbsolute(targetPath)
+            ? targetPath
+            : path.resolve(this.workspaceRoot, targetPath);
+    }
+
+    private findConfigRoot(startDir: string): string {
+        let currentDir = path.resolve(startDir);
+
+        while (true) {
+            if (fs.existsSync(path.join(currentDir, 'n8nac-config.json'))) {
+                return currentDir;
+            }
+
+            const parentDir = path.dirname(currentDir);
+            if (parentDir === currentDir) {
+                return path.resolve(startDir);
+            }
+            currentDir = parentDir;
+        }
     }
 
     private loadWorkspaceConfig(): { config: IWorkspaceConfig; shouldPersist: boolean } {
@@ -820,13 +854,9 @@ export class ConfigService {
             ? profile.name.trim()
             : this.createDefaultInstanceName(localConfig.host);
 
-        // Recompute workflowDir whenever all three deps are present, so the stored value stays in sync
-        if (localConfig.syncFolder && localConfig.instanceIdentifier && localConfig.projectName) {
-            localConfig.workflowDir = this.normalizeConfigPath(
-                localConfig.syncFolder,
-                localConfig.instanceIdentifier,
-                createProjectSlug(localConfig.projectName),
-            );
+        // Compute workflowDir when absent; preserve explicit/pinned paths from config.
+        if (!localConfig.workflowDir) {
+            localConfig.workflowDir = this.computeWorkflowDir(localConfig);
         }
 
         return {
@@ -835,6 +865,50 @@ export class ConfigService {
             ...localConfig,
             verification: this.sanitizeVerification((profile as Partial<IInstanceProfile>).verification),
         };
+    }
+
+    private prepareInstanceProfile(
+        current: IInstanceProfile | undefined,
+        profile: Record<string, unknown> | Partial<IInstanceProfile>
+    ): IInstanceProfile {
+        const next = { ...profile } as Partial<IInstanceProfile>;
+        const incomingWorkflowDir = typeof next.workflowDir === 'string' && next.workflowDir.trim() !== ''
+            ? next.workflowDir.trim()
+            : undefined;
+        const currentWorkflowDir = current?.workflowDir;
+        const currentWorkflowDirIsGenerated = !!current && this.isGeneratedWorkflowDir(current);
+        const workflowDirIsExplicit = !!incomingWorkflowDir && (
+            !current ||
+            incomingWorkflowDir !== currentWorkflowDir ||
+            !currentWorkflowDirIsGenerated
+        );
+
+        if (workflowDirIsExplicit) {
+            next.workflowDir = incomingWorkflowDir;
+        } else if (!incomingWorkflowDir && currentWorkflowDir && !currentWorkflowDirIsGenerated) {
+            next.workflowDir = currentWorkflowDir;
+        } else {
+            delete next.workflowDir;
+        }
+
+        return this.sanitizeInstanceProfile(next);
+    }
+
+    private computeWorkflowDir(config: Partial<ILocalConfig>): string | undefined {
+        if (!config.syncFolder || !config.instanceIdentifier || !config.projectName) {
+            return undefined;
+        }
+
+        return this.normalizeConfigPath(
+            config.syncFolder,
+            config.instanceIdentifier,
+            createProjectSlug(config.projectName),
+        );
+    }
+
+    private isGeneratedWorkflowDir(config: Partial<ILocalConfig>): boolean {
+        const expectedWorkflowDir = this.computeWorkflowDir(config);
+        return !!config.workflowDir && !!expectedWorkflowDir && config.workflowDir === expectedWorkflowDir;
     }
 
     private sanitizeVerification(verification: IInstanceVerification | undefined): IInstanceVerification | undefined {

--- a/packages/cli/tests/unit/config-service.test.ts
+++ b/packages/cli/tests/unit/config-service.test.ts
@@ -45,6 +45,37 @@ describe('ConfigService', () => {
         }));
     });
 
+    it('finds n8nac-config.json in a parent directory when no workspace root is provided', () => {
+        const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/tmp/workspace/backend');
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockImplementation((filePath: string) =>
+            filePath === '/tmp/workspace/n8nac-config.json'
+        );
+
+        try {
+            const discoveredConfigService = new ConfigService();
+
+            expect(discoveredConfigService.getWorkspaceRoot()).toBe('/tmp/workspace');
+            expect(discoveredConfigService.getInstanceConfigPath()).toBe('/tmp/workspace/n8nac-config.json');
+            expect(discoveredConfigService.resolveWorkspacePath('workflows')).toBe('/tmp/workspace/workflows');
+        } finally {
+            cwdSpy.mockRestore();
+        }
+    });
+
+    it('uses the current directory as workspace root when no config file is found', () => {
+        const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/tmp/workspace/backend');
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+        try {
+            const discoveredConfigService = new ConfigService();
+
+            expect(discoveredConfigService.getWorkspaceRoot()).toBe('/tmp/workspace/backend');
+            expect(discoveredConfigService.getInstanceConfigPath()).toBe('/tmp/workspace/backend/n8nac-config.json');
+        } finally {
+            cwdSpy.mockRestore();
+        }
+    });
+
     it('returns the active instance as the local config when the workspace config already contains a library', () => {
         const workspaceConfig: IWorkspaceConfig = {
             version: 2,
@@ -253,6 +284,69 @@ describe('ConfigService', () => {
         expect(persistedConfig.workflowDir).toBe('//server/share/workflows/unc_instance/production');
     });
 
+    it('preserves an explicit workflowDir instead of recomputing it', () => {
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+        const savedProfile = configService.saveLocalConfig({
+            host: 'https://prod.example.com',
+            syncFolder: 'workflows',
+            projectId: 'project-prod',
+            projectName: 'Production',
+            instanceIdentifier: 'prod_identifier',
+            workflowDir: 'shared/workflows/project',
+        }, {
+            instanceName: 'Production'
+        });
+
+        expect(savedProfile.workflowDir).toBe('shared/workflows/project');
+        const persistedConfig = JSON.parse((fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1]);
+        expect(persistedConfig.workflowDir).toBe('shared/workflows/project');
+    });
+
+    it('recomputes a generated workflowDir when project settings change', () => {
+        const workspaceConfig: IWorkspaceConfig = {
+            version: 2,
+            activeInstanceId: 'prod',
+            instances: [
+                {
+                    id: 'prod',
+                    name: 'Production',
+                    host: 'https://prod.example.com',
+                    syncFolder: 'workflows',
+                    projectId: 'project-old',
+                    projectName: 'Old Project',
+                    instanceIdentifier: 'prod_identifier',
+                    workflowDir: 'workflows/prod_identifier/old_project',
+                }
+            ],
+            host: 'https://prod.example.com',
+            syncFolder: 'workflows',
+            projectId: 'project-old',
+            projectName: 'Old Project',
+            instanceIdentifier: 'prod_identifier',
+            workflowDir: 'workflows/prod_identifier/old_project',
+        };
+
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+        (fs.readFileSync as any).mockReturnValue(JSON.stringify(workspaceConfig));
+
+        const updated = configService.updateInstanceConfig({
+            host: 'https://prod.example.com',
+            syncFolder: 'n8n-workflows',
+            projectId: 'project-new',
+            projectName: 'New Project',
+        }, {
+            instanceId: 'prod',
+            instanceName: 'Production',
+            setActive: true,
+        });
+
+        expect(updated.workflowDir).toBe('n8n-workflows/prod_identifier/new_project');
+        const persistedConfig = JSON.parse((fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1]);
+        expect(persistedConfig.workflowDir).toBe('n8n-workflows/prod_identifier/new_project');
+        expect(persistedConfig.instances[0].workflowDir).toBe('n8n-workflows/prod_identifier/new_project');
+    });
+
     it('rejects creating a duplicate verified instance config for the same host and authenticated user', async () => {
         (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
 
@@ -308,6 +402,67 @@ describe('ConfigService', () => {
         if (duplicate.status === 'duplicate') {
             expect(duplicate.duplicateInstance.name).toContain('prod.example.com');
         }
+    });
+
+    it('keeps pinned instanceIdentifier and workflowDir when verification resolves a different user', async () => {
+        const workspaceConfig: IWorkspaceConfig = {
+            version: 2,
+            activeInstanceId: 'prod',
+            instances: [
+                {
+                    id: 'prod',
+                    name: 'Production',
+                    host: 'https://prod.example.com',
+                    syncFolder: 'workflows',
+                    projectId: 'project-prod',
+                    projectName: 'Production',
+                    instanceIdentifier: 'shared_instance',
+                    workflowDir: 'workflows/shared/project',
+                }
+            ],
+            host: 'https://prod.example.com',
+            syncFolder: 'workflows',
+            projectId: 'project-prod',
+            projectName: 'Production',
+            instanceIdentifier: 'shared_instance',
+            workflowDir: 'workflows/shared/project',
+        };
+
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+        (fs.readFileSync as any).mockReturnValue(JSON.stringify(workspaceConfig));
+
+        const result = await configService.upsertInstanceConfigWithVerification({
+            host: 'https://prod.example.com',
+            apiKey: 'bob-key',
+            syncFolder: 'workflows',
+            projectId: 'project-prod',
+            projectName: 'Production',
+        }, {
+            createNew: false,
+            setActive: true,
+            client: {
+                async getCurrentUser() {
+                    return {
+                        id: 'bob',
+                        email: 'bob@example.com',
+                        firstName: 'Bob',
+                        lastName: 'Jones',
+                    };
+                }
+            }
+        });
+
+        expect(result.status).toBe('saved');
+        if (result.status === 'saved') {
+            expect(result.profile.instanceIdentifier).toBe('shared_instance');
+            expect(result.profile.workflowDir).toBe('workflows/shared/project');
+        }
+
+        const persistedConfig = JSON.parse((fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1]);
+        expect(persistedConfig.instanceIdentifier).toBe('shared_instance');
+        expect(persistedConfig.workflowDir).toBe('workflows/shared/project');
+        expect(persistedConfig.instances[0].instanceIdentifier).toBe('shared_instance');
+        expect(persistedConfig.instances[0].workflowDir).toBe('workflows/shared/project');
     });
 
     it('setActiveInstance rewrites the top-level active config cache', () => {
@@ -477,6 +632,39 @@ describe('ConfigService', () => {
         const persistedConfig = JSON.parse((fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1]);
         expect(persistedConfig.instanceIdentifier).toBe('recomputed-id');
         expect(persistedConfig.instances[0].instanceIdentifier).toBe('recomputed-id');
+    });
+
+    it('getOrCreateInstanceIdentifier returns the pinned identifier without re-verifying', async () => {
+        const workspaceConfig: IWorkspaceConfig = {
+            version: 2,
+            activeInstanceId: 'prod',
+            instances: [
+                {
+                    id: 'prod',
+                    name: 'Production',
+                    host: 'https://prod.example.com',
+                    syncFolder: 'workflows',
+                    projectId: 'project-prod',
+                    projectName: 'Production',
+                    instanceIdentifier: 'shared_instance'
+                }
+            ],
+            host: 'https://prod.example.com',
+            syncFolder: 'workflows',
+            projectId: 'project-prod',
+            projectName: 'Production',
+            instanceIdentifier: 'shared_instance'
+        };
+
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+        (fs.readFileSync as any).mockReturnValue(JSON.stringify(workspaceConfig));
+        mockConf.get.mockReturnValue({ prod: 'test-key' });
+
+        const result = await configService.getOrCreateInstanceIdentifier('https://prod.example.com', 'prod');
+
+        expect(result).toBe('shared_instance');
+        expect(mockResolveInstanceIdentifier).not.toHaveBeenCalled();
+        expect(fs.writeFileSync).not.toHaveBeenCalled();
     });
 
     it('selectInstanceConfigWithVerification switches to the already verified duplicate config', async () => {

--- a/packages/cli/tests/unit/n8n-api-client.test.ts
+++ b/packages/cli/tests/unit/n8n-api-client.test.ts
@@ -226,6 +226,87 @@ describe('N8nApiClient test workflow support', () => {
         expect(mockAxiosGet).toHaveBeenNthCalledWith(2, '/api/v1/projects');
     });
 
+    it('strips fields rejected by the workflow create endpoint and restores description via update', async () => {
+        const client = new N8nApiClient({ host: 'https://n8n.local', apiKey: 'secret' });
+        mockAxiosPost.mockResolvedValueOnce({
+            data: {
+                id: 'wf-1',
+                name: 'Created Workflow',
+                nodes: [],
+                connections: {},
+                settings: { executionOrder: 'v1' },
+            },
+        });
+        mockAxiosPut.mockResolvedValueOnce({
+            status: 200,
+            data: {
+                id: 'wf-1',
+                name: 'Created Workflow',
+                description: 'Local-only workflow description',
+                nodes: [],
+                connections: {},
+                settings: { executionOrder: 'v1' },
+            },
+        });
+
+        await client.createWorkflow({
+            id: 'local-id',
+            name: 'Created Workflow',
+            description: 'Local-only workflow description',
+            active: false,
+            tags: [{ id: 'tag-1', name: 'Tag 1' }],
+            nodes: [],
+            connections: {},
+            settings: { executionOrder: 'v1' },
+            projectId: 'project-1',
+        } as any);
+
+        expect(mockAxiosPost).toHaveBeenCalledWith('/api/v1/workflows', {
+            name: 'Created Workflow',
+            nodes: [],
+            connections: {},
+            settings: { executionOrder: 'v1' },
+            projectId: 'project-1',
+        });
+        expect(mockAxiosPut).toHaveBeenCalledWith('/api/v1/workflows/wf-1', {
+            name: 'Created Workflow',
+            description: 'Local-only workflow description',
+            nodes: [],
+            connections: {},
+            settings: { executionOrder: 'v1' },
+        });
+    });
+
+    it('still returns the created workflow when the follow-up description update fails', async () => {
+        const client = new N8nApiClient({ host: 'https://n8n.local', apiKey: 'secret' });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        mockAxiosPost.mockResolvedValueOnce({
+            data: {
+                id: 'wf-created',
+                name: 'Created Workflow',
+                nodes: [],
+                connections: {},
+                settings: { executionOrder: 'v1' },
+            },
+        });
+        mockAxiosPut.mockRejectedValueOnce(new Error('update failed'));
+
+        await expect(client.createWorkflow({
+            name: 'Created Workflow',
+            description: 'Description that may need update support',
+            nodes: [],
+            connections: {},
+            settings: { executionOrder: 'v1' },
+        } as any)).resolves.toMatchObject({
+            id: 'wf-created',
+            name: 'Created Workflow',
+        });
+
+        expect(mockAxiosPost).toHaveBeenCalledOnce();
+        expect(mockAxiosPut).toHaveBeenCalledOnce();
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Workflow wf-created was created'));
+    });
+
     it('normalizes webhook paths with leading slashes and special characters', () => {
         const client = new N8nApiClient({ host: 'https://n8n.local', apiKey: 'secret' });
 

--- a/packages/cli/tests/unit/sync-manager.test.ts
+++ b/packages/cli/tests/unit/sync-manager.test.ts
@@ -167,4 +167,24 @@ describe('SyncManager push filename contract', () => {
         expect(refreshLocalState.mock.invocationCallOrder[0]).toBeLessThan(getWorkflowIdForFilename.mock.invocationCallOrder[0]);
         expect(push).toHaveBeenCalledWith(workflowFilename, 'wf-123', expect.any(String));
     });
+
+    it('uses an explicit workflowDir as the active sync scope', async () => {
+        const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-sync-manager-'));
+        const workflowDir = path.join(workspaceDir, 'shared', 'project');
+        const manager = new SyncManager(new MockN8nApiClient() as any, {
+            directory: path.join(workspaceDir, 'generated-base'),
+            workflowDir,
+            syncInactive: true,
+            ignoredTags: [],
+            projectId: 'project-1',
+            projectName: 'Personal',
+            instanceIdentifier: 'generated_instance',
+        });
+
+        await (manager as any).ensureInitialized();
+
+        expect((manager as any).watcher.getDirectory()).toBe(workflowDir);
+        expect(fs.existsSync(path.join(workflowDir, 'n8n-workflows.d.ts'))).toBe(true);
+        expect(fs.existsSync(path.join(workspaceDir, 'generated-base', 'generated_instance', 'personal'))).toBe(false);
+    });
 });


### PR DESCRIPTION
## Summary

- Discover `n8nac-config.json` from parent directories and resolve configured workflow paths relative to the workspace root.
- Preserve explicit/pinned `workflowDir` and `instanceIdentifier` values while still recomputing generated workflow directories when project settings change.
- Allow sync to use an explicit workflow directory and keep workflow descriptions when creating workflows by stripping create-only payload fields, then applying descriptions through update.

## Validation

- `npm run test:unit --workspace=packages/cli -- --run tests/unit/config-service.test.ts tests/unit/n8n-api-client.test.ts tests/unit/sync-manager.test.ts`
- Result: 23 test files passed, 164 tests passed.