### PR TITLE
[codex] Stabilize instance sync identifiers

### DIFF
--- a/packages/cli/src/core/services/instance-identifier.ts
+++ b/packages/cli/src/core/services/instance-identifier.ts
@@ -15,6 +15,8 @@ export interface IInstanceIdentifierClient {
 
 export interface IResolvedInstanceIdentifier {
     identifier: string;
+    source: 'user' | 'apiKey';
+    usedFallback: boolean;
 }
 
 export interface IResolveInstanceIdentifierOptions {
@@ -43,17 +45,23 @@ export async function resolveInstanceIdentifier(
             throw error;
         }
         return {
-            identifier: createApiKeyInstanceIdentifier(credentials.apiKey)
+            identifier: createApiKeyInstanceIdentifier(credentials.apiKey),
+            source: 'apiKey',
+            usedFallback: true,
         };
     }
 
     if (!user?.id) {
         return {
-            identifier: createApiKeyInstanceIdentifier(credentials.apiKey)
+            identifier: createApiKeyInstanceIdentifier(credentials.apiKey),
+            source: 'apiKey',
+            usedFallback: true,
         };
     }
 
     return {
-        identifier: createInstanceIdentifier(credentials.host, user)
+        identifier: createInstanceIdentifier(credentials.host, user),
+        source: 'user',
+        usedFallback: false,
     };
 }

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -2,7 +2,7 @@ import Conf from 'conf';
 import { randomUUID } from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import { N8nApiClient, createInstanceIdentifier, createProjectSlug, normalizeHostForIdentity } from '../core/index.js';
+import { N8nApiClient, createApiKeyInstanceIdentifier, createInstanceIdentifier, createProjectSlug, normalizeHostForIdentity } from '../core/index.js';
 
 // Unified local config written to n8nac-config.json (legacy n8nac.json/n8nac-instance.json deprecated)
 export interface ILocalConfig {
@@ -962,7 +962,7 @@ export class ConfigService {
 
             const resolvedUser = user ?? {};
 
-            const duplicateInstance = this.findVerifiedDuplicate(normalizedHost, userId, exceptInstanceId);
+            const duplicateInstance = this.findVerifiedDuplicate(normalizedHost, userId, resolvedUser.email, exceptInstanceId);
             if (duplicateInstance) {
                 return {
                     status: 'duplicate',
@@ -980,7 +980,9 @@ export class ConfigService {
                 userId,
                 userName: this.createUserDisplayName(resolvedUser),
                 userEmail: resolvedUser.email,
-                instanceIdentifier: createInstanceIdentifier(host, resolvedUser),
+                instanceIdentifier: resolvedUser.id
+                    ? createInstanceIdentifier(host, resolvedUser)
+                    : createApiKeyInstanceIdentifier(apiKey),
             };
         } catch (error: any) {
             return {
@@ -993,13 +995,19 @@ export class ConfigService {
     private findVerifiedDuplicate(
         normalizedHost: string,
         userId: string,
+        userEmail?: string,
         exceptInstanceId?: string
     ): IInstanceProfile | undefined {
+        const normalizedUserEmail = userEmail?.trim().toLowerCase();
+
         return this.listInstances().find((instance) =>
             instance.id !== exceptInstanceId &&
             instance.verification?.status === 'verified' &&
             instance.verification.normalizedHost === normalizedHost &&
-            instance.verification.userId === userId
+            (
+                instance.verification.userId === userId ||
+                (!!normalizedUserEmail && instance.verification.userEmail?.trim().toLowerCase() === normalizedUserEmail)
+            )
         );
     }
 

--- a/packages/cli/tests/unit/config-service.test.ts
+++ b/packages/cli/tests/unit/config-service.test.ts
@@ -405,6 +405,90 @@ describe('ConfigService', () => {
         }
     });
 
+    it('uses the API-key fallback identifier when verification resolves email but no user ID', async () => {
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+        const result = await configService.upsertInstanceConfigWithVerification({
+            host: 'https://prod.example.com',
+            apiKey: 'prod-key',
+            syncFolder: 'workflows',
+            projectId: 'project-prod',
+            projectName: 'Production'
+        }, {
+            createNew: true,
+            setActive: true,
+            client: {
+                async getCurrentUser() {
+                    return {
+                        email: 'etienne@example.com',
+                    };
+                }
+            }
+        });
+
+        expect(result.status).toBe('saved');
+        if (result.status === 'saved') {
+            expect(result.profile.verification?.status).toBe('verified');
+            expect(result.profile.verification?.userId).toBe('etienne@example.com');
+            expect(result.profile.instanceIdentifier).toBe('key_037abd8d69');
+            expect(result.profile.workflowDir).toBe('workflows/key_037abd8d69/production');
+        }
+    });
+
+    it('detects duplicates when an email-only verification later resolves a stable user ID', async () => {
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+        const emailOnly = await configService.upsertInstanceConfigWithVerification({
+            host: 'https://prod.example.com',
+            apiKey: 'prod-key',
+            syncFolder: 'workflows',
+            projectId: 'project-prod',
+            projectName: 'Production'
+        }, {
+            createNew: true,
+            setActive: true,
+            client: {
+                async getCurrentUser() {
+                    return {
+                        email: 'etienne@example.com',
+                    };
+                }
+            }
+        });
+
+        expect(emailOnly.status).toBe('saved');
+
+        const persisted = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1];
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+        (fs.readFileSync as any).mockReturnValue(persisted);
+
+        const withStableId = await configService.upsertInstanceConfigWithVerification({
+            host: 'https://prod.example.com',
+            apiKey: 'another-key',
+            syncFolder: 'workflows-copy',
+            projectId: 'project-prod',
+            projectName: 'Production'
+        }, {
+            createNew: true,
+            setActive: true,
+            client: {
+                async getCurrentUser() {
+                    return {
+                        id: 'user-1',
+                        email: 'etienne@example.com',
+                        firstName: 'Etienne',
+                        lastName: 'Lescot',
+                    };
+                }
+            }
+        });
+
+        expect(withStableId.status).toBe('duplicate');
+        if (withStableId.status === 'duplicate') {
+            expect(withStableId.duplicateInstance.verification?.userId).toBe('etienne@example.com');
+        }
+    });
+
     it('keeps pinned instanceIdentifier and workflowDir when verification resolves a different user', async () => {
         const workspaceConfig: IWorkspaceConfig = {
             version: 2,

--- a/packages/vscode-extension/tests/unit/unified-config.test.ts
+++ b/packages/vscode-extension/tests/unit/unified-config.test.ts
@@ -29,6 +29,7 @@ test('buildUnifiedWorkspaceConfig regenerates stale instanceIdentifier from curr
         client: {
             async getCurrentUser() {
                 return {
+                    id: 'user-1',
                     email: 'etienne@example.com',
                     firstName: 'Etienne',
                     lastName: 'Lescot'
@@ -37,10 +38,10 @@ test('buildUnifiedWorkspaceConfig regenerates stale instanceIdentifier from curr
         }
     });
 
-    assert.strictEqual(unified.instanceIdentifier, 'etiennel_cloud_etienne_l');
+    assert.strictEqual(unified.instanceIdentifier, 'n8n_c6c289e49e_etienne_l');
     assert.strictEqual(unified.activeInstanceId, unified.instances[0].id);
     assert.strictEqual(unified.instances[0].name, 'Cloud');
-    assert.strictEqual(unified.instances[0].instanceIdentifier, 'etiennel_cloud_etienne_l');
+    assert.strictEqual(unified.instances[0].instanceIdentifier, 'n8n_c6c289e49e_etienne_l');
 });
 
 test('buildUnifiedWorkspaceConfig clears instanceIdentifier when credentials are incomplete', async () => {


### PR DESCRIPTION
## What changed

- Generate sync instance identifiers from the stable n8n user ID when available, instead of the host slug.
- Add a hostless API-key hash fallback for cases where n8n user identity cannot be resolved.
- Remove the previous host-based fallback path so host changes do not move the local sync folder.
- Cover stable user IDs and hostless fallback behavior in unit tests.

## Why

The sync folder path included host-derived values such as `local_5681`, so changing a variable host URL moved the local workflow directory. The identifier now avoids host-derived data and prefers a stable user identity.

## Validation

- `npx vitest run tests/unit/directory-utils.test.ts tests/unit/config-service.test.ts`
- `npm run build`