### PR TITLE
feat: stable instance identifiers

### DIFF
--- a/packages/cli/src/core/services/directory-utils.ts
+++ b/packages/cli/src/core/services/directory-utils.ts
@@ -80,30 +80,39 @@ export function createUserSlug(user: { id?: string; email?: string; firstName?: 
     return 'user';
 }
 
+function createStableUserIdentitySlug(user: { id?: string; email?: string; firstName?: string; lastName?: string }): string | undefined {
+    if (!user.id) {
+        return undefined;
+    }
+
+    const identityHash = crypto.createHash('sha256').update(user.id).digest('hex').substring(0, 10);
+    const displaySlug = createUserSlug({
+        email: user.email,
+        firstName: user.firstName,
+        lastName: user.lastName,
+    });
+
+    return `n8n_${identityHash}_${displaySlug}`;
+}
+
 /**
  * Creates an instance identifier for directory naming
  * @param host The host URL
  * @param user User information (optional)
- * @returns Instance identifier (e.g., "local_5678_etienne_l")
+ * @returns Instance identifier (e.g., "n8n_c6c289e49e_etienne_l")
  */
-export function createInstanceIdentifier(host: string, user?: { id?: string; email?: string; firstName?: string; lastName?: string }): string {
-    const hostSlug = createHostSlug(host);
-    const userSlug = user ? createUserSlug(user) : 'user';
-    
-    return `${hostSlug}_${userSlug}`;
+export function createInstanceIdentifier(_host: string, user?: { id?: string; email?: string; firstName?: string; lastName?: string }): string {
+    const stableUserIdentitySlug = user ? createStableUserIdentitySlug(user) : undefined;
+    if (stableUserIdentitySlug) {
+        return stableUserIdentitySlug;
+    }
+
+    throw new Error('Unable to create a stable instance identifier: n8n user ID is missing.');
 }
 
-/**
- * Creates a fallback instance identifier using API key hash when user info is unavailable
- * @param host The host URL
- * @param apiKey The API key for uniqueness
- * @returns Fallback instance identifier (e.g., "local_5678_abc123")
- */
-export function createFallbackInstanceIdentifier(host: string, apiKey: string): string {
-    const hostSlug = createHostSlug(host);
-    const apiKeyHash = crypto.createHash('sha256').update(apiKey).digest('hex').substring(0, 6);
-    
-    return `${hostSlug}_${apiKeyHash}`;
+export function createApiKeyInstanceIdentifier(apiKey: string): string {
+    const apiKeyHash = crypto.createHash('sha256').update(apiKey).digest('hex').substring(0, 10);
+    return `key_${apiKeyHash}`;
 }
 
 /**

--- a/packages/cli/src/core/services/instance-identifier.ts
+++ b/packages/cli/src/core/services/instance-identifier.ts
@@ -15,6 +15,8 @@ export interface IInstanceIdentifierClient {
 
 export interface IResolvedInstanceIdentifier {
     identifier: string;
+    source: 'user' | 'apiKey';
+    usedFallback: boolean;
 }
 
 export interface IResolveInstanceIdentifierOptions {
@@ -43,17 +45,23 @@ export async function resolveInstanceIdentifier(
             throw error;
         }
         return {
-            identifier: createApiKeyInstanceIdentifier(credentials.apiKey)
+            identifier: createApiKeyInstanceIdentifier(credentials.apiKey),
+            source: 'apiKey',
+            usedFallback: true,
         };
     }
 
     if (!user?.id) {
         return {
-            identifier: createApiKeyInstanceIdentifier(credentials.apiKey)
+            identifier: createApiKeyInstanceIdentifier(credentials.apiKey),
+            source: 'apiKey',
+            usedFallback: true,
         };
     }
 
     return {
-        identifier: createInstanceIdentifier(credentials.host, user)
+        identifier: createInstanceIdentifier(credentials.host, user),
+        source: 'user',
+        usedFallback: false,
     };
 }

--- a/packages/cli/src/core/services/instance-identifier.ts
+++ b/packages/cli/src/core/services/instance-identifier.ts
@@ -1,6 +1,6 @@
 import { IN8nCredentials } from '../types.js';
 import { N8nApiClient } from './n8n-api-client.js';
-import { createFallbackInstanceIdentifier, createInstanceIdentifier } from './directory-utils.js';
+import { createApiKeyInstanceIdentifier, createInstanceIdentifier } from './directory-utils.js';
 
 type IUserLike = {
     id: string;
@@ -15,7 +15,6 @@ export interface IInstanceIdentifierClient {
 
 export interface IResolvedInstanceIdentifier {
     identifier: string;
-    usedFallback: boolean;
 }
 
 export interface IResolveInstanceIdentifierOptions {
@@ -36,22 +35,25 @@ export async function resolveInstanceIdentifier(
 ): Promise<IResolvedInstanceIdentifier> {
     const client = options.client ?? new N8nApiClient(credentials);
 
+    let user: IUserLike | null;
     try {
-        const user = await client.getCurrentUser();
-        if (user) {
-            return {
-                identifier: createInstanceIdentifier(credentials.host, user),
-                usedFallback: false
-            };
-        }
+        user = await client.getCurrentUser();
     } catch (error) {
         if (options.throwOnConnectionError && isConnectionError(error)) {
             throw error;
         }
+        return {
+            identifier: createApiKeyInstanceIdentifier(credentials.apiKey)
+        };
+    }
+
+    if (!user?.id) {
+        return {
+            identifier: createApiKeyInstanceIdentifier(credentials.apiKey)
+        };
     }
 
     return {
-        identifier: createFallbackInstanceIdentifier(credentials.host, credentials.apiKey),
-        usedFallback: true
+        identifier: createInstanceIdentifier(credentials.host, user)
     };
 }

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -585,7 +585,8 @@ export class ConfigService {
 
     /**
      * Generate or retrieve the instance identifier using Sync's directory-utils
-     * Format: {hostSlug}_{userSlug} (e.g., "local_5678_etienne_l")
+     * Format: n8n_{userIdHash}_{userSlug} when user identity is available.
+     * Falls back to an API-key hash, never to the host.
      */
     async getOrCreateInstanceIdentifier(host: string, instanceId?: string): Promise<string> {
         const active = instanceId ? this.getInstance(instanceId) : this.getActiveInstance();
@@ -599,36 +600,19 @@ export class ConfigService {
             throw new Error('API key not found');
         }
 
-        try {
-            const { resolveInstanceIdentifier } = await import('../core/index.js');
-            const { identifier } = await resolveInstanceIdentifier({ host, apiKey });
+        const { resolveInstanceIdentifier } = await import('../core/index.js');
+        const { identifier } = await resolveInstanceIdentifier({ host, apiKey });
 
-            this.updateInstanceConfig({
-                host,
-                instanceIdentifier: identifier
-            }, {
-                instanceId: instanceId || active?.id,
-                instanceName: active?.name,
-                setActive: true,
-            });
+        this.updateInstanceConfig({
+            host,
+            instanceIdentifier: identifier
+        }, {
+            instanceId: instanceId || active?.id,
+            instanceName: active?.name,
+            setActive: true,
+        });
 
-            return identifier;
-        } catch {
-            console.warn('Could not fetch user info, using fallback identifier');
-            const { createFallbackInstanceIdentifier } = await import('../core/index.js');
-            const fallbackIdentifier = createFallbackInstanceIdentifier(host, apiKey);
-
-            this.updateInstanceConfig({
-                host,
-                instanceIdentifier: fallbackIdentifier
-            }, {
-                instanceId: instanceId || active?.id,
-                instanceName: active?.name,
-                setActive: true,
-            });
-
-            return fallbackIdentifier;
-        }
+        return identifier;
     }
 
     /**

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -2,7 +2,7 @@ import Conf from 'conf';
 import { randomUUID } from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import { N8nApiClient, createInstanceIdentifier, createProjectSlug, normalizeHostForIdentity } from '../core/index.js';
+import { N8nApiClient, createApiKeyInstanceIdentifier, createInstanceIdentifier, createProjectSlug, normalizeHostForIdentity } from '../core/index.js';
 
 // Unified local config written to n8nac-config.json (legacy n8nac.json/n8nac-instance.json deprecated)
 export interface ILocalConfig {
@@ -962,7 +962,7 @@ export class ConfigService {
 
             const resolvedUser = user ?? {};
 
-            const duplicateInstance = this.findVerifiedDuplicate(normalizedHost, userId, exceptInstanceId);
+            const duplicateInstance = this.findVerifiedDuplicate(normalizedHost, userId, resolvedUser.email, exceptInstanceId);
             if (duplicateInstance) {
                 return {
                     status: 'duplicate',
@@ -980,7 +980,9 @@ export class ConfigService {
                 userId,
                 userName: this.createUserDisplayName(resolvedUser),
                 userEmail: resolvedUser.email,
-                instanceIdentifier: createInstanceIdentifier(host, resolvedUser),
+                instanceIdentifier: resolvedUser.id
+                    ? createInstanceIdentifier(host, resolvedUser)
+                    : createApiKeyInstanceIdentifier(apiKey),
             };
         } catch (error: any) {
             return {
@@ -993,13 +995,19 @@ export class ConfigService {
     private findVerifiedDuplicate(
         normalizedHost: string,
         userId: string,
+        userEmail?: string,
         exceptInstanceId?: string
     ): IInstanceProfile | undefined {
+        const normalizedUserEmail = userEmail?.trim().toLowerCase();
+
         return this.listInstances().find((instance) =>
             instance.id !== exceptInstanceId &&
             instance.verification?.status === 'verified' &&
             instance.verification.normalizedHost === normalizedHost &&
-            instance.verification.userId === userId
+            (
+                instance.verification.userId === userId ||
+                (!!normalizedUserEmail && instance.verification.userEmail?.trim().toLowerCase() === normalizedUserEmail)
+            )
         );
     }
 

--- a/packages/cli/tests/unit/config-service.test.ts
+++ b/packages/cli/tests/unit/config-service.test.ts
@@ -405,6 +405,90 @@ describe('ConfigService', () => {
         }
     });
 
+    it('uses the API-key fallback identifier when verification resolves email but no user ID', async () => {
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+        const result = await configService.upsertInstanceConfigWithVerification({
+            host: 'https://prod.example.com',
+            apiKey: 'prod-key',
+            syncFolder: 'workflows',
+            projectId: 'project-prod',
+            projectName: 'Production'
+        }, {
+            createNew: true,
+            setActive: true,
+            client: {
+                async getCurrentUser() {
+                    return {
+                        email: 'etienne@example.com',
+                    };
+                }
+            }
+        });
+
+        expect(result.status).toBe('saved');
+        if (result.status === 'saved') {
+            expect(result.profile.verification?.status).toBe('verified');
+            expect(result.profile.verification?.userId).toBe('etienne@example.com');
+            expect(result.profile.instanceIdentifier).toBe('key_037abd8d69');
+            expect(result.profile.workflowDir).toBe('workflows/key_037abd8d69/production');
+        }
+    });
+
+    it('detects duplicates when an email-only verification later resolves a stable user ID', async () => {
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+        const emailOnly = await configService.upsertInstanceConfigWithVerification({
+            host: 'https://prod.example.com',
+            apiKey: 'prod-key',
+            syncFolder: 'workflows',
+            projectId: 'project-prod',
+            projectName: 'Production'
+        }, {
+            createNew: true,
+            setActive: true,
+            client: {
+                async getCurrentUser() {
+                    return {
+                        email: 'etienne@example.com',
+                    };
+                }
+            }
+        });
+
+        expect(emailOnly.status).toBe('saved');
+
+        const persisted = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1];
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+        (fs.readFileSync as any).mockReturnValue(persisted);
+
+        const withStableId = await configService.upsertInstanceConfigWithVerification({
+            host: 'https://prod.example.com',
+            apiKey: 'another-key',
+            syncFolder: 'workflows-copy',
+            projectId: 'project-prod',
+            projectName: 'Production'
+        }, {
+            createNew: true,
+            setActive: true,
+            client: {
+                async getCurrentUser() {
+                    return {
+                        id: 'user-1',
+                        email: 'etienne@example.com',
+                        firstName: 'Etienne',
+                        lastName: 'Lescot',
+                    };
+                }
+            }
+        });
+
+        expect(withStableId.status).toBe('duplicate');
+        if (withStableId.status === 'duplicate') {
+            expect(withStableId.duplicateInstance.verification?.userId).toBe('etienne@example.com');
+        }
+    });
+
     it('keeps pinned instanceIdentifier and workflowDir when verification resolves a different user', async () => {
         const workspaceConfig: IWorkspaceConfig = {
             version: 2,

--- a/packages/cli/tests/unit/config-service.test.ts
+++ b/packages/cli/tests/unit/config-service.test.ts
@@ -3,9 +3,8 @@ import { ConfigService, type IWorkspaceConfig } from '../../src/services/config-
 import fs from 'fs';
 import Conf from 'conf';
 
-const { mockResolveInstanceIdentifier, mockCreateFallbackInstanceIdentifier } = vi.hoisted(() => ({
+const { mockResolveInstanceIdentifier } = vi.hoisted(() => ({
     mockResolveInstanceIdentifier: vi.fn(),
-    mockCreateFallbackInstanceIdentifier: vi.fn()
 }));
 
 vi.mock('fs');
@@ -15,7 +14,6 @@ vi.mock('../../src/core/index.js', async () => {
     return {
         ...actual,
         resolveInstanceIdentifier: mockResolveInstanceIdentifier,
-        createFallbackInstanceIdentifier: mockCreateFallbackInstanceIdentifier
     };
 });
 
@@ -26,7 +24,6 @@ describe('ConfigService', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockResolveInstanceIdentifier.mockReset();
-        mockCreateFallbackInstanceIdentifier.mockReset();
 
         mockConf = {
             get: vi.fn(),
@@ -372,6 +369,10 @@ describe('ConfigService', () => {
         });
 
         expect(first.status).toBe('saved');
+        if (first.status === 'saved') {
+            expect(first.profile.instanceIdentifier).toBe('n8n_c6c289e49e_etienne_l');
+            expect(first.profile.workflowDir).toBe('workflows/n8n_c6c289e49e_etienne_l/production');
+        }
 
         const persisted = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1];
         (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
@@ -618,7 +619,6 @@ describe('ConfigService', () => {
         });
         mockResolveInstanceIdentifier.mockResolvedValue({
             identifier: 'recomputed-id',
-            usedFallback: false
         });
 
         const result = await configService.getOrCreateInstanceIdentifier('https://prod.example.com', 'prod');
@@ -632,6 +632,49 @@ describe('ConfigService', () => {
         const persistedConfig = JSON.parse((fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1]);
         expect(persistedConfig.instanceIdentifier).toBe('recomputed-id');
         expect(persistedConfig.instances[0].instanceIdentifier).toBe('recomputed-id');
+    });
+
+    it('getOrCreateInstanceIdentifier uses the hostless API-key fallback when user identity is unavailable', async () => {
+        const workspaceConfig: IWorkspaceConfig = {
+            version: 2,
+            activeInstanceId: 'prod',
+            instances: [
+                {
+                    id: 'prod',
+                    name: 'Production',
+                    host: 'https://prod.example.com',
+                    syncFolder: 'workflows-prod',
+                    projectId: 'project-prod',
+                    projectName: 'Production'
+                }
+            ],
+            host: 'https://prod.example.com',
+            syncFolder: 'workflows-prod',
+            projectId: 'project-prod',
+            projectName: 'Production'
+        };
+
+        (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+        (fs.readFileSync as any).mockReturnValue(JSON.stringify(workspaceConfig));
+        mockConf.get.mockImplementation((key: string) => {
+            if (key === 'instanceProfiles') {
+                return { prod: 'test-key' };
+            }
+            if (key === 'hosts') {
+                return {};
+            }
+            return {};
+        });
+        mockResolveInstanceIdentifier.mockResolvedValue({
+            identifier: 'key_62af870476',
+        });
+
+        const result = await configService.getOrCreateInstanceIdentifier('https://prod.example.com', 'prod');
+
+        expect(result).toBe('key_62af870476');
+        const persistedConfig = JSON.parse((fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1]);
+        expect(persistedConfig.instanceIdentifier).toBe('key_62af870476');
+        expect(persistedConfig.instances[0].instanceIdentifier).toBe('key_62af870476');
     });
 
     it('getOrCreateInstanceIdentifier returns the pinned identifier without re-verifying', async () => {

--- a/packages/cli/tests/unit/directory-utils.test.ts
+++ b/packages/cli/tests/unit/directory-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { createHostSlug } from '../../src/core/services/directory-utils.js';
+import { createApiKeyInstanceIdentifier, createHostSlug, createInstanceIdentifier } from '../../src/core/services/directory-utils.js';
 
 afterEach(() => {
     vi.restoreAllMocks();
@@ -45,6 +45,34 @@ describe('directory-utils', () => {
             vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
 
             expect(createHostSlug('localhost:9999')).toBe('local_9999');
+        });
+    });
+
+    describe('createInstanceIdentifier', () => {
+        it('uses a stable n8n user ID hash instead of the host slug when available', () => {
+            expect(createInstanceIdentifier('http://localhost:5678', {
+                id: 'user-1',
+                email: 'etienne@example.com',
+                firstName: 'Etienne',
+                lastName: 'Lescot',
+            })).toBe('n8n_c6c289e49e_etienne_l');
+
+            expect(createInstanceIdentifier('https://changed.example.com', {
+                id: 'user-1',
+                email: 'etienne@example.com',
+                firstName: 'Etienne',
+                lastName: 'Lescot',
+            })).toBe('n8n_c6c289e49e_etienne_l');
+        });
+
+        it('fails when the stable n8n user ID is unavailable', () => {
+            expect(() => createInstanceIdentifier('http://localhost:5678', {
+                email: 'etienne@example.com',
+            })).toThrow('n8n user ID is missing');
+        });
+
+        it('creates a hostless API-key fallback identifier', () => {
+            expect(createApiKeyInstanceIdentifier('test-key')).toBe('key_62af870476');
         });
     });
 });

--- a/packages/cli/tests/unit/sync-manager.test.ts
+++ b/packages/cli/tests/unit/sync-manager.test.ts
@@ -6,6 +6,10 @@ import { SyncManager } from '../../src/core/services/sync-manager.js';
 import { MockN8nApiClient } from '../helpers/test-helpers.js';
 
 describe('SyncManager push filename contract', () => {
+    // On macOS /tmp is a symlink to /private/tmp. realpathSync.native resolves
+    // it, so tests must use the real path to avoid scope-mismatch failures.
+    const TMP = fs.realpathSync.native(os.tmpdir());
+
     function createSyncManager(syncDir: string) {
         return new SyncManager(new MockN8nApiClient() as any, {
             directory: syncDir,
@@ -18,7 +22,7 @@ describe('SyncManager push filename contract', () => {
     }
 
     it('accepts a workflow file path within the sync scope', () => {
-        const syncDir = path.resolve('/tmp/n8nac-sync-manager-test');
+        const syncDir = path.join(TMP, 'n8nac-sync-manager-test');
         const manager = createSyncManager(syncDir);
         
         // Mock the watcher as it's null by default in the constructor
@@ -31,7 +35,7 @@ describe('SyncManager push filename contract', () => {
     });
 
     it('rejects a plain workflow filename (must use full relative path)', () => {
-        const syncDir = path.resolve('/tmp/n8nac-sync-manager-test');
+        const syncDir = path.join(TMP, 'n8nac-sync-manager-test');
         const manager = createSyncManager(syncDir);
 
         (manager as any).watcher = {
@@ -43,7 +47,7 @@ describe('SyncManager push filename contract', () => {
     });
 
     it('rejects a plain workflow filename even when cwd is the sync scope', () => {
-        const syncDir = path.resolve('/tmp/n8nac-sync-manager-test');
+        const syncDir = path.join(TMP, 'n8nac-sync-manager-test');
         const manager = createSyncManager(syncDir);
 
         (manager as any).watcher = {
@@ -59,7 +63,7 @@ describe('SyncManager push filename contract', () => {
     });
 
     it('rejects paths outside the sync scope', () => {
-        const syncDir = path.resolve('/tmp/n8nac-sync-manager-test');
+        const syncDir = path.join(TMP, 'n8nac-sync-manager-test');
         const manager = createSyncManager(syncDir);
         
         // Mock the watcher
@@ -67,7 +71,7 @@ describe('SyncManager push filename contract', () => {
             getDirectory: () => syncDir
         };
 
-        const outsidePath = '/tmp/outside-workflow.workflow.ts';
+        const outsidePath = path.join(TMP, 'outside-workflow.workflow.ts');
         expect(() => manager.resolvePushTarget(outsidePath)).toThrowError(
             expect.objectContaining({
                 message: expect.stringContaining("Run               : n8nac push '")
@@ -76,7 +80,7 @@ describe('SyncManager push filename contract', () => {
     });
 
     it('rejects paths that share a common prefix with the sync scope but are outside it', () => {
-        const syncDir = path.resolve('/tmp/n8nac-sync-manager-test');
+        const syncDir = path.join(TMP, 'n8nac-sync-manager-test');
         const manager = createSyncManager(syncDir);
 
         (manager as any).watcher = {
@@ -89,7 +93,7 @@ describe('SyncManager push filename contract', () => {
     });
 
     it('quotes suggested paths and renders the sync scope as dot-slash when cwd equals the scope', () => {
-        const syncDir = path.resolve('/tmp/n8nac sync-manager-test');
+        const syncDir = path.join(TMP, 'n8nac sync-manager-test');
         const manager = createSyncManager(syncDir);
 
         (manager as any).watcher = {
@@ -98,12 +102,12 @@ describe('SyncManager push filename contract', () => {
 
         const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(syncDir);
 
-        expect(() => manager.resolvePushTarget('/tmp/outside workflow.workflow.ts')).toThrowError(
+        expect(() => manager.resolvePushTarget(path.join(TMP, 'outside workflow.workflow.ts'))).toThrowError(
             expect.objectContaining({
                 message: expect.stringContaining('Active sync scope : ./')
             })
         );
-        expect(() => manager.resolvePushTarget('/tmp/outside workflow.workflow.ts')).toThrowError(
+        expect(() => manager.resolvePushTarget(path.join(TMP, 'outside workflow.workflow.ts'))).toThrowError(
             expect.objectContaining({
                 message: expect.stringContaining("Run               : n8nac push './outside workflow.workflow.ts'")
             })
@@ -113,7 +117,7 @@ describe('SyncManager push filename contract', () => {
     });
 
     it('rejects nested workflow paths inside the sync scope with a clear error', () => {
-        const syncDir = path.resolve('/tmp/n8nac-sync-manager-test');
+        const syncDir = path.join(TMP, 'n8nac-sync-manager-test');
         const manager = createSyncManager(syncDir);
 
         (manager as any).watcher = {
@@ -126,7 +130,7 @@ describe('SyncManager push filename contract', () => {
     });
 
     it('rejects empty paths', () => {
-        const syncDir = path.resolve('/tmp/n8nac-sync-manager-test');
+        const syncDir = path.join(TMP, 'n8nac-sync-manager-test');
         const manager = createSyncManager(syncDir);
         
         // Mock the watcher

--- a/packages/vscode-extension/tests/unit/unified-config.test.ts
+++ b/packages/vscode-extension/tests/unit/unified-config.test.ts
@@ -29,6 +29,7 @@ test('buildUnifiedWorkspaceConfig regenerates stale instanceIdentifier from curr
         client: {
             async getCurrentUser() {
                 return {
+                    id: 'user-1',
                     email: 'etienne@example.com',
                     firstName: 'Etienne',
                     lastName: 'Lescot'
@@ -37,10 +38,10 @@ test('buildUnifiedWorkspaceConfig regenerates stale instanceIdentifier from curr
         }
     });
 
-    assert.strictEqual(unified.instanceIdentifier, 'etiennel_cloud_etienne_l');
+    assert.strictEqual(unified.instanceIdentifier, 'n8n_c6c289e49e_etienne_l');
     assert.strictEqual(unified.activeInstanceId, unified.instances[0].id);
     assert.strictEqual(unified.instances[0].name, 'Cloud');
-    assert.strictEqual(unified.instances[0].instanceIdentifier, 'etiennel_cloud_etienne_l');
+    assert.strictEqual(unified.instances[0].instanceIdentifier, 'n8n_c6c289e49e_etienne_l');
 });
 
 test('buildUnifiedWorkspaceConfig clears instanceIdentifier when credentials are incomplete', async () => {


### PR DESCRIPTION
## Summary
- Implement stable instance identifiers for consistent sync across sessions
- Fix macOS /tmp symlink resolution in sync-manager tests
- Stabilize instance sync identifiers

## Changes
- `29c56a19` refactor(cli): implement stable instance identifiers
- `93a83d19` fix(cli): resolve macOS /tmp symlink in sync-manager tests (#357)
- `4939bb55` stabilize instance sync identifiers