### PR TITLE
feat(cli): add remote workflow tag commands

### DIFF
--- a/docs/docs/usage/cli.md
+++ b/docs/docs/usage/cli.md
@@ -170,6 +170,9 @@ Shows a color-coded table of all workflows with their sync status, helping you u
 - `--local`: Show only workflows that exist locally (including `EXIST_ONLY_LOCALLY`, `TRACKED`, `CONFLICT`)
 - `--remote` / `--distant`: Show only workflows that exist remotely (including `EXIST_ONLY_REMOTELY`, `TRACKED`, `CONFLICT`)
 - `--search <query>`: Case-insensitive partial match on workflow name, workflow ID, or local filename
+- `--tag <name>`: Exact workflow tag filter. Repeat this option to require multiple tags.
+- `--tag-contains <query>`: Case-insensitive partial match against workflow tag names
+- `--tag-starts-with <prefix>`: Case-insensitive prefix match against workflow tag names
 - `--sort <status|name>`: Keep the default sync-oriented ordering or force alphabetical sorting
 - `--limit <n>`: Return only the first `n` matching workflows after filtering/sorting
 - `--include-archived`: Include archived workflows in the output (by default only non-archived workflows are shown)
@@ -184,6 +187,8 @@ n8nac list --only-archived      # Show only archived workflows
 n8nac list --local              # Show only local workflows
 n8nac list --remote            # Show only remote workflows
 n8nac list --search billing     # Find workflows by partial name, ID, or filename
+n8nac list --tag folder:billing # Find workflows with an exact tag
+n8nac list --tag-starts-with folder:
 n8nac list --sort name         # Sort alphabetically
 n8nac list --raw               # Output raw JSON
 ```
@@ -203,6 +208,9 @@ Optimized for large installations where you already know part of the workflow na
 - `<query>` (**required**): Search text
 - `--local`: Limit results to workflows with a local file
 - `--remote` / `--distant`: Limit results to workflows known remotely
+- `--tag <name>`: Exact workflow tag filter. Repeat this option to require multiple tags.
+- `--tag-contains <query>`: Case-insensitive partial match against workflow tag names
+- `--tag-starts-with <prefix>`: Case-insensitive prefix match against workflow tag names
 - `--sort <status|name>`: Sort search results by sync status or alphabetically (defaults to `name`)
 - `--limit <n>`: Return only the first `n` matching workflows
 - `--include-archived`: Include archived workflows in search results
@@ -214,6 +222,7 @@ Optimized for large installations where you already know part of the workflow na
 n8nac find billing
 n8nac find wf-123 --raw
 n8nac find importer --limit 10
+n8nac find billing --tag folder:billing
 n8nac find archived-workflow --only-archived
 ```
 
@@ -317,6 +326,26 @@ Activate a workflow once credentials are provisioned.
 
 ```bash
 n8nac workflow activate <workflowId>
+```
+
+### `tag`
+Manage remote n8n workflow tags.
+
+Tag commands update n8n's remote workflow tag metadata. They do not edit local workflow files automatically; run `n8nac pull <workflowId>` after attaching or detaching tags if you want the local file metadata refreshed.
+
+```bash
+n8nac tag list
+n8nac tag list --json
+n8nac tag workflows folder:billing
+n8nac tag attach <workflowId> folder:billing
+n8nac tag detach <workflowId> folder:billing
+```
+
+Aliases are available for users who prefer add/remove wording:
+
+```bash
+n8nac tag add <workflowId> folder:billing
+n8nac tag remove <workflowId> folder:billing
 ```
 
 ### `credential`

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -11,6 +11,9 @@ export interface ListCommandOptions {
     remote?: boolean;
     raw?: boolean;
     search?: string;
+    tags?: string[];
+    tagContains?: string;
+    tagStartsWith?: string;
     sort?: WorkflowListSortMode;
     limit?: number;
     includeArchived?: boolean;
@@ -26,6 +29,37 @@ export function matchesWorkflowSearch(workflow: IWorkflowStatus, query?: string)
     return [workflow.name, workflow.id, workflow.filename]
         .filter((value): value is string => Boolean(value))
         .some(value => value.toLowerCase().includes(normalizedQuery));
+}
+
+const normalizeTagFilter = (value: string): string => value.trim().toLowerCase();
+
+function getWorkflowTagNames(workflow: IWorkflowStatus): string[] {
+    return (workflow.tags || [])
+        .map(tag => tag.name)
+        .filter((value): value is string => Boolean(value));
+}
+
+export function matchesWorkflowTags(workflow: IWorkflowStatus, options?: ListCommandOptions): boolean {
+    const tagNames = getWorkflowTagNames(workflow).map(normalizeTagFilter);
+    const exactTags = (options?.tags || [])
+        .map(normalizeTagFilter)
+        .filter(Boolean);
+
+    if (exactTags.length > 0 && !exactTags.every(tag => tagNames.includes(tag))) {
+        return false;
+    }
+
+    const contains = options?.tagContains ? normalizeTagFilter(options.tagContains) : '';
+    if (contains && !tagNames.some(tag => tag.includes(contains))) {
+        return false;
+    }
+
+    const startsWith = options?.tagStartsWith ? normalizeTagFilter(options.tagStartsWith) : '';
+    if (startsWith && !tagNames.some(tag => tag.startsWith(startsWith))) {
+        return false;
+    }
+
+    return true;
 }
 
 export function sortWorkflows(workflows: IWorkflowStatus[], sortMode: WorkflowListSortMode = 'status'): IWorkflowStatus[] {
@@ -64,7 +98,10 @@ function filterWorkflowsByScopeAndSearch(workflows: IWorkflowStatus[], options?:
         );
     }
 
-    return filtered.filter(workflow => matchesWorkflowSearch(workflow, options?.search));
+    return filtered.filter(workflow =>
+        matchesWorkflowSearch(workflow, options?.search) &&
+        matchesWorkflowTags(workflow, options)
+    );
 }
 
 export function applyListCommandOptions(workflows: IWorkflowStatus[], options?: ListCommandOptions): IWorkflowStatus[] {

--- a/packages/cli/src/commands/tag.ts
+++ b/packages/cli/src/commands/tag.ts
@@ -1,0 +1,158 @@
+import chalk from 'chalk';
+import Table from 'cli-table3';
+
+import { BaseCommand } from './base.js';
+import { ITag, IWorkflow } from '../core/index.js';
+
+export class TagCommand extends BaseCommand {
+    private normalizeTagName(tagName: string): string {
+        const normalized = tagName.trim();
+        if (!normalized) {
+            this.exitWithError('Tag name cannot be empty');
+        }
+        return normalized;
+    }
+
+    private tagNames(tags: ITag[] | undefined): string[] {
+        return (tags || []).map(tag => tag.name).filter(Boolean);
+    }
+
+    private workflowHasTag(workflow: IWorkflow, tagName: string): boolean {
+        return this.tagNames(workflow.tags).some(tag => tag.toLowerCase() === tagName.toLowerCase());
+    }
+
+    private async getOrCreateTag(tagName: string): Promise<ITag> {
+        const existing = (await this.client.getTags())
+            .find(tag => tag.name.toLowerCase() === tagName.toLowerCase());
+
+        return existing || this.client.createTag(tagName);
+    }
+
+    async list(options: { json?: boolean } = {}): Promise<void> {
+        try {
+            const tags = await this.client.getTags();
+
+            if (options.json) {
+                console.log(JSON.stringify(tags, null, 2));
+                return;
+            }
+
+            if (tags.length === 0) {
+                console.log(chalk.yellow('No tags found.'));
+                return;
+            }
+
+            const table = new Table({
+                head: [chalk.white('ID'), chalk.white('Name')],
+                style: { head: [], border: [] },
+            });
+
+            for (const tag of tags) {
+                table.push([tag.id, tag.name]);
+            }
+
+            console.log(table.toString());
+            console.log(chalk.dim(`\nTotal: ${tags.length} tag(s)`));
+        } catch (error) {
+            this.exitWithError('Failed to list tags', error);
+        }
+    }
+
+    async workflows(tagName: string, options: { json?: boolean } = {}): Promise<void> {
+        const normalizedTagName = this.normalizeTagName(tagName);
+
+        try {
+            const syncConfig = await this.getSyncConfig();
+            const workflows = await this.client.getAllWorkflows(syncConfig.projectId);
+            const matches = workflows
+                .filter(workflow => this.workflowHasTag(workflow, normalizedTagName))
+                .sort((left, right) => left.name.localeCompare(right.name, undefined, { sensitivity: 'base' }));
+
+            if (options.json) {
+                console.log(JSON.stringify(matches, null, 2));
+                return;
+            }
+
+            if (matches.length === 0) {
+                console.log(chalk.yellow(`No remote workflows found with tag "${normalizedTagName}".`));
+                return;
+            }
+
+            const table = new Table({
+                head: [chalk.white('ID'), chalk.white('Name'), chalk.white('Active')],
+                style: { head: [], border: [] },
+            });
+
+            for (const workflow of matches) {
+                table.push([workflow.id, workflow.name, workflow.active ? 'yes' : 'no']);
+            }
+
+            console.log(table.toString());
+            console.log(chalk.dim(`\nTotal: ${matches.length} remote workflow(s)`));
+        } catch (error) {
+            this.exitWithError(`Failed to list remote workflows with tag "${normalizedTagName}"`, error);
+        }
+    }
+
+    async attach(workflowId: string, tagName: string, options: { json?: boolean } = {}): Promise<void> {
+        const normalizedTagName = this.normalizeTagName(tagName);
+
+        try {
+            const existingWorkflowTags = await this.client.getWorkflowTags(workflowId);
+            const existing = existingWorkflowTags.find(tag => tag.name.toLowerCase() === normalizedTagName.toLowerCase());
+
+            if (existing) {
+                if (options.json) {
+                    console.log(JSON.stringify({ workflowId, changed: false, tags: existingWorkflowTags }, null, 2));
+                    return;
+                }
+                console.log(chalk.yellow(`Remote workflow ${workflowId} already has tag "${existing.name}".`));
+                return;
+            }
+
+            const tag = await this.getOrCreateTag(normalizedTagName);
+            const updatedTags = await this.client.updateWorkflowTags(workflowId, [...existingWorkflowTags, tag]);
+
+            if (options.json) {
+                console.log(JSON.stringify({ workflowId, changed: true, tags: updatedTags }, null, 2));
+                return;
+            }
+
+            console.log(chalk.green(`✅ Attached tag "${tag.name}" to remote workflow ${workflowId}.`));
+            console.log(chalk.dim(`Run \`n8nac pull ${workflowId}\` to refresh the local workflow file.`));
+        } catch (error) {
+            this.exitWithError(`Failed to attach tag "${normalizedTagName}" to remote workflow ${workflowId}`, error);
+        }
+    }
+
+    async detach(workflowId: string, tagName: string, options: { json?: boolean } = {}): Promise<void> {
+        const normalizedTagName = this.normalizeTagName(tagName);
+
+        try {
+            const existingWorkflowTags = await this.client.getWorkflowTags(workflowId);
+            const nextTags = existingWorkflowTags
+                .filter(tag => tag.name.toLowerCase() !== normalizedTagName.toLowerCase());
+
+            if (nextTags.length === existingWorkflowTags.length) {
+                if (options.json) {
+                    console.log(JSON.stringify({ workflowId, changed: false, tags: existingWorkflowTags }, null, 2));
+                    return;
+                }
+                console.log(chalk.yellow(`Remote workflow ${workflowId} does not have tag "${normalizedTagName}".`));
+                return;
+            }
+
+            const updatedTags = await this.client.updateWorkflowTags(workflowId, nextTags);
+
+            if (options.json) {
+                console.log(JSON.stringify({ workflowId, changed: true, tags: updatedTags }, null, 2));
+                return;
+            }
+
+            console.log(chalk.green(`✅ Detached tag "${normalizedTagName}" from remote workflow ${workflowId}.`));
+            console.log(chalk.dim(`Run \`n8nac pull ${workflowId}\` to refresh the local workflow file.`));
+        } catch (error) {
+            this.exitWithError(`Failed to detach tag "${normalizedTagName}" from remote workflow ${workflowId}`, error);
+        }
+    }
+}

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -69,6 +69,8 @@ export class WorkflowStateTracker extends EventEmitter {
     private remoteNames: Map<string, string> = new Map(); // workflowId -> name
     /** Remote active flag per workflow (populated by refreshRemoteState / updateSingleRemoteState). */
     private remoteActive: Map<string, boolean> = new Map(); // workflowId -> active
+    /** Remote tags per workflow (populated by refreshRemoteState / updateSingleRemoteState). */
+    private remoteTags: Map<string, IWorkflow['tags']> = new Map(); // workflowId -> tags
     /** Remote archived flag per workflow (populated by refreshRemoteState / updateSingleRemoteState). */
     private remoteArchived: Map<string, boolean> = new Map(); // workflowId -> isArchived
 
@@ -262,6 +264,7 @@ export class WorkflowStateTracker extends EventEmitter {
             this.remoteIds.clear();
             this.remoteNames.clear();
             this.remoteActive.clear();
+            this.remoteTags.clear();
             this.remoteArchived.clear();
 
             // Build set of already-assigned filenames to prevent collisions
@@ -275,6 +278,7 @@ export class WorkflowStateTracker extends EventEmitter {
                 if (wf.name) this.remoteNames.set(wf.id, wf.name);
                 // Store active and archived flags from API
                 this.remoteActive.set(wf.id, wf.active === true);
+                this.remoteTags.set(wf.id, wf.tags || []);
                 this.remoteArchived.set(wf.id, wf.isArchived === true);
 
                 // CRITICAL: Use ID-based mapping with PERSISTED state as source of truth
@@ -460,6 +464,7 @@ export class WorkflowStateTracker extends EventEmitter {
         this.remoteTimestamps.delete(id);
         this.remoteNames.delete(id);
         this.remoteActive.delete(id);
+        this.remoteTags.delete(id);
         this.remoteArchived.delete(id);
         this.remoteIds.delete(id);
     }
@@ -709,6 +714,19 @@ export class WorkflowStateTracker extends EventEmitter {
                         result.name = nameMatch[1];
                     }
 
+                    const tagsMatch = decoratorContent.match(/tags:\s*\[([\s\S]*?)\]/);
+                    if (tagsMatch) {
+                        const tags: Array<{ id: string; name: string }> = [];
+                        const tagPattern = /["'`]([^"'`]+)["'`]/g;
+                        let tagMatch: RegExpExecArray | null;
+                        while ((tagMatch = tagPattern.exec(tagsMatch[1])) !== null) {
+                            // Local decorator tags only store names; use the name as a placeholder ID
+                            // because lightweight filters only need tag names.
+                            tags.push({ id: tagMatch[1], name: tagMatch[1] });
+                        }
+                        result.tags = tags;
+                    }
+
                     // Return at least the extracted data (even if no id)
                     // This allows EXIST_ONLY_LOCALLY workflows to be detected
                     return Object.keys(result).length > 0 ? result : {};
@@ -814,9 +832,13 @@ export class WorkflowStateTracker extends EventEmitter {
             // Prefer the remote canonical name (keyed by ID, not by name since names are non-unique).
             // For local-only files, extract the name from the @workflow decorator for an accurate display.
             // Fall back to filename-derived name as last resort.
+            const localMetadata = this.readJsonFile(path.join(this.directory, filename));
             const workflowName = (workflowId && this.remoteNames.get(workflowId))
-                || this.readJsonFile(path.join(this.directory, filename))?.name
+                || localMetadata?.name
                 || filename.replace('.workflow.ts', '');
+            const tags = workflowId && remoteKnown
+                ? this.remoteTags.get(workflowId)
+                : localMetadata?.tags;
 
             results.set(filename, {
                 id: workflowId || '',
@@ -824,6 +846,7 @@ export class WorkflowStateTracker extends EventEmitter {
                 filename: filename,
                 status: status,
                 active,
+                tags,
                 projectId: undefined, // Not available in lightweight mode
                 projectName: undefined, // Not available in lightweight mode
                 homeProject: undefined, // Not available in lightweight mode
@@ -855,6 +878,7 @@ export class WorkflowStateTracker extends EventEmitter {
                     filename: filename,
                     status: WorkflowSyncStatus.EXIST_ONLY_REMOTELY, // Remote only
                     active,
+                    tags: this.remoteTags.get(workflowId),
                     projectId: undefined, // Not available in lightweight mode
                     projectName: undefined, // Not available in lightweight mode
                     homeProject: undefined, // Not available in lightweight mode
@@ -1095,11 +1119,16 @@ export class WorkflowStateTracker extends EventEmitter {
             this.remoteTimestamps.set(newId, timestamp);
         }
 
-        // Migrate name entry
+        // Migrate display metadata
         const name = this.remoteNames.get(oldId);
         if (name) {
             this.remoteNames.delete(oldId);
             this.remoteNames.set(newId, name);
+        }
+        const tags = this.remoteTags.get(oldId);
+        if (tags) {
+            this.remoteTags.delete(oldId);
+            this.remoteTags.set(newId, tags);
         }
 
         // Migrate remote ID set
@@ -1135,6 +1164,7 @@ export class WorkflowStateTracker extends EventEmitter {
             this.remoteIds.add(remoteWf.id);
             // Store active and archived flags
             this.remoteActive.set(remoteWf.id, remoteWf.active === true);
+            this.remoteTags.set(remoteWf.id, remoteWf.tags || []);
             this.remoteArchived.set(remoteWf.id, remoteWf.isArchived === true);
 
             // Establish mapping if it doesn't exist yet (allows 'pull' after single 'fetch')

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -49,6 +49,7 @@ export interface IWorkflowStatus {
     filename: string;
     active: boolean;
     status: WorkflowSyncStatus;
+    tags?: ITag[];
     projectId?: string;
     projectName?: string;
     homeProject?: IProject;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ import { TestPlanCommand } from './commands/test-plan.js';
 import { CredentialCommand } from './commands/credential.js';
 import { WorkflowCommand } from './commands/workflow.js';
 import { ExecutionCommand } from './commands/execution.js';
+import { TagCommand } from './commands/tag.js';
 import chalk from 'chalk';
 
 import { readFileSync, existsSync } from 'fs';
@@ -196,6 +197,8 @@ program.hook('postAction', restoreGlobalInstanceOption);
 const initCommand = new InitCommand();
 const switchCommand = new SwitchCommand(program);
 
+const collectOptionValue = (value: string, previous: string[] = []): string[] => [...previous, value];
+
 const registerInstanceOptions = (command: Command, options: { includeNewInstance?: boolean } = {}) => {
     command
         .option('--host <url>', 'n8n instance URL')
@@ -317,6 +320,9 @@ program.command('list')
     .option('--remote', 'Show only remote workflows')
     .option('--distant', 'Alias for --remote')
     .option('--search <query>', 'Filter by workflow name, ID, or local filename (case-insensitive partial match)')
+    .option('--tag <name>', 'Filter by exact workflow tag name. Repeat to require multiple tags.', collectOptionValue, [])
+    .option('--tag-contains <query>', 'Filter by workflow tags containing text (case-insensitive)')
+    .option('--tag-starts-with <prefix>', 'Filter by workflow tags starting with text (case-insensitive)')
     .option('--sort <mode>', 'Sort by "status" (default) or "name"', 'status')
     .option('--limit <number>', 'Limit the number of returned workflows', (value) => parsePositiveIntegerOption(value, '--limit'))
     .option('--include-archived', 'Include archived workflows in the output')
@@ -335,6 +341,9 @@ program.command('list')
             remote,
             raw: options.json || options.raw,
             search: options.search,
+            tags: options.tag,
+            tagContains: options.tagContains,
+            tagStartsWith: options.tagStartsWith,
             sort: options.sort,
             limit: options.limit,
             includeArchived: options.includeArchived,
@@ -349,6 +358,9 @@ program.command('find')
     .option('--remote', 'Show only remote workflows')
     .option('--distant', 'Alias for --remote')
     .option('--sort <mode>', 'Sort by "status" or "name"', 'name')
+    .option('--tag <name>', 'Filter by exact workflow tag name. Repeat to require multiple tags.', collectOptionValue, [])
+    .option('--tag-contains <query>', 'Filter by workflow tags containing text (case-insensitive)')
+    .option('--tag-starts-with <prefix>', 'Filter by workflow tags starting with text (case-insensitive)')
     .option('--limit <number>', 'Limit the number of returned workflows', (value) => parsePositiveIntegerOption(value, '--limit'))
     .option('--include-archived', 'Include archived workflows in the search')
     .option('--only-archived', 'Search only archived workflows')
@@ -365,6 +377,9 @@ program.command('find')
             remote,
             raw: options.json || options.raw,
             search: query,
+            tags: options.tag,
+            tagContains: options.tagContains,
+            tagStartsWith: options.tagStartsWith,
             sort: options.sort,
             limit: options.limit,
             includeArchived: options.includeArchived,
@@ -680,6 +695,50 @@ credentialCmd
     .description('Permanently delete a credential')
     .action(async (id) => {
         await new CredentialCommand().delete(id);
+    });
+
+// tag - Manage remote n8n workflow tag metadata
+const tagCmd = program
+    .command('tag')
+    .description('Manage remote n8n workflow tags');
+
+tagCmd
+    .command('list')
+    .description('List remote n8n tags')
+    .option('--json', 'Output JSON for agents and scripts')
+    .action(async (options) => {
+        await new TagCommand().list({ json: options.json });
+    });
+
+tagCmd
+    .command('workflows')
+    .argument('<tagName>', 'Exact tag name')
+    .description('List remote workflows with an exact tag name')
+    .option('--json', 'Output JSON for agents and scripts')
+    .action(async (tagName, options) => {
+        await new TagCommand().workflows(tagName, { json: options.json });
+    });
+
+tagCmd
+    .command('attach')
+    .alias('add')
+    .argument('<workflowId>', 'Remote workflow ID')
+    .argument('<tagName>', 'Tag name to attach')
+    .description('Attach a tag to a remote n8n workflow')
+    .option('--json', 'Output JSON for agents and scripts')
+    .action(async (workflowId, tagName, options) => {
+        await new TagCommand().attach(workflowId, tagName, { json: options.json });
+    });
+
+tagCmd
+    .command('detach')
+    .alias('remove')
+    .argument('<workflowId>', 'Remote workflow ID')
+    .argument('<tagName>', 'Tag name to detach')
+    .description('Detach a tag from a remote n8n workflow')
+    .option('--json', 'Output JSON for agents and scripts')
+    .action(async (workflowId, tagName, options) => {
+        await new TagCommand().detach(workflowId, tagName, { json: options.json });
     });
 
 // skills - AI knowledge tools subcommand group

--- a/packages/cli/tests/unit/list-command.test.ts
+++ b/packages/cli/tests/unit/list-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applyListCommandOptions, countMatchingWorkflows, matchesWorkflowSearch, sortWorkflows } from '../../src/commands/list.js';
+import { applyListCommandOptions, countMatchingWorkflows, matchesWorkflowSearch, matchesWorkflowTags, sortWorkflows } from '../../src/commands/list.js';
 import { IWorkflowStatus, WorkflowSyncStatus } from '../../src/core/types.js';
 
 const workflows: IWorkflowStatus[] = [
@@ -9,6 +9,7 @@ const workflows: IWorkflowStatus[] = [
         filename: 'zulu-sync.workflow.ts',
         active: true,
         status: WorkflowSyncStatus.TRACKED,
+        tags: [{ id: 'tag-prod', name: 'prod' }, { id: 'tag-billing', name: 'folder:billing' }],
     },
     {
         id: 'wf-150',
@@ -16,6 +17,7 @@ const workflows: IWorkflowStatus[] = [
         filename: 'billing-alerts.workflow.ts',
         active: true,
         status: WorkflowSyncStatus.EXIST_ONLY_LOCALLY,
+        tags: [{ id: 'tag-billing', name: 'folder:billing' }],
     },
     {
         id: 'wf-300',
@@ -23,6 +25,7 @@ const workflows: IWorkflowStatus[] = [
         filename: 'imports/alpha-importer.workflow.ts',
         active: false,
         status: WorkflowSyncStatus.CONFLICT,
+        tags: [{ id: 'tag-import', name: 'folder:imports' }],
     },
     {
         id: 'remote-44',
@@ -30,6 +33,7 @@ const workflows: IWorkflowStatus[] = [
         filename: '',
         active: false,
         status: WorkflowSyncStatus.EXIST_ONLY_REMOTELY,
+        tags: [{ id: 'tag-remote', name: 'remote' }],
     },
 ];
 
@@ -74,7 +78,29 @@ describe('list command helpers', () => {
         expect(countMatchingWorkflows(workflows, { search: 'missing' })).toBe(0);
     });
 
+    it('matches exact, contains, and starts-with tag filters case-insensitively', () => {
+        expect(matchesWorkflowTags(workflows[0], { tags: ['PROD'] })).toBe(true);
+        expect(matchesWorkflowTags(workflows[0], { tags: ['prod', 'folder:billing'] })).toBe(true);
+        expect(matchesWorkflowTags(workflows[0], { tags: ['prod', 'missing'] })).toBe(false);
+        expect(matchesWorkflowTags(workflows[1], { tagContains: 'billing' })).toBe(true);
+        expect(matchesWorkflowTags(workflows[2], { tagStartsWith: 'folder:' })).toBe(true);
+        expect(matchesWorkflowTags(workflows[3], { tagContains: 'billing' })).toBe(false);
+    });
+
+    it('filters workflows by tag options', () => {
+        expect(applyListCommandOptions(workflows, { tags: ['folder:billing'], sort: 'name' }).map(workflow => workflow.id)).toEqual([
+            'wf-150',
+            'wf-200',
+        ]);
+
+        expect(applyListCommandOptions(workflows, { tagStartsWith: 'folder:', remote: true }).map(workflow => workflow.id)).toEqual([
+            'wf-300',
+            'wf-200',
+        ]);
+    });
+
     it('ignores sort and limit when counting matches', () => {
         expect(countMatchingWorkflows(workflows, { search: 'wf-', sort: 'name', limit: 1 })).toBe(3);
+        expect(countMatchingWorkflows(workflows, { tags: ['folder:billing'], limit: 1 })).toBe(2);
     });
 });

--- a/packages/cli/tests/unit/n8n-api-client.test.ts
+++ b/packages/cli/tests/unit/n8n-api-client.test.ts
@@ -277,6 +277,52 @@ describe('N8nApiClient test workflow support', () => {
         });
     });
 
+    it('paginates tags from the public API', async () => {
+        const client = new N8nApiClient({ host: 'https://n8n.local', apiKey: 'secret' });
+        mockAxiosGet
+            .mockResolvedValueOnce({
+                data: {
+                    data: [{ id: 'tag-1', name: 'Tag 1' }],
+                    nextCursor: 'cursor-2',
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    data: [{ id: 'tag-2', name: 'Tag 2' }],
+                },
+            });
+
+        await expect(client.getTags()).resolves.toEqual([
+            { id: 'tag-1', name: 'Tag 1' },
+            { id: 'tag-2', name: 'Tag 2' },
+        ]);
+        expect(mockAxiosGet).toHaveBeenNthCalledWith(1, '/api/v1/tags', { params: undefined });
+        expect(mockAxiosGet).toHaveBeenNthCalledWith(2, '/api/v1/tags', { params: { cursor: 'cursor-2' } });
+    });
+
+    it('updates workflow tags through the dedicated tags endpoint', async () => {
+        const client = new N8nApiClient({ host: 'https://n8n.local', apiKey: 'secret' });
+        mockAxiosPut.mockResolvedValueOnce({
+            data: [
+                { id: 'tag-1', name: 'Tag 1' },
+                { id: 'tag-2', name: 'Tag 2' },
+            ],
+        });
+
+        await expect(client.updateWorkflowTags('wf-1', [
+            { id: 'tag-1' },
+            { id: 'tag-2' },
+        ])).resolves.toEqual([
+            { id: 'tag-1', name: 'Tag 1' },
+            { id: 'tag-2', name: 'Tag 2' },
+        ]);
+
+        expect(mockAxiosPut).toHaveBeenCalledWith('/api/v1/workflows/wf-1/tags', [
+            { id: 'tag-1' },
+            { id: 'tag-2' },
+        ]);
+    });
+
     it('still returns the created workflow when the follow-up description update fails', async () => {
         const client = new N8nApiClient({ host: 'https://n8n.local', apiKey: 'secret' });
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);

--- a/packages/cli/tests/unit/tag-command.test.ts
+++ b/packages/cli/tests/unit/tag-command.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TagCommand } from '../../src/commands/tag.js';
+
+vi.mock('chalk', () => {
+    const identity = (s: string) => s;
+    const proxy: any = new Proxy(identity, {
+        get: (_target, prop) => {
+            if (prop === 'level') return 0;
+            return proxy;
+        },
+        apply: (_target, _this, args) => args[0],
+    });
+    return { default: proxy };
+});
+
+function makeCommand(): TagCommand {
+    process.env.N8N_HOST = 'https://n8n.test';
+    process.env.N8N_API_KEY = 'test-key';
+    return new TagCommand();
+}
+
+describe('TagCommand', () => {
+    let cmd: TagCommand;
+    let logSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+            throw new Error(`process.exit:${code ?? 0}`);
+        }) as never);
+        cmd = makeCommand();
+    });
+
+    it('attaches an existing tag to a remote workflow without dropping existing tags', async () => {
+        vi.spyOn(cmd['client'], 'getWorkflowTags').mockResolvedValue([
+            { id: 'tag-existing', name: 'existing' },
+        ]);
+        vi.spyOn(cmd['client'], 'getTags').mockResolvedValue([
+            { id: 'tag-existing', name: 'existing' },
+            { id: 'tag-new', name: 'new-tag' },
+        ]);
+        vi.spyOn(cmd['client'], 'createTag');
+        const updateSpy = vi.spyOn(cmd['client'], 'updateWorkflowTags').mockResolvedValue([
+            { id: 'tag-existing', name: 'existing' },
+            { id: 'tag-new', name: 'new-tag' },
+        ]);
+
+        await cmd.attach('wf-1', 'new-tag', { json: true });
+
+        expect(cmd['client'].createTag).not.toHaveBeenCalled();
+        expect(updateSpy).toHaveBeenCalledWith('wf-1', [
+            { id: 'tag-existing', name: 'existing' },
+            { id: 'tag-new', name: 'new-tag' },
+        ]);
+        expect(JSON.parse(String(logSpy.mock.calls[0]?.[0]))).toMatchObject({
+            workflowId: 'wf-1',
+            changed: true,
+        });
+    });
+
+    it('creates a tag before attaching when it does not exist yet', async () => {
+        vi.spyOn(cmd['client'], 'getWorkflowTags').mockResolvedValue([]);
+        vi.spyOn(cmd['client'], 'getTags').mockResolvedValue([]);
+        vi.spyOn(cmd['client'], 'createTag').mockResolvedValue({ id: 'tag-created', name: 'created-tag' });
+        const updateSpy = vi.spyOn(cmd['client'], 'updateWorkflowTags').mockResolvedValue([
+            { id: 'tag-created', name: 'created-tag' },
+        ]);
+
+        await cmd.attach('wf-1', 'created-tag');
+
+        expect(cmd['client'].createTag).toHaveBeenCalledWith('created-tag');
+        expect(updateSpy).toHaveBeenCalledWith('wf-1', [
+            { id: 'tag-created', name: 'created-tag' },
+        ]);
+    });
+
+    it('does not update tags when attaching a tag already present on the workflow', async () => {
+        vi.spyOn(cmd['client'], 'getWorkflowTags').mockResolvedValue([
+            { id: 'tag-existing', name: 'Existing' },
+        ]);
+        vi.spyOn(cmd['client'], 'updateWorkflowTags');
+
+        await cmd.attach('wf-1', 'existing', { json: true });
+
+        expect(cmd['client'].updateWorkflowTags).not.toHaveBeenCalled();
+        expect(JSON.parse(String(logSpy.mock.calls[0]?.[0]))).toMatchObject({
+            workflowId: 'wf-1',
+            changed: false,
+        });
+    });
+
+    it('detaches only the requested tag from a remote workflow', async () => {
+        vi.spyOn(cmd['client'], 'getWorkflowTags').mockResolvedValue([
+            { id: 'tag-keep', name: 'keep' },
+            { id: 'tag-remove', name: 'remove-me' },
+        ]);
+        const updateSpy = vi.spyOn(cmd['client'], 'updateWorkflowTags').mockResolvedValue([
+            { id: 'tag-keep', name: 'keep' },
+        ]);
+
+        await cmd.detach('wf-1', 'remove-me', { json: true });
+
+        expect(updateSpy).toHaveBeenCalledWith('wf-1', [
+            { id: 'tag-keep', name: 'keep' },
+        ]);
+        expect(JSON.parse(String(logSpy.mock.calls[0]?.[0]))).toMatchObject({
+            workflowId: 'wf-1',
+            changed: true,
+        });
+    });
+
+    it('lists remote workflows with an exact tag', async () => {
+        vi.spyOn(cmd as any, 'getSyncConfig').mockResolvedValue({
+            projectId: 'project-1',
+        });
+        vi.spyOn(cmd['client'], 'getAllWorkflows').mockResolvedValue([
+            {
+                id: 'wf-1',
+                name: 'Tagged',
+                active: true,
+                nodes: [],
+                connections: {},
+                tags: [{ id: 'tag-target', name: 'target' }],
+            },
+            {
+                id: 'wf-2',
+                name: 'Other',
+                active: false,
+                nodes: [],
+                connections: {},
+                tags: [{ id: 'tag-other', name: 'other' }],
+            },
+        ]);
+
+        await cmd.workflows('target', { json: true });
+
+        const parsed = JSON.parse(String(logSpy.mock.calls[0]?.[0]));
+        expect(parsed).toHaveLength(1);
+        expect(parsed[0]).toMatchObject({ id: 'wf-1', name: 'Tagged' });
+    });
+});


### PR DESCRIPTION
**What does this PR do?**

Adds explicit CLI support for remote n8n workflow tags without changing normal workflow push semantics.

- adds tag filters to `list` and `find`: `--tag`, `--tag-contains`, and `--tag-starts-with`
- adds `n8nac tag` commands for remote tag metadata:
  - `tag list`
  - `tag workflows <tagName>`
  - `tag attach|add <workflowId> <tagName>`
  - `tag detach|remove <workflowId> <tagName>`
- carries workflow tag metadata through lightweight list results for remote and local workflows
- documents tag filters and remote tag commands in the CLI guide

`n8nac push` is intentionally unchanged. Tags use dedicated n8n API endpoints, so tag mutations are explicit remote metadata operations rather than implicit side effects of pushing workflow source. After attaching or detaching a tag, users can run `n8nac pull <workflowId>` when they want local workflow metadata refreshed.

**Related issue (if any):** #

No related issue.

**Validation**

- `npm run build --workspace=packages/transformer`
- `npx vitest run packages/cli/tests/unit/list-command.test.ts packages/cli/tests/unit/tag-command.test.ts packages/cli/tests/unit/n8n-api-client.test.ts` — 42 tests passed
- `npm run build:cli`
- `npm test --workspace=n8nac` — 24 test files / 179 tests passed

> ⚠️ All PRs must target the `next` branch as base.