### PR TITLE
Fix VS Code project selection and sync feedback

### DIFF
--- a/packages/cli/src/core/assets/n8n-workflows.d.ts
+++ b/packages/cli/src/core/assets/n8n-workflows.d.ts
@@ -16,28 +16,24 @@
 // properties (typed from their literal values) get full IntelliSense
 // inside defineRouting() without explicit type casts.
 // =========================================================================
-export {};
-
-declare global {
-    interface Object {
-        /** Regular output connector (index = output slot, default 0) */
-        out(index?: number): OutputConnection;
-        /** Regular input connector (index = input slot, default 0) */
-        in(index?: number): InputConnection;
-        /** Error output connector */
-        error(): OutputConnection;
-        /** Declare AI/LangChain sub-node dependencies */
-        uses(dependencies: AIDependencyMap): void;
-        /** Output reference used as target of .uses() values */
-        readonly output: any;
-    }
+interface Object {
+    /** Regular output connector (index = output slot, default 0) */
+    out(index?: number): OutputConnection;
+    /** Regular input connector (index = input slot, default 0) */
+    in(index?: number): InputConnection;
+    /** Error output connector */
+    error(): OutputConnection;
+    /** Declare AI/LangChain sub-node dependencies */
+    uses(dependencies: AIDependencyMap): void;
+    /** Output reference used as target of .uses() values */
+    readonly output: any;
 }
 
 // =========================================================================
 // WORKFLOW SETTINGS
 // =========================================================================
 
-export interface WorkflowSettings {
+interface WorkflowSettings {
     executionOrder?: 'v0' | 'v1' | 'v2';
     timeSavedMode?: 'fixed' | 'calculated';
     errorWorkflow?: string;
@@ -54,7 +50,7 @@ export interface WorkflowSettings {
 // DECORATOR METADATA
 // =========================================================================
 
-export interface WorkflowDecoratorOptions {
+interface WorkflowDecoratorOptions {
     /** Workflow ID (assigned by n8n) */
     id: string;
     /** Human-readable name */
@@ -73,7 +69,7 @@ export interface WorkflowDecoratorOptions {
     isArchived?: boolean;
 }
 
-export interface NodeDecoratorOptions {
+interface NodeDecoratorOptions {
     /** Unique identifier of the node (matches workflow JSON) */
     id?: string;
     /** Stable webhook ID assigned by n8n to webhook nodes */
@@ -96,7 +92,7 @@ export interface NodeDecoratorOptions {
 // AI / LANGCHAIN DEPENDENCY MAP (.uses())
 // =========================================================================
 
-export interface AIDependencyMap {
+interface AIDependencyMap {
     ai_languageModel?: any;
     ai_memory?: any;
     ai_outputParser?: any;
@@ -115,11 +111,11 @@ export interface AIDependencyMap {
 // FLUENT CONNECTION API
 // =========================================================================
 
-export interface InputConnection {
+interface InputConnection {
     readonly _to: { node: string; input: number };
 }
 
-export interface OutputConnection {
+interface OutputConnection {
     readonly _from: { node: string; output: number; isError?: boolean };
     to(input: InputConnection): void;
 }
@@ -137,7 +133,7 @@ export interface OutputConnection {
  * export class MyWorkflow { ... }
  * ```
  */
-export declare function workflow(options: WorkflowDecoratorOptions): ClassDecorator;
+declare function workflow(options: WorkflowDecoratorOptions): ClassDecorator;
 
 /**
  * Marks a class property as an n8n node.
@@ -149,7 +145,7 @@ export declare function workflow(options: WorkflowDecoratorOptions): ClassDecora
  * MyHttp = { url: 'https://api.example.com' };
  * ```
  */
-export declare function node(options: NodeDecoratorOptions): PropertyDecorator;
+declare function node(options: NodeDecoratorOptions): PropertyDecorator;
 
 /**
  * Marks a method as the routing/connections definition.
@@ -163,7 +159,7 @@ export declare function node(options: NodeDecoratorOptions): PropertyDecorator;
  * }
  * ```
  */
-export declare function links(): MethodDecorator;
+declare function links(): MethodDecorator;
 
 
 declare module '@n8n-as-code/transformer' {

--- a/packages/cli/src/core/assets/n8n-workflows.d.ts
+++ b/packages/cli/src/core/assets/n8n-workflows.d.ts
@@ -18,149 +18,35 @@
 // =========================================================================
 interface Object {
     /** Regular output connector (index = output slot, default 0) */
-    out(index?: number): OutputConnection;
+    out(index?: number): {
+        readonly _from: { node: string; output: number; isError?: boolean };
+        to(input: { readonly _to: { node: string; input: number } }): void;
+    };
     /** Regular input connector (index = input slot, default 0) */
-    in(index?: number): InputConnection;
+    in(index?: number): { readonly _to: { node: string; input: number } };
     /** Error output connector */
-    error(): OutputConnection;
+    error(): {
+        readonly _from: { node: string; output: number; isError?: boolean };
+        to(input: { readonly _to: { node: string; input: number } }): void;
+    };
     /** Declare AI/LangChain sub-node dependencies */
-    uses(dependencies: AIDependencyMap): void;
+    uses(dependencies: {
+        ai_languageModel?: any;
+        ai_memory?: any;
+        ai_outputParser?: any;
+        ai_tool?: any[];
+        ai_agent?: any;
+        ai_chain?: any;
+        ai_document?: any[];
+        ai_textSplitter?: any;
+        ai_embedding?: any;
+        ai_retriever?: any;
+        ai_reranker?: any;
+        ai_vectorStore?: any;
+    }): void;
     /** Output reference used as target of .uses() values */
     readonly output: any;
 }
-
-// =========================================================================
-// WORKFLOW SETTINGS
-// =========================================================================
-
-interface WorkflowSettings {
-    executionOrder?: 'v0' | 'v1' | 'v2';
-    timeSavedMode?: 'fixed' | 'calculated';
-    errorWorkflow?: string;
-    timezone?: string;
-    saveManualExecutions?: boolean;
-    saveDataErrorExecution?: 'all' | 'none';
-    saveExecutionProgress?: boolean;
-    callerPolicy?: 'workflowsFromSameOwner' | 'any' | 'none';
-    availableInMCP?: boolean;
-    [key: string]: any;
-}
-
-// =========================================================================
-// DECORATOR METADATA
-// =========================================================================
-
-interface WorkflowDecoratorOptions {
-    /** Workflow ID (assigned by n8n) */
-    id: string;
-    /** Human-readable name */
-    name: string;
-    /** Whether the workflow is active */
-    active: boolean;
-    /** Workflow description */
-    description?: string;
-    /** Workflow execution settings */
-    settings?: WorkflowSettings;
-    /** Project ID for organization */
-    projectId?: string;
-    /** Project name */
-    projectName?: string;
-    /** Whether the workflow is archived */
-    isArchived?: boolean;
-}
-
-interface NodeDecoratorOptions {
-    /** Unique identifier of the node (matches workflow JSON) */
-    id?: string;
-    /** Stable webhook ID assigned by n8n to webhook nodes */
-    webhookId?: string;
-    /** Display name shown in n8n UI */
-    name: string;
-    /** Node type identifier (e.g. "n8n-nodes-base.httpRequest") */
-    type: string;
-    /** Node version */
-    version: number;
-    /** Position [x, y] on the canvas */
-    position?: [number, number];
-    /** Credential references */
-    credentials?: Record<string, { id: string; name: string }>;
-    /** Error handling mode */
-    onError?: 'continueErrorOutput' | 'continueRegularOutput' | 'stopWorkflow';
-}
-
-// =========================================================================
-// AI / LANGCHAIN DEPENDENCY MAP (.uses())
-// =========================================================================
-
-interface AIDependencyMap {
-    ai_languageModel?: any;
-    ai_memory?: any;
-    ai_outputParser?: any;
-    ai_tool?: any[];
-    ai_agent?: any;
-    ai_chain?: any;
-    ai_document?: any[];
-    ai_textSplitter?: any;
-    ai_embedding?: any;
-    ai_retriever?: any;
-    ai_reranker?: any;
-    ai_vectorStore?: any;
-}
-
-// =========================================================================
-// FLUENT CONNECTION API
-// =========================================================================
-
-interface InputConnection {
-    readonly _to: { node: string; input: number };
-}
-
-interface OutputConnection {
-    readonly _from: { node: string; output: number; isError?: boolean };
-    to(input: InputConnection): void;
-}
-
-// =========================================================================
-// DECORATORS
-// =========================================================================
-
-/**
- * Marks a class as an n8n workflow.
- *
- * @example
- * ```ts
- * @workflow({ id: 'abc123', name: 'My Workflow', active: false })
- * export class MyWorkflow { ... }
- * ```
- */
-declare function workflow(options: WorkflowDecoratorOptions): ClassDecorator;
-
-/**
- * Marks a class property as an n8n node.
- * The property value is used as node parameters.
- *
- * @example
- * ```ts
- * @node({ name: 'HTTP Request', type: 'n8n-nodes-base.httpRequest', version: 4.2, position: [300, 200] })
- * MyHttp = { url: 'https://api.example.com' };
- * ```
- */
-declare function node(options: NodeDecoratorOptions): PropertyDecorator;
-
-/**
- * Marks a method as the routing/connections definition.
- *
- * @example
- * ```ts
- * @links()
- * defineRouting() {
- *     this.Trigger.out(0).to(this.Agent.in(0));
- *     this.Agent.uses({ ai_languageModel: this.Model.output });
- * }
- * ```
- */
-declare function links(): MethodDecorator;
-
 
 declare module '@n8n-as-code/transformer' {
     // =========================================================================

--- a/packages/cli/tests/unit/workspace-setup-service.test.ts
+++ b/packages/cli/tests/unit/workspace-setup-service.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import ts from 'typescript';
 import { afterEach, describe, expect, it } from 'vitest';
 import { WorkspaceSetupService } from '../../src/core/services/workspace-setup-service.js';
 
@@ -40,8 +41,45 @@ describe('WorkspaceSetupService', () => {
         expect(fs.existsSync(declarationPath)).toBe(true);
 
         const declaration = fs.readFileSync(declarationPath, 'utf-8');
+        expect(declaration).not.toContain('export {};');
         expect(declaration).toContain("declare module '@n8n-as-code/transformer' {");
         expect(declaration).toContain('/** Unique identifier of the node (matches workflow JSON) */');
         expect(declaration).toMatch(/export interface NodeDecoratorOptions\s*\{[\s\S]*?\bid\?:\s*string;/);
+    });
+
+    it('type-checks generated workflow imports without installing transformer locally', () => {
+        const workflowDir = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-workspace-'));
+        tempDirs.push(workflowDir);
+
+        WorkspaceSetupService.ensureWorkspaceFiles(workflowDir);
+        fs.writeFileSync(
+            path.join(workflowDir, 'sample.workflow.ts'),
+            [
+                "import { workflow, node, links } from '@n8n-as-code/transformer';",
+                '',
+                "@workflow({ id: 'wf_1', name: 'Sample', active: false })",
+                'export class SampleWorkflow {',
+                "    @node({ id: 'node_1', name: 'Manual Trigger', type: 'n8n-nodes-base.manualTrigger', version: 1 })",
+                '    Trigger = {};',
+                '',
+                '    @links()',
+                '    defineRouting() {}',
+                '}',
+                '',
+            ].join('\n'),
+            'utf-8'
+        );
+
+        const configPath = path.join(workflowDir, 'tsconfig.json');
+        const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+        expect(configFile.error).toBeUndefined();
+
+        const parsed = ts.parseJsonConfigFileContent(configFile.config, ts.sys, workflowDir);
+        const program = ts.createProgram(parsed.fileNames, parsed.options);
+        const diagnostics = ts.getPreEmitDiagnostics(program).filter(
+            (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error
+        );
+
+        expect(diagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'))).toEqual([]);
     });
 });

--- a/packages/cli/tests/unit/workspace-setup-service.test.ts
+++ b/packages/cli/tests/unit/workspace-setup-service.test.ts
@@ -53,6 +53,19 @@ describe('WorkspaceSetupService', () => {
 
         WorkspaceSetupService.ensureWorkspaceFiles(workflowDir);
         fs.writeFileSync(
+            path.join(workflowDir, 'colliding-globals.d.ts'),
+            [
+                'interface WorkflowSettings { requiredGlobalOnly: string; }',
+                'interface WorkflowDecoratorOptions { requiredGlobalOnly: string; }',
+                'interface NodeDecoratorOptions { requiredGlobalOnly: string; }',
+                'interface AIDependencyMap { requiredGlobalOnly: string; }',
+                'interface InputConnection { requiredGlobalOnly: string; }',
+                'interface OutputConnection { requiredGlobalOnly: string; }',
+                '',
+            ].join('\n'),
+            'utf-8'
+        );
+        fs.writeFileSync(
             path.join(workflowDir, 'sample.workflow.ts'),
             [
                 "import { workflow, node, links } from '@n8n-as-code/transformer';",

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -28,6 +28,7 @@ import { getN8nConfig, getResolvedN8nConfig, validateN8nConfig, getWorkspaceRoot
 import { NO_WORKSPACE_ERROR_MESSAGE, OPEN_FOLDER_ACTION } from './constants/workspace.js';
 import { buildWorkflowQuickPickItems } from './utils/workflow-finder.js';
 import { isClipboardBridgeRequired } from './utils/clipboard-utils.js';
+import { getProjectDetail, getProjectDisplayLabel } from './utils/project-display.js';
 import { IWorkflowStatus } from 'n8nac';
 
 import {
@@ -101,6 +102,25 @@ type DeleteInstanceCommandArgs = {
 type InstanceQuickPickItem = vscode.QuickPickItem & {
     instanceId: string;
 };
+
+function findWorkflowByCommandArg(arg: any): IWorkflowStatus | undefined {
+    const candidate = arg?.workflow ? arg.workflow : arg;
+    if (!candidate) return undefined;
+    if (typeof candidate === 'string') {
+        return selectAllWorkflows(store.getState()).find((workflow) => (
+            workflow.id === candidate || workflow.filename === candidate
+        ));
+    }
+    return candidate;
+}
+
+async function refreshWorkflowList(): Promise<IWorkflowStatus[]> {
+    if (!cli) return [];
+    const workflows = await cli.list();
+    store.dispatch(setWorkflows(workflows));
+    enhancedTreeProvider.refresh();
+    return workflows;
+}
 
 export async function activate(context: vscode.ExtensionContext) {
     outputChannel.show(true);
@@ -231,15 +251,24 @@ export async function activate(context: vscode.ExtensionContext) {
                 vscode.window.showWarningMessage('n8n: Settings changed. Click "Apply Changes" to resume syncing.');
                 return;
             }
-            const wf = arg?.workflow ? arg.workflow : arg;
-            if (!wf || !cli || !syncManager) return;
+            const wf = findWorkflowByCommandArg(arg);
+            if (!cli || !syncManager) {
+                vscode.window.showWarningMessage('n8n is not initialized yet.');
+                outputChannel.appendLine('[n8n] Push skipped: CLI or sync manager is not initialized.');
+                return;
+            }
+            if (!wf?.filename) {
+                vscode.window.showWarningMessage('Cannot push: no local workflow file is available.');
+                outputChannel.appendLine(`[n8n] Push skipped: invalid workflow argument ${JSON.stringify(arg)}`);
+                return;
+            }
 
             const workflowPath = path.join(syncManager.getInstanceDirectory(), wf.filename);
 
             statusBar.showSyncing();
             try {
                 const pushedId = await cli.push(workflowPath);
-                const workflows = await cli.list();
+                const workflows = await refreshWorkflowList();
                 const updatedWorkflow = workflows.find(candidate => candidate.filename === wf.filename);
                 const workflowId = updatedWorkflow?.id ?? pushedId ?? wf.id;
 
@@ -248,8 +277,6 @@ export async function activate(context: vscode.ExtensionContext) {
                 }
 
                 outputChannel.appendLine(`[n8n] Push successful: ${wf.name} (${workflowId ?? 'unknown id'})`);
-                store.dispatch(setWorkflows(workflows));
-                enhancedTreeProvider.refresh();
                 statusBar.showSynced();
                 vscode.window.showInformationMessage(`✅ Pushed "${wf.name}"`);
             } catch (e: any) {
@@ -257,9 +284,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 if (isOcc) {
                     statusBar.showError('Conflict');
                     await vscode.commands.executeCommand('n8n.resolveConflict', { workflow: wf, choice: undefined });
-                    const workflows = await cli.list();
-                    store.dispatch(setWorkflows(workflows));
-                    enhancedTreeProvider.refresh();
+                    await refreshWorkflowList();
                     statusBar.showSynced();
                 } else {
                     statusBar.showError(e.message);
@@ -274,8 +299,17 @@ export async function activate(context: vscode.ExtensionContext) {
                 vscode.window.showWarningMessage('n8n: Settings changed. Click "Apply Changes" to resume syncing.');
                 return;
             }
-            const wf = arg?.workflow ? arg.workflow : arg;
-            if (!wf || !cli || !syncManager || !wf.id) return;
+            const wf = findWorkflowByCommandArg(arg);
+            if (!cli || !syncManager) {
+                vscode.window.showWarningMessage('n8n is not initialized yet.');
+                outputChannel.appendLine('[n8n] Pull skipped: CLI or sync manager is not initialized.');
+                return;
+            }
+            if (!wf?.id) {
+                vscode.window.showWarningMessage('Cannot pull: no remote workflow ID is available.');
+                outputChannel.appendLine(`[n8n] Pull skipped: invalid workflow argument ${JSON.stringify(arg)}`);
+                return;
+            }
 
             if (wf.filename) {
                 const workflowStatus = await cli.getSingleWorkflowDetailedStatus(wf.id, wf.filename);
@@ -286,9 +320,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 if (hasConflict || hasLocalChanges) {
                     statusBar.showError('Conflict');
                     await vscode.commands.executeCommand('n8n.resolveConflict', { workflow: wf, choice: undefined });
-                    const workflows = await cli.list();
-                    store.dispatch(setWorkflows(workflows));
-                    enhancedTreeProvider.refresh();
+                    await refreshWorkflowList();
                     statusBar.showSynced();
                     return; // Conflict resolution handles the pull/push
                 }
@@ -296,11 +328,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
             statusBar.showSyncing();
             try {
+                outputChannel.appendLine(`[n8n] Pulling workflow: ${wf.name} (${wf.id})`);
                 await cli.pull(wf.id);
-                const workflows = await cli.list();
-                store.dispatch(setWorkflows(workflows));
-                enhancedTreeProvider.refresh();
+                await refreshWorkflowList();
                 statusBar.showSynced();
+                outputChannel.appendLine(`[n8n] Pull successful: ${wf.name} (${wf.id})`);
                 vscode.window.showInformationMessage(`✅ Pulled "${wf.name}"`);
             } catch (e: any) {
                 statusBar.showError(e.message);
@@ -1304,15 +1336,14 @@ async function initializeSyncManager(context: vscode.ExtensionContext) {
         });
         if (!projects.length) throw new Error('No projects found. Cannot initialize sync.');
 
-        let selectedProject = projects.find((p: any) => p.type === 'personal');
-        if (!selectedProject && projects.length === 1) selectedProject = projects[0];
+        let selectedProject = projects.length === 1 ? projects[0] : undefined;
 
         if (!selectedProject) {
             const picked = await vscode.window.showQuickPick(
                 projects.map((p: any) => ({
-                    label: p.type === 'personal' ? 'Personal' : p.name,
+                    label: getProjectDisplayLabel(p),
                     description: p.type,
-                    detail: p.id,
+                    detail: getProjectDetail(p),
                     project: p
                 })),
                 { title: 'Select the n8n project to sync', ignoreFocusOut: true }
@@ -1323,7 +1354,7 @@ async function initializeSyncManager(context: vscode.ExtensionContext) {
 
         if (!selectedProject) throw new Error('No project selected.');
         projectId = selectedProject.id;
-        projectName = selectedProject.type === 'personal' ? 'Personal' : selectedProject.name;
+        projectName = getProjectDisplayLabel(selectedProject);
         outputChannel.appendLine(`[n8n] Selected project: ${projectName} (${projectId})`);
     }
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -28,7 +28,7 @@ import { getN8nConfig, getResolvedN8nConfig, validateN8nConfig, getWorkspaceRoot
 import { NO_WORKSPACE_ERROR_MESSAGE, OPEN_FOLDER_ACTION } from './constants/workspace.js';
 import { buildWorkflowQuickPickItems } from './utils/workflow-finder.js';
 import { isClipboardBridgeRequired } from './utils/clipboard-utils.js';
-import { getProjectDetail, getProjectDisplayLabel } from './utils/project-display.js';
+import { getCanonicalProjectName, getProjectDetail, getProjectDisplayLabel } from './utils/project-display.js';
 import { IWorkflowStatus } from 'n8nac';
 
 import {
@@ -1354,8 +1354,8 @@ async function initializeSyncManager(context: vscode.ExtensionContext) {
 
         if (!selectedProject) throw new Error('No project selected.');
         projectId = selectedProject.id;
-        projectName = getProjectDisplayLabel(selectedProject);
-        outputChannel.appendLine(`[n8n] Selected project: ${projectName} (${projectId})`);
+        projectName = getCanonicalProjectName(selectedProject);
+        outputChannel.appendLine(`[n8n] Selected project: ${getProjectDisplayLabel(selectedProject)} (${projectId})`);
     }
 
     const absDirectory = path.isAbsolute(folder) ? folder : path.resolve(workspaceRoot, folder);

--- a/packages/vscode-extension/src/ui/configuration-webview-html.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview-html.ts
@@ -590,8 +590,8 @@ export function getConfigurationHtml(nonce: string): string {
         const opt = document.createElement('option');
         opt.value = project.id;
         opt.dataset.projectName = project.name;
-        opt.textContent = opt.dataset.projectName;
-        opt.title = project.detail || project.name;
+        opt.textContent = project.displayName || project.name;
+        opt.title = project.detail || opt.textContent;
         els.workspaceProject.appendChild(opt);
       }
       if (selectedId && !availableProjects.some((project) => project.id === selectedId)) {

--- a/packages/vscode-extension/src/ui/configuration-webview-html.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview-html.ts
@@ -589,8 +589,9 @@ export function getConfigurationHtml(nonce: string): string {
       for (const project of availableProjects) {
         const opt = document.createElement('option');
         opt.value = project.id;
-        opt.dataset.projectName = project.type === 'personal' ? 'Personal' : project.name;
+        opt.dataset.projectName = project.name;
         opt.textContent = opt.dataset.projectName;
+        opt.title = project.detail || project.name;
         els.workspaceProject.appendChild(opt);
       }
       if (selectedId && !availableProjects.some((project) => project.id === selectedId)) {

--- a/packages/vscode-extension/src/ui/configuration-webview.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview.ts
@@ -3,17 +3,20 @@ import { createN8nManagerFacade } from '@n8n-as-code/manager-adapter';
 import { getWorkspaceRoot } from '../utils/state-detection.js';
 import type { N8nConfigurationController, N8nConfigurationSnapshot } from '../services/n8n-configuration-controller.js';
 import { getConfigurationHtml } from './configuration-webview-html.js';
+import { getProjectDetail, getProjectDisplayLabel } from '../utils/project-display.js';
 
 type UiProject = {
   id: string;
   name: string;
   type?: string;
+  detail?: string;
 };
 
 const PERSONAL_PROJECT: UiProject = {
   id: 'personal',
   name: 'Personal',
   type: 'personal',
+  detail: 'Type: personal | ID: personal',
 };
 
 function normalizeHost(host: string): string {
@@ -138,8 +141,9 @@ export class ConfigurationWebview {
             autoStart: true,
           })).map((project) => ({
             id: project.id,
-            name: project.type === 'personal' ? 'Personal' : (project.name || project.id),
+            name: getProjectDisplayLabel(project),
             type: project.type,
+            detail: getProjectDetail(project),
           }));
           this._panel.webview.postMessage({
             type: 'projectsLoaded',

--- a/packages/vscode-extension/src/ui/configuration-webview.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview.ts
@@ -3,13 +3,14 @@ import { createN8nManagerFacade } from '@n8n-as-code/manager-adapter';
 import { getWorkspaceRoot } from '../utils/state-detection.js';
 import type { N8nConfigurationController, N8nConfigurationSnapshot } from '../services/n8n-configuration-controller.js';
 import { getConfigurationHtml } from './configuration-webview-html.js';
-import { getProjectDetail, getProjectDisplayLabel } from '../utils/project-display.js';
+import { getCanonicalProjectName, getProjectDetail, getProjectDisplayLabel } from '../utils/project-display.js';
 
 type UiProject = {
   id: string;
   name: string;
   type?: string;
   detail?: string;
+  displayName?: string;
 };
 
 const PERSONAL_PROJECT: UiProject = {
@@ -17,6 +18,7 @@ const PERSONAL_PROJECT: UiProject = {
   name: 'Personal',
   type: 'personal',
   detail: 'Type: personal | ID: personal',
+  displayName: 'Personal',
 };
 
 function normalizeHost(host: string): string {
@@ -141,9 +143,10 @@ export class ConfigurationWebview {
             autoStart: true,
           })).map((project) => ({
             id: project.id,
-            name: getProjectDisplayLabel(project),
+            name: getCanonicalProjectName(project),
             type: project.type,
             detail: getProjectDetail(project),
+            displayName: getProjectDisplayLabel(project),
           }));
           this._panel.webview.postMessage({
             type: 'projectsLoaded',

--- a/packages/vscode-extension/src/ui/tree-items/action-item.ts
+++ b/packages/vscode-extension/src/ui/tree-items/action-item.ts
@@ -108,13 +108,13 @@ export class ActionItem extends BaseTreeItem {
         return {
           command: 'n8n.pullWorkflow',
           title: 'Pull',
-          arguments: [workflow.id]
+          arguments: [workflow]
         };
       case ActionItemType.PUSH:
         return {
           command: 'n8n.pushWorkflow',
           title: 'Push',
-          arguments: [workflow.filename]
+          arguments: [workflow]
         };
       case ActionItemType.OPEN:
         return {

--- a/packages/vscode-extension/src/utils/project-display.ts
+++ b/packages/vscode-extension/src/utils/project-display.ts
@@ -19,11 +19,19 @@ export function getPersonalProjectOwner(project: DisplayableProject): string | u
 
 export function getProjectDisplayLabel(project: DisplayableProject): string {
     if (project.type !== 'personal') {
-        return project.name?.trim() || project.id || 'Unnamed project';
+        return getCanonicalProjectName(project);
     }
 
     const owner = getPersonalProjectOwner(project);
     return owner ? `Personal - ${owner}` : 'Personal';
+}
+
+export function getCanonicalProjectName(project: DisplayableProject): string {
+    if (project.type === 'personal') {
+        return 'Personal';
+    }
+
+    return project.name?.trim() || project.id || 'Unnamed project';
 }
 
 export function getProjectDetail(project: DisplayableProject): string {

--- a/packages/vscode-extension/src/utils/project-display.ts
+++ b/packages/vscode-extension/src/utils/project-display.ts
@@ -1,0 +1,46 @@
+export type DisplayableProject = {
+    id?: string;
+    name?: string;
+    type?: string;
+};
+
+export function getPersonalProjectOwner(project: DisplayableProject): string | undefined {
+    if (project.type !== 'personal') {
+        return undefined;
+    }
+
+    const name = project.name?.trim();
+    if (!name || name.toLowerCase() === 'personal') {
+        return undefined;
+    }
+
+    return name;
+}
+
+export function getProjectDisplayLabel(project: DisplayableProject): string {
+    if (project.type !== 'personal') {
+        return project.name?.trim() || project.id || 'Unnamed project';
+    }
+
+    const owner = getPersonalProjectOwner(project);
+    return owner ? `Personal - ${owner}` : 'Personal';
+}
+
+export function getProjectDetail(project: DisplayableProject): string {
+    const parts: string[] = [];
+
+    if (project.type) {
+        parts.push(`Type: ${project.type}`);
+    }
+
+    const owner = getPersonalProjectOwner(project);
+    if (owner) {
+        parts.push(`Owner: ${owner}`);
+    }
+
+    if (project.id) {
+        parts.push(`ID: ${project.id}`);
+    }
+
+    return parts.join(' | ');
+}

--- a/plugins/claude/n8n-as-code/skills/n8n-architect/SKILL.md
+++ b/plugins/claude/n8n-as-code/skills/n8n-architect/SKILL.md
@@ -11,44 +11,44 @@ Use this skill for workflow engineering. Use the `n8n-manager` skill for instanc
 
 - Treat the current context root as the directory containing `n8nac-config.json`, `AGENTS.md`, `.agents/skills`, and the workflow sync folder.
 - Generated context root hint: not embedded. Use the shell launch directory or the workspace path explicitly given by the user.
-- Before any n8n work, first run `npx --yes n8nac@next update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
+- Before any n8n work, first run `npx --yes n8nac update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
 - Use the exact `n8nac command` and `n8n-manager command` listed in `AGENTS.md`. Those context-root commands override the portable examples in this skill.
-- Run every `npx --yes n8nac@next workspace ...`, `npx --yes n8nac@next list`, `pull`, `push`, `validate`, `test`, and `update-ai` command from the context root unless the user explicitly gives another context root.
+- Run every `npx --yes n8nac workspace ...`, `npx --yes n8nac list`, `pull`, `push`, `validate`, `test`, and `update-ai` command from the context root unless the user explicitly gives another context root.
 - `AGENTS.md` is bootstrap context only, not a source of configuration truth.
 - Do not infer instance, project, sync folder, or workflow directory from `AGENTS.md`.
 - Before n8n work, resolve the effective context from the backend:
 
 ```bash
-npx --yes n8nac@next workspace status --json
+npx --yes n8nac workspace status --json
 ```
 
 - Use the returned `workflowDir` for workflow files. Do not reconstruct it from `syncFolder`, `instanceIdentifier`, or `projectName`.
-- Never write `n8nac-config.json` by hand. Use `npx --yes n8nac@next workspace ...` commands.
+- Never write `n8nac-config.json` by hand. Use `npx --yes n8nac workspace ...` commands.
 
 ## Bootstrap Order
 
 1. `cd` to the context root.
-2. Run `npx --yes n8nac@next update-ai`, then read `AGENTS.md`.
-3. Run `npx --yes n8nac@next workspace status --json`.
-4. If the context root is not ready, inspect instances with `npx --yes @n8n-as-code/n8n-manager@next instances list`.
+2. Run `npx --yes n8nac update-ai`, then read `AGENTS.md`.
+3. Run `npx --yes n8nac workspace status --json`.
+4. If the context root is not ready, inspect instances with `npx --yes @n8n-as-code/n8n-manager instances list`.
 5. Reuse an existing instance when suitable.
 6. If no suitable instance exists, stop and ask the user whether they want to reuse/configure an existing instance, create a managed local n8n instance, or connect an existing/remote n8n instance. Do not create infrastructure by default. If the user chooses a managed local instance, ask separately whether they want a public tunnel.
 7. Ask for host/API key only for an explicitly remote or existing n8n instance.
 8. Configure context-root overrides with:
 
 ```bash
-npx --yes n8nac@next workspace pin-instance --instance-id <id>
-npx --yes n8nac@next workspace set-sync-folder workflows
-npx --yes n8nac@next workspace set-project --project-id <id> --project-name <name>
+npx --yes n8nac workspace pin-instance --instance-id <id>
+npx --yes n8nac workspace set-sync-folder workflows
+npx --yes n8nac workspace set-project --project-id <id> --project-name <name>
 ```
 
 For self-hosted n8n instances where the projects API is unavailable or returns 401/403, do not keep retrying project discovery. Use the standard personal project override unless the user gave another project:
 
 ```bash
-npx --yes n8nac@next workspace set-project --project-id personal --project-name Personal
+npx --yes n8nac workspace set-project --project-id personal --project-name Personal
 ```
 
-9. Run `npx --yes n8nac@next update-ai` after changing context-root overrides when the facade does not do it automatically.
+9. Run `npx --yes n8nac update-ai` after changing context-root overrides when the facade does not do it automatically.
 
 ## Sync Discipline
 
@@ -57,13 +57,13 @@ npx --yes n8nac@next workspace set-project --project-id personal --project-name 
 - Use `list` to inspect workflow IDs, file paths, and sync status.
 
 ```bash
-npx --yes n8nac@next list
-npx --yes n8nac@next pull <workflowId>
-npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
+npx --yes n8nac list
+npx --yes n8nac pull <workflowId>
+npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
 ```
 
 - `push` requires the full workflow file path, either absolute or context-root-relative. Do not pass a bare filename.
-- For a new workflow, create the file inside the `workflowDir` returned by `workspace status --json`, then confirm it with `npx --yes n8nac@next list --local`.
+- For a new workflow, create the file inside the `workflowDir` returned by `workspace status --json`, then confirm it with `npx --yes n8nac list --local`.
 - If push/pull reports a conflict, use explicit resolution commands. Do not overwrite remote changes blindly.
 - `pull` and conflict resolution operate on a single workflow ID.
 - `list` is the lightweight command that covers all workflows at once.
@@ -74,8 +74,8 @@ npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
 If push or pull reports a conflict, stop and inspect the conflict. Use explicit resolution commands only after choosing the intended direction:
 
 ```bash
-npx --yes n8nac@next resolve <workflowId> --mode keep-current
-npx --yes n8nac@next resolve <workflowId> --mode keep-incoming
+npx --yes n8nac resolve <workflowId> --mode keep-current
+npx --yes n8nac resolve <workflowId> --mode keep-incoming
 ```
 
 - `keep-current` force-pushes the local version.
@@ -87,10 +87,10 @@ npx --yes n8nac@next resolve <workflowId> --mode keep-incoming
 Never guess n8n node parameters.
 
 ```bash
-npx --yes n8nac@next skills examples search "<workflow pattern>"
-npx --yes n8nac@next skills search "<node or capability>"
-npx --yes n8nac@next skills node-info <nodeName>
-npx --yes n8nac@next skills validate <workflow.workflow.ts>
+npx --yes n8nac skills examples search "<workflow pattern>"
+npx --yes n8nac skills search "<node or capability>"
+npx --yes n8nac skills node-info <nodeName>
+npx --yes n8nac skills validate <workflow.workflow.ts>
 ```
 
 - Use exact node `type` and valid `typeVersion` values from `node-info`.
@@ -105,19 +105,19 @@ npx --yes n8nac@next skills validate <workflow.workflow.ts>
 Use these commands instead of guessing:
 
 ```bash
-npx --yes n8nac@next skills search "<node or capability>"
-npx --yes n8nac@next skills node-info <nodeName>
-npx --yes n8nac@next skills node-schema <nodeName>
-npx --yes n8nac@next skills docs "<topic>"
-npx --yes n8nac@next skills guides "<topic>"
-npx --yes n8nac@next skills examples search "<workflow pattern>"
-npx --yes n8nac@next skills examples info <id>
-npx --yes n8nac@next skills examples download <id>
+npx --yes n8nac skills search "<node or capability>"
+npx --yes n8nac skills node-info <nodeName>
+npx --yes n8nac skills node-schema <nodeName>
+npx --yes n8nac skills docs "<topic>"
+npx --yes n8nac skills guides "<topic>"
+npx --yes n8nac skills examples search "<workflow pattern>"
+npx --yes n8nac skills examples info <id>
+npx --yes n8nac skills examples download <id>
 ```
 
 - Start with `examples search` when the user asks for a common automation pattern.
 - Use examples to learn patterns, not as authority over current node schemas.
-- If a command or flag is unfamiliar, run `npx --yes n8nac@next <subcommand> --help`; do not invent flags.
+- If a command or flag is unfamiliar, run `npx --yes n8nac <subcommand> --help`; do not invent flags.
 
 ## Workflow Authoring Rules
 
@@ -257,15 +257,15 @@ defineRouting() {
 After pushing:
 
 ```bash
-npx --yes n8nac@next verify <workflowId>
-npx --yes n8nac@next test-plan <workflowId> --json
+npx --yes n8nac verify <workflowId>
+npx --yes n8nac test-plan <workflowId> --json
 ```
 
 For webhook, chat, or form workflows, prefer the production test sequence:
 
 ```bash
-npx --yes n8nac@next workflow activate <workflowId>
-npx --yes n8nac@next test <workflowId> --prod
+npx --yes n8nac workflow activate <workflowId>
+npx --yes n8nac test <workflowId> --prod
 ```
 
 - Class A configuration gaps require user/config action, not workflow rewrites.
@@ -285,7 +285,7 @@ Run it whenever one of these is true:
 - the user asks to show, open, present, display, or give the URL/link for a workflow.
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
+npx --yes @n8n-as-code/n8n-manager presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
 ```
 
 Rules:
@@ -293,7 +293,7 @@ Rules:
 - Do not manually construct n8n workflow URLs.
 - Do not return an internal local n8n URL when a presentation URL is available.
 - Use the `url` returned by `presentWorkflowResult` as the user-facing URL.
-- If you do not know the workflow ID, run `npx --yes n8nac@next list` first and select the matching workflow.
+- If you do not know the workflow ID, run `npx --yes n8nac list` first and select the matching workflow.
 - If `presentWorkflowResult` fails, report the backend diagnostic and then provide the best direct n8n URL only as a fallback.
 - Do this before the final response when the task created, changed, pushed, ran, or explicitly asks to show a workflow.
 
@@ -307,18 +307,18 @@ For webhook, chat, or form workflows:
 4. Test with `--prod` by default.
 
 ```bash
-npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
-npx --yes n8nac@next test-plan <workflowId> --json
-npx --yes n8nac@next workflow activate <workflowId>
-npx --yes n8nac@next test <workflowId> --prod
+npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
+npx --yes n8nac test-plan <workflowId> --json
+npx --yes n8nac workflow activate <workflowId>
+npx --yes n8nac test <workflowId> --prod
 ```
 
-Use bare `npx --yes n8nac@next test <workflowId>` only when a test URL was intentionally armed in the n8n editor.
+Use bare `npx --yes n8nac test <workflowId>` only when a test URL was intentionally armed in the n8n editor.
 
 For GET/HEAD webhooks that read from `$json.query`, prefer:
 
 ```bash
-npx --yes n8nac@next test <workflowId> --query '{"key":"value"}' --prod
+npx --yes n8nac test <workflowId> --query '{"key":"value"}' --prod
 ```
 
 ## Execution Debugging
@@ -326,8 +326,8 @@ npx --yes n8nac@next test <workflowId> --query '{"key":"value"}' --prod
 If a webhook returns success but the workflow behavior is wrong, inspect executions instead of guessing:
 
 ```bash
-npx --yes n8nac@next execution list --workflow-id <workflowId> --limit 5 --json
-npx --yes n8nac@next execution get <executionId> --include-data --json
+npx --yes n8nac execution list --workflow-id <workflowId> --limit 5 --json
+npx --yes n8nac execution get <executionId> --include-data --json
 ```
 
 - A successful HTTP trigger only means n8n accepted the request.
@@ -339,11 +339,11 @@ npx --yes n8nac@next execution get <executionId> --include-data --json
 When a workflow is blocked by missing credentials, resolve the credential gap without rewriting unrelated workflow logic.
 
 ```bash
-npx --yes n8nac@next workflow credential-required <workflowId> --json
-npx --yes n8nac@next credential schema <type>
-npx --yes n8nac@next credential list --json
-npx --yes n8nac@next credential create --type <type> --name <name> --file cred.json --json
-npx --yes n8nac@next workflow activate <workflowId>
+npx --yes n8nac workflow credential-required <workflowId> --json
+npx --yes n8nac credential schema <type>
+npx --yes n8nac credential list --json
+npx --yes n8nac credential create --type <type> --name <name> --file cred.json --json
+npx --yes n8nac workflow activate <workflowId>
 ```
 
 - `workflow credential-required` exits non-zero when at least one credential is missing. Treat that as a signal to act, not as a workflow-code failure.

--- a/plugins/claude/n8n-as-code/skills/n8n-manager/SKILL.md
+++ b/plugins/claude/n8n-as-code/skills/n8n-manager/SKILL.md
@@ -10,11 +10,11 @@ Use this skill for global n8n instance management. `n8n-manager` is the source o
 ## Responsibility Boundary
 
 - Generated context root hint: not embedded. Use the shell launch directory or the workspace path explicitly given by the user.
-- If `n8nac` is available, first run `npx --yes n8nac@next update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
+- If `n8nac` is available, first run `npx --yes n8nac update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
 - Use the exact `n8n-manager command` and `n8nac command` listed in `AGENTS.md` when present. Those context-root commands override the portable examples in this skill.
-- Use `npx --yes @n8n-as-code/n8n-manager@next` for global instance, auth, runtime, tunnel, project-default, credential, and workflow-presentation operations.
-- Use `npx --yes n8nac@next workspace ...` only for context-root overrides such as pinned instance, sync folder, and project override.
-- Use `npx --yes n8nac@next` workflow commands only after the effective context is ready.
+- Use `npx --yes @n8n-as-code/n8n-manager` for global instance, auth, runtime, tunnel, project-default, credential, and workflow-presentation operations.
+- Use `npx --yes n8nac workspace ...` only for context-root overrides such as pinned instance, sync folder, and project override.
+- Use `npx --yes n8nac` workflow commands only after the effective context is ready.
 - Never edit `n8nac-config.json`, `~/.n8n-manager`, or n8n-manager secret files by hand.
 
 ## Core Commands
@@ -22,9 +22,9 @@ Use this skill for global n8n instance management. `n8n-manager` is the source o
 Inspect existing instances before changing state:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances list
-npx --yes @n8n-as-code/n8n-manager@next instances --help
-npx --yes @n8n-as-code/n8n-manager@next config get
+npx --yes @n8n-as-code/n8n-manager instances list
+npx --yes @n8n-as-code/n8n-manager instances --help
+npx --yes @n8n-as-code/n8n-manager config get
 ```
 
 Do not invent n8n-manager subcommands. In particular, `instances create` and `--type local` are not valid. Use `instances add --mode ...` exactly as documented by `instances --help`.
@@ -53,56 +53,56 @@ Only run these commands after the user has explicitly chosen the corresponding o
 Managed local Docker without public tunnel:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances add --name <name> --mode managed-local-docker
-npx --yes @n8n-as-code/n8n-manager@next instances setup <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances add --name <name> --mode managed-local-docker
+npx --yes @n8n-as-code/n8n-manager instances setup <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances status <id-or-name>
 ```
 
 Managed local Docker with public tunnel:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances add --name <name> --mode managed-local-docker --tunnel
-npx --yes @n8n-as-code/n8n-manager@next instances setup <id-or-name> --tunnel
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances add --name <name> --mode managed-local-docker --tunnel
+npx --yes @n8n-as-code/n8n-manager instances setup <id-or-name> --tunnel
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel status <id-or-name>
 ```
 
 Remote or existing instances require user-provided credentials. Prefer stdin for API keys:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next auth set --url <url> --api-key-stdin --name <name>
-npx --yes @n8n-as-code/n8n-manager@next auth test --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager auth set --url <url> --api-key-stdin --name <name>
+npx --yes @n8n-as-code/n8n-manager auth test --instance <id-or-name>
 ```
 
 Project selection is instance-level unless the context root explicitly needs a workspace override:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next projects list --instance <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next projects select <project-id-or-name> --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager projects list --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager projects select <project-id-or-name> --instance <id-or-name>
 ```
 
 Self-hosted n8n may not expose the projects API or may return 401/403. In that case, do not retry project discovery. Use the n8n-architect workspace override path with the standard personal project unless the user gave another project:
 
 ```bash
-npx --yes n8nac@next workspace set-project --project-id personal --project-name Personal
+npx --yes n8nac workspace set-project --project-id personal --project-name Personal
 ```
 
 Runtime and tunnel operations are per instance:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances stop <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances restart <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel status <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel refresh <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances stop <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances restart <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel refresh <id-or-name>
 ```
 
 Present workflow results after creating, modifying, pushing, or running a workflow:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
+npx --yes @n8n-as-code/n8n-manager presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
 ```
 
 ## Guardrails

--- a/plugins/cursor/n8n-as-code/skills/n8n-architect/SKILL.md
+++ b/plugins/cursor/n8n-as-code/skills/n8n-architect/SKILL.md
@@ -11,44 +11,44 @@ Use this skill for workflow engineering. Use the `n8n-manager` skill for instanc
 
 - Treat the current context root as the directory containing `n8nac-config.json`, `AGENTS.md`, `.agents/skills`, and the workflow sync folder.
 - Generated context root hint: not embedded. Use the shell launch directory or the workspace path explicitly given by the user.
-- Before any n8n work, first run `npx --yes n8nac@next update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
+- Before any n8n work, first run `npx --yes n8nac update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
 - Use the exact `n8nac command` and `n8n-manager command` listed in `AGENTS.md`. Those context-root commands override the portable examples in this skill.
-- Run every `npx --yes n8nac@next workspace ...`, `npx --yes n8nac@next list`, `pull`, `push`, `validate`, `test`, and `update-ai` command from the context root unless the user explicitly gives another context root.
+- Run every `npx --yes n8nac workspace ...`, `npx --yes n8nac list`, `pull`, `push`, `validate`, `test`, and `update-ai` command from the context root unless the user explicitly gives another context root.
 - `AGENTS.md` is bootstrap context only, not a source of configuration truth.
 - Do not infer instance, project, sync folder, or workflow directory from `AGENTS.md`.
 - Before n8n work, resolve the effective context from the backend:
 
 ```bash
-npx --yes n8nac@next workspace status --json
+npx --yes n8nac workspace status --json
 ```
 
 - Use the returned `workflowDir` for workflow files. Do not reconstruct it from `syncFolder`, `instanceIdentifier`, or `projectName`.
-- Never write `n8nac-config.json` by hand. Use `npx --yes n8nac@next workspace ...` commands.
+- Never write `n8nac-config.json` by hand. Use `npx --yes n8nac workspace ...` commands.
 
 ## Bootstrap Order
 
 1. `cd` to the context root.
-2. Run `npx --yes n8nac@next update-ai`, then read `AGENTS.md`.
-3. Run `npx --yes n8nac@next workspace status --json`.
-4. If the context root is not ready, inspect instances with `npx --yes @n8n-as-code/n8n-manager@next instances list`.
+2. Run `npx --yes n8nac update-ai`, then read `AGENTS.md`.
+3. Run `npx --yes n8nac workspace status --json`.
+4. If the context root is not ready, inspect instances with `npx --yes @n8n-as-code/n8n-manager instances list`.
 5. Reuse an existing instance when suitable.
 6. If no suitable instance exists, stop and ask the user whether they want to reuse/configure an existing instance, create a managed local n8n instance, or connect an existing/remote n8n instance. Do not create infrastructure by default. If the user chooses a managed local instance, ask separately whether they want a public tunnel.
 7. Ask for host/API key only for an explicitly remote or existing n8n instance.
 8. Configure context-root overrides with:
 
 ```bash
-npx --yes n8nac@next workspace pin-instance --instance-id <id>
-npx --yes n8nac@next workspace set-sync-folder workflows
-npx --yes n8nac@next workspace set-project --project-id <id> --project-name <name>
+npx --yes n8nac workspace pin-instance --instance-id <id>
+npx --yes n8nac workspace set-sync-folder workflows
+npx --yes n8nac workspace set-project --project-id <id> --project-name <name>
 ```
 
 For self-hosted n8n instances where the projects API is unavailable or returns 401/403, do not keep retrying project discovery. Use the standard personal project override unless the user gave another project:
 
 ```bash
-npx --yes n8nac@next workspace set-project --project-id personal --project-name Personal
+npx --yes n8nac workspace set-project --project-id personal --project-name Personal
 ```
 
-9. Run `npx --yes n8nac@next update-ai` after changing context-root overrides when the facade does not do it automatically.
+9. Run `npx --yes n8nac update-ai` after changing context-root overrides when the facade does not do it automatically.
 
 ## Sync Discipline
 
@@ -57,13 +57,13 @@ npx --yes n8nac@next workspace set-project --project-id personal --project-name 
 - Use `list` to inspect workflow IDs, file paths, and sync status.
 
 ```bash
-npx --yes n8nac@next list
-npx --yes n8nac@next pull <workflowId>
-npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
+npx --yes n8nac list
+npx --yes n8nac pull <workflowId>
+npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
 ```
 
 - `push` requires the full workflow file path, either absolute or context-root-relative. Do not pass a bare filename.
-- For a new workflow, create the file inside the `workflowDir` returned by `workspace status --json`, then confirm it with `npx --yes n8nac@next list --local`.
+- For a new workflow, create the file inside the `workflowDir` returned by `workspace status --json`, then confirm it with `npx --yes n8nac list --local`.
 - If push/pull reports a conflict, use explicit resolution commands. Do not overwrite remote changes blindly.
 - `pull` and conflict resolution operate on a single workflow ID.
 - `list` is the lightweight command that covers all workflows at once.
@@ -74,8 +74,8 @@ npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
 If push or pull reports a conflict, stop and inspect the conflict. Use explicit resolution commands only after choosing the intended direction:
 
 ```bash
-npx --yes n8nac@next resolve <workflowId> --mode keep-current
-npx --yes n8nac@next resolve <workflowId> --mode keep-incoming
+npx --yes n8nac resolve <workflowId> --mode keep-current
+npx --yes n8nac resolve <workflowId> --mode keep-incoming
 ```
 
 - `keep-current` force-pushes the local version.
@@ -87,10 +87,10 @@ npx --yes n8nac@next resolve <workflowId> --mode keep-incoming
 Never guess n8n node parameters.
 
 ```bash
-npx --yes n8nac@next skills examples search "<workflow pattern>"
-npx --yes n8nac@next skills search "<node or capability>"
-npx --yes n8nac@next skills node-info <nodeName>
-npx --yes n8nac@next skills validate <workflow.workflow.ts>
+npx --yes n8nac skills examples search "<workflow pattern>"
+npx --yes n8nac skills search "<node or capability>"
+npx --yes n8nac skills node-info <nodeName>
+npx --yes n8nac skills validate <workflow.workflow.ts>
 ```
 
 - Use exact node `type` and valid `typeVersion` values from `node-info`.
@@ -105,19 +105,19 @@ npx --yes n8nac@next skills validate <workflow.workflow.ts>
 Use these commands instead of guessing:
 
 ```bash
-npx --yes n8nac@next skills search "<node or capability>"
-npx --yes n8nac@next skills node-info <nodeName>
-npx --yes n8nac@next skills node-schema <nodeName>
-npx --yes n8nac@next skills docs "<topic>"
-npx --yes n8nac@next skills guides "<topic>"
-npx --yes n8nac@next skills examples search "<workflow pattern>"
-npx --yes n8nac@next skills examples info <id>
-npx --yes n8nac@next skills examples download <id>
+npx --yes n8nac skills search "<node or capability>"
+npx --yes n8nac skills node-info <nodeName>
+npx --yes n8nac skills node-schema <nodeName>
+npx --yes n8nac skills docs "<topic>"
+npx --yes n8nac skills guides "<topic>"
+npx --yes n8nac skills examples search "<workflow pattern>"
+npx --yes n8nac skills examples info <id>
+npx --yes n8nac skills examples download <id>
 ```
 
 - Start with `examples search` when the user asks for a common automation pattern.
 - Use examples to learn patterns, not as authority over current node schemas.
-- If a command or flag is unfamiliar, run `npx --yes n8nac@next <subcommand> --help`; do not invent flags.
+- If a command or flag is unfamiliar, run `npx --yes n8nac <subcommand> --help`; do not invent flags.
 
 ## Workflow Authoring Rules
 
@@ -257,15 +257,15 @@ defineRouting() {
 After pushing:
 
 ```bash
-npx --yes n8nac@next verify <workflowId>
-npx --yes n8nac@next test-plan <workflowId> --json
+npx --yes n8nac verify <workflowId>
+npx --yes n8nac test-plan <workflowId> --json
 ```
 
 For webhook, chat, or form workflows, prefer the production test sequence:
 
 ```bash
-npx --yes n8nac@next workflow activate <workflowId>
-npx --yes n8nac@next test <workflowId> --prod
+npx --yes n8nac workflow activate <workflowId>
+npx --yes n8nac test <workflowId> --prod
 ```
 
 - Class A configuration gaps require user/config action, not workflow rewrites.
@@ -285,7 +285,7 @@ Run it whenever one of these is true:
 - the user asks to show, open, present, display, or give the URL/link for a workflow.
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
+npx --yes @n8n-as-code/n8n-manager presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
 ```
 
 Rules:
@@ -293,7 +293,7 @@ Rules:
 - Do not manually construct n8n workflow URLs.
 - Do not return an internal local n8n URL when a presentation URL is available.
 - Use the `url` returned by `presentWorkflowResult` as the user-facing URL.
-- If you do not know the workflow ID, run `npx --yes n8nac@next list` first and select the matching workflow.
+- If you do not know the workflow ID, run `npx --yes n8nac list` first and select the matching workflow.
 - If `presentWorkflowResult` fails, report the backend diagnostic and then provide the best direct n8n URL only as a fallback.
 - Do this before the final response when the task created, changed, pushed, ran, or explicitly asks to show a workflow.
 
@@ -307,18 +307,18 @@ For webhook, chat, or form workflows:
 4. Test with `--prod` by default.
 
 ```bash
-npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
-npx --yes n8nac@next test-plan <workflowId> --json
-npx --yes n8nac@next workflow activate <workflowId>
-npx --yes n8nac@next test <workflowId> --prod
+npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
+npx --yes n8nac test-plan <workflowId> --json
+npx --yes n8nac workflow activate <workflowId>
+npx --yes n8nac test <workflowId> --prod
 ```
 
-Use bare `npx --yes n8nac@next test <workflowId>` only when a test URL was intentionally armed in the n8n editor.
+Use bare `npx --yes n8nac test <workflowId>` only when a test URL was intentionally armed in the n8n editor.
 
 For GET/HEAD webhooks that read from `$json.query`, prefer:
 
 ```bash
-npx --yes n8nac@next test <workflowId> --query '{"key":"value"}' --prod
+npx --yes n8nac test <workflowId> --query '{"key":"value"}' --prod
 ```
 
 ## Execution Debugging
@@ -326,8 +326,8 @@ npx --yes n8nac@next test <workflowId> --query '{"key":"value"}' --prod
 If a webhook returns success but the workflow behavior is wrong, inspect executions instead of guessing:
 
 ```bash
-npx --yes n8nac@next execution list --workflow-id <workflowId> --limit 5 --json
-npx --yes n8nac@next execution get <executionId> --include-data --json
+npx --yes n8nac execution list --workflow-id <workflowId> --limit 5 --json
+npx --yes n8nac execution get <executionId> --include-data --json
 ```
 
 - A successful HTTP trigger only means n8n accepted the request.
@@ -339,11 +339,11 @@ npx --yes n8nac@next execution get <executionId> --include-data --json
 When a workflow is blocked by missing credentials, resolve the credential gap without rewriting unrelated workflow logic.
 
 ```bash
-npx --yes n8nac@next workflow credential-required <workflowId> --json
-npx --yes n8nac@next credential schema <type>
-npx --yes n8nac@next credential list --json
-npx --yes n8nac@next credential create --type <type> --name <name> --file cred.json --json
-npx --yes n8nac@next workflow activate <workflowId>
+npx --yes n8nac workflow credential-required <workflowId> --json
+npx --yes n8nac credential schema <type>
+npx --yes n8nac credential list --json
+npx --yes n8nac credential create --type <type> --name <name> --file cred.json --json
+npx --yes n8nac workflow activate <workflowId>
 ```
 
 - `workflow credential-required` exits non-zero when at least one credential is missing. Treat that as a signal to act, not as a workflow-code failure.

--- a/plugins/cursor/n8n-as-code/skills/n8n-manager/SKILL.md
+++ b/plugins/cursor/n8n-as-code/skills/n8n-manager/SKILL.md
@@ -10,11 +10,11 @@ Use this skill for global n8n instance management. `n8n-manager` is the source o
 ## Responsibility Boundary
 
 - Generated context root hint: not embedded. Use the shell launch directory or the workspace path explicitly given by the user.
-- If `n8nac` is available, first run `npx --yes n8nac@next update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
+- If `n8nac` is available, first run `npx --yes n8nac update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
 - Use the exact `n8n-manager command` and `n8nac command` listed in `AGENTS.md` when present. Those context-root commands override the portable examples in this skill.
-- Use `npx --yes @n8n-as-code/n8n-manager@next` for global instance, auth, runtime, tunnel, project-default, credential, and workflow-presentation operations.
-- Use `npx --yes n8nac@next workspace ...` only for context-root overrides such as pinned instance, sync folder, and project override.
-- Use `npx --yes n8nac@next` workflow commands only after the effective context is ready.
+- Use `npx --yes @n8n-as-code/n8n-manager` for global instance, auth, runtime, tunnel, project-default, credential, and workflow-presentation operations.
+- Use `npx --yes n8nac workspace ...` only for context-root overrides such as pinned instance, sync folder, and project override.
+- Use `npx --yes n8nac` workflow commands only after the effective context is ready.
 - Never edit `n8nac-config.json`, `~/.n8n-manager`, or n8n-manager secret files by hand.
 
 ## Core Commands
@@ -22,9 +22,9 @@ Use this skill for global n8n instance management. `n8n-manager` is the source o
 Inspect existing instances before changing state:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances list
-npx --yes @n8n-as-code/n8n-manager@next instances --help
-npx --yes @n8n-as-code/n8n-manager@next config get
+npx --yes @n8n-as-code/n8n-manager instances list
+npx --yes @n8n-as-code/n8n-manager instances --help
+npx --yes @n8n-as-code/n8n-manager config get
 ```
 
 Do not invent n8n-manager subcommands. In particular, `instances create` and `--type local` are not valid. Use `instances add --mode ...` exactly as documented by `instances --help`.
@@ -53,56 +53,56 @@ Only run these commands after the user has explicitly chosen the corresponding o
 Managed local Docker without public tunnel:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances add --name <name> --mode managed-local-docker
-npx --yes @n8n-as-code/n8n-manager@next instances setup <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances add --name <name> --mode managed-local-docker
+npx --yes @n8n-as-code/n8n-manager instances setup <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances status <id-or-name>
 ```
 
 Managed local Docker with public tunnel:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances add --name <name> --mode managed-local-docker --tunnel
-npx --yes @n8n-as-code/n8n-manager@next instances setup <id-or-name> --tunnel
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances add --name <name> --mode managed-local-docker --tunnel
+npx --yes @n8n-as-code/n8n-manager instances setup <id-or-name> --tunnel
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel status <id-or-name>
 ```
 
 Remote or existing instances require user-provided credentials. Prefer stdin for API keys:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next auth set --url <url> --api-key-stdin --name <name>
-npx --yes @n8n-as-code/n8n-manager@next auth test --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager auth set --url <url> --api-key-stdin --name <name>
+npx --yes @n8n-as-code/n8n-manager auth test --instance <id-or-name>
 ```
 
 Project selection is instance-level unless the context root explicitly needs a workspace override:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next projects list --instance <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next projects select <project-id-or-name> --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager projects list --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager projects select <project-id-or-name> --instance <id-or-name>
 ```
 
 Self-hosted n8n may not expose the projects API or may return 401/403. In that case, do not retry project discovery. Use the n8n-architect workspace override path with the standard personal project unless the user gave another project:
 
 ```bash
-npx --yes n8nac@next workspace set-project --project-id personal --project-name Personal
+npx --yes n8nac workspace set-project --project-id personal --project-name Personal
 ```
 
 Runtime and tunnel operations are per instance:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances stop <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances restart <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel status <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel refresh <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances stop <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances restart <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel refresh <id-or-name>
 ```
 
 Present workflow results after creating, modifying, pushing, or running a workflow:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
+npx --yes @n8n-as-code/n8n-manager presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
 ```
 
 ## Guardrails

--- a/plugins/openclaw/n8n-as-code/skills/n8n-architect/SKILL.md
+++ b/plugins/openclaw/n8n-as-code/skills/n8n-architect/SKILL.md
@@ -11,44 +11,44 @@ Use this skill for workflow engineering. Use the `n8n-manager` skill for instanc
 
 - Treat the current context root as the directory containing `n8nac-config.json`, `AGENTS.md`, `.agents/skills`, and the workflow sync folder.
 - Generated context root hint: not embedded. Use the shell launch directory or the workspace path explicitly given by the user.
-- Before any n8n work, first run `npx --yes n8nac@next update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
+- Before any n8n work, first run `npx --yes n8nac update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
 - Use the exact `n8nac command` and `n8n-manager command` listed in `AGENTS.md`. Those context-root commands override the portable examples in this skill.
-- Run every `npx --yes n8nac@next workspace ...`, `npx --yes n8nac@next list`, `pull`, `push`, `validate`, `test`, and `update-ai` command from the context root unless the user explicitly gives another context root.
+- Run every `npx --yes n8nac workspace ...`, `npx --yes n8nac list`, `pull`, `push`, `validate`, `test`, and `update-ai` command from the context root unless the user explicitly gives another context root.
 - `AGENTS.md` is bootstrap context only, not a source of configuration truth.
 - Do not infer instance, project, sync folder, or workflow directory from `AGENTS.md`.
 - Before n8n work, resolve the effective context from the backend:
 
 ```bash
-npx --yes n8nac@next workspace status --json
+npx --yes n8nac workspace status --json
 ```
 
 - Use the returned `workflowDir` for workflow files. Do not reconstruct it from `syncFolder`, `instanceIdentifier`, or `projectName`.
-- Never write `n8nac-config.json` by hand. Use `npx --yes n8nac@next workspace ...` commands.
+- Never write `n8nac-config.json` by hand. Use `npx --yes n8nac workspace ...` commands.
 
 ## Bootstrap Order
 
 1. `cd` to the context root.
-2. Run `npx --yes n8nac@next update-ai`, then read `AGENTS.md`.
-3. Run `npx --yes n8nac@next workspace status --json`.
-4. If the context root is not ready, inspect instances with `npx --yes @n8n-as-code/n8n-manager@next instances list`.
+2. Run `npx --yes n8nac update-ai`, then read `AGENTS.md`.
+3. Run `npx --yes n8nac workspace status --json`.
+4. If the context root is not ready, inspect instances with `npx --yes @n8n-as-code/n8n-manager instances list`.
 5. Reuse an existing instance when suitable.
 6. If no suitable instance exists, stop and ask the user whether they want to reuse/configure an existing instance, create a managed local n8n instance, or connect an existing/remote n8n instance. Do not create infrastructure by default. If the user chooses a managed local instance, ask separately whether they want a public tunnel.
 7. Ask for host/API key only for an explicitly remote or existing n8n instance.
 8. Configure context-root overrides with:
 
 ```bash
-npx --yes n8nac@next workspace pin-instance --instance-id <id>
-npx --yes n8nac@next workspace set-sync-folder workflows
-npx --yes n8nac@next workspace set-project --project-id <id> --project-name <name>
+npx --yes n8nac workspace pin-instance --instance-id <id>
+npx --yes n8nac workspace set-sync-folder workflows
+npx --yes n8nac workspace set-project --project-id <id> --project-name <name>
 ```
 
 For self-hosted n8n instances where the projects API is unavailable or returns 401/403, do not keep retrying project discovery. Use the standard personal project override unless the user gave another project:
 
 ```bash
-npx --yes n8nac@next workspace set-project --project-id personal --project-name Personal
+npx --yes n8nac workspace set-project --project-id personal --project-name Personal
 ```
 
-9. Run `npx --yes n8nac@next update-ai` after changing context-root overrides when the facade does not do it automatically.
+9. Run `npx --yes n8nac update-ai` after changing context-root overrides when the facade does not do it automatically.
 
 ## Sync Discipline
 
@@ -57,13 +57,13 @@ npx --yes n8nac@next workspace set-project --project-id personal --project-name 
 - Use `list` to inspect workflow IDs, file paths, and sync status.
 
 ```bash
-npx --yes n8nac@next list
-npx --yes n8nac@next pull <workflowId>
-npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
+npx --yes n8nac list
+npx --yes n8nac pull <workflowId>
+npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
 ```
 
 - `push` requires the full workflow file path, either absolute or context-root-relative. Do not pass a bare filename.
-- For a new workflow, create the file inside the `workflowDir` returned by `workspace status --json`, then confirm it with `npx --yes n8nac@next list --local`.
+- For a new workflow, create the file inside the `workflowDir` returned by `workspace status --json`, then confirm it with `npx --yes n8nac list --local`.
 - If push/pull reports a conflict, use explicit resolution commands. Do not overwrite remote changes blindly.
 - `pull` and conflict resolution operate on a single workflow ID.
 - `list` is the lightweight command that covers all workflows at once.
@@ -74,8 +74,8 @@ npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
 If push or pull reports a conflict, stop and inspect the conflict. Use explicit resolution commands only after choosing the intended direction:
 
 ```bash
-npx --yes n8nac@next resolve <workflowId> --mode keep-current
-npx --yes n8nac@next resolve <workflowId> --mode keep-incoming
+npx --yes n8nac resolve <workflowId> --mode keep-current
+npx --yes n8nac resolve <workflowId> --mode keep-incoming
 ```
 
 - `keep-current` force-pushes the local version.
@@ -87,10 +87,10 @@ npx --yes n8nac@next resolve <workflowId> --mode keep-incoming
 Never guess n8n node parameters.
 
 ```bash
-npx --yes n8nac@next skills examples search "<workflow pattern>"
-npx --yes n8nac@next skills search "<node or capability>"
-npx --yes n8nac@next skills node-info <nodeName>
-npx --yes n8nac@next skills validate <workflow.workflow.ts>
+npx --yes n8nac skills examples search "<workflow pattern>"
+npx --yes n8nac skills search "<node or capability>"
+npx --yes n8nac skills node-info <nodeName>
+npx --yes n8nac skills validate <workflow.workflow.ts>
 ```
 
 - Use exact node `type` and valid `typeVersion` values from `node-info`.
@@ -105,19 +105,19 @@ npx --yes n8nac@next skills validate <workflow.workflow.ts>
 Use these commands instead of guessing:
 
 ```bash
-npx --yes n8nac@next skills search "<node or capability>"
-npx --yes n8nac@next skills node-info <nodeName>
-npx --yes n8nac@next skills node-schema <nodeName>
-npx --yes n8nac@next skills docs "<topic>"
-npx --yes n8nac@next skills guides "<topic>"
-npx --yes n8nac@next skills examples search "<workflow pattern>"
-npx --yes n8nac@next skills examples info <id>
-npx --yes n8nac@next skills examples download <id>
+npx --yes n8nac skills search "<node or capability>"
+npx --yes n8nac skills node-info <nodeName>
+npx --yes n8nac skills node-schema <nodeName>
+npx --yes n8nac skills docs "<topic>"
+npx --yes n8nac skills guides "<topic>"
+npx --yes n8nac skills examples search "<workflow pattern>"
+npx --yes n8nac skills examples info <id>
+npx --yes n8nac skills examples download <id>
 ```
 
 - Start with `examples search` when the user asks for a common automation pattern.
 - Use examples to learn patterns, not as authority over current node schemas.
-- If a command or flag is unfamiliar, run `npx --yes n8nac@next <subcommand> --help`; do not invent flags.
+- If a command or flag is unfamiliar, run `npx --yes n8nac <subcommand> --help`; do not invent flags.
 
 ## Workflow Authoring Rules
 
@@ -257,15 +257,15 @@ defineRouting() {
 After pushing:
 
 ```bash
-npx --yes n8nac@next verify <workflowId>
-npx --yes n8nac@next test-plan <workflowId> --json
+npx --yes n8nac verify <workflowId>
+npx --yes n8nac test-plan <workflowId> --json
 ```
 
 For webhook, chat, or form workflows, prefer the production test sequence:
 
 ```bash
-npx --yes n8nac@next workflow activate <workflowId>
-npx --yes n8nac@next test <workflowId> --prod
+npx --yes n8nac workflow activate <workflowId>
+npx --yes n8nac test <workflowId> --prod
 ```
 
 - Class A configuration gaps require user/config action, not workflow rewrites.
@@ -285,7 +285,7 @@ Run it whenever one of these is true:
 - the user asks to show, open, present, display, or give the URL/link for a workflow.
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
+npx --yes @n8n-as-code/n8n-manager presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
 ```
 
 Rules:
@@ -293,7 +293,7 @@ Rules:
 - Do not manually construct n8n workflow URLs.
 - Do not return an internal local n8n URL when a presentation URL is available.
 - Use the `url` returned by `presentWorkflowResult` as the user-facing URL.
-- If you do not know the workflow ID, run `npx --yes n8nac@next list` first and select the matching workflow.
+- If you do not know the workflow ID, run `npx --yes n8nac list` first and select the matching workflow.
 - If `presentWorkflowResult` fails, report the backend diagnostic and then provide the best direct n8n URL only as a fallback.
 - Do this before the final response when the task created, changed, pushed, ran, or explicitly asks to show a workflow.
 
@@ -307,18 +307,18 @@ For webhook, chat, or form workflows:
 4. Test with `--prod` by default.
 
 ```bash
-npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
-npx --yes n8nac@next test-plan <workflowId> --json
-npx --yes n8nac@next workflow activate <workflowId>
-npx --yes n8nac@next test <workflowId> --prod
+npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
+npx --yes n8nac test-plan <workflowId> --json
+npx --yes n8nac workflow activate <workflowId>
+npx --yes n8nac test <workflowId> --prod
 ```
 
-Use bare `npx --yes n8nac@next test <workflowId>` only when a test URL was intentionally armed in the n8n editor.
+Use bare `npx --yes n8nac test <workflowId>` only when a test URL was intentionally armed in the n8n editor.
 
 For GET/HEAD webhooks that read from `$json.query`, prefer:
 
 ```bash
-npx --yes n8nac@next test <workflowId> --query '{"key":"value"}' --prod
+npx --yes n8nac test <workflowId> --query '{"key":"value"}' --prod
 ```
 
 ## Execution Debugging
@@ -326,8 +326,8 @@ npx --yes n8nac@next test <workflowId> --query '{"key":"value"}' --prod
 If a webhook returns success but the workflow behavior is wrong, inspect executions instead of guessing:
 
 ```bash
-npx --yes n8nac@next execution list --workflow-id <workflowId> --limit 5 --json
-npx --yes n8nac@next execution get <executionId> --include-data --json
+npx --yes n8nac execution list --workflow-id <workflowId> --limit 5 --json
+npx --yes n8nac execution get <executionId> --include-data --json
 ```
 
 - A successful HTTP trigger only means n8n accepted the request.
@@ -339,11 +339,11 @@ npx --yes n8nac@next execution get <executionId> --include-data --json
 When a workflow is blocked by missing credentials, resolve the credential gap without rewriting unrelated workflow logic.
 
 ```bash
-npx --yes n8nac@next workflow credential-required <workflowId> --json
-npx --yes n8nac@next credential schema <type>
-npx --yes n8nac@next credential list --json
-npx --yes n8nac@next credential create --type <type> --name <name> --file cred.json --json
-npx --yes n8nac@next workflow activate <workflowId>
+npx --yes n8nac workflow credential-required <workflowId> --json
+npx --yes n8nac credential schema <type>
+npx --yes n8nac credential list --json
+npx --yes n8nac credential create --type <type> --name <name> --file cred.json --json
+npx --yes n8nac workflow activate <workflowId>
 ```
 
 - `workflow credential-required` exits non-zero when at least one credential is missing. Treat that as a signal to act, not as a workflow-code failure.

--- a/plugins/openclaw/n8n-as-code/skills/n8n-manager/SKILL.md
+++ b/plugins/openclaw/n8n-as-code/skills/n8n-manager/SKILL.md
@@ -10,11 +10,11 @@ Use this skill for global n8n instance management. `n8n-manager` is the source o
 ## Responsibility Boundary
 
 - Generated context root hint: not embedded. Use the shell launch directory or the workspace path explicitly given by the user.
-- If `n8nac` is available, first run `npx --yes n8nac@next update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
+- If `n8nac` is available, first run `npx --yes n8nac update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
 - Use the exact `n8n-manager command` and `n8nac command` listed in `AGENTS.md` when present. Those context-root commands override the portable examples in this skill.
-- Use `npx --yes @n8n-as-code/n8n-manager@next` for global instance, auth, runtime, tunnel, project-default, credential, and workflow-presentation operations.
-- Use `npx --yes n8nac@next workspace ...` only for context-root overrides such as pinned instance, sync folder, and project override.
-- Use `npx --yes n8nac@next` workflow commands only after the effective context is ready.
+- Use `npx --yes @n8n-as-code/n8n-manager` for global instance, auth, runtime, tunnel, project-default, credential, and workflow-presentation operations.
+- Use `npx --yes n8nac workspace ...` only for context-root overrides such as pinned instance, sync folder, and project override.
+- Use `npx --yes n8nac` workflow commands only after the effective context is ready.
 - Never edit `n8nac-config.json`, `~/.n8n-manager`, or n8n-manager secret files by hand.
 
 ## Core Commands
@@ -22,9 +22,9 @@ Use this skill for global n8n instance management. `n8n-manager` is the source o
 Inspect existing instances before changing state:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances list
-npx --yes @n8n-as-code/n8n-manager@next instances --help
-npx --yes @n8n-as-code/n8n-manager@next config get
+npx --yes @n8n-as-code/n8n-manager instances list
+npx --yes @n8n-as-code/n8n-manager instances --help
+npx --yes @n8n-as-code/n8n-manager config get
 ```
 
 Do not invent n8n-manager subcommands. In particular, `instances create` and `--type local` are not valid. Use `instances add --mode ...` exactly as documented by `instances --help`.
@@ -53,56 +53,56 @@ Only run these commands after the user has explicitly chosen the corresponding o
 Managed local Docker without public tunnel:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances add --name <name> --mode managed-local-docker
-npx --yes @n8n-as-code/n8n-manager@next instances setup <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances add --name <name> --mode managed-local-docker
+npx --yes @n8n-as-code/n8n-manager instances setup <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances status <id-or-name>
 ```
 
 Managed local Docker with public tunnel:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances add --name <name> --mode managed-local-docker --tunnel
-npx --yes @n8n-as-code/n8n-manager@next instances setup <id-or-name> --tunnel
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances add --name <name> --mode managed-local-docker --tunnel
+npx --yes @n8n-as-code/n8n-manager instances setup <id-or-name> --tunnel
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel status <id-or-name>
 ```
 
 Remote or existing instances require user-provided credentials. Prefer stdin for API keys:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next auth set --url <url> --api-key-stdin --name <name>
-npx --yes @n8n-as-code/n8n-manager@next auth test --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager auth set --url <url> --api-key-stdin --name <name>
+npx --yes @n8n-as-code/n8n-manager auth test --instance <id-or-name>
 ```
 
 Project selection is instance-level unless the context root explicitly needs a workspace override:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next projects list --instance <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next projects select <project-id-or-name> --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager projects list --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager projects select <project-id-or-name> --instance <id-or-name>
 ```
 
 Self-hosted n8n may not expose the projects API or may return 401/403. In that case, do not retry project discovery. Use the n8n-architect workspace override path with the standard personal project unless the user gave another project:
 
 ```bash
-npx --yes n8nac@next workspace set-project --project-id personal --project-name Personal
+npx --yes n8nac workspace set-project --project-id personal --project-name Personal
 ```
 
 Runtime and tunnel operations are per instance:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances stop <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances restart <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel status <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel refresh <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances stop <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances restart <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel refresh <id-or-name>
 ```
 
 Present workflow results after creating, modifying, pushing, or running a workflow:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
+npx --yes @n8n-as-code/n8n-manager presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
 ```
 
 ## Guardrails

--- a/skills/n8n-architect/SKILL.md
+++ b/skills/n8n-architect/SKILL.md
@@ -11,44 +11,44 @@ Use this skill for workflow engineering. Use the `n8n-manager` skill for instanc
 
 - Treat the current context root as the directory containing `n8nac-config.json`, `AGENTS.md`, `.agents/skills`, and the workflow sync folder.
 - Generated context root hint: not embedded. Use the shell launch directory or the workspace path explicitly given by the user.
-- Before any n8n work, first run `npx --yes n8nac@next update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
+- Before any n8n work, first run `npx --yes n8nac update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
 - Use the exact `n8nac command` and `n8n-manager command` listed in `AGENTS.md`. Those context-root commands override the portable examples in this skill.
-- Run every `npx --yes n8nac@next workspace ...`, `npx --yes n8nac@next list`, `pull`, `push`, `validate`, `test`, and `update-ai` command from the context root unless the user explicitly gives another context root.
+- Run every `npx --yes n8nac workspace ...`, `npx --yes n8nac list`, `pull`, `push`, `validate`, `test`, and `update-ai` command from the context root unless the user explicitly gives another context root.
 - `AGENTS.md` is bootstrap context only, not a source of configuration truth.
 - Do not infer instance, project, sync folder, or workflow directory from `AGENTS.md`.
 - Before n8n work, resolve the effective context from the backend:
 
 ```bash
-npx --yes n8nac@next workspace status --json
+npx --yes n8nac workspace status --json
 ```
 
 - Use the returned `workflowDir` for workflow files. Do not reconstruct it from `syncFolder`, `instanceIdentifier`, or `projectName`.
-- Never write `n8nac-config.json` by hand. Use `npx --yes n8nac@next workspace ...` commands.
+- Never write `n8nac-config.json` by hand. Use `npx --yes n8nac workspace ...` commands.
 
 ## Bootstrap Order
 
 1. `cd` to the context root.
-2. Run `npx --yes n8nac@next update-ai`, then read `AGENTS.md`.
-3. Run `npx --yes n8nac@next workspace status --json`.
-4. If the context root is not ready, inspect instances with `npx --yes @n8n-as-code/n8n-manager@next instances list`.
+2. Run `npx --yes n8nac update-ai`, then read `AGENTS.md`.
+3. Run `npx --yes n8nac workspace status --json`.
+4. If the context root is not ready, inspect instances with `npx --yes @n8n-as-code/n8n-manager instances list`.
 5. Reuse an existing instance when suitable.
 6. If no suitable instance exists, stop and ask the user whether they want to reuse/configure an existing instance, create a managed local n8n instance, or connect an existing/remote n8n instance. Do not create infrastructure by default. If the user chooses a managed local instance, ask separately whether they want a public tunnel.
 7. Ask for host/API key only for an explicitly remote or existing n8n instance.
 8. Configure context-root overrides with:
 
 ```bash
-npx --yes n8nac@next workspace pin-instance --instance-id <id>
-npx --yes n8nac@next workspace set-sync-folder workflows
-npx --yes n8nac@next workspace set-project --project-id <id> --project-name <name>
+npx --yes n8nac workspace pin-instance --instance-id <id>
+npx --yes n8nac workspace set-sync-folder workflows
+npx --yes n8nac workspace set-project --project-id <id> --project-name <name>
 ```
 
 For self-hosted n8n instances where the projects API is unavailable or returns 401/403, do not keep retrying project discovery. Use the standard personal project override unless the user gave another project:
 
 ```bash
-npx --yes n8nac@next workspace set-project --project-id personal --project-name Personal
+npx --yes n8nac workspace set-project --project-id personal --project-name Personal
 ```
 
-9. Run `npx --yes n8nac@next update-ai` after changing context-root overrides when the facade does not do it automatically.
+9. Run `npx --yes n8nac update-ai` after changing context-root overrides when the facade does not do it automatically.
 
 ## Sync Discipline
 
@@ -57,13 +57,13 @@ npx --yes n8nac@next workspace set-project --project-id personal --project-name 
 - Use `list` to inspect workflow IDs, file paths, and sync status.
 
 ```bash
-npx --yes n8nac@next list
-npx --yes n8nac@next pull <workflowId>
-npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
+npx --yes n8nac list
+npx --yes n8nac pull <workflowId>
+npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
 ```
 
 - `push` requires the full workflow file path, either absolute or context-root-relative. Do not pass a bare filename.
-- For a new workflow, create the file inside the `workflowDir` returned by `workspace status --json`, then confirm it with `npx --yes n8nac@next list --local`.
+- For a new workflow, create the file inside the `workflowDir` returned by `workspace status --json`, then confirm it with `npx --yes n8nac list --local`.
 - If push/pull reports a conflict, use explicit resolution commands. Do not overwrite remote changes blindly.
 - `pull` and conflict resolution operate on a single workflow ID.
 - `list` is the lightweight command that covers all workflows at once.
@@ -74,8 +74,8 @@ npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
 If push or pull reports a conflict, stop and inspect the conflict. Use explicit resolution commands only after choosing the intended direction:
 
 ```bash
-npx --yes n8nac@next resolve <workflowId> --mode keep-current
-npx --yes n8nac@next resolve <workflowId> --mode keep-incoming
+npx --yes n8nac resolve <workflowId> --mode keep-current
+npx --yes n8nac resolve <workflowId> --mode keep-incoming
 ```
 
 - `keep-current` force-pushes the local version.
@@ -87,10 +87,10 @@ npx --yes n8nac@next resolve <workflowId> --mode keep-incoming
 Never guess n8n node parameters.
 
 ```bash
-npx --yes n8nac@next skills examples search "<workflow pattern>"
-npx --yes n8nac@next skills search "<node or capability>"
-npx --yes n8nac@next skills node-info <nodeName>
-npx --yes n8nac@next skills validate <workflow.workflow.ts>
+npx --yes n8nac skills examples search "<workflow pattern>"
+npx --yes n8nac skills search "<node or capability>"
+npx --yes n8nac skills node-info <nodeName>
+npx --yes n8nac skills validate <workflow.workflow.ts>
 ```
 
 - Use exact node `type` and valid `typeVersion` values from `node-info`.
@@ -105,19 +105,19 @@ npx --yes n8nac@next skills validate <workflow.workflow.ts>
 Use these commands instead of guessing:
 
 ```bash
-npx --yes n8nac@next skills search "<node or capability>"
-npx --yes n8nac@next skills node-info <nodeName>
-npx --yes n8nac@next skills node-schema <nodeName>
-npx --yes n8nac@next skills docs "<topic>"
-npx --yes n8nac@next skills guides "<topic>"
-npx --yes n8nac@next skills examples search "<workflow pattern>"
-npx --yes n8nac@next skills examples info <id>
-npx --yes n8nac@next skills examples download <id>
+npx --yes n8nac skills search "<node or capability>"
+npx --yes n8nac skills node-info <nodeName>
+npx --yes n8nac skills node-schema <nodeName>
+npx --yes n8nac skills docs "<topic>"
+npx --yes n8nac skills guides "<topic>"
+npx --yes n8nac skills examples search "<workflow pattern>"
+npx --yes n8nac skills examples info <id>
+npx --yes n8nac skills examples download <id>
 ```
 
 - Start with `examples search` when the user asks for a common automation pattern.
 - Use examples to learn patterns, not as authority over current node schemas.
-- If a command or flag is unfamiliar, run `npx --yes n8nac@next <subcommand> --help`; do not invent flags.
+- If a command or flag is unfamiliar, run `npx --yes n8nac <subcommand> --help`; do not invent flags.
 
 ## Workflow Authoring Rules
 
@@ -257,15 +257,15 @@ defineRouting() {
 After pushing:
 
 ```bash
-npx --yes n8nac@next verify <workflowId>
-npx --yes n8nac@next test-plan <workflowId> --json
+npx --yes n8nac verify <workflowId>
+npx --yes n8nac test-plan <workflowId> --json
 ```
 
 For webhook, chat, or form workflows, prefer the production test sequence:
 
 ```bash
-npx --yes n8nac@next workflow activate <workflowId>
-npx --yes n8nac@next test <workflowId> --prod
+npx --yes n8nac workflow activate <workflowId>
+npx --yes n8nac test <workflowId> --prod
 ```
 
 - Class A configuration gaps require user/config action, not workflow rewrites.
@@ -285,7 +285,7 @@ Run it whenever one of these is true:
 - the user asks to show, open, present, display, or give the URL/link for a workflow.
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
+npx --yes @n8n-as-code/n8n-manager presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
 ```
 
 Rules:
@@ -293,7 +293,7 @@ Rules:
 - Do not manually construct n8n workflow URLs.
 - Do not return an internal local n8n URL when a presentation URL is available.
 - Use the `url` returned by `presentWorkflowResult` as the user-facing URL.
-- If you do not know the workflow ID, run `npx --yes n8nac@next list` first and select the matching workflow.
+- If you do not know the workflow ID, run `npx --yes n8nac list` first and select the matching workflow.
 - If `presentWorkflowResult` fails, report the backend diagnostic and then provide the best direct n8n URL only as a fallback.
 - Do this before the final response when the task created, changed, pushed, ran, or explicitly asks to show a workflow.
 
@@ -307,18 +307,18 @@ For webhook, chat, or form workflows:
 4. Test with `--prod` by default.
 
 ```bash
-npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
-npx --yes n8nac@next test-plan <workflowId> --json
-npx --yes n8nac@next workflow activate <workflowId>
-npx --yes n8nac@next test <workflowId> --prod
+npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
+npx --yes n8nac test-plan <workflowId> --json
+npx --yes n8nac workflow activate <workflowId>
+npx --yes n8nac test <workflowId> --prod
 ```
 
-Use bare `npx --yes n8nac@next test <workflowId>` only when a test URL was intentionally armed in the n8n editor.
+Use bare `npx --yes n8nac test <workflowId>` only when a test URL was intentionally armed in the n8n editor.
 
 For GET/HEAD webhooks that read from `$json.query`, prefer:
 
 ```bash
-npx --yes n8nac@next test <workflowId> --query '{"key":"value"}' --prod
+npx --yes n8nac test <workflowId> --query '{"key":"value"}' --prod
 ```
 
 ## Execution Debugging
@@ -326,8 +326,8 @@ npx --yes n8nac@next test <workflowId> --query '{"key":"value"}' --prod
 If a webhook returns success but the workflow behavior is wrong, inspect executions instead of guessing:
 
 ```bash
-npx --yes n8nac@next execution list --workflow-id <workflowId> --limit 5 --json
-npx --yes n8nac@next execution get <executionId> --include-data --json
+npx --yes n8nac execution list --workflow-id <workflowId> --limit 5 --json
+npx --yes n8nac execution get <executionId> --include-data --json
 ```
 
 - A successful HTTP trigger only means n8n accepted the request.
@@ -339,11 +339,11 @@ npx --yes n8nac@next execution get <executionId> --include-data --json
 When a workflow is blocked by missing credentials, resolve the credential gap without rewriting unrelated workflow logic.
 
 ```bash
-npx --yes n8nac@next workflow credential-required <workflowId> --json
-npx --yes n8nac@next credential schema <type>
-npx --yes n8nac@next credential list --json
-npx --yes n8nac@next credential create --type <type> --name <name> --file cred.json --json
-npx --yes n8nac@next workflow activate <workflowId>
+npx --yes n8nac workflow credential-required <workflowId> --json
+npx --yes n8nac credential schema <type>
+npx --yes n8nac credential list --json
+npx --yes n8nac credential create --type <type> --name <name> --file cred.json --json
+npx --yes n8nac workflow activate <workflowId>
 ```
 
 - `workflow credential-required` exits non-zero when at least one credential is missing. Treat that as a signal to act, not as a workflow-code failure.

--- a/skills/n8n-manager/SKILL.md
+++ b/skills/n8n-manager/SKILL.md
@@ -10,11 +10,11 @@ Use this skill for global n8n instance management. `n8n-manager` is the source o
 ## Responsibility Boundary
 
 - Generated context root hint: not embedded. Use the shell launch directory or the workspace path explicitly given by the user.
-- If `n8nac` is available, first run `npx --yes n8nac@next update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
+- If `n8nac` is available, first run `npx --yes n8nac update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
 - Use the exact `n8n-manager command` and `n8nac command` listed in `AGENTS.md` when present. Those context-root commands override the portable examples in this skill.
-- Use `npx --yes @n8n-as-code/n8n-manager@next` for global instance, auth, runtime, tunnel, project-default, credential, and workflow-presentation operations.
-- Use `npx --yes n8nac@next workspace ...` only for context-root overrides such as pinned instance, sync folder, and project override.
-- Use `npx --yes n8nac@next` workflow commands only after the effective context is ready.
+- Use `npx --yes @n8n-as-code/n8n-manager` for global instance, auth, runtime, tunnel, project-default, credential, and workflow-presentation operations.
+- Use `npx --yes n8nac workspace ...` only for context-root overrides such as pinned instance, sync folder, and project override.
+- Use `npx --yes n8nac` workflow commands only after the effective context is ready.
 - Never edit `n8nac-config.json`, `~/.n8n-manager`, or n8n-manager secret files by hand.
 
 ## Core Commands
@@ -22,9 +22,9 @@ Use this skill for global n8n instance management. `n8n-manager` is the source o
 Inspect existing instances before changing state:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances list
-npx --yes @n8n-as-code/n8n-manager@next instances --help
-npx --yes @n8n-as-code/n8n-manager@next config get
+npx --yes @n8n-as-code/n8n-manager instances list
+npx --yes @n8n-as-code/n8n-manager instances --help
+npx --yes @n8n-as-code/n8n-manager config get
 ```
 
 Do not invent n8n-manager subcommands. In particular, `instances create` and `--type local` are not valid. Use `instances add --mode ...` exactly as documented by `instances --help`.
@@ -53,56 +53,56 @@ Only run these commands after the user has explicitly chosen the corresponding o
 Managed local Docker without public tunnel:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances add --name <name> --mode managed-local-docker
-npx --yes @n8n-as-code/n8n-manager@next instances setup <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances add --name <name> --mode managed-local-docker
+npx --yes @n8n-as-code/n8n-manager instances setup <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances status <id-or-name>
 ```
 
 Managed local Docker with public tunnel:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances add --name <name> --mode managed-local-docker --tunnel
-npx --yes @n8n-as-code/n8n-manager@next instances setup <id-or-name> --tunnel
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances add --name <name> --mode managed-local-docker --tunnel
+npx --yes @n8n-as-code/n8n-manager instances setup <id-or-name> --tunnel
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel status <id-or-name>
 ```
 
 Remote or existing instances require user-provided credentials. Prefer stdin for API keys:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next auth set --url <url> --api-key-stdin --name <name>
-npx --yes @n8n-as-code/n8n-manager@next auth test --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager auth set --url <url> --api-key-stdin --name <name>
+npx --yes @n8n-as-code/n8n-manager auth test --instance <id-or-name>
 ```
 
 Project selection is instance-level unless the context root explicitly needs a workspace override:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next projects list --instance <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next projects select <project-id-or-name> --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager projects list --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager projects select <project-id-or-name> --instance <id-or-name>
 ```
 
 Self-hosted n8n may not expose the projects API or may return 401/403. In that case, do not retry project discovery. Use the n8n-architect workspace override path with the standard personal project unless the user gave another project:
 
 ```bash
-npx --yes n8nac@next workspace set-project --project-id personal --project-name Personal
+npx --yes n8nac workspace set-project --project-id personal --project-name Personal
 ```
 
 Runtime and tunnel operations are per instance:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances stop <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances restart <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel status <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel refresh <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances stop <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances restart <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel refresh <id-or-name>
 ```
 
 Present workflow results after creating, modifying, pushing, or running a workflow:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
+npx --yes @n8n-as-code/n8n-manager presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
 ```
 
 ## Guardrails


### PR DESCRIPTION
## Summary
- Stop auto-selecting the first personal project when multiple projects exist and show personal-project owner metadata when available.
- Fix VS Code workflow Pull/Push child actions so they pass full workflow state and report invalid states instead of silently returning.
- Fix generated workflow ambient typings for @n8n-as-code/transformer and add a regression type-check test.

## Validation
- npm run test --workspace=n8nac -- --runInBand
- npm run test --workspace=packages/vscode-extension
- git diff --check