### PR TITLE
Add privacy-first product telemetry

### DIFF
--- a/docs/docs/usage/telemetry.md
+++ b/docs/docs/usage/telemetry.md
@@ -45,6 +45,8 @@ CI=true
 
 The VS Code extension also respects VS Code's telemetry setting.
 
+On the documentation site, use the telemetry control in the bottom-right corner to disable or re-enable anonymous docs telemetry in your browser.
+
 ## What Is Collected
 
 Telemetry events contain only coarse product usage metadata:

--- a/docs/docs/usage/telemetry.md
+++ b/docs/docs/usage/telemetry.md
@@ -1,0 +1,97 @@
+---
+title: Telemetry
+---
+
+# Telemetry
+
+n8n-as-code collects anonymous, privacy-first product telemetry to understand active usage across the CLI, VS Code/Cursor extension, MCP server, skills commands, and OpenClaw plugin.
+
+Telemetry is used to answer product-level questions such as:
+
+- How many active users use n8n-as-code?
+- Which facades are used most: CLI, VS Code, MCP, skills, or plugins?
+- Where does setup fail?
+- Which workflows are common: sync, validation, conversion, credentials, or execution inspection?
+
+## Disable Telemetry
+
+Use the CLI:
+
+```bash
+n8nac telemetry disable
+```
+
+Check status:
+
+```bash
+n8nac telemetry status
+```
+
+Enable again:
+
+```bash
+n8nac telemetry enable
+```
+
+Telemetry is also disabled when any of these environment variables are set:
+
+```bash
+N8NAC_TELEMETRY=0
+N8NAC_TELEMETRY=false
+N8NAC_TELEMETRY_DISABLED=1
+DO_NOT_TRACK=1
+CI=true
+```
+
+The VS Code extension also respects VS Code's telemetry setting.
+
+## What Is Collected
+
+Telemetry events contain only coarse product usage metadata:
+
+- anonymous installation ID
+- facade, such as `cli`, `vscode`, `mcp`, `skills`, or `openclaw`
+- package or extension version
+- command or tool name from a controlled list
+- success or failure outcome
+- coarse error category
+- operation duration
+- operating system family
+- Node.js major version
+- counts, such as result count, warning count, or conflict count
+- booleans, such as whether a workspace is configured
+
+## What Is Never Collected
+
+n8n-as-code telemetry must not collect:
+
+- API keys
+- credential values or credential names
+- cookies
+- clipboard contents
+- workflow JSON or TypeScript source
+- node parameters or expressions
+- pinned or static workflow data
+- webhook paths
+- execution payloads or execution data
+- raw n8n host URLs
+- local file paths
+- project names
+- workflow names
+- user emails or names
+- git remotes
+- raw search queries
+
+## Identity
+
+The telemetry identity is a random anonymous UUID stored locally. It is not derived from your username, machine name, workspace path, n8n host, API key, or project.
+
+The local telemetry config is stored at:
+
+```text
+~/.config/n8n-as-code/telemetry.json
+```
+
+## Backend
+
+Events are sent through the shared n8n-as-code telemetry layer. The initial backend is PostHog, but product code calls only the internal telemetry API so the backend can be moved to self-hosted PostHog or replaced later.

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -8,6 +8,10 @@ const config: Config = {
   title: 'n8n-as-code',
   tagline: 'Manage n8n workflows as code with version control and AI assistance',
   favicon: 'img/favicon.ico',
+  customFields: {
+    posthogKey: process.env.N8NAC_POSTHOG_KEY || process.env.POSTHOG_KEY || '',
+    posthogHost: process.env.N8NAC_POSTHOG_HOST || process.env.POSTHOG_HOST || 'https://eu.i.posthog.com',
+  },
 
 
   // Set the production url of your site here
@@ -90,6 +94,8 @@ const config: Config = {
     //   },
     // ],
   ],
+
+  clientModules: [require.resolve('./src/telemetry/posthog.ts')],
 
   themeConfig: {
     // Replace with your project's social card

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -63,6 +63,11 @@ const sidebars: SidebarsConfig = {
           id: 'usage/claude-plugin-privacy',
           label: 'Claude Plugin Privacy',
         },
+        {
+          type: 'doc',
+          id: 'usage/telemetry',
+          label: 'Telemetry',
+        },
       ],
     },
     {

--- a/docs/src/telemetry/posthog.ts
+++ b/docs/src/telemetry/posthog.ts
@@ -4,12 +4,21 @@ const customFields = siteConfig.customFields as { posthogKey?: string; posthogHo
 const POSTHOG_KEY = customFields.posthogKey;
 const POSTHOG_HOST = (customFields.posthogHost || 'https://eu.i.posthog.com').replace(/\/$/, '');
 const STORAGE_KEY = 'n8n-as-code:docs-telemetry-id';
+const DISABLED_KEY = 'n8n-as-code:telemetry-disabled';
 
 function isTelemetryDisabled(): boolean {
   if (!POSTHOG_KEY) return true;
   if (navigator.doNotTrack === '1') return true;
-  if (localStorage.getItem('n8n-as-code:telemetry-disabled') === '1') return true;
+  if (localStorage.getItem(DISABLED_KEY) === '1') return true;
   return false;
+}
+
+function setTelemetryDisabled(disabled: boolean): void {
+  if (disabled) {
+    localStorage.setItem(DISABLED_KEY, '1');
+  } else {
+    localStorage.removeItem(DISABLED_KEY);
+  }
 }
 
 function getAnonymousId(): string {
@@ -68,7 +77,64 @@ function installRouteTracking(): void {
   window.addEventListener('popstate', notifyIfChanged);
 }
 
+function installTelemetryControl(): void {
+  if (document.getElementById('n8n-as-code-telemetry-control')) return;
+
+  const root = document.createElement('div');
+  root.id = 'n8n-as-code-telemetry-control';
+  root.style.position = 'fixed';
+  root.style.right = '1rem';
+  root.style.bottom = '1rem';
+  root.style.zIndex = '9999';
+  root.style.maxWidth = '18rem';
+  root.style.padding = '0.75rem';
+  root.style.border = '1px solid var(--ifm-color-emphasis-300)';
+  root.style.borderRadius = '0.5rem';
+  root.style.background = 'var(--ifm-background-surface-color)';
+  root.style.boxShadow = 'var(--ifm-global-shadow-md)';
+  root.style.fontSize = '0.8rem';
+
+  const text = document.createElement('div');
+  text.style.marginBottom = '0.5rem';
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.style.cursor = 'pointer';
+  button.style.border = '1px solid var(--ifm-color-primary)';
+  button.style.borderRadius = '0.35rem';
+  button.style.background = 'var(--ifm-color-primary)';
+  button.style.color = 'var(--ifm-color-primary-contrast-foreground)';
+  button.style.padding = '0.35rem 0.5rem';
+
+  const render = () => {
+    const disabled = localStorage.getItem(DISABLED_KEY) === '1' || navigator.doNotTrack === '1' || !POSTHOG_KEY;
+    text.textContent = disabled
+      ? 'Anonymous docs telemetry is disabled.'
+      : 'Anonymous docs telemetry is enabled.';
+    button.textContent = disabled ? 'Enable telemetry' : 'Disable telemetry';
+    button.disabled = navigator.doNotTrack === '1' || !POSTHOG_KEY;
+  };
+
+  button.addEventListener('click', () => {
+    setTelemetryDisabled(localStorage.getItem(DISABLED_KEY) !== '1');
+    render();
+  });
+
+  root.append(text, button);
+  document.body.append(root);
+  render();
+}
+
+function initializeTelemetry(): void {
+    trackDocsPageView();
+    installRouteTracking();
+    installTelemetryControl();
+}
+
 if (typeof window !== 'undefined') {
-  trackDocsPageView();
-  installRouteTracking();
+  if (document.readyState === 'loading') {
+    window.addEventListener('DOMContentLoaded', initializeTelemetry, { once: true });
+  } else {
+    initializeTelemetry();
+  }
 }

--- a/docs/src/telemetry/posthog.ts
+++ b/docs/src/telemetry/posthog.ts
@@ -1,0 +1,74 @@
+import siteConfig from '@generated/docusaurus.config';
+
+const customFields = siteConfig.customFields as { posthogKey?: string; posthogHost?: string };
+const POSTHOG_KEY = customFields.posthogKey;
+const POSTHOG_HOST = (customFields.posthogHost || 'https://eu.i.posthog.com').replace(/\/$/, '');
+const STORAGE_KEY = 'n8n-as-code:docs-telemetry-id';
+
+function isTelemetryDisabled(): boolean {
+  if (!POSTHOG_KEY) return true;
+  if (navigator.doNotTrack === '1') return true;
+  if (localStorage.getItem('n8n-as-code:telemetry-disabled') === '1') return true;
+  return false;
+}
+
+function getAnonymousId(): string {
+  const existing = localStorage.getItem(STORAGE_KEY);
+  if (existing) return existing;
+
+  const generated = crypto.randomUUID();
+  localStorage.setItem(STORAGE_KEY, generated);
+  return generated;
+}
+
+function getPathGroup(pathname: string): string {
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments[0] !== 'docs') return 'site';
+  return segments.slice(0, 3).join('/') || 'docs';
+}
+
+function trackDocsPageView(): void {
+  if (isTelemetryDisabled()) return;
+
+  const pathname = window.location.pathname;
+  void fetch(`${POSTHOG_HOST}/capture/`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      api_key: POSTHOG_KEY,
+      event: 'docs_page_viewed',
+      distinct_id: getAnonymousId(),
+      properties: {
+        app: 'n8n-as-code',
+        facade: 'docs',
+        telemetry_schema_version: 1,
+        path_group: getPathGroup(pathname),
+      },
+    }),
+  }).catch(() => undefined);
+}
+
+function installRouteTracking(): void {
+  let lastPath = window.location.pathname;
+  const notifyIfChanged = () => {
+    if (window.location.pathname === lastPath) return;
+    lastPath = window.location.pathname;
+    trackDocsPageView();
+  };
+
+  for (const methodName of ['pushState', 'replaceState'] as const) {
+    const original = window.history[methodName];
+    window.history[methodName] = function patchedHistoryMethod(...args) {
+      const result = original.apply(this, args);
+      queueMicrotask(notifyIfChanged);
+      return result;
+    };
+  }
+
+  window.addEventListener('popstate', notifyIfChanged);
+}
+
+if (typeof window !== 'undefined') {
+  trackDocsPageView();
+  installRouteTracking();
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,6 +25,7 @@
         "@n8n-as-code/manager-adapter": "0.1.0",
         "@n8n-as-code/n8n-manager-core": "^0.5.0",
         "@n8n-as-code/skills": "1.10.0",
+        "@n8n-as-code/telemetry": "0.1.0",
         "@n8n-as-code/transformer": "1.2.1",
         "@n8n-as-code/workflow-core": "0.1.0",
         "@types/json-stable-stringify": "^1.1.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,6 +29,8 @@ import {
     getTelemetryStatus,
     setTelemetryEnabled,
     classifyTelemetryError,
+    shouldShowTelemetryNotice,
+    markTelemetryNoticeShown,
     type TelemetryProperties,
 } from '@n8n-as-code/telemetry';
 
@@ -196,6 +198,11 @@ const program = new Command();
 const telemetry = createTelemetryClient({ facade: 'cli', version: getVersion() });
 const commandStartTimes = new WeakMap<Command, number>();
 
+const exitWithTelemetry = async (code: number): Promise<never> => {
+    await telemetry.flush();
+    process.exit(code);
+};
+
 const getCommandPath = (command: Command): string => {
     const names: string[] = [];
     let current: Command | null = command;
@@ -243,6 +250,21 @@ const normalizeSetupMode = (mode: string): 'managed_local' | 'existing_n8n' | 'g
     if (mode === 'generation-only') return 'generation_only';
     return 'unknown';
 };
+
+const maybeShowTelemetryNotice = (): void => {
+    const topLevelCommand = getTopLevelCommand(process.argv);
+    if (!topLevelCommand || topLevelCommand === 'help' || topLevelCommand === 'telemetry') return;
+    if (!shouldShowTelemetryNotice()) return;
+
+    process.stderr.write([
+        'n8n-as-code collects anonymous, privacy-first telemetry to understand product usage.',
+        'Disable it with `n8nac telemetry disable` or `N8NAC_TELEMETRY_DISABLED=1`.',
+        '',
+    ].join('\n'));
+    markTelemetryNoticeShown();
+};
+
+maybeShowTelemetryNotice();
 
 process.on('beforeExit', () => {
     void telemetry.flush();
@@ -455,7 +477,7 @@ program.command('setup')
                 duration_ms: Date.now() - setupStartedAt,
             });
             console.error(chalk.red(`❌ Invalid setup mode. Use one of: ${N8N_FACADE_SETUP_MODES.map((item) => item.id).join(', ')}`));
-            process.exit(1);
+            await exitWithTelemetry(1);
         }
 
         const facade = createManagerFacadeFromOptions(options);
@@ -641,7 +663,7 @@ program.command('list')
         const remote = options.remote || options.distant;
         if (options.sort !== 'status' && options.sort !== 'name') {
             console.error(chalk.red('❌ Invalid sort mode. Use "status" or "name".'));
-            process.exit(1);
+            await exitWithTelemetry(1);
         }
         await new ListCommand().run({
             local: options.local,
@@ -671,7 +693,7 @@ program.command('find')
         const remote = options.remote || options.distant;
         if (options.sort !== 'status' && options.sort !== 'name') {
             console.error(chalk.red('❌ Invalid sort mode. Use "status" or "name".'));
-            process.exit(1);
+            await exitWithTelemetry(1);
         }
         await new ListCommand().run({
             local: options.local,
@@ -704,7 +726,7 @@ program.command('push')
         if (options.verify && workflowId) {
             console.log(chalk.dim('\n── Post-push verification ──────────────────────────────'));
             const ok = await cmd.verifyRemote(workflowId);
-            if (!ok) process.exit(1);
+            if (!ok) await exitWithTelemetry(1);
         }
     });
 
@@ -714,7 +736,7 @@ program.command('verify')
     .argument('<workflowId>', 'Workflow ID to verify')
     .action(async (workflowId) => {
         const ok = await new SyncCommand().verifyRemote(workflowId);
-        if (!ok) process.exit(1);
+        if (!ok) await exitWithTelemetry(1);
     });
 
 // test - Trigger a workflow in test mode and report the result
@@ -744,7 +766,7 @@ Notes:
   - For classic Webhook/Form test URLs, you may need to manually arm the workflow in the n8n editor before the test URL will accept a request.
 `)
     .action(async (workflowId, options) => {
-        process.exit(await new TestCommand().run(workflowId, options));
+        await exitWithTelemetry(await new TestCommand().run(workflowId, options));
     });
 
 program.command('test-plan')
@@ -752,7 +774,7 @@ program.command('test-plan')
     .argument('<workflowId>', 'Workflow ID to inspect')
     .option('--json', 'Output the test plan as JSON for agents and scripts')
     .action(async (workflowId, options) => {
-        process.exit(await new TestPlanCommand().run(workflowId, options));
+        await exitWithTelemetry(await new TestPlanCommand().run(workflowId, options));
     });
 
 // fetch - Update remote state cache for a specific workflow
@@ -772,7 +794,7 @@ program.command('resolve')
     .action(async (workflowId, options) => {
         if (options.mode !== 'keep-current' && options.mode !== 'keep-incoming') {
             console.error(chalk.red('❌ Invalid mode. Use "keep-current" or "keep-incoming"'));
-            process.exit(1);
+            await exitWithTelemetry(1);
         }
         await new SyncCommand().resolveOne(workflowId, options.mode);
     });
@@ -797,7 +819,7 @@ program.command('convert-batch')
     .action(async (directory, options) => {
         if (options.format !== 'json' && options.format !== 'typescript') {
             console.error(chalk.red('❌ Invalid format. Use "json" or "typescript"'));
-            process.exit(1);
+            await exitWithTelemetry(1);
         }
         await new ConvertCommand().batch(directory, options);
     });
@@ -834,8 +856,7 @@ program.command('mcp')
                 outcome: 'failure',
                 error_category: classifyTelemetryError(error),
             });
-            await telemetry.flush();
-            process.exit(1);
+            await exitWithTelemetry(1);
         });
     });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,6 +24,13 @@ import {
     isN8nFacadeSetupMode,
     type N8nFacadeSetupMode,
 } from '@n8n-as-code/workflow-core';
+import {
+    createTelemetryClient,
+    getTelemetryStatus,
+    setTelemetryEnabled,
+    classifyTelemetryError,
+    type TelemetryProperties,
+} from '@n8n-as-code/telemetry';
 
 async function readSecretFromStdin(): Promise<string> {
     const chunks: Buffer[] = [];
@@ -186,6 +193,60 @@ const getMcpEntry = (): string => {
 };
 
 const program = new Command();
+const telemetry = createTelemetryClient({ facade: 'cli', version: getVersion() });
+const commandStartTimes = new WeakMap<Command, number>();
+
+const getCommandPath = (command: Command): string => {
+    const names: string[] = [];
+    let current: Command | null = command;
+
+    while (current && current.parent) {
+        names.unshift(current.name());
+        current = current.parent;
+    }
+
+    return names.join(' ');
+};
+
+const isActiveCliCommand = (commandPath: string): boolean => {
+    if (!commandPath || commandPath.startsWith('telemetry')) return false;
+    return commandPath !== 'setup-modes' && commandPath !== 'workspace status';
+};
+
+const telemetryCommandProperties = (command: Command): TelemetryProperties => {
+    const commandPath = getCommandPath(command);
+    const [commandName, ...rest] = commandPath.split(' ');
+    let hasWorkspace = false;
+    let hasApiKey = false;
+
+    try {
+        const configService = new ConfigService();
+        const workspaceConfig = configService.getWorkspaceConfig();
+        hasWorkspace = Boolean(workspaceConfig.syncFolder || workspaceConfig.workflowDir || workspaceConfig.projectId);
+        const localConfig = configService.getLocalConfig();
+        hasApiKey = Boolean(localConfig.host && configService.getApiKey(localConfig.host, configService.getActiveInstanceId()));
+    } catch {
+        // Best-effort context only; never let telemetry affect command execution.
+    }
+
+    return {
+        command: commandName || 'unknown',
+        subcommand: rest.length > 0 ? rest.join(' ') : undefined,
+        has_workspace: hasWorkspace,
+        has_api_key: hasApiKey,
+    };
+};
+
+const normalizeSetupMode = (mode: string): 'managed_local' | 'existing_n8n' | 'generation_only' | 'unknown' => {
+    if (mode === 'managed-local') return 'managed_local';
+    if (mode === 'connect-existing') return 'existing_n8n';
+    if (mode === 'generation-only') return 'generation_only';
+    return 'unknown';
+};
+
+process.on('beforeExit', () => {
+    void telemetry.flush();
+});
 program.showSuggestionAfterError(true);
 program.showHelpAfterError('(run with --help for usage details)');
 
@@ -225,6 +286,59 @@ const restoreGlobalInstanceOption = () => {
 
 program.hook('preAction', applyGlobalInstanceOption);
 program.hook('postAction', restoreGlobalInstanceOption);
+program.hook('preAction', (_thisCommand, actionCommand) => {
+    commandStartTimes.set(actionCommand, Date.now());
+});
+program.hook('postAction', (_thisCommand, actionCommand) => {
+    const commandPath = getCommandPath(actionCommand);
+    const startedAt = commandStartTimes.get(actionCommand) ?? Date.now();
+    telemetry.track('cli_command_completed', {
+        ...telemetryCommandProperties(actionCommand),
+        outcome: 'success',
+        duration_ms: Date.now() - startedAt,
+    });
+
+    if (isActiveCliCommand(commandPath)) {
+        telemetry.trackActive({ activation_source_event: 'cli_command_completed' });
+    }
+});
+
+const telemetryProgram = program.command('telemetry')
+    .description('Manage anonymous n8n-as-code telemetry');
+
+telemetryProgram.command('status')
+    .description('Show anonymous telemetry status')
+    .option('--json', 'Output status as JSON')
+    .action((options) => {
+        const status = getTelemetryStatus();
+        printJsonOrText(
+            options,
+            status,
+            [
+                `Telemetry: ${status.enabled ? chalk.green('enabled') : chalk.yellow('disabled')}`,
+                `Configured: ${status.configured ? chalk.green('yes') : chalk.yellow('no PostHog key configured')}`,
+                status.disabledReason ? `Disabled reason: ${status.disabledReason}` : undefined,
+                `Config: ${status.configPath}`,
+                `Host: ${status.posthogHost}`,
+            ].filter(Boolean).join('\n'),
+        );
+    });
+
+telemetryProgram.command('enable')
+    .description('Enable anonymous telemetry')
+    .option('--json', 'Output status as JSON')
+    .action((options) => {
+        const status = setTelemetryEnabled(true);
+        printJsonOrText(options, status, chalk.green('Anonymous telemetry enabled.'));
+    });
+
+telemetryProgram.command('disable')
+    .description('Disable anonymous telemetry')
+    .option('--json', 'Output status as JSON')
+    .action((options) => {
+        const status = setTelemetryEnabled(false);
+        printJsonOrText(options, status, chalk.green('Anonymous telemetry disabled.'));
+    });
 
 const workspaceProgram = program.command('workspace')
     .description('Manage n8n workspace overrides');
@@ -329,19 +443,44 @@ program.command('setup')
     .option('--project-id <id>', 'n8n project ID for credential operations')
     .option('--json', 'Output setup result as JSON')
     .action(async (options) => {
+        const setupStartedAt = Date.now();
         await hydrateApiKeyFromStdin(options);
         const mode = String(options.mode);
+        telemetry.track('setup_started', { entrypoint: 'cli_setup', setup_mode: normalizeSetupMode(mode) });
+        telemetry.track('setup_mode_selected', { setup_mode: normalizeSetupMode(mode) });
         if (!isN8nFacadeSetupMode(mode)) {
+            telemetry.track('setup_failed', {
+                setup_mode: normalizeSetupMode(mode),
+                error_category: 'configuration_error',
+                duration_ms: Date.now() - setupStartedAt,
+            });
             console.error(chalk.red(`❌ Invalid setup mode. Use one of: ${N8N_FACADE_SETUP_MODES.map((item) => item.id).join(', ')}`));
             process.exit(1);
         }
 
         const facade = createManagerFacadeFromOptions(options);
-        const instance = await facade.setup({
-            mode: mode as N8nFacadeSetupMode,
-            n8nHost: options.host,
-            n8nApiKeyRef: options.apiKey ? 'n8nac:provided-api-key' : undefined,
-        });
+        let instance: Awaited<ReturnType<ReturnType<typeof createManagerFacadeFromOptions>['setup']>>;
+        try {
+            instance = await facade.setup({
+                mode: mode as N8nFacadeSetupMode,
+                n8nHost: options.host,
+                n8nApiKeyRef: options.apiKey ? 'n8nac:provided-api-key' : undefined,
+            });
+            telemetry.track('setup_completed', {
+                setup_mode: normalizeSetupMode(mode),
+                has_project: Boolean(options.projectId),
+                has_sync_folder: false,
+                duration_ms: Date.now() - setupStartedAt,
+            });
+            telemetry.trackActive({ activation_source_event: 'setup_completed' });
+        } catch (error) {
+            telemetry.track('setup_failed', {
+                setup_mode: normalizeSetupMode(mode),
+                error_category: classifyTelemetryError(error),
+                duration_ms: Date.now() - setupStartedAt,
+            });
+            throw error;
+        }
 
         printJsonOrText(
             options,
@@ -679,7 +818,8 @@ program.command('mcp')
             stdio: 'inherit',
         });
 
-        child.on('exit', (code, signal) => {
+        child.on('exit', async (code, signal) => {
+            await telemetry.flush();
             if (signal) {
                 process.kill(process.pid, signal);
                 return;
@@ -687,8 +827,14 @@ program.command('mcp')
             process.exit(code ?? 1);
         });
 
-        child.on('error', (error) => {
+        child.on('error', async (error) => {
             console.error(chalk.red(`❌ Failed to start MCP server: ${error.message}`));
+            telemetry.track('cli_command_completed', {
+                command: 'mcp',
+                outcome: 'failure',
+                error_category: classifyTelemetryError(error),
+            });
+            await telemetry.flush();
             process.exit(1);
         });
     });
@@ -866,4 +1012,15 @@ if (shouldLoadSkillsCommands(process.argv)) {
     registerSkillsCommands(skillsCmd, getSkillsAssetsDir());
 }
 
-program.parse();
+try {
+    await program.parseAsync();
+    await telemetry.flush();
+} catch (error) {
+    telemetry.track('cli_command_completed', {
+        command: getTopLevelCommand(process.argv) || 'unknown',
+        outcome: 'failure',
+        error_category: classifyTelemetryError(error),
+    });
+    await telemetry.flush();
+    throw error;
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -13,6 +13,9 @@
     ],
     "references": [
         {
+            "path": "../telemetry"
+        },
+        {
             "path": "../workflow-core"
         },
         {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@hono/node-server": "^1.19.12",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@n8n-as-code/telemetry": "0.1.0",
     "n8nac": "1.8.1",
     "zod": "^3.25.76"
   },

--- a/packages/mcp/src/services/mcp-server.ts
+++ b/packages/mcp/src/services/mcp-server.ts
@@ -437,7 +437,6 @@ export async function startN8nAsCodeMcpServer(options: StartServerOptions = {}):
             host_type: LOOPBACK_HOSTS.has(httpOptions.host ?? '127.0.0.1') ? 'loopback' : 'non_loopback',
             port_configured: httpOptions.port !== undefined,
         });
-        telemetry.trackActive({ activation_source_event: 'mcp_server_started' });
         return startHttpServer(service, httpOptions, telemetry);
     }
     if (sseOptions) {
@@ -446,11 +445,9 @@ export async function startN8nAsCodeMcpServer(options: StartServerOptions = {}):
             host_type: LOOPBACK_HOSTS.has(sseOptions.host ?? '127.0.0.1') ? 'loopback' : 'non_loopback',
             port_configured: sseOptions.port !== undefined,
         });
-        telemetry.trackActive({ activation_source_event: 'mcp_server_started' });
         return startSseServer(service, sseOptions, telemetry);
     }
     telemetry.track('mcp_server_started', { transport: 'stdio' });
-    telemetry.trackActive({ activation_source_event: 'mcp_server_started' });
     return startStdioServer(service, telemetry);
 }
 

--- a/packages/mcp/src/services/mcp-server.ts
+++ b/packages/mcp/src/services/mcp-server.ts
@@ -7,6 +7,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { isInitializeRequest, type ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { N8nAsCodeMcpService, type N8nAsCodeMcpServiceOptions } from './mcp-service.js';
+import { createTelemetryClient, classifyTelemetryError, type TelemetryClient } from '@n8n-as-code/telemetry';
 
 export interface HttpServerOptions {
     port?: number;
@@ -76,7 +77,7 @@ const searchDocsSchema = {
     limit: z.number().int().min(1).max(10).optional().describe('Maximum number of pages to return.'),
 };
 
-function buildMcpServer(service: N8nAsCodeMcpService): McpServer {
+function buildMcpServer(service: N8nAsCodeMcpService, telemetry: TelemetryClient): McpServer {
     const server = new McpServer({
         name: 'n8n-as-code',
         version: '1.0.0',
@@ -87,6 +88,35 @@ function buildMcpServer(service: N8nAsCodeMcpService): McpServer {
     // types are explicitly annotated below for full type safety at the call site.
     const s = server as unknown as {
         tool(name: string, description: string, schema: object, annotations: ToolAnnotations, handler: (args: any) => any): void;
+    };
+
+    const trackTool = (toolName: string, handler: (args: any) => any) => async (args: any) => {
+        const startedAt = Date.now();
+        try {
+            const result = await handler(args);
+            const isError = Boolean((result as any)?.isError);
+            telemetry.track('mcp_tool_called', {
+                tool_name: toolName,
+                outcome: isError ? 'failure' : 'success',
+                duration_ms: Date.now() - startedAt,
+                limit: typeof args?.limit === 'number' ? args.limit : undefined,
+                format: typeof args?.format === 'string' ? args.format : undefined,
+                error_category: isError ? 'unknown_error' : undefined,
+            });
+            telemetry.trackActive({ activation_source_event: 'mcp_tool_called' });
+            return result;
+        } catch (error) {
+            telemetry.track('mcp_tool_called', {
+                tool_name: toolName,
+                outcome: 'failure',
+                duration_ms: Date.now() - startedAt,
+                limit: typeof args?.limit === 'number' ? args.limit : undefined,
+                format: typeof args?.format === 'string' ? args.format : undefined,
+                error_category: classifyTelemetryError(error),
+            });
+            telemetry.trackActive({ activation_source_event: 'mcp_tool_called' });
+            throw error;
+        }
     };
 
     // All tools operate exclusively on local/bundled data and produce no lasting side effects.
@@ -102,9 +132,9 @@ function buildMcpServer(service: N8nAsCodeMcpService): McpServer {
         'Search the local n8n-as-code knowledge base for nodes, documentation, and examples.',
         searchKnowledgeSchema,
         localReadOnlyHints,
-        async ({ query, category, type, limit }: { query: string; category?: string; type?: 'node' | 'documentation'; limit?: number }) => ({
+        trackTool('search_n8n_knowledge', async ({ query, category, type, limit }: { query: string; category?: string; type?: 'node' | 'documentation'; limit?: number }) => ({
             content: [{ type: 'text' as const, text: asJsonText(await service.searchKnowledge(query, { category, type, limit })) }],
-        }),
+        })),
     );
 
     s.tool(
@@ -112,7 +142,7 @@ function buildMcpServer(service: N8nAsCodeMcpService): McpServer {
         'Get the full offline schema and metadata for a specific n8n node.',
         getNodeInfoSchema,
         localReadOnlyHints,
-        async ({ name }: { name: string }) => {
+        trackTool('get_n8n_node_info', async ({ name }: { name: string }) => {
             try {
                 return {
                     content: [{ type: 'text' as const, text: asJsonText(await service.getNodeInfo(name)) }],
@@ -123,7 +153,7 @@ function buildMcpServer(service: N8nAsCodeMcpService): McpServer {
                     content: [{ type: 'text' as const, text: error.message }],
                 };
             }
-        },
+        }),
     );
 
     s.tool(
@@ -131,9 +161,9 @@ function buildMcpServer(service: N8nAsCodeMcpService): McpServer {
         'Search the bundled n8n community workflow index for reusable example workflows.',
         searchExamplesSchema,
         localReadOnlyHints,
-        async ({ query, limit }: { query: string; limit?: number }) => ({
+        trackTool('search_n8n_workflow_examples', async ({ query, limit }: { query: string; limit?: number }) => ({
             content: [{ type: 'text' as const, text: asJsonText(await service.searchExamples(query, limit)) }],
-        }),
+        })),
     );
 
     s.tool(
@@ -141,7 +171,7 @@ function buildMcpServer(service: N8nAsCodeMcpService): McpServer {
         'Get metadata and the raw download URL for a specific community workflow example.',
         getExampleInfoSchema,
         localReadOnlyHints,
-        async ({ id }: { id: string }) => {
+        trackTool('get_n8n_workflow_example', async ({ id }: { id: string }) => {
             try {
                 return {
                     content: [{ type: 'text' as const, text: asJsonText(await service.getExampleInfo(id)) }],
@@ -152,7 +182,7 @@ function buildMcpServer(service: N8nAsCodeMcpService): McpServer {
                     content: [{ type: 'text' as const, text: error.message }],
                 };
             }
-        },
+        }),
     );
 
     s.tool(
@@ -160,9 +190,16 @@ function buildMcpServer(service: N8nAsCodeMcpService): McpServer {
         'Validate an n8n workflow from JSON or TypeScript content against the bundled schema.',
         validateWorkflowSchema,
         localReadOnlyHints,
-        async ({ workflowContent, format }: { workflowContent: string; format?: 'auto' | 'json' | 'typescript' }) => {
+        trackTool('validate_n8n_workflow', async ({ workflowContent, format }: { workflowContent: string; format?: 'auto' | 'json' | 'typescript' }) => {
             try {
                 const result = await service.validateWorkflow({ workflowContent, format });
+                telemetry.track('workflow_validated', {
+                    source: 'mcp',
+                    format: format ?? 'auto',
+                    valid: Boolean((result as any)?.valid),
+                    error_count: Array.isArray((result as any)?.errors) ? (result as any).errors.length : undefined,
+                    warning_count: Array.isArray((result as any)?.warnings) ? (result as any).warnings.length : undefined,
+                });
                 return {
                     content: [{ type: 'text' as const, text: asJsonText(result) }],
                 };
@@ -172,7 +209,7 @@ function buildMcpServer(service: N8nAsCodeMcpService): McpServer {
                     content: [{ type: 'text' as const, text: error.message }],
                 };
             }
-        },
+        }),
     );
 
     s.tool(
@@ -180,15 +217,15 @@ function buildMcpServer(service: N8nAsCodeMcpService): McpServer {
         'Search bundled n8n documentation pages and return matching excerpts.',
         searchDocsSchema,
         localReadOnlyHints,
-        async ({ query, category, type, limit }: { query: string; category?: string; type?: 'node' | 'documentation'; limit?: number }) => ({
+        trackTool('search_n8n_docs', async ({ query, category, type, limit }: { query: string; category?: string; type?: 'node' | 'documentation'; limit?: number }) => ({
             content: [{ type: 'text' as const, text: asJsonText(await service.searchDocs(query, { category, type, limit })) }],
-        }),
+        })),
     );
 
     return server;
 }
 
-async function startHttpServer(service: N8nAsCodeMcpService, httpOptions: HttpServerOptions): Promise<void> {
+async function startHttpServer(service: N8nAsCodeMcpService, httpOptions: HttpServerOptions, telemetry: TelemetryClient): Promise<void> {
     const port = httpOptions.port ?? 3000;
     const host = httpOptions.host ?? '127.0.0.1';
 
@@ -264,7 +301,7 @@ async function startHttpServer(service: N8nAsCodeMcpService, httpOptions: HttpSe
                     }
                 };
 
-                const server = buildMcpServer(service);
+                const server = buildMcpServer(service, telemetry);
                 await server.connect(transport);
             } else {
                 const status = sessionId ? 404 : 400;
@@ -304,6 +341,7 @@ async function startHttpServer(service: N8nAsCodeMcpService, httpOptions: HttpSe
             await transport.close();
         }
         transports.clear();
+        await telemetry.flush();
         process.exit(0);
     };
 
@@ -314,7 +352,7 @@ async function startHttpServer(service: N8nAsCodeMcpService, httpOptions: HttpSe
     await new Promise<void>(() => {});
 }
 
-async function startSseServer(service: N8nAsCodeMcpService, sseOptions: SseServerOptions): Promise<void> {
+async function startSseServer(service: N8nAsCodeMcpService, sseOptions: SseServerOptions, telemetry: TelemetryClient): Promise<void> {
     const port = sseOptions.port ?? 3000;
     const host = sseOptions.host ?? '127.0.0.1';
 
@@ -332,7 +370,7 @@ async function startSseServer(service: N8nAsCodeMcpService, sseOptions: SseServe
                 transports.delete(transport.sessionId);
             };
 
-            const server = buildMcpServer(service);
+            const server = buildMcpServer(service, telemetry);
             await server.connect(transport);
             await transport.start();
         } else if (req.url?.startsWith('/message') && req.method === 'POST') {
@@ -377,6 +415,7 @@ async function startSseServer(service: N8nAsCodeMcpService, sseOptions: SseServe
             await transport.close();
         }
         transports.clear();
+        await telemetry.flush();
         process.exit(0);
     };
 
@@ -390,18 +429,33 @@ async function startSseServer(service: N8nAsCodeMcpService, sseOptions: SseServe
 export async function startN8nAsCodeMcpServer(options: StartServerOptions = {}): Promise<void> {
     const { http: httpOptions, sse: sseOptions, ...serviceOptions } = options;
     const service = new N8nAsCodeMcpService(serviceOptions);
+    const telemetry = createTelemetryClient({ facade: 'mcp' });
 
     if (httpOptions) {
-        return startHttpServer(service, httpOptions);
+        telemetry.track('mcp_server_started', {
+            transport: 'http',
+            host_type: LOOPBACK_HOSTS.has(httpOptions.host ?? '127.0.0.1') ? 'loopback' : 'non_loopback',
+            port_configured: httpOptions.port !== undefined,
+        });
+        telemetry.trackActive({ activation_source_event: 'mcp_server_started' });
+        return startHttpServer(service, httpOptions, telemetry);
     }
     if (sseOptions) {
-        return startSseServer(service, sseOptions);
+        telemetry.track('mcp_server_started', {
+            transport: 'sse',
+            host_type: LOOPBACK_HOSTS.has(sseOptions.host ?? '127.0.0.1') ? 'loopback' : 'non_loopback',
+            port_configured: sseOptions.port !== undefined,
+        });
+        telemetry.trackActive({ activation_source_event: 'mcp_server_started' });
+        return startSseServer(service, sseOptions, telemetry);
     }
-    return startStdioServer(service);
+    telemetry.track('mcp_server_started', { transport: 'stdio' });
+    telemetry.trackActive({ activation_source_event: 'mcp_server_started' });
+    return startStdioServer(service, telemetry);
 }
 
-async function startStdioServer(service: N8nAsCodeMcpService): Promise<void> {
-    const server = buildMcpServer(service);
+async function startStdioServer(service: N8nAsCodeMcpService, telemetry: TelemetryClient): Promise<void> {
+    const server = buildMcpServer(service, telemetry);
     const transport = new StdioServerTransport();
     await server.connect(transport);
 }

--- a/packages/mcp/src/services/mcp-server.ts
+++ b/packages/mcp/src/services/mcp-server.ts
@@ -457,5 +457,35 @@ export async function startN8nAsCodeMcpServer(options: StartServerOptions = {}):
 async function startStdioServer(service: N8nAsCodeMcpService, telemetry: TelemetryClient): Promise<void> {
     const server = buildMcpServer(service, telemetry);
     const transport = new StdioServerTransport();
+    let flushPromise: Promise<void> | undefined;
+    let resolveClosed: () => void;
+    const closed = new Promise<void>((resolve) => {
+        resolveClosed = resolve;
+    });
+
+    const flushOnce = (): Promise<void> => {
+        flushPromise ??= telemetry.flush(1000);
+        return flushPromise;
+    };
+
+    const flushAndResolve = async (): Promise<void> => {
+        await flushOnce();
+        resolveClosed();
+    };
+
+    transport.onclose = () => {
+        void flushAndResolve();
+    };
+
+    const shutdown = async () => {
+        await transport.close();
+        await flushAndResolve();
+        process.exit(0);
+    };
+
+    process.once('SIGINT', shutdown);
+    process.once('SIGTERM', shutdown);
+
     await server.connect(transport);
+    await closed;
 }

--- a/packages/mcp/src/services/mcp-server.ts
+++ b/packages/mcp/src/services/mcp-server.ts
@@ -462,7 +462,7 @@ async function startStdioServer(service: N8nAsCodeMcpService, telemetry: Telemet
 
     const flushOnce = (): Promise<void> => {
         flushPromise ??= telemetry.flush(1000);
-        return flushPromise;
+        return flushPromise!;
     };
 
     const flushAndResolve = async (): Promise<void> => {

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -11,6 +11,9 @@
   },
   "references": [
     {
+      "path": "../telemetry"
+    },
+    {
       "path": "../cli"
     }
   ],

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -17,6 +17,7 @@
     },
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@n8n-as-code/telemetry": "0.1.0",
         "@n8n-as-code/transformer": "1.2.1",
         "chalk": "^4.1.2",
         "commander": "^11.1.0",

--- a/packages/skills/src/commands/skills-commander.ts
+++ b/packages/skills/src/commands/skills-commander.ts
@@ -19,6 +19,25 @@ import type { DocsProvider } from '../services/docs-provider.js';
 import type { KnowledgeSearch } from '../services/knowledge-search.js';
 import type { WorkflowRegistry } from '../services/workflow-registry.js';
 import type { CustomNodesResolution } from '../services/custom-nodes-config.js';
+import { createTelemetryClient, type TelemetryProperties } from '@n8n-as-code/telemetry';
+
+let telemetryFlushRegistered = false;
+
+function getSkillsCommandPath(command: Command): string {
+    const names: string[] = [];
+    let current: Command | null = command;
+
+    while (current && current.parent) {
+        names.unshift(current.name());
+        current = current.parent;
+    }
+
+    if (names[0] === 'skills') {
+        names.shift();
+    }
+
+    return names.join(' ');
+}
 
 function getUnifiedCliEntryPath(): string {
     if (process.env.N8NAC_CLI_ENTRY) {
@@ -74,6 +93,34 @@ function printSearchCustomNodesNote(customNodesConfig: CustomNodesResolution, qu
 }
 
 export function registerSkillsCommands(program: Command, assetsDir: string): void {
+    const telemetry = createTelemetryClient({ facade: 'skills' });
+    const commandStartTimes = new WeakMap<Command, number>();
+
+    if (!telemetryFlushRegistered) {
+        telemetryFlushRegistered = true;
+        process.on('beforeExit', () => {
+            void telemetry.flush();
+        });
+    }
+
+    program.hook('preAction', (_thisCommand, actionCommand) => {
+        commandStartTimes.set(actionCommand, Date.now());
+    });
+
+    program.hook('postAction', (_thisCommand, actionCommand) => {
+        const commandPath = getSkillsCommandPath(actionCommand);
+        const [commandName, ...rest] = commandPath.split(' ');
+        const properties: TelemetryProperties = {
+            command: commandName || 'unknown',
+            subcommand: rest.length > 0 ? rest.join(' ') : undefined,
+            outcome: 'success',
+            duration_ms: Date.now() - (commandStartTimes.get(actionCommand) ?? Date.now()),
+        };
+
+        telemetry.track('skills_command_completed', properties);
+        telemetry.trackActive({ activation_source_event: 'skills_command_completed' });
+    });
+
     let customNodesConfigPromise: Promise<CustomNodesResolution> | undefined;
     let providerPromise: Promise<NodeSchemaProvider> | undefined;
     let docsProviderPromise: Promise<DocsProvider> | undefined;

--- a/packages/skills/tsconfig.json
+++ b/packages/skills/tsconfig.json
@@ -11,6 +11,9 @@
     },
     "references": [
         {
+            "path": "../telemetry"
+        },
+        {
             "path": "../transformer"
         }
     ],

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@n8n-as-code/telemetry",
+  "version": "0.1.0",
+  "description": "Privacy-first telemetry primitives for n8n-as-code facades",
+  "type": "module",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -70,6 +70,7 @@ export interface TelemetryStatus {
     configPath: string;
     anonymousId?: string;
     posthogHost: string;
+    noticeShownAt?: string;
 }
 
 export interface TelemetryClient {
@@ -87,6 +88,7 @@ interface TelemetryConfigFile {
     telemetryVersion?: number;
     enabled?: boolean;
     activeByFacade?: Record<string, string>;
+    noticeShownAt?: string;
 }
 
 interface QueuedEvent {
@@ -315,7 +317,22 @@ export function getTelemetryStatus(context?: Pick<TelemetryContext, 'forceDisabl
         configPath: path,
         anonymousId: config.anonymousId,
         posthogHost: getPostHogHost(),
+        noticeShownAt: config.noticeShownAt,
     };
+}
+
+export function shouldShowTelemetryNotice(context?: Pick<TelemetryContext, 'forceDisabled'>): boolean {
+    const { config } = ensureConfig();
+    const status = getTelemetryStatus(context);
+    return status.enabled && !config.noticeShownAt;
+}
+
+export function markTelemetryNoticeShown(): void {
+    const { config, path } = ensureConfig();
+    if (config.noticeShownAt) return;
+    config.noticeShownAt = new Date().toISOString();
+    config.telemetryVersion = TELEMETRY_SCHEMA_VERSION;
+    writeConfig(config, path);
 }
 
 export function setTelemetryEnabled(enabled: boolean): TelemetryStatus {

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -1,0 +1,415 @@
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir, platform } from 'node:os';
+import { dirname, join } from 'node:path';
+
+export type TelemetryFacade = 'cli' | 'vscode' | 'mcp' | 'skills' | 'openclaw' | 'claude' | 'docs' | 'yagr';
+export type TelemetryOutcome = 'success' | 'failure' | 'cancelled' | 'skipped';
+export type ErrorCategory =
+    | 'configuration_error'
+    | 'network_error'
+    | 'authentication_error'
+    | 'authorization_error'
+    | 'validation_error'
+    | 'conflict_error'
+    | 'runtime_unavailable'
+    | 'not_found'
+    | 'rate_limited'
+    | 'timeout'
+    | 'unknown_error';
+
+export type TelemetryEventName =
+    | 'first_seen'
+    | 'product_active'
+    | 'setup_started'
+    | 'setup_mode_selected'
+    | 'setup_completed'
+    | 'setup_failed'
+    | 'cli_command_completed'
+    | 'vscode_extension_activated'
+    | 'vscode_command_completed'
+    | 'vscode_workflow_view_opened'
+    | 'mcp_server_started'
+    | 'mcp_tool_called'
+    | 'skills_command_completed'
+    | 'workflow_listed'
+    | 'workflow_pulled'
+    | 'workflow_pushed'
+    | 'workflow_fetched'
+    | 'conflict_detected'
+    | 'conflict_resolved'
+    | 'workflow_converted'
+    | 'workflow_validated'
+    | 'ai_context_initialized'
+    | 'credential_recipe_listed'
+    | 'credential_starter_kit_used'
+    | 'credential_tested'
+    | 'credential_created'
+    | 'workflow_activated'
+    | 'workflow_deactivated'
+    | 'workflow_execution_listed'
+    | 'workflow_execution_inspected'
+    | 'openclaw_service_started'
+    | 'openclaw_cli_command_completed';
+
+export type TelemetryPropertyValue = string | number | boolean | null | undefined;
+export type TelemetryProperties = Record<string, TelemetryPropertyValue>;
+
+export interface TelemetryContext {
+    facade: TelemetryFacade;
+    version?: string;
+    workspaceId?: string;
+    sessionId?: string;
+    forceDisabled?: boolean;
+}
+
+export interface TelemetryStatus {
+    enabled: boolean;
+    configured: boolean;
+    disabledReason?: string;
+    configPath: string;
+    anonymousId?: string;
+    posthogHost: string;
+}
+
+export interface TelemetryClient {
+    track(event: TelemetryEventName, properties?: TelemetryProperties): void;
+    trackActive(properties?: TelemetryProperties): void;
+    withTelemetry<T>(event: TelemetryEventName, properties: TelemetryProperties, operation: () => Promise<T>): Promise<T>;
+    flush(timeoutMs?: number): Promise<void>;
+    isEnabled(): boolean;
+    isConfigured(): boolean;
+}
+
+interface TelemetryConfigFile {
+    anonymousId?: string;
+    createdAt?: string;
+    telemetryVersion?: number;
+    enabled?: boolean;
+    activeByFacade?: Record<string, string>;
+}
+
+interface QueuedEvent {
+    event: TelemetryEventName;
+    properties: TelemetryProperties;
+}
+
+const TELEMETRY_SCHEMA_VERSION = 1;
+const DEFAULT_POSTHOG_HOST = 'https://eu.i.posthog.com';
+
+const ALLOWED_PROPERTY_KEYS = new Set([
+    'activation_source_event',
+    'app',
+    'archive_filter',
+    'command',
+    'conflict_count',
+    'conflict_detected',
+    'credential_type',
+    'credential_type_count',
+    'custom_nodes_configured',
+    'duration_ms',
+    'entrypoint',
+    'error_category',
+    'error_count',
+    'execution_status',
+    'extension_state',
+    'extension_version',
+    'facade',
+    'format',
+    'has_api_key',
+    'has_project',
+    'has_sync_folder',
+    'has_workspace',
+    'host_type',
+    'include_data',
+    'input_format',
+    'is_ci',
+    'limit',
+    'local_only_count',
+    'mode',
+    'node_major',
+    'operation',
+    'os',
+    'outcome',
+    'output_format',
+    'package_version',
+    'port_configured',
+    'remote_only_count',
+    'resolution',
+    'result_count',
+    'session_id',
+    'setup_mode',
+    'source',
+    'status_filter',
+    'subcommand',
+    'target',
+    'telemetry_schema_version',
+    'tool_name',
+    'tracked_count',
+    'transport',
+    'valid',
+    'vscode_version',
+    'warning_count',
+    'workflow_count',
+    'workflow_state',
+    'workspace_initialized',
+    'workspace_id',
+]);
+
+export function getTelemetryConfigPath(): string {
+    const configHome = process.env.XDG_CONFIG_HOME?.trim() || join(homedir(), '.config');
+    return join(configHome, 'n8n-as-code', 'telemetry.json');
+}
+
+function readConfig(path = getTelemetryConfigPath()): TelemetryConfigFile {
+    try {
+        if (!existsSync(path)) return {};
+        return JSON.parse(readFileSync(path, 'utf8')) as TelemetryConfigFile;
+    } catch {
+        return {};
+    }
+}
+
+function writeConfig(config: TelemetryConfigFile, path = getTelemetryConfigPath()): void {
+    try {
+        mkdirSync(dirname(path), { recursive: true });
+        writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+    } catch {
+        // Telemetry config must never break product behavior.
+    }
+}
+
+function ensureConfig(): { config: TelemetryConfigFile; created: boolean; path: string } {
+    const path = getTelemetryConfigPath();
+    const config = readConfig(path);
+    let created = false;
+
+    if (!config.anonymousId) {
+        config.anonymousId = randomUUID();
+        config.createdAt = new Date().toISOString();
+        config.telemetryVersion = TELEMETRY_SCHEMA_VERSION;
+        created = true;
+        writeConfig(config, path);
+    }
+
+    return { config, created, path };
+}
+
+function getEnvDisabledReason(): string | undefined {
+    if (process.env.CI === 'true') return 'ci';
+    if (process.env.DO_NOT_TRACK === '1') return 'do_not_track';
+    if (process.env.N8NAC_TELEMETRY_DISABLED === '1') return 'environment';
+
+    const raw = process.env.N8NAC_TELEMETRY?.trim().toLowerCase();
+    if (raw === '0' || raw === 'false' || raw === 'off' || raw === 'no') {
+        return 'environment';
+    }
+
+    return undefined;
+}
+
+function normalizeOs(): 'linux' | 'macos' | 'windows' | 'other' {
+    const value = platform();
+    if (value === 'linux') return 'linux';
+    if (value === 'darwin') return 'macos';
+    if (value === 'win32') return 'windows';
+    return 'other';
+}
+
+function getNodeMajor(): number | undefined {
+    const [major] = process.versions.node.split('.');
+    const parsed = Number.parseInt(major, 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function getPostHogKey(): string | undefined {
+    return process.env.N8NAC_POSTHOG_KEY?.trim() || process.env.POSTHOG_KEY?.trim() || undefined;
+}
+
+function getPostHogHost(): string {
+    return (process.env.N8NAC_POSTHOG_HOST?.trim() || process.env.POSTHOG_HOST?.trim() || DEFAULT_POSTHOG_HOST).replace(/\/$/, '');
+}
+
+function sanitizeProperties(properties: TelemetryProperties): TelemetryProperties {
+    const sanitized: TelemetryProperties = {};
+
+    for (const [key, value] of Object.entries(properties)) {
+        if (!ALLOWED_PROPERTY_KEYS.has(key)) continue;
+        if (value === undefined) continue;
+        if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' || value === null) {
+            sanitized[key] = value;
+        }
+    }
+
+    return sanitized;
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | undefined> {
+    return new Promise((resolve) => {
+        const timer = setTimeout(() => resolve(undefined), timeoutMs);
+        promise.then(
+            (value) => {
+                clearTimeout(timer);
+                resolve(value);
+            },
+            () => {
+                clearTimeout(timer);
+                resolve(undefined);
+            },
+        );
+    });
+}
+
+function debugEvent(event: QueuedEvent): void {
+    if (process.env.N8NAC_TELEMETRY_DEBUG !== '1') return;
+    try {
+        process.stderr.write(`[n8n-as-code telemetry] ${JSON.stringify(event)}\n`);
+    } catch {
+        // ignore debug logging failures
+    }
+}
+
+async function sendPostHogEvent(host: string, apiKey: string, distinctId: string, queued: QueuedEvent): Promise<void> {
+    await fetch(`${host}/capture/`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+            api_key: apiKey,
+            event: queued.event,
+            distinct_id: distinctId,
+            properties: queued.properties,
+        }),
+    });
+}
+
+export function classifyTelemetryError(error: unknown): ErrorCategory {
+    const anyError = error as any;
+    const status = anyError?.response?.status ?? anyError?.status;
+    const code = typeof anyError?.code === 'string' ? anyError.code.toLowerCase() : '';
+    const message = typeof anyError?.message === 'string' ? anyError.message.toLowerCase() : '';
+
+    if (status === 401 || message.includes('api key') || message.includes('authentication')) return 'authentication_error';
+    if (status === 403 || message.includes('forbidden') || message.includes('authorization')) return 'authorization_error';
+    if (status === 404 || message.includes('not found')) return 'not_found';
+    if (status === 409 || message.includes('conflict') || message.includes('push rejected')) return 'conflict_error';
+    if (status === 422 || message.includes('validation') || message.includes('invalid')) return 'validation_error';
+    if (status === 429 || message.includes('rate limit')) return 'rate_limited';
+    if (code.includes('timeout') || message.includes('timeout') || message.includes('timed out')) return 'timeout';
+    if (code.includes('econn') || code.includes('enotfound') || message.includes('network')) return 'network_error';
+    if (message.includes('not configured') || message.includes('missing required') || message.includes('configuration')) return 'configuration_error';
+    if (message.includes('runtime') || message.includes('docker')) return 'runtime_unavailable';
+    return 'unknown_error';
+}
+
+export function getTelemetryStatus(context?: Pick<TelemetryContext, 'forceDisabled'>): TelemetryStatus {
+    const { config, path } = ensureConfig();
+    const envDisabledReason = getEnvDisabledReason();
+    const disabledReason = context?.forceDisabled
+        ? 'forced_disabled'
+        : envDisabledReason ?? (config.enabled === false ? 'user_disabled' : undefined);
+
+    return {
+        enabled: !disabledReason,
+        configured: Boolean(getPostHogKey()),
+        disabledReason,
+        configPath: path,
+        anonymousId: config.anonymousId,
+        posthogHost: getPostHogHost(),
+    };
+}
+
+export function setTelemetryEnabled(enabled: boolean): TelemetryStatus {
+    const { config, path } = ensureConfig();
+    config.enabled = enabled;
+    config.telemetryVersion = TELEMETRY_SCHEMA_VERSION;
+    writeConfig(config, path);
+    return getTelemetryStatus();
+}
+
+export function createTelemetryClient(context: TelemetryContext): TelemetryClient {
+    const { config, created, path } = ensureConfig();
+    const sessionId = context.sessionId ?? randomUUID();
+    const posthogHost = getPostHogHost();
+    const posthogKey = getPostHogKey();
+    const status = getTelemetryStatus({ forceDisabled: context.forceDisabled });
+    const queue: QueuedEvent[] = [];
+
+    const baseProperties = (): TelemetryProperties => ({
+        app: 'n8n-as-code',
+        facade: context.facade,
+        telemetry_schema_version: TELEMETRY_SCHEMA_VERSION,
+        package_version: context.version,
+        session_id: sessionId,
+        workspace_id: context.workspaceId,
+        os: normalizeOs(),
+        node_major: getNodeMajor(),
+        is_ci: process.env.CI === 'true',
+    });
+
+    const enqueue = (event: TelemetryEventName, properties: TelemetryProperties = {}): void => {
+        if (!status.enabled) return;
+
+        const queued: QueuedEvent = {
+            event,
+            properties: sanitizeProperties({ ...baseProperties(), ...properties }),
+        };
+        debugEvent(queued);
+        queue.push(queued);
+    };
+
+    const client: TelemetryClient = {
+        track(event, properties = {}) {
+            enqueue(event, properties);
+        },
+
+        trackActive(properties = {}) {
+            if (!status.enabled) return;
+            const today = new Date().toISOString().slice(0, 10);
+            const activeByFacade = config.activeByFacade ?? {};
+            if (activeByFacade[context.facade] === today) return;
+
+            activeByFacade[context.facade] = today;
+            config.activeByFacade = activeByFacade;
+            writeConfig(config, path);
+            enqueue('product_active', properties);
+        },
+
+        async withTelemetry(event, properties, operation) {
+            const startedAt = Date.now();
+            try {
+                const result = await operation();
+                enqueue(event, { ...properties, outcome: 'success', duration_ms: Date.now() - startedAt });
+                return result;
+            } catch (error) {
+                enqueue(event, {
+                    ...properties,
+                    outcome: 'failure',
+                    duration_ms: Date.now() - startedAt,
+                    error_category: classifyTelemetryError(error),
+                });
+                throw error;
+            }
+        },
+
+        async flush(timeoutMs = 500) {
+            if (!status.enabled || !posthogKey || queue.length === 0) return;
+
+            const pending = queue.splice(0, queue.length);
+            await withTimeout(Promise.all(pending.map((event) => sendPostHogEvent(posthogHost, posthogKey, config.anonymousId!, event))).then(() => undefined), timeoutMs);
+        },
+
+        isEnabled() {
+            return status.enabled;
+        },
+
+        isConfigured() {
+            return Boolean(posthogKey);
+        },
+    };
+
+    if (created) {
+        enqueue('first_seen');
+    }
+
+    return client;
+}

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -371,6 +371,7 @@ export function createTelemetryClient(context: TelemetryContext): TelemetryClien
             properties: sanitizeProperties({ ...baseProperties(), ...properties }),
         };
         debugEvent(queued);
+        if (!posthogKey) return;
         queue.push(queued);
     };
 
@@ -409,7 +410,11 @@ export function createTelemetryClient(context: TelemetryContext): TelemetryClien
         },
 
         async flush(timeoutMs = 500) {
-            if (!status.enabled || !posthogKey || queue.length === 0) return;
+            if (!status.enabled || queue.length === 0) return;
+            if (!posthogKey) {
+                queue.splice(0, queue.length);
+                return;
+            }
 
             const pending = queue.splice(0, queue.length);
             await withTimeout(Promise.all(pending.map((event) => sendPostHogEvent(posthogHost, posthogKey, config.anonymousId!, event))).then(() => undefined), timeoutMs);

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "composite": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -301,8 +301,9 @@
   "dependencies": {
     "@n8n-as-code/manager-adapter": "0.1.0",
     "@n8n-as-code/n8n-manager-core": "^0.5.0",
-    "@n8n-as-code/workflow-core": "0.1.0",
     "@n8n-as-code/skills": "1.10.0",
+    "@n8n-as-code/telemetry": "0.1.0",
+    "@n8n-as-code/workflow-core": "0.1.0",
     "@reduxjs/toolkit": "^2.11.2",
     "http-proxy": "^1.18.1",
     "n8nac": "1.8.1",

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -23,6 +23,7 @@ import {
     type N8nConfigurationChangeEvent,
 } from './services/n8n-configuration-controller.js';
 import { createN8nManagerFacade } from '@n8n-as-code/manager-adapter';
+import { createTelemetryClient, type TelemetryClient } from '@n8n-as-code/telemetry';
 import { ExtensionState } from './types.js';
 import { getN8nConfig, getResolvedN8nConfig, validateN8nConfig, getWorkspaceRoot } from './utils/state-detection.js';
 import { NO_WORKSPACE_ERROR_MESSAGE, OPEN_FOLDER_ACTION } from './constants/workspace.js';
@@ -84,6 +85,7 @@ const enhancedTreeProvider = new EnhancedWorkflowTreeProvider();
 const decorationProvider = new WorkflowDecorationProvider();
 const outputChannel = vscode.window.createOutputChannel("n8n-as-code");
 let workflowsTreeView: vscode.TreeView<any> | undefined;
+let telemetryClient: TelemetryClient | undefined;
 
 const conflictStore = new Map<string, string>();
 
@@ -105,6 +107,40 @@ type InstanceQuickPickItem = vscode.QuickPickItem & {
 export async function activate(context: vscode.ExtensionContext) {
     outputChannel.show(true);
     outputChannel.appendLine('🔌 Activation of "n8n-as-code"...');
+    telemetryClient = createTelemetryClient({
+        facade: 'vscode',
+        version: String(context.extension.packageJSON?.version ?? __N8NAC_CLI_SEMVER__ ?? ''),
+        forceDisabled: !vscode.env.isTelemetryEnabled,
+    });
+    telemetryClient.track('vscode_extension_activated', {
+        vscode_version: vscode.version,
+        extension_version: String(context.extension.packageJSON?.version ?? ''),
+        has_workspace: Boolean(vscode.workspace.workspaceFolders?.length),
+    });
+    context.subscriptions.push(vscode.env.onDidChangeTelemetryEnabled((enabled) => {
+        telemetryClient = createTelemetryClient({
+            facade: 'vscode',
+            version: String(context.extension.packageJSON?.version ?? __N8NAC_CLI_SEMVER__ ?? ''),
+            forceDisabled: !enabled,
+        });
+    }));
+
+    const registerTelemetryCommand = (command: string, callback: (...args: any[]) => any): vscode.Disposable => (
+        vscode.commands.registerCommand(command, async (...args: any[]) => {
+            const telemetry = telemetryClient;
+            if (!telemetry) {
+                return callback(...args);
+            }
+
+            const result = await telemetry.withTelemetry('vscode_command_completed', {
+                command,
+                has_workspace: Boolean(vscode.workspace.workspaceFolders?.length),
+                extension_state: String(enhancedTreeProvider.getExtensionState?.() ?? 'unknown'),
+            }, async () => callback(...args));
+            telemetry.trackActive({ activation_source_event: 'vscode_command_completed' });
+            return result;
+        })
+    );
 
     // Register Remote Content Provider for Diffs
     context.subscriptions.push(
@@ -140,63 +176,65 @@ export async function activate(context: vscode.ExtensionContext) {
     // Handlers that need `cli` guard against it being undefined.
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('n8n.init', async () => {
+        registerTelemetryCommand('n8n.init', async () => {
             await handleInitializeCommand(context);
         }),
 
-        vscode.commands.registerCommand('n8n.configure', async () => {
+        registerTelemetryCommand('n8n.configure', async () => {
             ConfigurationWebview.createOrShow(context, requireConfigurationController());
         }),
 
-        vscode.commands.registerCommand('n8n.switchInstance', async (args?: SwitchInstanceCommandArgs) => {
+        registerTelemetryCommand('n8n.switchInstance', async (args?: SwitchInstanceCommandArgs) => {
             await switchWorkspaceInstance(context, args);
         }),
 
-        vscode.commands.registerCommand('n8n.pinWorkspaceInstance', async (args?: SwitchInstanceCommandArgs) => {
+        registerTelemetryCommand('n8n.pinWorkspaceInstance', async (args?: SwitchInstanceCommandArgs) => {
             await pinWorkspaceInstance(context, args);
         }),
 
-        vscode.commands.registerCommand('n8n.clearWorkspaceInstance', async () => {
+        registerTelemetryCommand('n8n.clearWorkspaceInstance', async () => {
             await clearWorkspaceInstancePin(context);
         }),
 
-        vscode.commands.registerCommand('n8n.deleteInstance', async (args?: DeleteInstanceCommandArgs) => {
+        registerTelemetryCommand('n8n.deleteInstance', async (args?: DeleteInstanceCommandArgs) => {
             await deleteWorkspaceInstance(context, args);
         }),
 
-        vscode.commands.registerCommand('n8n.applySettings', async () => {
+        registerTelemetryCommand('n8n.applySettings', async () => {
             outputChannel.appendLine('[n8n] Applying new settings...');
             await reinitializeSyncManager(context);
             updateContextKeys();
         }),
 
-        vscode.commands.registerCommand('n8n.showActive', async () => {
+        registerTelemetryCommand('n8n.showActive', async () => {
             store.dispatch(setArchiveFilter('workflows'));
             if (workflowsTreeView) workflowsTreeView.title = 'Workflows';
             await store.dispatch(loadWorkflows());
         }),
 
-        vscode.commands.registerCommand('n8n.showArchived', async () => {
+        registerTelemetryCommand('n8n.showArchived', async () => {
             store.dispatch(setArchiveFilter('archived'));
             if (workflowsTreeView) workflowsTreeView.title = 'Archived Workflows';
             await store.dispatch(loadWorkflows());
         }),
 
-        vscode.commands.registerCommand('n8n.showAll', async () => {
+        registerTelemetryCommand('n8n.showAll', async () => {
             store.dispatch(setArchiveFilter('all'));
             if (workflowsTreeView) workflowsTreeView.title = 'All Workflows';
             await store.dispatch(loadWorkflows());
         }),
 
-        vscode.commands.registerCommand('n8n.openBoard', async (arg: any) => {
+        registerTelemetryCommand('n8n.openBoard', async (arg: any) => {
             const wf = arg?.workflow ? arg.workflow : arg;
             if (!wf) return;
+            telemetryClient?.track('vscode_workflow_view_opened', { mode: 'board', workflow_state: 'unknown' });
             await openWorkflowBoard(wf);
         }),
 
-        vscode.commands.registerCommand('n8n.openJson', async (arg: any) => {
+        registerTelemetryCommand('n8n.openJson', async (arg: any) => {
             const wf = arg?.workflow ? arg.workflow : arg;
             if (!wf || !syncManager) return;
+            telemetryClient?.track('vscode_workflow_view_opened', { mode: 'json', workflow_state: 'unknown' });
             const uri = getExistingWorkflowFileUri(wf);
             if (uri) {
                 try {
@@ -210,9 +248,10 @@ export async function activate(context: vscode.ExtensionContext) {
             }
         }),
 
-        vscode.commands.registerCommand('n8n.openSplit', async (arg: any) => {
+        registerTelemetryCommand('n8n.openSplit', async (arg: any) => {
             const wf = arg?.workflow ? arg.workflow : arg;
             if (!wf || !syncManager) return;
+            telemetryClient?.track('vscode_workflow_view_opened', { mode: 'split', workflow_state: 'unknown' });
             const uri = getExistingWorkflowFileUri(wf);
             if (uri) {
                 try {
@@ -226,7 +265,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }),
 
         // n8nac push <path>
-        vscode.commands.registerCommand('n8n.pushWorkflow', async (arg: any) => {
+        registerTelemetryCommand('n8n.pushWorkflow', async (arg: any) => {
             if (enhancedTreeProvider.getExtensionState() === ExtensionState.SETTINGS_CHANGED) {
                 vscode.window.showWarningMessage('n8n: Settings changed. Click "Apply Changes" to resume syncing.');
                 return;
@@ -269,7 +308,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }),
 
         // n8nac pull <id>
-        vscode.commands.registerCommand('n8n.pullWorkflow', async (arg: any) => {
+        registerTelemetryCommand('n8n.pullWorkflow', async (arg: any) => {
             if (enhancedTreeProvider.getExtensionState() === ExtensionState.SETTINGS_CHANGED) {
                 vscode.window.showWarningMessage('n8n: Settings changed. Click "Apply Changes" to resume syncing.');
                 return;
@@ -309,7 +348,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }),
 
         // n8nac fetch <id>
-        vscode.commands.registerCommand('n8n.fetchWorkflow', async (arg: any) => {
+        registerTelemetryCommand('n8n.fetchWorkflow', async (arg: any) => {
             if (enhancedTreeProvider.getExtensionState() === ExtensionState.SETTINGS_CHANGED) {
                 vscode.window.showWarningMessage('n8n: Settings changed. Click "Apply Changes" to resume syncing.');
                 return;
@@ -338,7 +377,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }),
 
         // n8nac list (global refresh — calls list with fresh remote fetch)
-        vscode.commands.registerCommand('n8n.refresh', async () => {
+        registerTelemetryCommand('n8n.refresh', async () => {
             outputChannel.appendLine('[n8n] Manual refresh — running list...');
             if (!cli) {
                 vscode.window.showErrorMessage('n8n as code is not initialized. Please configure and initialize first.');
@@ -359,7 +398,7 @@ export async function activate(context: vscode.ExtensionContext) {
             enhancedTreeProvider.refresh();
         }),
 
-        vscode.commands.registerCommand('n8n.findWorkflow', async () => {
+        registerTelemetryCommand('n8n.findWorkflow', async () => {
             if (enhancedTreeProvider.getExtensionState() === ExtensionState.SETTINGS_CHANGED) {
                 vscode.window.showWarningMessage('n8n: Settings changed. Click "Apply Changes" to resume syncing.');
                 return;
@@ -400,7 +439,7 @@ export async function activate(context: vscode.ExtensionContext) {
             await openWorkflowFromFinder(picked.workflow);
         }),
 
-        vscode.commands.registerCommand('n8n.initializeAI', async (options?: { silent?: boolean }) => {
+        registerTelemetryCommand('n8n.initializeAI', async (options?: { silent?: boolean }) => {
             if (!vscode.workspace.workspaceFolders?.length) {
                 if (!options?.silent) await showNoWorkspaceError();
                 return;
@@ -441,11 +480,11 @@ export async function activate(context: vscode.ExtensionContext) {
             }
         }),
 
-        vscode.commands.registerCommand('n8n.openSettings', () => {
+        registerTelemetryCommand('n8n.openSettings', () => {
             vscode.commands.executeCommand('workbench.action.openSettings', 'n8n');
         }),
 
-        vscode.commands.registerCommand('n8n.resolveConflict', async (arg: any) => {
+        registerTelemetryCommand('n8n.resolveConflict', async (arg: any) => {
             const wf = arg?.workflow ? arg.workflow : arg;
             if (!wf || !cli || !syncManager) return;
 
@@ -1526,6 +1565,7 @@ async function reinitializeSyncManager(
 }
 
 export function deactivate() {
+    void telemetryClient?.flush(1000);
     disposeRuntimeDisposables();
     proxyService.stop();
 }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1564,8 +1564,8 @@ async function reinitializeSyncManager(
     }
 }
 
-export function deactivate() {
-    void telemetryClient?.flush(1000);
+export async function deactivate(): Promise<void> {
+    await telemetryClient?.flush(1000);
     disposeRuntimeDisposables();
     proxyService.stop();
 }

--- a/packages/vscode-extension/tsconfig.json
+++ b/packages/vscode-extension/tsconfig.json
@@ -9,6 +9,9 @@
     ],
     "references": [
         {
+            "path": "../telemetry"
+        },
+        {
             "path": "../workflow-core"
         },
         {

--- a/plugins/claude/n8n-as-code/skills/n8n-architect/SKILL.md
+++ b/plugins/claude/n8n-as-code/skills/n8n-architect/SKILL.md
@@ -11,44 +11,44 @@ Use this skill for workflow engineering. Use the `n8n-manager` skill for instanc
 
 - Treat the current context root as the directory containing `n8nac-config.json`, `AGENTS.md`, `.agents/skills`, and the workflow sync folder.
 - Generated context root hint: not embedded. Use the shell launch directory or the workspace path explicitly given by the user.
-- Before any n8n work, first run `npx --yes n8nac@next update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
+- Before any n8n work, first run `npx --yes n8nac update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
 - Use the exact `n8nac command` and `n8n-manager command` listed in `AGENTS.md`. Those context-root commands override the portable examples in this skill.
-- Run every `npx --yes n8nac@next workspace ...`, `npx --yes n8nac@next list`, `pull`, `push`, `validate`, `test`, and `update-ai` command from the context root unless the user explicitly gives another context root.
+- Run every `npx --yes n8nac workspace ...`, `npx --yes n8nac list`, `pull`, `push`, `validate`, `test`, and `update-ai` command from the context root unless the user explicitly gives another context root.
 - `AGENTS.md` is bootstrap context only, not a source of configuration truth.
 - Do not infer instance, project, sync folder, or workflow directory from `AGENTS.md`.
 - Before n8n work, resolve the effective context from the backend:
 
 ```bash
-npx --yes n8nac@next workspace status --json
+npx --yes n8nac workspace status --json
 ```
 
 - Use the returned `workflowDir` for workflow files. Do not reconstruct it from `syncFolder`, `instanceIdentifier`, or `projectName`.
-- Never write `n8nac-config.json` by hand. Use `npx --yes n8nac@next workspace ...` commands.
+- Never write `n8nac-config.json` by hand. Use `npx --yes n8nac workspace ...` commands.
 
 ## Bootstrap Order
 
 1. `cd` to the context root.
-2. Run `npx --yes n8nac@next update-ai`, then read `AGENTS.md`.
-3. Run `npx --yes n8nac@next workspace status --json`.
-4. If the context root is not ready, inspect instances with `npx --yes @n8n-as-code/n8n-manager@next instances list`.
+2. Run `npx --yes n8nac update-ai`, then read `AGENTS.md`.
+3. Run `npx --yes n8nac workspace status --json`.
+4. If the context root is not ready, inspect instances with `npx --yes @n8n-as-code/n8n-manager instances list`.
 5. Reuse an existing instance when suitable.
 6. If no suitable instance exists, stop and ask the user whether they want to reuse/configure an existing instance, create a managed local n8n instance, or connect an existing/remote n8n instance. Do not create infrastructure by default. If the user chooses a managed local instance, ask separately whether they want a public tunnel.
 7. Ask for host/API key only for an explicitly remote or existing n8n instance.
 8. Configure context-root overrides with:
 
 ```bash
-npx --yes n8nac@next workspace pin-instance --instance-id <id>
-npx --yes n8nac@next workspace set-sync-folder workflows
-npx --yes n8nac@next workspace set-project --project-id <id> --project-name <name>
+npx --yes n8nac workspace pin-instance --instance-id <id>
+npx --yes n8nac workspace set-sync-folder workflows
+npx --yes n8nac workspace set-project --project-id <id> --project-name <name>
 ```
 
 For self-hosted n8n instances where the projects API is unavailable or returns 401/403, do not keep retrying project discovery. Use the standard personal project override unless the user gave another project:
 
 ```bash
-npx --yes n8nac@next workspace set-project --project-id personal --project-name Personal
+npx --yes n8nac workspace set-project --project-id personal --project-name Personal
 ```
 
-9. Run `npx --yes n8nac@next update-ai` after changing context-root overrides when the facade does not do it automatically.
+9. Run `npx --yes n8nac update-ai` after changing context-root overrides when the facade does not do it automatically.
 
 ## Sync Discipline
 
@@ -57,13 +57,13 @@ npx --yes n8nac@next workspace set-project --project-id personal --project-name 
 - Use `list` to inspect workflow IDs, file paths, and sync status.
 
 ```bash
-npx --yes n8nac@next list
-npx --yes n8nac@next pull <workflowId>
-npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
+npx --yes n8nac list
+npx --yes n8nac pull <workflowId>
+npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
 ```
 
 - `push` requires the full workflow file path, either absolute or context-root-relative. Do not pass a bare filename.
-- For a new workflow, create the file inside the `workflowDir` returned by `workspace status --json`, then confirm it with `npx --yes n8nac@next list --local`.
+- For a new workflow, create the file inside the `workflowDir` returned by `workspace status --json`, then confirm it with `npx --yes n8nac list --local`.
 - If push/pull reports a conflict, use explicit resolution commands. Do not overwrite remote changes blindly.
 - `pull` and conflict resolution operate on a single workflow ID.
 - `list` is the lightweight command that covers all workflows at once.
@@ -74,8 +74,8 @@ npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
 If push or pull reports a conflict, stop and inspect the conflict. Use explicit resolution commands only after choosing the intended direction:
 
 ```bash
-npx --yes n8nac@next resolve <workflowId> --mode keep-current
-npx --yes n8nac@next resolve <workflowId> --mode keep-incoming
+npx --yes n8nac resolve <workflowId> --mode keep-current
+npx --yes n8nac resolve <workflowId> --mode keep-incoming
 ```
 
 - `keep-current` force-pushes the local version.
@@ -87,10 +87,10 @@ npx --yes n8nac@next resolve <workflowId> --mode keep-incoming
 Never guess n8n node parameters.
 
 ```bash
-npx --yes n8nac@next skills examples search "<workflow pattern>"
-npx --yes n8nac@next skills search "<node or capability>"
-npx --yes n8nac@next skills node-info <nodeName>
-npx --yes n8nac@next skills validate <workflow.workflow.ts>
+npx --yes n8nac skills examples search "<workflow pattern>"
+npx --yes n8nac skills search "<node or capability>"
+npx --yes n8nac skills node-info <nodeName>
+npx --yes n8nac skills validate <workflow.workflow.ts>
 ```
 
 - Use exact node `type` and valid `typeVersion` values from `node-info`.
@@ -105,19 +105,19 @@ npx --yes n8nac@next skills validate <workflow.workflow.ts>
 Use these commands instead of guessing:
 
 ```bash
-npx --yes n8nac@next skills search "<node or capability>"
-npx --yes n8nac@next skills node-info <nodeName>
-npx --yes n8nac@next skills node-schema <nodeName>
-npx --yes n8nac@next skills docs "<topic>"
-npx --yes n8nac@next skills guides "<topic>"
-npx --yes n8nac@next skills examples search "<workflow pattern>"
-npx --yes n8nac@next skills examples info <id>
-npx --yes n8nac@next skills examples download <id>
+npx --yes n8nac skills search "<node or capability>"
+npx --yes n8nac skills node-info <nodeName>
+npx --yes n8nac skills node-schema <nodeName>
+npx --yes n8nac skills docs "<topic>"
+npx --yes n8nac skills guides "<topic>"
+npx --yes n8nac skills examples search "<workflow pattern>"
+npx --yes n8nac skills examples info <id>
+npx --yes n8nac skills examples download <id>
 ```
 
 - Start with `examples search` when the user asks for a common automation pattern.
 - Use examples to learn patterns, not as authority over current node schemas.
-- If a command or flag is unfamiliar, run `npx --yes n8nac@next <subcommand> --help`; do not invent flags.
+- If a command or flag is unfamiliar, run `npx --yes n8nac <subcommand> --help`; do not invent flags.
 
 ## Workflow Authoring Rules
 
@@ -257,15 +257,15 @@ defineRouting() {
 After pushing:
 
 ```bash
-npx --yes n8nac@next verify <workflowId>
-npx --yes n8nac@next test-plan <workflowId> --json
+npx --yes n8nac verify <workflowId>
+npx --yes n8nac test-plan <workflowId> --json
 ```
 
 For webhook, chat, or form workflows, prefer the production test sequence:
 
 ```bash
-npx --yes n8nac@next workflow activate <workflowId>
-npx --yes n8nac@next test <workflowId> --prod
+npx --yes n8nac workflow activate <workflowId>
+npx --yes n8nac test <workflowId> --prod
 ```
 
 - Class A configuration gaps require user/config action, not workflow rewrites.
@@ -285,7 +285,7 @@ Run it whenever one of these is true:
 - the user asks to show, open, present, display, or give the URL/link for a workflow.
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
+npx --yes @n8n-as-code/n8n-manager presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
 ```
 
 Rules:
@@ -293,7 +293,7 @@ Rules:
 - Do not manually construct n8n workflow URLs.
 - Do not return an internal local n8n URL when a presentation URL is available.
 - Use the `url` returned by `presentWorkflowResult` as the user-facing URL.
-- If you do not know the workflow ID, run `npx --yes n8nac@next list` first and select the matching workflow.
+- If you do not know the workflow ID, run `npx --yes n8nac list` first and select the matching workflow.
 - If `presentWorkflowResult` fails, report the backend diagnostic and then provide the best direct n8n URL only as a fallback.
 - Do this before the final response when the task created, changed, pushed, ran, or explicitly asks to show a workflow.
 
@@ -307,18 +307,18 @@ For webhook, chat, or form workflows:
 4. Test with `--prod` by default.
 
 ```bash
-npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
-npx --yes n8nac@next test-plan <workflowId> --json
-npx --yes n8nac@next workflow activate <workflowId>
-npx --yes n8nac@next test <workflowId> --prod
+npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
+npx --yes n8nac test-plan <workflowId> --json
+npx --yes n8nac workflow activate <workflowId>
+npx --yes n8nac test <workflowId> --prod
 ```
 
-Use bare `npx --yes n8nac@next test <workflowId>` only when a test URL was intentionally armed in the n8n editor.
+Use bare `npx --yes n8nac test <workflowId>` only when a test URL was intentionally armed in the n8n editor.
 
 For GET/HEAD webhooks that read from `$json.query`, prefer:
 
 ```bash
-npx --yes n8nac@next test <workflowId> --query '{"key":"value"}' --prod
+npx --yes n8nac test <workflowId> --query '{"key":"value"}' --prod
 ```
 
 ## Execution Debugging
@@ -326,8 +326,8 @@ npx --yes n8nac@next test <workflowId> --query '{"key":"value"}' --prod
 If a webhook returns success but the workflow behavior is wrong, inspect executions instead of guessing:
 
 ```bash
-npx --yes n8nac@next execution list --workflow-id <workflowId> --limit 5 --json
-npx --yes n8nac@next execution get <executionId> --include-data --json
+npx --yes n8nac execution list --workflow-id <workflowId> --limit 5 --json
+npx --yes n8nac execution get <executionId> --include-data --json
 ```
 
 - A successful HTTP trigger only means n8n accepted the request.
@@ -339,11 +339,11 @@ npx --yes n8nac@next execution get <executionId> --include-data --json
 When a workflow is blocked by missing credentials, resolve the credential gap without rewriting unrelated workflow logic.
 
 ```bash
-npx --yes n8nac@next workflow credential-required <workflowId> --json
-npx --yes n8nac@next credential schema <type>
-npx --yes n8nac@next credential list --json
-npx --yes n8nac@next credential create --type <type> --name <name> --file cred.json --json
-npx --yes n8nac@next workflow activate <workflowId>
+npx --yes n8nac workflow credential-required <workflowId> --json
+npx --yes n8nac credential schema <type>
+npx --yes n8nac credential list --json
+npx --yes n8nac credential create --type <type> --name <name> --file cred.json --json
+npx --yes n8nac workflow activate <workflowId>
 ```
 
 - `workflow credential-required` exits non-zero when at least one credential is missing. Treat that as a signal to act, not as a workflow-code failure.

--- a/plugins/claude/n8n-as-code/skills/n8n-manager/SKILL.md
+++ b/plugins/claude/n8n-as-code/skills/n8n-manager/SKILL.md
@@ -10,11 +10,11 @@ Use this skill for global n8n instance management. `n8n-manager` is the source o
 ## Responsibility Boundary
 
 - Generated context root hint: not embedded. Use the shell launch directory or the workspace path explicitly given by the user.
-- If `n8nac` is available, first run `npx --yes n8nac@next update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
+- If `n8nac` is available, first run `npx --yes n8nac update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
 - Use the exact `n8n-manager command` and `n8nac command` listed in `AGENTS.md` when present. Those context-root commands override the portable examples in this skill.
-- Use `npx --yes @n8n-as-code/n8n-manager@next` for global instance, auth, runtime, tunnel, project-default, credential, and workflow-presentation operations.
-- Use `npx --yes n8nac@next workspace ...` only for context-root overrides such as pinned instance, sync folder, and project override.
-- Use `npx --yes n8nac@next` workflow commands only after the effective context is ready.
+- Use `npx --yes @n8n-as-code/n8n-manager` for global instance, auth, runtime, tunnel, project-default, credential, and workflow-presentation operations.
+- Use `npx --yes n8nac workspace ...` only for context-root overrides such as pinned instance, sync folder, and project override.
+- Use `npx --yes n8nac` workflow commands only after the effective context is ready.
 - Never edit `n8nac-config.json`, `~/.n8n-manager`, or n8n-manager secret files by hand.
 
 ## Core Commands
@@ -22,9 +22,9 @@ Use this skill for global n8n instance management. `n8n-manager` is the source o
 Inspect existing instances before changing state:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances list
-npx --yes @n8n-as-code/n8n-manager@next instances --help
-npx --yes @n8n-as-code/n8n-manager@next config get
+npx --yes @n8n-as-code/n8n-manager instances list
+npx --yes @n8n-as-code/n8n-manager instances --help
+npx --yes @n8n-as-code/n8n-manager config get
 ```
 
 Do not invent n8n-manager subcommands. In particular, `instances create` and `--type local` are not valid. Use `instances add --mode ...` exactly as documented by `instances --help`.
@@ -53,56 +53,56 @@ Only run these commands after the user has explicitly chosen the corresponding o
 Managed local Docker without public tunnel:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances add --name <name> --mode managed-local-docker
-npx --yes @n8n-as-code/n8n-manager@next instances setup <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances add --name <name> --mode managed-local-docker
+npx --yes @n8n-as-code/n8n-manager instances setup <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances status <id-or-name>
 ```
 
 Managed local Docker with public tunnel:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances add --name <name> --mode managed-local-docker --tunnel
-npx --yes @n8n-as-code/n8n-manager@next instances setup <id-or-name> --tunnel
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances add --name <name> --mode managed-local-docker --tunnel
+npx --yes @n8n-as-code/n8n-manager instances setup <id-or-name> --tunnel
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel status <id-or-name>
 ```
 
 Remote or existing instances require user-provided credentials. Prefer stdin for API keys:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next auth set --url <url> --api-key-stdin --name <name>
-npx --yes @n8n-as-code/n8n-manager@next auth test --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager auth set --url <url> --api-key-stdin --name <name>
+npx --yes @n8n-as-code/n8n-manager auth test --instance <id-or-name>
 ```
 
 Project selection is instance-level unless the context root explicitly needs a workspace override:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next projects list --instance <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next projects select <project-id-or-name> --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager projects list --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager projects select <project-id-or-name> --instance <id-or-name>
 ```
 
 Self-hosted n8n may not expose the projects API or may return 401/403. In that case, do not retry project discovery. Use the n8n-architect workspace override path with the standard personal project unless the user gave another project:
 
 ```bash
-npx --yes n8nac@next workspace set-project --project-id personal --project-name Personal
+npx --yes n8nac workspace set-project --project-id personal --project-name Personal
 ```
 
 Runtime and tunnel operations are per instance:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances stop <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances restart <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel status <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel refresh <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances stop <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances restart <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel refresh <id-or-name>
 ```
 
 Present workflow results after creating, modifying, pushing, or running a workflow:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
+npx --yes @n8n-as-code/n8n-manager presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
 ```
 
 ## Guardrails

--- a/plugins/cursor/n8n-as-code/skills/n8n-architect/SKILL.md
+++ b/plugins/cursor/n8n-as-code/skills/n8n-architect/SKILL.md
@@ -11,44 +11,44 @@ Use this skill for workflow engineering. Use the `n8n-manager` skill for instanc
 
 - Treat the current context root as the directory containing `n8nac-config.json`, `AGENTS.md`, `.agents/skills`, and the workflow sync folder.
 - Generated context root hint: not embedded. Use the shell launch directory or the workspace path explicitly given by the user.
-- Before any n8n work, first run `npx --yes n8nac@next update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
+- Before any n8n work, first run `npx --yes n8nac update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
 - Use the exact `n8nac command` and `n8n-manager command` listed in `AGENTS.md`. Those context-root commands override the portable examples in this skill.
-- Run every `npx --yes n8nac@next workspace ...`, `npx --yes n8nac@next list`, `pull`, `push`, `validate`, `test`, and `update-ai` command from the context root unless the user explicitly gives another context root.
+- Run every `npx --yes n8nac workspace ...`, `npx --yes n8nac list`, `pull`, `push`, `validate`, `test`, and `update-ai` command from the context root unless the user explicitly gives another context root.
 - `AGENTS.md` is bootstrap context only, not a source of configuration truth.
 - Do not infer instance, project, sync folder, or workflow directory from `AGENTS.md`.
 - Before n8n work, resolve the effective context from the backend:
 
 ```bash
-npx --yes n8nac@next workspace status --json
+npx --yes n8nac workspace status --json
 ```
 
 - Use the returned `workflowDir` for workflow files. Do not reconstruct it from `syncFolder`, `instanceIdentifier`, or `projectName`.
-- Never write `n8nac-config.json` by hand. Use `npx --yes n8nac@next workspace ...` commands.
+- Never write `n8nac-config.json` by hand. Use `npx --yes n8nac workspace ...` commands.
 
 ## Bootstrap Order
 
 1. `cd` to the context root.
-2. Run `npx --yes n8nac@next update-ai`, then read `AGENTS.md`.
-3. Run `npx --yes n8nac@next workspace status --json`.
-4. If the context root is not ready, inspect instances with `npx --yes @n8n-as-code/n8n-manager@next instances list`.
+2. Run `npx --yes n8nac update-ai`, then read `AGENTS.md`.
+3. Run `npx --yes n8nac workspace status --json`.
+4. If the context root is not ready, inspect instances with `npx --yes @n8n-as-code/n8n-manager instances list`.
 5. Reuse an existing instance when suitable.
 6. If no suitable instance exists, stop and ask the user whether they want to reuse/configure an existing instance, create a managed local n8n instance, or connect an existing/remote n8n instance. Do not create infrastructure by default. If the user chooses a managed local instance, ask separately whether they want a public tunnel.
 7. Ask for host/API key only for an explicitly remote or existing n8n instance.
 8. Configure context-root overrides with:
 
 ```bash
-npx --yes n8nac@next workspace pin-instance --instance-id <id>
-npx --yes n8nac@next workspace set-sync-folder workflows
-npx --yes n8nac@next workspace set-project --project-id <id> --project-name <name>
+npx --yes n8nac workspace pin-instance --instance-id <id>
+npx --yes n8nac workspace set-sync-folder workflows
+npx --yes n8nac workspace set-project --project-id <id> --project-name <name>
 ```
 
 For self-hosted n8n instances where the projects API is unavailable or returns 401/403, do not keep retrying project discovery. Use the standard personal project override unless the user gave another project:
 
 ```bash
-npx --yes n8nac@next workspace set-project --project-id personal --project-name Personal
+npx --yes n8nac workspace set-project --project-id personal --project-name Personal
 ```
 
-9. Run `npx --yes n8nac@next update-ai` after changing context-root overrides when the facade does not do it automatically.
+9. Run `npx --yes n8nac update-ai` after changing context-root overrides when the facade does not do it automatically.
 
 ## Sync Discipline
 
@@ -57,13 +57,13 @@ npx --yes n8nac@next workspace set-project --project-id personal --project-name 
 - Use `list` to inspect workflow IDs, file paths, and sync status.
 
 ```bash
-npx --yes n8nac@next list
-npx --yes n8nac@next pull <workflowId>
-npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
+npx --yes n8nac list
+npx --yes n8nac pull <workflowId>
+npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
 ```
 
 - `push` requires the full workflow file path, either absolute or context-root-relative. Do not pass a bare filename.
-- For a new workflow, create the file inside the `workflowDir` returned by `workspace status --json`, then confirm it with `npx --yes n8nac@next list --local`.
+- For a new workflow, create the file inside the `workflowDir` returned by `workspace status --json`, then confirm it with `npx --yes n8nac list --local`.
 - If push/pull reports a conflict, use explicit resolution commands. Do not overwrite remote changes blindly.
 - `pull` and conflict resolution operate on a single workflow ID.
 - `list` is the lightweight command that covers all workflows at once.
@@ -74,8 +74,8 @@ npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
 If push or pull reports a conflict, stop and inspect the conflict. Use explicit resolution commands only after choosing the intended direction:
 
 ```bash
-npx --yes n8nac@next resolve <workflowId> --mode keep-current
-npx --yes n8nac@next resolve <workflowId> --mode keep-incoming
+npx --yes n8nac resolve <workflowId> --mode keep-current
+npx --yes n8nac resolve <workflowId> --mode keep-incoming
 ```
 
 - `keep-current` force-pushes the local version.
@@ -87,10 +87,10 @@ npx --yes n8nac@next resolve <workflowId> --mode keep-incoming
 Never guess n8n node parameters.
 
 ```bash
-npx --yes n8nac@next skills examples search "<workflow pattern>"
-npx --yes n8nac@next skills search "<node or capability>"
-npx --yes n8nac@next skills node-info <nodeName>
-npx --yes n8nac@next skills validate <workflow.workflow.ts>
+npx --yes n8nac skills examples search "<workflow pattern>"
+npx --yes n8nac skills search "<node or capability>"
+npx --yes n8nac skills node-info <nodeName>
+npx --yes n8nac skills validate <workflow.workflow.ts>
 ```
 
 - Use exact node `type` and valid `typeVersion` values from `node-info`.
@@ -105,19 +105,19 @@ npx --yes n8nac@next skills validate <workflow.workflow.ts>
 Use these commands instead of guessing:
 
 ```bash
-npx --yes n8nac@next skills search "<node or capability>"
-npx --yes n8nac@next skills node-info <nodeName>
-npx --yes n8nac@next skills node-schema <nodeName>
-npx --yes n8nac@next skills docs "<topic>"
-npx --yes n8nac@next skills guides "<topic>"
-npx --yes n8nac@next skills examples search "<workflow pattern>"
-npx --yes n8nac@next skills examples info <id>
-npx --yes n8nac@next skills examples download <id>
+npx --yes n8nac skills search "<node or capability>"
+npx --yes n8nac skills node-info <nodeName>
+npx --yes n8nac skills node-schema <nodeName>
+npx --yes n8nac skills docs "<topic>"
+npx --yes n8nac skills guides "<topic>"
+npx --yes n8nac skills examples search "<workflow pattern>"
+npx --yes n8nac skills examples info <id>
+npx --yes n8nac skills examples download <id>
 ```
 
 - Start with `examples search` when the user asks for a common automation pattern.
 - Use examples to learn patterns, not as authority over current node schemas.
-- If a command or flag is unfamiliar, run `npx --yes n8nac@next <subcommand> --help`; do not invent flags.
+- If a command or flag is unfamiliar, run `npx --yes n8nac <subcommand> --help`; do not invent flags.
 
 ## Workflow Authoring Rules
 
@@ -257,15 +257,15 @@ defineRouting() {
 After pushing:
 
 ```bash
-npx --yes n8nac@next verify <workflowId>
-npx --yes n8nac@next test-plan <workflowId> --json
+npx --yes n8nac verify <workflowId>
+npx --yes n8nac test-plan <workflowId> --json
 ```
 
 For webhook, chat, or form workflows, prefer the production test sequence:
 
 ```bash
-npx --yes n8nac@next workflow activate <workflowId>
-npx --yes n8nac@next test <workflowId> --prod
+npx --yes n8nac workflow activate <workflowId>
+npx --yes n8nac test <workflowId> --prod
 ```
 
 - Class A configuration gaps require user/config action, not workflow rewrites.
@@ -285,7 +285,7 @@ Run it whenever one of these is true:
 - the user asks to show, open, present, display, or give the URL/link for a workflow.
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
+npx --yes @n8n-as-code/n8n-manager presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
 ```
 
 Rules:
@@ -293,7 +293,7 @@ Rules:
 - Do not manually construct n8n workflow URLs.
 - Do not return an internal local n8n URL when a presentation URL is available.
 - Use the `url` returned by `presentWorkflowResult` as the user-facing URL.
-- If you do not know the workflow ID, run `npx --yes n8nac@next list` first and select the matching workflow.
+- If you do not know the workflow ID, run `npx --yes n8nac list` first and select the matching workflow.
 - If `presentWorkflowResult` fails, report the backend diagnostic and then provide the best direct n8n URL only as a fallback.
 - Do this before the final response when the task created, changed, pushed, ran, or explicitly asks to show a workflow.
 
@@ -307,18 +307,18 @@ For webhook, chat, or form workflows:
 4. Test with `--prod` by default.
 
 ```bash
-npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
-npx --yes n8nac@next test-plan <workflowId> --json
-npx --yes n8nac@next workflow activate <workflowId>
-npx --yes n8nac@next test <workflowId> --prod
+npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
+npx --yes n8nac test-plan <workflowId> --json
+npx --yes n8nac workflow activate <workflowId>
+npx --yes n8nac test <workflowId> --prod
 ```
 
-Use bare `npx --yes n8nac@next test <workflowId>` only when a test URL was intentionally armed in the n8n editor.
+Use bare `npx --yes n8nac test <workflowId>` only when a test URL was intentionally armed in the n8n editor.
 
 For GET/HEAD webhooks that read from `$json.query`, prefer:
 
 ```bash
-npx --yes n8nac@next test <workflowId> --query '{"key":"value"}' --prod
+npx --yes n8nac test <workflowId> --query '{"key":"value"}' --prod
 ```
 
 ## Execution Debugging
@@ -326,8 +326,8 @@ npx --yes n8nac@next test <workflowId> --query '{"key":"value"}' --prod
 If a webhook returns success but the workflow behavior is wrong, inspect executions instead of guessing:
 
 ```bash
-npx --yes n8nac@next execution list --workflow-id <workflowId> --limit 5 --json
-npx --yes n8nac@next execution get <executionId> --include-data --json
+npx --yes n8nac execution list --workflow-id <workflowId> --limit 5 --json
+npx --yes n8nac execution get <executionId> --include-data --json
 ```
 
 - A successful HTTP trigger only means n8n accepted the request.
@@ -339,11 +339,11 @@ npx --yes n8nac@next execution get <executionId> --include-data --json
 When a workflow is blocked by missing credentials, resolve the credential gap without rewriting unrelated workflow logic.
 
 ```bash
-npx --yes n8nac@next workflow credential-required <workflowId> --json
-npx --yes n8nac@next credential schema <type>
-npx --yes n8nac@next credential list --json
-npx --yes n8nac@next credential create --type <type> --name <name> --file cred.json --json
-npx --yes n8nac@next workflow activate <workflowId>
+npx --yes n8nac workflow credential-required <workflowId> --json
+npx --yes n8nac credential schema <type>
+npx --yes n8nac credential list --json
+npx --yes n8nac credential create --type <type> --name <name> --file cred.json --json
+npx --yes n8nac workflow activate <workflowId>
 ```
 
 - `workflow credential-required` exits non-zero when at least one credential is missing. Treat that as a signal to act, not as a workflow-code failure.

--- a/plugins/cursor/n8n-as-code/skills/n8n-manager/SKILL.md
+++ b/plugins/cursor/n8n-as-code/skills/n8n-manager/SKILL.md
@@ -10,11 +10,11 @@ Use this skill for global n8n instance management. `n8n-manager` is the source o
 ## Responsibility Boundary
 
 - Generated context root hint: not embedded. Use the shell launch directory or the workspace path explicitly given by the user.
-- If `n8nac` is available, first run `npx --yes n8nac@next update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
+- If `n8nac` is available, first run `npx --yes n8nac update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
 - Use the exact `n8n-manager command` and `n8nac command` listed in `AGENTS.md` when present. Those context-root commands override the portable examples in this skill.
-- Use `npx --yes @n8n-as-code/n8n-manager@next` for global instance, auth, runtime, tunnel, project-default, credential, and workflow-presentation operations.
-- Use `npx --yes n8nac@next workspace ...` only for context-root overrides such as pinned instance, sync folder, and project override.
-- Use `npx --yes n8nac@next` workflow commands only after the effective context is ready.
+- Use `npx --yes @n8n-as-code/n8n-manager` for global instance, auth, runtime, tunnel, project-default, credential, and workflow-presentation operations.
+- Use `npx --yes n8nac workspace ...` only for context-root overrides such as pinned instance, sync folder, and project override.
+- Use `npx --yes n8nac` workflow commands only after the effective context is ready.
 - Never edit `n8nac-config.json`, `~/.n8n-manager`, or n8n-manager secret files by hand.
 
 ## Core Commands
@@ -22,9 +22,9 @@ Use this skill for global n8n instance management. `n8n-manager` is the source o
 Inspect existing instances before changing state:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances list
-npx --yes @n8n-as-code/n8n-manager@next instances --help
-npx --yes @n8n-as-code/n8n-manager@next config get
+npx --yes @n8n-as-code/n8n-manager instances list
+npx --yes @n8n-as-code/n8n-manager instances --help
+npx --yes @n8n-as-code/n8n-manager config get
 ```
 
 Do not invent n8n-manager subcommands. In particular, `instances create` and `--type local` are not valid. Use `instances add --mode ...` exactly as documented by `instances --help`.
@@ -53,56 +53,56 @@ Only run these commands after the user has explicitly chosen the corresponding o
 Managed local Docker without public tunnel:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances add --name <name> --mode managed-local-docker
-npx --yes @n8n-as-code/n8n-manager@next instances setup <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances add --name <name> --mode managed-local-docker
+npx --yes @n8n-as-code/n8n-manager instances setup <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances status <id-or-name>
 ```
 
 Managed local Docker with public tunnel:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances add --name <name> --mode managed-local-docker --tunnel
-npx --yes @n8n-as-code/n8n-manager@next instances setup <id-or-name> --tunnel
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances add --name <name> --mode managed-local-docker --tunnel
+npx --yes @n8n-as-code/n8n-manager instances setup <id-or-name> --tunnel
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel status <id-or-name>
 ```
 
 Remote or existing instances require user-provided credentials. Prefer stdin for API keys:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next auth set --url <url> --api-key-stdin --name <name>
-npx --yes @n8n-as-code/n8n-manager@next auth test --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager auth set --url <url> --api-key-stdin --name <name>
+npx --yes @n8n-as-code/n8n-manager auth test --instance <id-or-name>
 ```
 
 Project selection is instance-level unless the context root explicitly needs a workspace override:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next projects list --instance <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next projects select <project-id-or-name> --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager projects list --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager projects select <project-id-or-name> --instance <id-or-name>
 ```
 
 Self-hosted n8n may not expose the projects API or may return 401/403. In that case, do not retry project discovery. Use the n8n-architect workspace override path with the standard personal project unless the user gave another project:
 
 ```bash
-npx --yes n8nac@next workspace set-project --project-id personal --project-name Personal
+npx --yes n8nac workspace set-project --project-id personal --project-name Personal
 ```
 
 Runtime and tunnel operations are per instance:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances stop <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances restart <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel status <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel refresh <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances stop <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances restart <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel refresh <id-or-name>
 ```
 
 Present workflow results after creating, modifying, pushing, or running a workflow:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
+npx --yes @n8n-as-code/n8n-manager presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
 ```
 
 ## Guardrails

--- a/plugins/openclaw/n8n-as-code/index.ts
+++ b/plugins/openclaw/n8n-as-code/index.ts
@@ -123,7 +123,6 @@ const n8nAcPlugin = {
       start: async () => {
         const initialized = isWorkspaceInitialized(workspaceDir);
         telemetry.track("openclaw_service_started", { workspace_initialized: initialized });
-        telemetry.trackActive({ activation_source_event: "openclaw_service_started" });
         if (initialized) {
           if (hasAgentsContext(workspaceDir)) {
             api.logger.info("[n8nac] Workspace ready — lightweight prompt context enabled; n8n skill available.");

--- a/plugins/openclaw/n8n-as-code/index.ts
+++ b/plugins/openclaw/n8n-as-code/index.ts
@@ -1,6 +1,7 @@
 import { accessSync, constants, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { N8N_FACADE_SETUP_MODES } from "@n8n-as-code/workflow-core";
+import { createTelemetryClient } from "@n8n-as-code/telemetry";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { registerN8nAcCli } from "./src/cli.js";
 import { getWorkspaceDir, isWorkspaceInitialized, readWorkspaceBinding } from "./src/workspace.js";
@@ -98,6 +99,7 @@ const n8nAcPlugin = {
 
   register(api: OpenClawPluginApi) {
     const workspaceDir = getWorkspaceDir();
+    const telemetry = createTelemetryClient({ facade: "openclaw" });
 
     // Ensure the plugin workspace directory always exists.
     mkdirSync(workspaceDir, { recursive: true });
@@ -111,7 +113,7 @@ const n8nAcPlugin = {
 
     // -- CLI status ----------------------------------------------------------
     api.registerCli(
-      ({ program }) => registerN8nAcCli({ program, workspaceDir }),
+      ({ program }) => registerN8nAcCli({ program, workspaceDir, telemetry }),
       { commands: ["n8nac:status"] },
     );
 
@@ -119,7 +121,10 @@ const n8nAcPlugin = {
     api.registerService({
       id: "n8nac-context",
       start: async () => {
-        if (isWorkspaceInitialized(workspaceDir)) {
+        const initialized = isWorkspaceInitialized(workspaceDir);
+        telemetry.track("openclaw_service_started", { workspace_initialized: initialized });
+        telemetry.trackActive({ activation_source_event: "openclaw_service_started" });
+        if (initialized) {
           if (hasAgentsContext(workspaceDir)) {
             api.logger.info("[n8nac] Workspace ready — lightweight prompt context enabled; n8n skill available.");
           } else {
@@ -129,7 +134,9 @@ const n8nAcPlugin = {
           api.logger.info("[n8nac] Workspace not initialized. Use the n8n-manager and n8n-architect skills to configure it.");
         }
       },
-      stop: async () => {},
+      stop: async () => {
+        await telemetry.flush(1000);
+      },
     });
   },
 };

--- a/plugins/openclaw/n8n-as-code/package.json
+++ b/plugins/openclaw/n8n-as-code/package.json
@@ -24,6 +24,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@n8n-as-code/telemetry": "0.1.0",
     "@n8n-as-code/workflow-core": "0.1.0"
   },
   "devDependencies": {

--- a/plugins/openclaw/n8n-as-code/skills/n8n-architect/SKILL.md
+++ b/plugins/openclaw/n8n-as-code/skills/n8n-architect/SKILL.md
@@ -11,44 +11,44 @@ Use this skill for workflow engineering. Use the `n8n-manager` skill for instanc
 
 - Treat the current context root as the directory containing `n8nac-config.json`, `AGENTS.md`, `.agents/skills`, and the workflow sync folder.
 - Generated context root hint: not embedded. Use the shell launch directory or the workspace path explicitly given by the user.
-- Before any n8n work, first run `npx --yes n8nac@next update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
+- Before any n8n work, first run `npx --yes n8nac update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
 - Use the exact `n8nac command` and `n8n-manager command` listed in `AGENTS.md`. Those context-root commands override the portable examples in this skill.
-- Run every `npx --yes n8nac@next workspace ...`, `npx --yes n8nac@next list`, `pull`, `push`, `validate`, `test`, and `update-ai` command from the context root unless the user explicitly gives another context root.
+- Run every `npx --yes n8nac workspace ...`, `npx --yes n8nac list`, `pull`, `push`, `validate`, `test`, and `update-ai` command from the context root unless the user explicitly gives another context root.
 - `AGENTS.md` is bootstrap context only, not a source of configuration truth.
 - Do not infer instance, project, sync folder, or workflow directory from `AGENTS.md`.
 - Before n8n work, resolve the effective context from the backend:
 
 ```bash
-npx --yes n8nac@next workspace status --json
+npx --yes n8nac workspace status --json
 ```
 
 - Use the returned `workflowDir` for workflow files. Do not reconstruct it from `syncFolder`, `instanceIdentifier`, or `projectName`.
-- Never write `n8nac-config.json` by hand. Use `npx --yes n8nac@next workspace ...` commands.
+- Never write `n8nac-config.json` by hand. Use `npx --yes n8nac workspace ...` commands.
 
 ## Bootstrap Order
 
 1. `cd` to the context root.
-2. Run `npx --yes n8nac@next update-ai`, then read `AGENTS.md`.
-3. Run `npx --yes n8nac@next workspace status --json`.
-4. If the context root is not ready, inspect instances with `npx --yes @n8n-as-code/n8n-manager@next instances list`.
+2. Run `npx --yes n8nac update-ai`, then read `AGENTS.md`.
+3. Run `npx --yes n8nac workspace status --json`.
+4. If the context root is not ready, inspect instances with `npx --yes @n8n-as-code/n8n-manager instances list`.
 5. Reuse an existing instance when suitable.
 6. If no suitable instance exists, stop and ask the user whether they want to reuse/configure an existing instance, create a managed local n8n instance, or connect an existing/remote n8n instance. Do not create infrastructure by default. If the user chooses a managed local instance, ask separately whether they want a public tunnel.
 7. Ask for host/API key only for an explicitly remote or existing n8n instance.
 8. Configure context-root overrides with:
 
 ```bash
-npx --yes n8nac@next workspace pin-instance --instance-id <id>
-npx --yes n8nac@next workspace set-sync-folder workflows
-npx --yes n8nac@next workspace set-project --project-id <id> --project-name <name>
+npx --yes n8nac workspace pin-instance --instance-id <id>
+npx --yes n8nac workspace set-sync-folder workflows
+npx --yes n8nac workspace set-project --project-id <id> --project-name <name>
 ```
 
 For self-hosted n8n instances where the projects API is unavailable or returns 401/403, do not keep retrying project discovery. Use the standard personal project override unless the user gave another project:
 
 ```bash
-npx --yes n8nac@next workspace set-project --project-id personal --project-name Personal
+npx --yes n8nac workspace set-project --project-id personal --project-name Personal
 ```
 
-9. Run `npx --yes n8nac@next update-ai` after changing context-root overrides when the facade does not do it automatically.
+9. Run `npx --yes n8nac update-ai` after changing context-root overrides when the facade does not do it automatically.
 
 ## Sync Discipline
 
@@ -57,13 +57,13 @@ npx --yes n8nac@next workspace set-project --project-id personal --project-name 
 - Use `list` to inspect workflow IDs, file paths, and sync status.
 
 ```bash
-npx --yes n8nac@next list
-npx --yes n8nac@next pull <workflowId>
-npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
+npx --yes n8nac list
+npx --yes n8nac pull <workflowId>
+npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
 ```
 
 - `push` requires the full workflow file path, either absolute or context-root-relative. Do not pass a bare filename.
-- For a new workflow, create the file inside the `workflowDir` returned by `workspace status --json`, then confirm it with `npx --yes n8nac@next list --local`.
+- For a new workflow, create the file inside the `workflowDir` returned by `workspace status --json`, then confirm it with `npx --yes n8nac list --local`.
 - If push/pull reports a conflict, use explicit resolution commands. Do not overwrite remote changes blindly.
 - `pull` and conflict resolution operate on a single workflow ID.
 - `list` is the lightweight command that covers all workflows at once.
@@ -74,8 +74,8 @@ npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
 If push or pull reports a conflict, stop and inspect the conflict. Use explicit resolution commands only after choosing the intended direction:
 
 ```bash
-npx --yes n8nac@next resolve <workflowId> --mode keep-current
-npx --yes n8nac@next resolve <workflowId> --mode keep-incoming
+npx --yes n8nac resolve <workflowId> --mode keep-current
+npx --yes n8nac resolve <workflowId> --mode keep-incoming
 ```
 
 - `keep-current` force-pushes the local version.
@@ -87,10 +87,10 @@ npx --yes n8nac@next resolve <workflowId> --mode keep-incoming
 Never guess n8n node parameters.
 
 ```bash
-npx --yes n8nac@next skills examples search "<workflow pattern>"
-npx --yes n8nac@next skills search "<node or capability>"
-npx --yes n8nac@next skills node-info <nodeName>
-npx --yes n8nac@next skills validate <workflow.workflow.ts>
+npx --yes n8nac skills examples search "<workflow pattern>"
+npx --yes n8nac skills search "<node or capability>"
+npx --yes n8nac skills node-info <nodeName>
+npx --yes n8nac skills validate <workflow.workflow.ts>
 ```
 
 - Use exact node `type` and valid `typeVersion` values from `node-info`.
@@ -105,19 +105,19 @@ npx --yes n8nac@next skills validate <workflow.workflow.ts>
 Use these commands instead of guessing:
 
 ```bash
-npx --yes n8nac@next skills search "<node or capability>"
-npx --yes n8nac@next skills node-info <nodeName>
-npx --yes n8nac@next skills node-schema <nodeName>
-npx --yes n8nac@next skills docs "<topic>"
-npx --yes n8nac@next skills guides "<topic>"
-npx --yes n8nac@next skills examples search "<workflow pattern>"
-npx --yes n8nac@next skills examples info <id>
-npx --yes n8nac@next skills examples download <id>
+npx --yes n8nac skills search "<node or capability>"
+npx --yes n8nac skills node-info <nodeName>
+npx --yes n8nac skills node-schema <nodeName>
+npx --yes n8nac skills docs "<topic>"
+npx --yes n8nac skills guides "<topic>"
+npx --yes n8nac skills examples search "<workflow pattern>"
+npx --yes n8nac skills examples info <id>
+npx --yes n8nac skills examples download <id>
 ```
 
 - Start with `examples search` when the user asks for a common automation pattern.
 - Use examples to learn patterns, not as authority over current node schemas.
-- If a command or flag is unfamiliar, run `npx --yes n8nac@next <subcommand> --help`; do not invent flags.
+- If a command or flag is unfamiliar, run `npx --yes n8nac <subcommand> --help`; do not invent flags.
 
 ## Workflow Authoring Rules
 
@@ -257,15 +257,15 @@ defineRouting() {
 After pushing:
 
 ```bash
-npx --yes n8nac@next verify <workflowId>
-npx --yes n8nac@next test-plan <workflowId> --json
+npx --yes n8nac verify <workflowId>
+npx --yes n8nac test-plan <workflowId> --json
 ```
 
 For webhook, chat, or form workflows, prefer the production test sequence:
 
 ```bash
-npx --yes n8nac@next workflow activate <workflowId>
-npx --yes n8nac@next test <workflowId> --prod
+npx --yes n8nac workflow activate <workflowId>
+npx --yes n8nac test <workflowId> --prod
 ```
 
 - Class A configuration gaps require user/config action, not workflow rewrites.
@@ -285,7 +285,7 @@ Run it whenever one of these is true:
 - the user asks to show, open, present, display, or give the URL/link for a workflow.
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
+npx --yes @n8n-as-code/n8n-manager presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
 ```
 
 Rules:
@@ -293,7 +293,7 @@ Rules:
 - Do not manually construct n8n workflow URLs.
 - Do not return an internal local n8n URL when a presentation URL is available.
 - Use the `url` returned by `presentWorkflowResult` as the user-facing URL.
-- If you do not know the workflow ID, run `npx --yes n8nac@next list` first and select the matching workflow.
+- If you do not know the workflow ID, run `npx --yes n8nac list` first and select the matching workflow.
 - If `presentWorkflowResult` fails, report the backend diagnostic and then provide the best direct n8n URL only as a fallback.
 - Do this before the final response when the task created, changed, pushed, ran, or explicitly asks to show a workflow.
 
@@ -307,18 +307,18 @@ For webhook, chat, or form workflows:
 4. Test with `--prod` by default.
 
 ```bash
-npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
-npx --yes n8nac@next test-plan <workflowId> --json
-npx --yes n8nac@next workflow activate <workflowId>
-npx --yes n8nac@next test <workflowId> --prod
+npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
+npx --yes n8nac test-plan <workflowId> --json
+npx --yes n8nac workflow activate <workflowId>
+npx --yes n8nac test <workflowId> --prod
 ```
 
-Use bare `npx --yes n8nac@next test <workflowId>` only when a test URL was intentionally armed in the n8n editor.
+Use bare `npx --yes n8nac test <workflowId>` only when a test URL was intentionally armed in the n8n editor.
 
 For GET/HEAD webhooks that read from `$json.query`, prefer:
 
 ```bash
-npx --yes n8nac@next test <workflowId> --query '{"key":"value"}' --prod
+npx --yes n8nac test <workflowId> --query '{"key":"value"}' --prod
 ```
 
 ## Execution Debugging
@@ -326,8 +326,8 @@ npx --yes n8nac@next test <workflowId> --query '{"key":"value"}' --prod
 If a webhook returns success but the workflow behavior is wrong, inspect executions instead of guessing:
 
 ```bash
-npx --yes n8nac@next execution list --workflow-id <workflowId> --limit 5 --json
-npx --yes n8nac@next execution get <executionId> --include-data --json
+npx --yes n8nac execution list --workflow-id <workflowId> --limit 5 --json
+npx --yes n8nac execution get <executionId> --include-data --json
 ```
 
 - A successful HTTP trigger only means n8n accepted the request.
@@ -339,11 +339,11 @@ npx --yes n8nac@next execution get <executionId> --include-data --json
 When a workflow is blocked by missing credentials, resolve the credential gap without rewriting unrelated workflow logic.
 
 ```bash
-npx --yes n8nac@next workflow credential-required <workflowId> --json
-npx --yes n8nac@next credential schema <type>
-npx --yes n8nac@next credential list --json
-npx --yes n8nac@next credential create --type <type> --name <name> --file cred.json --json
-npx --yes n8nac@next workflow activate <workflowId>
+npx --yes n8nac workflow credential-required <workflowId> --json
+npx --yes n8nac credential schema <type>
+npx --yes n8nac credential list --json
+npx --yes n8nac credential create --type <type> --name <name> --file cred.json --json
+npx --yes n8nac workflow activate <workflowId>
 ```
 
 - `workflow credential-required` exits non-zero when at least one credential is missing. Treat that as a signal to act, not as a workflow-code failure.

--- a/plugins/openclaw/n8n-as-code/skills/n8n-manager/SKILL.md
+++ b/plugins/openclaw/n8n-as-code/skills/n8n-manager/SKILL.md
@@ -10,11 +10,11 @@ Use this skill for global n8n instance management. `n8n-manager` is the source o
 ## Responsibility Boundary
 
 - Generated context root hint: not embedded. Use the shell launch directory or the workspace path explicitly given by the user.
-- If `n8nac` is available, first run `npx --yes n8nac@next update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
+- If `n8nac` is available, first run `npx --yes n8nac update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
 - Use the exact `n8n-manager command` and `n8nac command` listed in `AGENTS.md` when present. Those context-root commands override the portable examples in this skill.
-- Use `npx --yes @n8n-as-code/n8n-manager@next` for global instance, auth, runtime, tunnel, project-default, credential, and workflow-presentation operations.
-- Use `npx --yes n8nac@next workspace ...` only for context-root overrides such as pinned instance, sync folder, and project override.
-- Use `npx --yes n8nac@next` workflow commands only after the effective context is ready.
+- Use `npx --yes @n8n-as-code/n8n-manager` for global instance, auth, runtime, tunnel, project-default, credential, and workflow-presentation operations.
+- Use `npx --yes n8nac workspace ...` only for context-root overrides such as pinned instance, sync folder, and project override.
+- Use `npx --yes n8nac` workflow commands only after the effective context is ready.
 - Never edit `n8nac-config.json`, `~/.n8n-manager`, or n8n-manager secret files by hand.
 
 ## Core Commands
@@ -22,9 +22,9 @@ Use this skill for global n8n instance management. `n8n-manager` is the source o
 Inspect existing instances before changing state:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances list
-npx --yes @n8n-as-code/n8n-manager@next instances --help
-npx --yes @n8n-as-code/n8n-manager@next config get
+npx --yes @n8n-as-code/n8n-manager instances list
+npx --yes @n8n-as-code/n8n-manager instances --help
+npx --yes @n8n-as-code/n8n-manager config get
 ```
 
 Do not invent n8n-manager subcommands. In particular, `instances create` and `--type local` are not valid. Use `instances add --mode ...` exactly as documented by `instances --help`.
@@ -53,56 +53,56 @@ Only run these commands after the user has explicitly chosen the corresponding o
 Managed local Docker without public tunnel:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances add --name <name> --mode managed-local-docker
-npx --yes @n8n-as-code/n8n-manager@next instances setup <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances add --name <name> --mode managed-local-docker
+npx --yes @n8n-as-code/n8n-manager instances setup <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances status <id-or-name>
 ```
 
 Managed local Docker with public tunnel:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances add --name <name> --mode managed-local-docker --tunnel
-npx --yes @n8n-as-code/n8n-manager@next instances setup <id-or-name> --tunnel
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances add --name <name> --mode managed-local-docker --tunnel
+npx --yes @n8n-as-code/n8n-manager instances setup <id-or-name> --tunnel
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel status <id-or-name>
 ```
 
 Remote or existing instances require user-provided credentials. Prefer stdin for API keys:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next auth set --url <url> --api-key-stdin --name <name>
-npx --yes @n8n-as-code/n8n-manager@next auth test --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager auth set --url <url> --api-key-stdin --name <name>
+npx --yes @n8n-as-code/n8n-manager auth test --instance <id-or-name>
 ```
 
 Project selection is instance-level unless the context root explicitly needs a workspace override:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next projects list --instance <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next projects select <project-id-or-name> --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager projects list --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager projects select <project-id-or-name> --instance <id-or-name>
 ```
 
 Self-hosted n8n may not expose the projects API or may return 401/403. In that case, do not retry project discovery. Use the n8n-architect workspace override path with the standard personal project unless the user gave another project:
 
 ```bash
-npx --yes n8nac@next workspace set-project --project-id personal --project-name Personal
+npx --yes n8nac workspace set-project --project-id personal --project-name Personal
 ```
 
 Runtime and tunnel operations are per instance:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances stop <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances restart <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel status <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel refresh <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances stop <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances restart <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel refresh <id-or-name>
 ```
 
 Present workflow results after creating, modifying, pushing, or running a workflow:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
+npx --yes @n8n-as-code/n8n-manager presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
 ```
 
 ## Guardrails

--- a/plugins/openclaw/n8n-as-code/src/cli.ts
+++ b/plugins/openclaw/n8n-as-code/src/cli.ts
@@ -1,4 +1,5 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { TelemetryClient } from "@n8n-as-code/telemetry";
 import { isWorkspaceInitialized } from "./workspace.js";
 
 type CliProgram = Parameters<Parameters<OpenClawPluginApi["registerCli"]>[0]>[0]["program"];
@@ -6,14 +7,23 @@ type CliProgram = Parameters<Parameters<OpenClawPluginApi["registerCli"]>[0]>[0]
 type CliOpts = {
   program: CliProgram;
   workspaceDir: string;
+  telemetry: TelemetryClient;
 };
 
-export function registerN8nAcCli({ program, workspaceDir }: CliOpts): void {
+export function registerN8nAcCli({ program, workspaceDir, telemetry }: CliOpts): void {
   program
     .command("n8nac:status")
     .description("Show n8n-as-code workspace status")
     .action(() => {
+      const startedAt = Date.now();
       const initialized = isWorkspaceInitialized(workspaceDir);
+      telemetry.track("openclaw_cli_command_completed", {
+        command: "n8nac:status",
+        outcome: "success",
+        duration_ms: Date.now() - startedAt,
+        workspace_initialized: initialized,
+      });
+      telemetry.trackActive({ activation_source_event: "openclaw_cli_command_completed" });
       console.log(`\nn8n-as-code workspace: ${workspaceDir}`);
       console.log(`Status: ${initialized ? "✓  Initialized" : "✗  Not initialized"}`);
       if (!initialized) {

--- a/skills/n8n-architect/SKILL.md
+++ b/skills/n8n-architect/SKILL.md
@@ -11,44 +11,44 @@ Use this skill for workflow engineering. Use the `n8n-manager` skill for instanc
 
 - Treat the current context root as the directory containing `n8nac-config.json`, `AGENTS.md`, `.agents/skills`, and the workflow sync folder.
 - Generated context root hint: not embedded. Use the shell launch directory or the workspace path explicitly given by the user.
-- Before any n8n work, first run `npx --yes n8nac@next update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
+- Before any n8n work, first run `npx --yes n8nac update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
 - Use the exact `n8nac command` and `n8n-manager command` listed in `AGENTS.md`. Those context-root commands override the portable examples in this skill.
-- Run every `npx --yes n8nac@next workspace ...`, `npx --yes n8nac@next list`, `pull`, `push`, `validate`, `test`, and `update-ai` command from the context root unless the user explicitly gives another context root.
+- Run every `npx --yes n8nac workspace ...`, `npx --yes n8nac list`, `pull`, `push`, `validate`, `test`, and `update-ai` command from the context root unless the user explicitly gives another context root.
 - `AGENTS.md` is bootstrap context only, not a source of configuration truth.
 - Do not infer instance, project, sync folder, or workflow directory from `AGENTS.md`.
 - Before n8n work, resolve the effective context from the backend:
 
 ```bash
-npx --yes n8nac@next workspace status --json
+npx --yes n8nac workspace status --json
 ```
 
 - Use the returned `workflowDir` for workflow files. Do not reconstruct it from `syncFolder`, `instanceIdentifier`, or `projectName`.
-- Never write `n8nac-config.json` by hand. Use `npx --yes n8nac@next workspace ...` commands.
+- Never write `n8nac-config.json` by hand. Use `npx --yes n8nac workspace ...` commands.
 
 ## Bootstrap Order
 
 1. `cd` to the context root.
-2. Run `npx --yes n8nac@next update-ai`, then read `AGENTS.md`.
-3. Run `npx --yes n8nac@next workspace status --json`.
-4. If the context root is not ready, inspect instances with `npx --yes @n8n-as-code/n8n-manager@next instances list`.
+2. Run `npx --yes n8nac update-ai`, then read `AGENTS.md`.
+3. Run `npx --yes n8nac workspace status --json`.
+4. If the context root is not ready, inspect instances with `npx --yes @n8n-as-code/n8n-manager instances list`.
 5. Reuse an existing instance when suitable.
 6. If no suitable instance exists, stop and ask the user whether they want to reuse/configure an existing instance, create a managed local n8n instance, or connect an existing/remote n8n instance. Do not create infrastructure by default. If the user chooses a managed local instance, ask separately whether they want a public tunnel.
 7. Ask for host/API key only for an explicitly remote or existing n8n instance.
 8. Configure context-root overrides with:
 
 ```bash
-npx --yes n8nac@next workspace pin-instance --instance-id <id>
-npx --yes n8nac@next workspace set-sync-folder workflows
-npx --yes n8nac@next workspace set-project --project-id <id> --project-name <name>
+npx --yes n8nac workspace pin-instance --instance-id <id>
+npx --yes n8nac workspace set-sync-folder workflows
+npx --yes n8nac workspace set-project --project-id <id> --project-name <name>
 ```
 
 For self-hosted n8n instances where the projects API is unavailable or returns 401/403, do not keep retrying project discovery. Use the standard personal project override unless the user gave another project:
 
 ```bash
-npx --yes n8nac@next workspace set-project --project-id personal --project-name Personal
+npx --yes n8nac workspace set-project --project-id personal --project-name Personal
 ```
 
-9. Run `npx --yes n8nac@next update-ai` after changing context-root overrides when the facade does not do it automatically.
+9. Run `npx --yes n8nac update-ai` after changing context-root overrides when the facade does not do it automatically.
 
 ## Sync Discipline
 
@@ -57,13 +57,13 @@ npx --yes n8nac@next workspace set-project --project-id personal --project-name 
 - Use `list` to inspect workflow IDs, file paths, and sync status.
 
 ```bash
-npx --yes n8nac@next list
-npx --yes n8nac@next pull <workflowId>
-npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
+npx --yes n8nac list
+npx --yes n8nac pull <workflowId>
+npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
 ```
 
 - `push` requires the full workflow file path, either absolute or context-root-relative. Do not pass a bare filename.
-- For a new workflow, create the file inside the `workflowDir` returned by `workspace status --json`, then confirm it with `npx --yes n8nac@next list --local`.
+- For a new workflow, create the file inside the `workflowDir` returned by `workspace status --json`, then confirm it with `npx --yes n8nac list --local`.
 - If push/pull reports a conflict, use explicit resolution commands. Do not overwrite remote changes blindly.
 - `pull` and conflict resolution operate on a single workflow ID.
 - `list` is the lightweight command that covers all workflows at once.
@@ -74,8 +74,8 @@ npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
 If push or pull reports a conflict, stop and inspect the conflict. Use explicit resolution commands only after choosing the intended direction:
 
 ```bash
-npx --yes n8nac@next resolve <workflowId> --mode keep-current
-npx --yes n8nac@next resolve <workflowId> --mode keep-incoming
+npx --yes n8nac resolve <workflowId> --mode keep-current
+npx --yes n8nac resolve <workflowId> --mode keep-incoming
 ```
 
 - `keep-current` force-pushes the local version.
@@ -87,10 +87,10 @@ npx --yes n8nac@next resolve <workflowId> --mode keep-incoming
 Never guess n8n node parameters.
 
 ```bash
-npx --yes n8nac@next skills examples search "<workflow pattern>"
-npx --yes n8nac@next skills search "<node or capability>"
-npx --yes n8nac@next skills node-info <nodeName>
-npx --yes n8nac@next skills validate <workflow.workflow.ts>
+npx --yes n8nac skills examples search "<workflow pattern>"
+npx --yes n8nac skills search "<node or capability>"
+npx --yes n8nac skills node-info <nodeName>
+npx --yes n8nac skills validate <workflow.workflow.ts>
 ```
 
 - Use exact node `type` and valid `typeVersion` values from `node-info`.
@@ -105,19 +105,19 @@ npx --yes n8nac@next skills validate <workflow.workflow.ts>
 Use these commands instead of guessing:
 
 ```bash
-npx --yes n8nac@next skills search "<node or capability>"
-npx --yes n8nac@next skills node-info <nodeName>
-npx --yes n8nac@next skills node-schema <nodeName>
-npx --yes n8nac@next skills docs "<topic>"
-npx --yes n8nac@next skills guides "<topic>"
-npx --yes n8nac@next skills examples search "<workflow pattern>"
-npx --yes n8nac@next skills examples info <id>
-npx --yes n8nac@next skills examples download <id>
+npx --yes n8nac skills search "<node or capability>"
+npx --yes n8nac skills node-info <nodeName>
+npx --yes n8nac skills node-schema <nodeName>
+npx --yes n8nac skills docs "<topic>"
+npx --yes n8nac skills guides "<topic>"
+npx --yes n8nac skills examples search "<workflow pattern>"
+npx --yes n8nac skills examples info <id>
+npx --yes n8nac skills examples download <id>
 ```
 
 - Start with `examples search` when the user asks for a common automation pattern.
 - Use examples to learn patterns, not as authority over current node schemas.
-- If a command or flag is unfamiliar, run `npx --yes n8nac@next <subcommand> --help`; do not invent flags.
+- If a command or flag is unfamiliar, run `npx --yes n8nac <subcommand> --help`; do not invent flags.
 
 ## Workflow Authoring Rules
 
@@ -257,15 +257,15 @@ defineRouting() {
 After pushing:
 
 ```bash
-npx --yes n8nac@next verify <workflowId>
-npx --yes n8nac@next test-plan <workflowId> --json
+npx --yes n8nac verify <workflowId>
+npx --yes n8nac test-plan <workflowId> --json
 ```
 
 For webhook, chat, or form workflows, prefer the production test sequence:
 
 ```bash
-npx --yes n8nac@next workflow activate <workflowId>
-npx --yes n8nac@next test <workflowId> --prod
+npx --yes n8nac workflow activate <workflowId>
+npx --yes n8nac test <workflowId> --prod
 ```
 
 - Class A configuration gaps require user/config action, not workflow rewrites.
@@ -285,7 +285,7 @@ Run it whenever one of these is true:
 - the user asks to show, open, present, display, or give the URL/link for a workflow.
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
+npx --yes @n8n-as-code/n8n-manager presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
 ```
 
 Rules:
@@ -293,7 +293,7 @@ Rules:
 - Do not manually construct n8n workflow URLs.
 - Do not return an internal local n8n URL when a presentation URL is available.
 - Use the `url` returned by `presentWorkflowResult` as the user-facing URL.
-- If you do not know the workflow ID, run `npx --yes n8nac@next list` first and select the matching workflow.
+- If you do not know the workflow ID, run `npx --yes n8nac list` first and select the matching workflow.
 - If `presentWorkflowResult` fails, report the backend diagnostic and then provide the best direct n8n URL only as a fallback.
 - Do this before the final response when the task created, changed, pushed, ran, or explicitly asks to show a workflow.
 
@@ -307,18 +307,18 @@ For webhook, chat, or form workflows:
 4. Test with `--prod` by default.
 
 ```bash
-npx --yes n8nac@next push <path-to-workflow.workflow.ts> --verify
-npx --yes n8nac@next test-plan <workflowId> --json
-npx --yes n8nac@next workflow activate <workflowId>
-npx --yes n8nac@next test <workflowId> --prod
+npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
+npx --yes n8nac test-plan <workflowId> --json
+npx --yes n8nac workflow activate <workflowId>
+npx --yes n8nac test <workflowId> --prod
 ```
 
-Use bare `npx --yes n8nac@next test <workflowId>` only when a test URL was intentionally armed in the n8n editor.
+Use bare `npx --yes n8nac test <workflowId>` only when a test URL was intentionally armed in the n8n editor.
 
 For GET/HEAD webhooks that read from `$json.query`, prefer:
 
 ```bash
-npx --yes n8nac@next test <workflowId> --query '{"key":"value"}' --prod
+npx --yes n8nac test <workflowId> --query '{"key":"value"}' --prod
 ```
 
 ## Execution Debugging
@@ -326,8 +326,8 @@ npx --yes n8nac@next test <workflowId> --query '{"key":"value"}' --prod
 If a webhook returns success but the workflow behavior is wrong, inspect executions instead of guessing:
 
 ```bash
-npx --yes n8nac@next execution list --workflow-id <workflowId> --limit 5 --json
-npx --yes n8nac@next execution get <executionId> --include-data --json
+npx --yes n8nac execution list --workflow-id <workflowId> --limit 5 --json
+npx --yes n8nac execution get <executionId> --include-data --json
 ```
 
 - A successful HTTP trigger only means n8n accepted the request.
@@ -339,11 +339,11 @@ npx --yes n8nac@next execution get <executionId> --include-data --json
 When a workflow is blocked by missing credentials, resolve the credential gap without rewriting unrelated workflow logic.
 
 ```bash
-npx --yes n8nac@next workflow credential-required <workflowId> --json
-npx --yes n8nac@next credential schema <type>
-npx --yes n8nac@next credential list --json
-npx --yes n8nac@next credential create --type <type> --name <name> --file cred.json --json
-npx --yes n8nac@next workflow activate <workflowId>
+npx --yes n8nac workflow credential-required <workflowId> --json
+npx --yes n8nac credential schema <type>
+npx --yes n8nac credential list --json
+npx --yes n8nac credential create --type <type> --name <name> --file cred.json --json
+npx --yes n8nac workflow activate <workflowId>
 ```
 
 - `workflow credential-required` exits non-zero when at least one credential is missing. Treat that as a signal to act, not as a workflow-code failure.

--- a/skills/n8n-manager/SKILL.md
+++ b/skills/n8n-manager/SKILL.md
@@ -10,11 +10,11 @@ Use this skill for global n8n instance management. `n8n-manager` is the source o
 ## Responsibility Boundary
 
 - Generated context root hint: not embedded. Use the shell launch directory or the workspace path explicitly given by the user.
-- If `n8nac` is available, first run `npx --yes n8nac@next update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
+- If `n8nac` is available, first run `npx --yes n8nac update-ai` from the context root, then read `AGENTS.md`. `update-ai` is designed to create or refresh the n8n-as-code block without destroying existing user or agent instructions.
 - Use the exact `n8n-manager command` and `n8nac command` listed in `AGENTS.md` when present. Those context-root commands override the portable examples in this skill.
-- Use `npx --yes @n8n-as-code/n8n-manager@next` for global instance, auth, runtime, tunnel, project-default, credential, and workflow-presentation operations.
-- Use `npx --yes n8nac@next workspace ...` only for context-root overrides such as pinned instance, sync folder, and project override.
-- Use `npx --yes n8nac@next` workflow commands only after the effective context is ready.
+- Use `npx --yes @n8n-as-code/n8n-manager` for global instance, auth, runtime, tunnel, project-default, credential, and workflow-presentation operations.
+- Use `npx --yes n8nac workspace ...` only for context-root overrides such as pinned instance, sync folder, and project override.
+- Use `npx --yes n8nac` workflow commands only after the effective context is ready.
 - Never edit `n8nac-config.json`, `~/.n8n-manager`, or n8n-manager secret files by hand.
 
 ## Core Commands
@@ -22,9 +22,9 @@ Use this skill for global n8n instance management. `n8n-manager` is the source o
 Inspect existing instances before changing state:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances list
-npx --yes @n8n-as-code/n8n-manager@next instances --help
-npx --yes @n8n-as-code/n8n-manager@next config get
+npx --yes @n8n-as-code/n8n-manager instances list
+npx --yes @n8n-as-code/n8n-manager instances --help
+npx --yes @n8n-as-code/n8n-manager config get
 ```
 
 Do not invent n8n-manager subcommands. In particular, `instances create` and `--type local` are not valid. Use `instances add --mode ...` exactly as documented by `instances --help`.
@@ -53,56 +53,56 @@ Only run these commands after the user has explicitly chosen the corresponding o
 Managed local Docker without public tunnel:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances add --name <name> --mode managed-local-docker
-npx --yes @n8n-as-code/n8n-manager@next instances setup <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances add --name <name> --mode managed-local-docker
+npx --yes @n8n-as-code/n8n-manager instances setup <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances status <id-or-name>
 ```
 
 Managed local Docker with public tunnel:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances add --name <name> --mode managed-local-docker --tunnel
-npx --yes @n8n-as-code/n8n-manager@next instances setup <id-or-name> --tunnel
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances add --name <name> --mode managed-local-docker --tunnel
+npx --yes @n8n-as-code/n8n-manager instances setup <id-or-name> --tunnel
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel status <id-or-name>
 ```
 
 Remote or existing instances require user-provided credentials. Prefer stdin for API keys:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next auth set --url <url> --api-key-stdin --name <name>
-npx --yes @n8n-as-code/n8n-manager@next auth test --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager auth set --url <url> --api-key-stdin --name <name>
+npx --yes @n8n-as-code/n8n-manager auth test --instance <id-or-name>
 ```
 
 Project selection is instance-level unless the context root explicitly needs a workspace override:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next projects list --instance <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next projects select <project-id-or-name> --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager projects list --instance <id-or-name>
+npx --yes @n8n-as-code/n8n-manager projects select <project-id-or-name> --instance <id-or-name>
 ```
 
 Self-hosted n8n may not expose the projects API or may return 401/403. In that case, do not retry project discovery. Use the n8n-architect workspace override path with the standard personal project unless the user gave another project:
 
 ```bash
-npx --yes n8nac@next workspace set-project --project-id personal --project-name Personal
+npx --yes n8nac workspace set-project --project-id personal --project-name Personal
 ```
 
 Runtime and tunnel operations are per instance:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next instances start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances stop <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances restart <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel status <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel start <id-or-name>
-npx --yes @n8n-as-code/n8n-manager@next instances tunnel refresh <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances stop <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances restart <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel status <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel start <id-or-name>
+npx --yes @n8n-as-code/n8n-manager instances tunnel refresh <id-or-name>
 ```
 
 Present workflow results after creating, modifying, pushing, or running a workflow:
 
 ```bash
-npx --yes @n8n-as-code/n8n-manager@next presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
+npx --yes @n8n-as-code/n8n-manager presentWorkflowResult --workflow-id <workflowId> --workspace-root <contextRoot>
 ```
 
 ## Guardrails

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,9 @@
             "path": "packages/manager-adapter"
         },
         {
+            "path": "packages/telemetry"
+        },
+        {
             "path": "packages/skills"
         },
         {


### PR DESCRIPTION
## Summary
- Add a shared privacy-first telemetry package with anonymous identity, opt-out controls, sanitized event properties, and PostHog capture transport.
- Instrument CLI, MCP, skills, VS Code/Cursor, OpenClaw, and docs surfaces with coarse product events for active-user and facade adoption metrics.
- Document telemetry behavior, collected fields, never-collected data, and disable controls.

## Verification
- `npx tsc -b`
- `npm run build --workspace=@n8n-as-code/telemetry`
- `npm run build --workspace=n8nac`
- `npm run build --workspace=@n8n-as-code/mcp`
- `npm run compile --workspace=packages/vscode-extension`
- `npm run typecheck --workspace=@n8n-as-code/n8nac`
- `N8NAC_TELEMETRY_DISABLED=1 npm run test:unit --workspace=n8nac`
- `N8NAC_TELEMETRY_DISABLED=1 npm test --workspace=@n8n-as-code/mcp`

## Privacy Notes
- Telemetry is disabled by CI, Do Not Track, explicit env flags, and VS Code telemetry settings.
- Events are allowlisted and avoid raw args, workflow content, IDs, paths, hosts, API keys, credential values, execution data, clipboard content, and search queries.