### PR TITLE
Add VS Code agent workbench shell

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,2 +1,7 @@
 N8N_API_Key=xxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 N8N_HOST = 'http://localhost:5678'
+
+# PostHog telemetry ingestion. Use the PostHog Project token, not the Project ID.
+N8NAC_POSTHOG_KEY=phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+N8NAC_POSTHOG_HOST=https://us.i.posthog.com
+N8NAC_TELEMETRY_ENV=dev

--- a/.env.test.example
+++ b/.env.test.example
@@ -1,2 +1,5 @@
 N8N_HOST=https://your-instance.app.n8n.cloud
 N8N_API_KEY=replace-me
+N8NAC_POSTHOG_KEY=phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+N8NAC_POSTHOG_HOST=https://us.i.posthog.com
+N8NAC_TELEMETRY_ENV=test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
     environment: prod
     env:
       GITHUB_TOKEN: ${{ github.token }}
+      N8NAC_POSTHOG_KEY: ${{ secrets.N8NAC_POSTHOG_KEY }}
+      N8NAC_POSTHOG_HOST: ${{ vars.N8NAC_POSTHOG_HOST }}
+      N8NAC_TELEMETRY_ENV: prod
     outputs:
       pending: ${{ steps.pending.outputs.pending }}
     steps:
@@ -77,6 +80,22 @@ jobs:
           key: ${{ runner.os }}-n8n-cache-${{ steps.n8n-tag.outputs.tag }}-${{ hashFiles('scripts/ensure-n8n-cache.cjs') }}
           restore-keys: |
             ${{ runner.os }}-n8n-cache-
+
+      - name: Verify telemetry release configuration
+        if: steps.pending.outputs.pending == 'true'
+        run: |
+          if [[ -z "${N8NAC_POSTHOG_KEY:-}" ]]; then
+            echo "❌ N8NAC_POSTHOG_KEY is missing in prod environment secrets."
+            exit 1
+          fi
+          if [[ -z "${N8NAC_POSTHOG_HOST:-}" ]]; then
+            echo "❌ N8NAC_POSTHOG_HOST is missing in prod environment variables."
+            exit 1
+          fi
+          if [[ "${N8NAC_TELEMETRY_ENV:-}" != "prod" ]]; then
+            echo "❌ N8NAC_TELEMETRY_ENV must be prod for stable releases."
+            exit 1
+          fi
 
       - name: Build all packages
         if: steps.pending.outputs.pending == 'true'
@@ -471,6 +490,9 @@ jobs:
     environment: next
     env:
       GITHUB_TOKEN: ${{ github.token }}
+      N8NAC_POSTHOG_KEY: ${{ secrets.N8NAC_POSTHOG_KEY }}
+      N8NAC_POSTHOG_HOST: ${{ vars.N8NAC_POSTHOG_HOST }}
+      N8NAC_TELEMETRY_ENV: next
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -525,6 +547,22 @@ jobs:
       - name: Refresh lockfile
         if: steps.prerelease-plan.outputs.changed == 'true'
         run: npm install --package-lock-only
+
+      - name: Verify telemetry release configuration
+        if: steps.prerelease-plan.outputs.changed == 'true'
+        run: |
+          if [[ -z "${N8NAC_POSTHOG_KEY:-}" ]]; then
+            echo "❌ N8NAC_POSTHOG_KEY is missing in next environment secrets."
+            exit 1
+          fi
+          if [[ -z "${N8NAC_POSTHOG_HOST:-}" ]]; then
+            echo "❌ N8NAC_POSTHOG_HOST is missing in next environment variables."
+            exit 1
+          fi
+          if [[ "${N8NAC_TELEMETRY_ENV:-}" != "next" ]]; then
+            echo "❌ N8NAC_TELEMETRY_ENV must be next for prereleases."
+            exit 1
+          fi
 
       - name: Build all packages
         if: steps.prerelease-plan.outputs.changed == 'true'

--- a/architecture/backlog/checkpoint-restore-delete-investigation.md
+++ b/architecture/backlog/checkpoint-restore-delete-investigation.md
@@ -1,0 +1,41 @@
+# Backlog: Checkpoint Restore/Delete Feature Investigation
+
+**Date:** 2026-05-05
+**Status:** Blocked
+
+## Issue
+
+Checkpoint restore and delete buttons in the Agent Workbench produce no visible effects. Additionally, an error is thrown:
+
+```
+ERROR: Cannot read "image.png" (this model does not support image input)
+```
+
+## Observations
+
+1. The error originates from the Yagr agent runtime when processing checkpoint data during `restoreCheckpoint` operation
+2. The checkpoint data may contain image references that the current model cannot process
+3. When an error occurs, the catch block in `agent-workbench-webview.ts` only sends an error stream event but doesn't trigger a UI state refresh, causing the UI to appear unresponsive
+
+## What Was Tried
+
+- Added `postWorkbenchState()` call in the error catch block to refresh UI on error
+- This ensured errors were displayed and UI refreshed, but didn't fix the underlying checkpoint data issue
+
+## Root Cause (Suspected)
+
+The Yagr agent's checkpoint data contains references to images or image data that gets processed when restoring a checkpoint. If the model doesn't support image input, this causes the error.
+
+## Next Steps
+
+1. Investigate how checkpoint data is serialized/deserialized in the Yagr runtime
+2. Determine if checkpoint data contains actual image binary data or just image references
+3. Check if the model being used supports vision/image input
+4. Consider adding a pre-check before restore to verify model capabilities
+5. Potentially filter out image data from checkpoint payloads if not needed for the use case
+
+## References
+
+- `packages/vscode-extension/src/services/agent-runtime-controller.ts` - `restoreCheckpoint()`, `deleteCheckpoint()`
+- `packages/vscode-extension/src/ui/agent-workbench-webview.ts` - message handler
+- `packages/vscode-extension/src/ui/agent-workbench-html.ts` - checkpoint UI

--- a/docs/docs/usage/telemetry.md
+++ b/docs/docs/usage/telemetry.md
@@ -47,11 +47,50 @@ The VS Code extension also respects VS Code's telemetry setting.
 
 On the documentation site, use the telemetry control in the bottom-right corner to disable or re-enable anonymous docs telemetry in your browser.
 
+## Connect PostHog Cloud
+
+n8n-as-code sends telemetry to a PostHog project using the PostHog **Project token**. The PostHog **Project ID** is for the PostHog API and is not used for event ingestion.
+
+For a US Cloud PostHog project:
+
+```bash
+export N8NAC_POSTHOG_KEY="phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+export N8NAC_POSTHOG_HOST="https://us.i.posthog.com"
+export N8NAC_TELEMETRY_ENV="dev"
+```
+
+For an EU Cloud PostHog project:
+
+```bash
+export N8NAC_POSTHOG_KEY="phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+export N8NAC_POSTHOG_HOST="https://eu.i.posthog.com"
+export N8NAC_TELEMETRY_ENV="dev"
+```
+
+Every event includes a `telemetry_environment` property so one PostHog project can safely separate local development, tests, prereleases, and production. Use `N8NAC_TELEMETRY_ENV=dev` in `./.env`, `N8NAC_TELEMETRY_ENV=test` in `./.env.test`, `N8NAC_TELEMETRY_ENV=next` for prerelease builds, and `N8NAC_TELEMETRY_ENV=prod` for stable production builds.
+
+During release builds, `@n8n-as-code/telemetry` embeds the PostHog project token, host, and telemetry environment from the build environment into the published package. Runtime environment variables still take precedence, so local development and tests can override the release defaults without changing the published artifacts.
+
+Check the local telemetry status:
+
+```bash
+n8nac telemetry status
+```
+
+To inspect events locally while testing:
+
+```bash
+N8NAC_TELEMETRY_DEBUG=1 n8nac workspace status
+```
+
+In PostHog, open the target project and use the `Events` or `Activity` view to verify events such as `first_seen`, `product_active`, `cli_command_completed`, or `vscode_extension_activated`. Dashboards are built from PostHog insights over those events; the product code only needs the project token and region host.
+
 ## What Is Collected
 
 Telemetry events contain only coarse product usage metadata:
 
 - anonymous installation ID
+- telemetry environment, such as `dev`, `test`, `next`, or `prod`
 - facade, such as `cli`, `vscode`, `mcp`, `skills`, or `openclaw`
 - package or extension version
 - command or tool name from a controlled list

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -4,6 +4,18 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
+function getTelemetryEnvironment(): string {
+  const explicit = process.env.N8NAC_TELEMETRY_ENV?.trim();
+  if (explicit) return explicit;
+
+  const refName = process.env.GITHUB_REF_NAME || process.env.GITHUB_REF?.replace(/^refs\/heads\//, '');
+  if (refName === 'main') return 'prod';
+  if (refName === 'next') return 'next';
+  if (process.env.NODE_ENV === 'test') return 'test';
+  if (process.env.CI === 'true') return 'ci';
+  return 'dev';
+}
+
 const config: Config = {
   title: 'n8n-as-code',
   tagline: 'Manage n8n workflows as code with version control and AI assistance',
@@ -11,6 +23,7 @@ const config: Config = {
   customFields: {
     posthogKey: process.env.N8NAC_POSTHOG_KEY || process.env.POSTHOG_KEY || '',
     posthogHost: process.env.N8NAC_POSTHOG_HOST || process.env.POSTHOG_HOST || 'https://eu.i.posthog.com',
+    telemetryEnvironment: getTelemetryEnvironment(),
   },
 
 

--- a/docs/src/telemetry/posthog.ts
+++ b/docs/src/telemetry/posthog.ts
@@ -1,8 +1,9 @@
 import siteConfig from '@generated/docusaurus.config';
 
-const customFields = siteConfig.customFields as { posthogKey?: string; posthogHost?: string };
+const customFields = siteConfig.customFields as { posthogKey?: string; posthogHost?: string; telemetryEnvironment?: string };
 const POSTHOG_KEY = customFields.posthogKey;
 const POSTHOG_HOST = (customFields.posthogHost || 'https://eu.i.posthog.com').replace(/\/$/, '');
+const TELEMETRY_ENVIRONMENT = customFields.telemetryEnvironment || 'dev';
 const STORAGE_KEY = 'n8n-as-code:docs-telemetry-id';
 const DISABLED_KEY = 'n8n-as-code:telemetry-disabled';
 
@@ -51,6 +52,7 @@ function trackDocsPageView(): void {
         app: 'n8n-as-code',
         facade: 'docs',
         telemetry_schema_version: 1,
+        telemetry_environment: TELEMETRY_ENVIRONMENT,
         path_group: getPathGroup(pathname),
       },
     }),

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "sync:deps": "node scripts/sync-dependencies.mjs --write",
     "check:deps": "node scripts/sync-dependencies.mjs --check",
     "update:n8n-manager": "node scripts/update-n8n-manager-versions.mjs",
+    "update:yagr": "node scripts/update-yagr-versions.mjs",
     "build": "npm run sync:brand-assets && npm run generate:nodes && tsc -b --force && npm run build --workspace=packages/telemetry && npm run build --workspace=packages/skills --workspace=packages/cli --workspace=packages/mcp --workspace=packages/vscode-extension --workspace=plugins/openclaw/n8n-as-code",
     "build:cli": "cd packages/cli && npm run build",
     "build:mcp": "cd packages/mcp && npm run build",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "sync:deps": "node scripts/sync-dependencies.mjs --write",
     "check:deps": "node scripts/sync-dependencies.mjs --check",
     "update:n8n-manager": "node scripts/update-n8n-manager-versions.mjs",
-    "build": "npm run sync:brand-assets && npm run generate:nodes && tsc -b --force && npm run build --workspace=packages/skills --workspace=packages/cli --workspace=packages/mcp --workspace=packages/vscode-extension --workspace=plugins/openclaw/n8n-as-code",
+    "build": "npm run sync:brand-assets && npm run generate:nodes && tsc -b --force && npm run build --workspace=packages/telemetry && npm run build --workspace=packages/skills --workspace=packages/cli --workspace=packages/mcp --workspace=packages/vscode-extension --workspace=plugins/openclaw/n8n-as-code",
     "build:cli": "cd packages/cli && npm run build",
     "build:mcp": "cd packages/mcp && npm run build",
     "build:claude-plugin": "npm run build --workspace=packages/skills && npm run build:adapters --workspace=packages/skills",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "@n8n-as-code/manager-adapter": "0.1.0",
-        "@n8n-as-code/n8n-manager-core": "^0.5.2",
+        "@n8n-as-code/n8n-manager-core": "^0.5.3",
         "@n8n-as-code/skills": "1.10.0",
         "@n8n-as-code/telemetry": "0.1.0",
         "@n8n-as-code/transformer": "1.2.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "@n8n-as-code/manager-adapter": "0.1.0",
-        "@n8n-as-code/n8n-manager-core": "^0.5.3",
+        "@n8n-as-code/n8n-manager-core": "^0.6.0",
         "@n8n-as-code/skills": "1.10.0",
         "@n8n-as-code/telemetry": "0.1.0",
         "@n8n-as-code/transformer": "1.2.1",

--- a/packages/cli/src/commands/base.ts
+++ b/packages/cli/src/commands/base.ts
@@ -139,6 +139,7 @@ export class BaseCommand {
      */
     protected async getSyncConfig(): Promise<any> {
         await this.prepareRuntimeContext();
+        const instanceIdentifier = await this.ensureInstanceIdentifier();
         const localConfig = this.activeInstanceId
             ? (this.configService.getEffectiveInstanceConfig(this.activeInstanceId) ?? this.configService.getLocalConfig())
             : this.configService.getLocalConfig();
@@ -153,8 +154,6 @@ export class BaseCommand {
             console.error(chalk.yellow('Set workspace context with `n8nac workspace set-sync-folder workflows`. For self-hosted n8n where the projects API is unavailable, use `n8nac workspace set-project --project-id personal --project-name Personal`; otherwise select a project with `n8n-manager projects select`.'));
             process.exit(1);
         }
-
-        const instanceIdentifier = await this.ensureInstanceIdentifier();
 
         return {
             directory: this.config.directory,

--- a/packages/cli/src/core/services/directory-utils.ts
+++ b/packages/cli/src/core/services/directory-utils.ts
@@ -97,7 +97,7 @@ function createStableUserIdentitySlug(user: { id?: string; email?: string; first
 
 /**
  * Creates an instance identifier for directory naming
- * @param host The host URL
+ * @param host The host URL. Kept for API compatibility; it is not used for identity.
  * @param user User information (optional)
  * @returns Instance identifier (e.g., "n8n_c6c289e49e_etienne_l")
  */
@@ -108,6 +108,10 @@ export function createInstanceIdentifier(_host: string, user?: { id?: string; em
     }
 
     throw new Error('Unable to create a stable instance identifier: n8n user ID is missing.');
+}
+
+export function isLegacyLocalInstanceIdentifier(identifier?: string): boolean {
+    return Boolean(identifier && /^local(?:_|$)/.test(identifier));
 }
 
 export function createApiKeyInstanceIdentifier(apiKey: string): string {

--- a/packages/cli/src/core/services/directory-utils.ts
+++ b/packages/cli/src/core/services/directory-utils.ts
@@ -86,20 +86,14 @@ function createStableUserIdentitySlug(user: { id?: string; email?: string; first
     }
 
     const identityHash = crypto.createHash('sha256').update(user.id).digest('hex').substring(0, 10);
-    const displaySlug = createUserSlug({
-        email: user.email,
-        firstName: user.firstName,
-        lastName: user.lastName,
-    });
-
-    return `n8n_${identityHash}_${displaySlug}`;
+    return `n8n_${identityHash}`;
 }
 
 /**
  * Creates an instance identifier for directory naming
  * @param host The host URL. Kept for API compatibility; it is not used for identity.
  * @param user User information (optional)
- * @returns Instance identifier (e.g., "n8n_c6c289e49e_etienne_l")
+ * @returns Instance identifier (e.g., "n8n_c6c289e49e")
  */
 export function createInstanceIdentifier(_host: string, user?: { id?: string; email?: string; firstName?: string; lastName?: string }): string {
     const stableUserIdentitySlug = user ? createStableUserIdentitySlug(user) : undefined;
@@ -112,6 +106,18 @@ export function createInstanceIdentifier(_host: string, user?: { id?: string; em
 
 export function isLegacyLocalInstanceIdentifier(identifier?: string): boolean {
     return Boolean(identifier && /^local(?:_|$)/.test(identifier));
+}
+
+export function isCanonicalUserInstanceIdentifier(identifier?: string): boolean {
+    return Boolean(identifier && /^n8n_[a-f0-9]{10}$/.test(identifier));
+}
+
+export function isApiKeyFallbackInstanceIdentifier(identifier?: string): boolean {
+    return Boolean(identifier && /^key_[a-f0-9]{10}$/.test(identifier));
+}
+
+export function isReusableInstanceIdentifier(identifier?: string): boolean {
+    return isCanonicalUserInstanceIdentifier(identifier) || isApiKeyFallbackInstanceIdentifier(identifier);
 }
 
 export function createApiKeyInstanceIdentifier(apiKey: string): string {

--- a/packages/cli/src/core/services/directory-utils.ts
+++ b/packages/cli/src/core/services/directory-utils.ts
@@ -1,85 +1,5 @@
 import crypto from 'crypto';
 
-export function normalizeHostForIdentity(host: string): string {
-    const trimmed = host.trim();
-    if (!trimmed) {
-        return '';
-    }
-
-    const parsed = new URL(trimmed);
-    return `${parsed.protocol}//${parsed.host}`.toLowerCase();
-}
-
-/**
- * Creates a user-friendly host slug for directory naming
- * @param host The host URL
- * @returns Cleaned host slug (e.g., "local_5678", "etiennel_cloud")
- */
-export function createHostSlug(host: string): string {
-    const isWindows = process.platform === 'win32';
-
-    // Remove protocol and trailing slashes
-    let cleanHost = host.replace(/^https?:\/\//, '').replace(/\/$/, '');
-    
-    // Handle localhost with port
-    if (cleanHost.startsWith('localhost:')) {
-        const port = cleanHost.split(':')[1];
-        return `local_${port}`;
-    }
-
-    if (isWindows) {
-        cleanHost = cleanHost.replace(/:/g, '_');
-    }
-    
-    // For domains, extract main parts
-    // etiennel.app.n8n.cloud -> etiennel_cloud
-    // prod.example.com -> prod_example
-    cleanHost = cleanHost
-        .replace(/\.app\.n8n\.cloud$/, '_cloud')
-        .replace(/\.example\.com$/, '_example')
-        .replace(/\.com$/, '')
-        .replace(/\.io$/, '')
-        .replace(/\.net$/, '')
-        .replace(/\.org$/, '');
-    
-    // Replace remaining dots and hyphens with underscores
-    return cleanHost
-        .replace(/[.-]/g, '_')
-        .toLowerCase();
-}
-
-/**
- * Creates a user-friendly slug from user information
- * @param user User object with id, email, firstName, lastName
- * @returns User slug (e.g., "etienne_l", "john_d", "user_123")
- */
-export function createUserSlug(user: { id?: string; email?: string; firstName?: string; lastName?: string }): string {
-    // Prefer first name + last name initial if available
-    if (user.firstName && user.lastName) {
-        return `${user.firstName.toLowerCase()}_${user.lastName.charAt(0).toLowerCase()}`;
-    }
-    
-    // Fallback to first name only
-    if (user.firstName) {
-        return user.firstName.toLowerCase();
-    }
-    
-    // Fallback to email username part
-    if (user.email) {
-        return user.email.split('@')[0]
-            .replace(/[^a-zA-Z0-9]/g, '_')
-            .toLowerCase();
-    }
-
-    // Fallback to normalized ID
-    if (user.id) {
-        return `user_${user.id.toLowerCase().replace(/[^a-z0-9]/g, '_')}`;
-    }
-    
-    // Final fallback
-    return 'user';
-}
-
 function createStableUserIdentitySlug(user: { id?: string; email?: string; firstName?: string; lastName?: string }): string | undefined {
     if (!user.id) {
         return undefined;
@@ -91,11 +11,10 @@ function createStableUserIdentitySlug(user: { id?: string; email?: string; first
 
 /**
  * Creates an instance identifier for directory naming
- * @param host The host URL. Kept for API compatibility; it is not used for identity.
  * @param user User information (optional)
  * @returns Instance identifier (e.g., "n8n_c6c289e49e")
  */
-export function createInstanceIdentifier(_host: string, user?: { id?: string; email?: string; firstName?: string; lastName?: string }): string {
+export function createInstanceIdentifier(user?: { id?: string; email?: string; firstName?: string; lastName?: string }): string {
     const stableUserIdentitySlug = user ? createStableUserIdentitySlug(user) : undefined;
     if (stableUserIdentitySlug) {
         return stableUserIdentitySlug;
@@ -104,25 +23,8 @@ export function createInstanceIdentifier(_host: string, user?: { id?: string; em
     throw new Error('Unable to create a stable instance identifier: n8n user ID is missing.');
 }
 
-export function isLegacyLocalInstanceIdentifier(identifier?: string): boolean {
-    return Boolean(identifier && /^local(?:_|$)/.test(identifier));
-}
-
 export function isCanonicalUserInstanceIdentifier(identifier?: string): boolean {
     return Boolean(identifier && /^n8n_[a-f0-9]{10}$/.test(identifier));
-}
-
-export function isApiKeyFallbackInstanceIdentifier(identifier?: string): boolean {
-    return Boolean(identifier && /^key_[a-f0-9]{10}$/.test(identifier));
-}
-
-export function isReusableInstanceIdentifier(identifier?: string): boolean {
-    return isCanonicalUserInstanceIdentifier(identifier) || isApiKeyFallbackInstanceIdentifier(identifier);
-}
-
-export function createApiKeyInstanceIdentifier(apiKey: string): string {
-    const apiKeyHash = crypto.createHash('sha256').update(apiKey).digest('hex').substring(0, 10);
-    return `key_${apiKeyHash}`;
 }
 
 /**

--- a/packages/cli/src/core/services/instance-identifier.ts
+++ b/packages/cli/src/core/services/instance-identifier.ts
@@ -1,6 +1,6 @@
 import { IN8nCredentials } from '../types.js';
 import { N8nApiClient } from './n8n-api-client.js';
-import { createApiKeyInstanceIdentifier, createInstanceIdentifier } from './directory-utils.js';
+import { createInstanceIdentifier } from './directory-utils.js';
 
 type IUserLike = {
     id: string;
@@ -15,20 +15,10 @@ export interface IInstanceIdentifierClient {
 
 export interface IResolvedInstanceIdentifier {
     identifier: string;
-    source: 'user' | 'apiKey';
-    usedFallback: boolean;
 }
 
 export interface IResolveInstanceIdentifierOptions {
     client?: IInstanceIdentifierClient;
-    throwOnConnectionError?: boolean;
-}
-
-function isConnectionError(error: any): boolean {
-    return !error?.response ||
-        error?.code === 'ECONNREFUSED' ||
-        error?.code === 'ENOTFOUND' ||
-        error?.code === 'ETIMEDOUT';
 }
 
 export async function resolveInstanceIdentifier(
@@ -37,31 +27,13 @@ export async function resolveInstanceIdentifier(
 ): Promise<IResolvedInstanceIdentifier> {
     const client = options.client ?? new N8nApiClient(credentials);
 
-    let user: IUserLike | null;
-    try {
-        user = await client.getCurrentUser();
-    } catch (error) {
-        if (options.throwOnConnectionError && isConnectionError(error)) {
-            throw error;
-        }
-        return {
-            identifier: createApiKeyInstanceIdentifier(credentials.apiKey),
-            source: 'apiKey',
-            usedFallback: true,
-        };
-    }
+    const user = await client.getCurrentUser();
 
     if (!user?.id) {
-        return {
-            identifier: createApiKeyInstanceIdentifier(credentials.apiKey),
-            source: 'apiKey',
-            usedFallback: true,
-        };
+        throw new Error('Unable to resolve the authenticated n8n user ID from the API key.');
     }
 
     return {
-        identifier: createInstanceIdentifier(credentials.host, user),
-        source: 'user',
-        usedFallback: false,
+        identifier: createInstanceIdentifier(user),
     };
 }

--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -97,8 +97,12 @@ export class N8nApiClient {
             } catch (error: any) {
                 if (process.env.DEBUG) console.debug(`[N8nApiClient] getCurrentUser: Fetching specific user ${jwtUserId} failed:`, error.message);
                 
-                // If it's a connection error, throw immediately
-                if (!error.response) throw error;
+                // The API key `sub` claim is the SSOT for sync folder identity.
+                // Network/API lookup only enriches display metadata and must not
+                // force a less stable API-key-hash fallback when `sub` is present.
+                if (!error.response) {
+                    return { id: jwtUserId };
+                }
 
                 // If it's a 403 or 404, we have the ID from JWT but can't get details.
                 // Return the ID at least to ensure correct instance identification.

--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -78,45 +78,17 @@ export class N8nApiClient {
     }
 
     async getCurrentUser(): Promise<{ id: string; email?: string; firstName?: string; lastName?: string; } | null> {
-        // 1. Try to extract userId from API key (JWT sub claim)
         const jwtUserId = this.extractUserIdFromApiKey();
-        if (jwtUserId) {
-            if (process.env.DEBUG) console.debug(`[N8nApiClient] getCurrentUser: Extracted userId ${jwtUserId} from API key`);
-            try {
-                const encodedJwtUserId = encodeURIComponent(jwtUserId);
-                const res = await this.client.get(`/api/v1/users/${encodedJwtUserId}`);
-                if (res.data && res.data.id) {
-                    if (process.env.DEBUG) console.debug('[N8nApiClient] getCurrentUser: Successfully retrieved specific user details');
-                    return {
-                        id: res.data.id,
-                        email: res.data.email,
-                        firstName: res.data.firstName,
-                        lastName: res.data.lastName
-                    };
-                }
-            } catch (error: any) {
-                if (process.env.DEBUG) console.debug(`[N8nApiClient] getCurrentUser: Fetching specific user ${jwtUserId} failed:`, error.message);
-                
-                // The API key `sub` claim is the SSOT for sync folder identity.
-                // Network/API lookup only enriches display metadata and must not
-                // force a less stable API-key-hash fallback when `sub` is present.
-                if (!error.response) {
-                    return { id: jwtUserId };
-                }
-
-                // If it's a 403 or 404, we have the ID from JWT but can't get details.
-                // Return the ID at least to ensure correct instance identification.
-                if (error.response.status === 403 || error.response.status === 404) {
-                    return { id: jwtUserId };
-                }
-            }
+        if (!jwtUserId) {
+            return null;
         }
 
-        // 2. Fallback: Try /me (not in official public API spec but kept for compatibility)
+        if (process.env.DEBUG) console.debug(`[N8nApiClient] getCurrentUser: Extracted userId ${jwtUserId} from API key`);
         try {
-            const res = await this.client.get('/api/v1/users/me');
-            if (process.env.DEBUG) console.debug('[N8nApiClient] getCurrentUser: Successfully retrieved user from /me endpoint');
+            const encodedJwtUserId = encodeURIComponent(jwtUserId);
+            const res = await this.client.get(`/api/v1/users/${encodedJwtUserId}`);
             if (res.data && res.data.id) {
+                if (process.env.DEBUG) console.debug('[N8nApiClient] getCurrentUser: Successfully retrieved specific user details');
                 return {
                     id: res.data.id,
                     email: res.data.email,
@@ -125,34 +97,11 @@ export class N8nApiClient {
                 };
             }
         } catch (error: any) {
-            if (process.env.DEBUG) console.debug('[N8nApiClient] getCurrentUser: /me endpoint failed:', error.message);
-            // If it's a connection error, throw immediately
-            if (!error.response) throw error;
+            if (process.env.DEBUG) console.debug(`[N8nApiClient] getCurrentUser: Fetching specific user ${jwtUserId} failed:`, error.message);
+            return { id: jwtUserId };
         }
 
-        // 3. Last resort: get all users and take the first one
-        // Note: This is unreliable on multi-user instances and only reached if JWT extraction failed.
-        if (process.env.DEBUG) console.debug('[N8nApiClient] getCurrentUser: Trying /api/v1/users endpoint as last resort');
-        try {
-            const res = await this.client.get('/api/v1/users');
-            if (res.data && res.data.data && res.data.data.length > 0) {
-                if (process.env.DEBUG) console.debug('[N8nApiClient] getCurrentUser: Found', res.data.data.length, 'users, taking first');
-                const user = res.data.data[0];
-                return {
-                    id: user.id,
-                    email: user.email,
-                    firstName: user.firstName,
-                    lastName: user.lastName
-                };
-            }
-        } catch (error: any) {
-            if (process.env.DEBUG) console.debug('[N8nApiClient] getCurrentUser: /api/v1/users endpoint failed:', error.message);
-            // If it's a connection error, throw immediately
-            if (!error.response) throw error;
-        }
-        
-        if (process.env.DEBUG) console.debug('[N8nApiClient] getCurrentUser: All attempts failed, returning null');
-        return null;
+        return { id: jwtUserId };
     }
 
     private shouldUsePersonalProjectFallback(error: any): boolean {

--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -98,6 +98,7 @@ export class N8nApiClient {
             }
         } catch (error: any) {
             if (process.env.DEBUG) console.debug(`[N8nApiClient] getCurrentUser: Fetching specific user ${jwtUserId} failed:`, error.message);
+            if (!error.response) throw error;
             return { id: jwtUserId };
         }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -340,6 +340,7 @@ telemetryProgram.command('status')
                 `Telemetry: ${status.enabled ? chalk.green('enabled') : chalk.yellow('disabled')}`,
                 `Configured: ${status.configured ? chalk.green('yes') : chalk.yellow('no PostHog key configured')}`,
                 status.disabledReason ? `Disabled reason: ${status.disabledReason}` : undefined,
+                `Environment: ${status.telemetryEnvironment}`,
                 `Config: ${status.configPath}`,
                 `Host: ${status.posthogHost}`,
             ].filter(Boolean).join('\n'),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -488,6 +488,9 @@ program.command('setup')
                 n8nHost: options.host,
                 n8nApiKeyRef: options.apiKey ? 'n8nac:provided-api-key' : undefined,
             });
+            if (instance.id && instance.baseUrl) {
+                await new ConfigService().getOrCreateInstanceIdentifier(instance.baseUrl, instance.id).catch(() => undefined);
+            }
             telemetry.track('setup_completed', {
                 setup_mode: normalizeSetupMode(mode),
                 has_project: Boolean(options.projectId),

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -80,17 +80,21 @@ export class ConfigService {
         const active = activeInstanceId ? instances.find((instance) => instance.id === activeInstanceId) : undefined;
         const activeProfile = effective ? this.contextToInstanceProfile(effective) : active;
 
+        const resolvedSyncFolder = overrides.syncFolder || effective?.syncFolder;
+        const resolvedProjectName = overrides.projectName || activeProfile?.projectName;
+
         return {
             version: 3,
             activeInstanceId,
             instances,
             ...this.toLocalConfig({
                 ...activeProfile,
-                syncFolder: overrides.syncFolder || effective?.syncFolder,
+                syncFolder: resolvedSyncFolder,
                 projectId: overrides.projectId || activeProfile?.projectId,
-                projectName: overrides.projectName || activeProfile?.projectName,
+                projectName: resolvedProjectName,
                 folderSync: overrides.folderSync ?? activeProfile?.folderSync,
                 customNodesPath: overrides.customNodesPath || activeProfile?.customNodesPath,
+                workflowDir: undefined,
             }),
         };
     }
@@ -533,7 +537,7 @@ export class ConfigService {
     }
 
     private contextToInstanceProfile(context: EffectiveN8nContext): IInstanceProfile {
-        const instanceIdentifier = this.canonicalInstanceIdentifier(context.instanceIdentifier);
+        const instanceIdentifier = context.instanceIdentifier;
         return {
             ...this.toInstanceProfile(context.instance),
             host: context.host,

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -8,7 +8,7 @@ import {
     type N8nInstanceVerification,
     type N8nInstanceVerificationStatus,
 } from '@n8n-as-code/n8n-manager-core';
-import { N8nApiClient, createProjectSlug, isLegacyLocalInstanceIdentifier } from '../core/index.js';
+import { N8nApiClient, createInstanceIdentifier, createProjectSlug, isCanonicalUserInstanceIdentifier, isReusableInstanceIdentifier, resolveInstanceIdentifier } from '../core/index.js';
 
 export interface ILocalConfig {
     host?: string;
@@ -141,7 +141,10 @@ export class ConfigService {
         if (prepared.runtime.blocked) {
             throw new Error(prepared.runtime.blocked.message);
         }
-        return prepared.context;
+        return {
+            ...prepared.context,
+            instanceIdentifier: this.reusableInstanceIdentifier(prepared.context.instanceIdentifier),
+        };
     }
 
     getCurrentInstanceConfigId(): string | undefined {
@@ -275,9 +278,12 @@ export class ConfigService {
         const verification = input.host && input.apiKey
             ? await this.verifyConnection(input.host, input.apiKey, options.client)
             : undefined;
+        const instanceIdentifier = input.host && input.apiKey
+            ? await this.resolveInstanceIdentifier(input.host, input.apiKey, options.client)
+            : this.reusableInstanceIdentifier(input.instanceIdentifier);
         const profile = this.saveLocalConfig({
             ...input,
-            instanceIdentifier: input.instanceIdentifier,
+            instanceIdentifier,
         }, {
             instanceId: options.createNew ? undefined : options.instanceId,
             instanceName: options.instanceName,
@@ -317,7 +323,7 @@ export class ConfigService {
             mode: current?.mode || 'existing',
             baseUrl: host,
             apiKey: options.apiKey,
-            instanceIdentifier: config.instanceIdentifier || current?.instanceIdentifier,
+            instanceIdentifier: this.reusableInstanceIdentifier(config.instanceIdentifier || current?.instanceIdentifier),
             verification: options.verification || current?.verification,
             defaultProject: current?.defaultProject,
         }, {
@@ -364,10 +370,12 @@ export class ConfigService {
         if (!apiKey) return { status: 'skipped', instance, reason: 'Missing API key' };
 
         const verification = await this.verifyConnection(instance.host, apiKey);
+        const instanceIdentifier = await this.resolveInstanceIdentifier(instance.host, apiKey);
         const updated = this.manager.upsertInstance({
             id: instance.id,
             name: instance.name,
             baseUrl: instance.host,
+            instanceIdentifier,
             verification,
         }, { setActive: instance.id === this.getActiveInstanceId() });
         const profile = this.toInstanceProfile(updated);
@@ -404,7 +412,8 @@ export class ConfigService {
             this.manager.saveApiKey(target.id, apiKey);
             return;
         }
-        const saved = this.manager.upsertInstance({ baseUrl: host, apiKey }, { setActive: true });
+        const instanceIdentifier = this.resolveInstanceIdentifierFromApiKey(apiKey) || undefined;
+        const saved = this.manager.upsertInstance({ baseUrl: host, apiKey, instanceIdentifier }, { setActive: true });
         this.manager.saveApiKey(saved.id, apiKey);
     }
 
@@ -420,19 +429,18 @@ export class ConfigService {
 
     async getOrCreateInstanceIdentifier(host: string, instanceId?: string): Promise<string> {
         const active = instanceId ? this.manager.getInstance(instanceId) : this.manager.getGlobalActiveInstance();
-        if (active?.instanceIdentifier && !isLegacyLocalInstanceIdentifier(active.instanceIdentifier)) {
-            return active.instanceIdentifier;
+        if (isCanonicalUserInstanceIdentifier(active?.instanceIdentifier)) {
+            return active!.instanceIdentifier!;
         }
         const apiKey = active ? this.manager.getApiKey(active.id) : this.getApiKey(host, instanceId);
         if (!apiKey) {
             throw new Error('API key not found');
         }
-        const { resolveInstanceIdentifier } = await import('../core/index.js');
-        const { identifier } = await resolveInstanceIdentifier({ host, apiKey });
+        const identifier = await this.resolveInstanceIdentifier(host, apiKey);
         const saved = this.manager.upsertInstance({
             id: active?.id || instanceId,
             name: active?.name || host,
-            baseUrl: host,
+            baseUrl: active?.baseUrl || host,
             instanceIdentifier: identifier,
         }, { setActive: true });
         return saved.instanceIdentifier || identifier;
@@ -452,6 +460,30 @@ export class ConfigService {
             : path.resolve(this.workspaceRoot, targetPath);
     }
 
+    private reusableInstanceIdentifier(identifier?: string): string | undefined {
+        return isReusableInstanceIdentifier(identifier) ? identifier : undefined;
+    }
+
+    private resolveInstanceIdentifierFromApiKey(apiKey: string): string | undefined {
+        try {
+            const parts = apiKey.split('.');
+            if (parts.length !== 3) return undefined;
+            const payload = JSON.parse(Buffer.from(parts[1], 'base64url' as BufferEncoding).toString('utf8'));
+            return typeof payload.sub === 'string' && payload.sub
+                ? createInstanceIdentifier('', { id: payload.sub })
+                : undefined;
+        } catch {
+            return undefined;
+        }
+    }
+
+    private async resolveInstanceIdentifier(host: string, apiKey: string, client?: IInstanceVerificationClient): Promise<string> {
+        const { identifier } = await resolveInstanceIdentifier({ host, apiKey }, {
+            client: client as any,
+        });
+        return identifier;
+    }
+
     private writeWorkspaceFields(instanceId: string, config: Partial<ILocalConfig>, setActive: boolean): void {
         const current = tryResolve(() => this.manager.readWorkspaceOverrides(this.workspaceRoot)) || { version: 3 as const };
         const hasConfigField = (key: keyof ILocalConfig): boolean => Object.prototype.hasOwnProperty.call(config, key);
@@ -467,11 +499,15 @@ export class ConfigService {
     }
 
     private resolveWorkspaceContext(instanceId?: string): EffectiveN8nContext {
-        return this.manager.resolveEffectiveContext({
+        const context = this.manager.resolveEffectiveContext({
             workspaceRoot: this.workspaceRoot,
             instanceId,
             syncFolderDefault: 'workspace',
         });
+        return {
+            ...context,
+            instanceIdentifier: this.reusableInstanceIdentifier(context.instanceIdentifier),
+        };
     }
 
     private toInstanceProfile(instance: GlobalN8nInstance, overrides?: Partial<ILocalConfig>): IInstanceProfile {
@@ -482,7 +518,7 @@ export class ConfigService {
             syncFolder: overrides?.syncFolder,
             projectId: overrides?.projectId || instance.defaultProject?.id,
             projectName: overrides?.projectName || instance.defaultProject?.name,
-            instanceIdentifier: instance.instanceIdentifier,
+            instanceIdentifier: this.reusableInstanceIdentifier(instance.instanceIdentifier),
             customNodesPath: overrides?.customNodesPath,
             folderSync: overrides?.folderSync,
             verification: instance.verification,
@@ -490,14 +526,15 @@ export class ConfigService {
     }
 
     private contextToInstanceProfile(context: EffectiveN8nContext): IInstanceProfile {
+        const instanceIdentifier = this.reusableInstanceIdentifier(context.instanceIdentifier);
         return {
             ...this.toInstanceProfile(context.instance),
             host: context.host,
             syncFolder: context.syncFolder,
             projectId: context.projectId,
             projectName: context.projectName,
-            instanceIdentifier: context.instanceIdentifier,
-            workflowDir: this.buildWorkflowDir(context.syncFolder, context.instanceIdentifier, context.projectName),
+            instanceIdentifier,
+            workflowDir: this.buildWorkflowDir(context.syncFolder, instanceIdentifier, context.projectName),
             customNodesPath: context.customNodesPath,
             folderSync: context.folderSync,
         };

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -8,7 +8,7 @@ import {
     type N8nInstanceVerification,
     type N8nInstanceVerificationStatus,
 } from '@n8n-as-code/n8n-manager-core';
-import { N8nApiClient, createProjectSlug } from '../core/index.js';
+import { N8nApiClient, createProjectSlug, isLegacyLocalInstanceIdentifier } from '../core/index.js';
 
 export interface ILocalConfig {
     host?: string;
@@ -420,7 +420,7 @@ export class ConfigService {
 
     async getOrCreateInstanceIdentifier(host: string, instanceId?: string): Promise<string> {
         const active = instanceId ? this.manager.getInstance(instanceId) : this.manager.getGlobalActiveInstance();
-        if (active?.instanceIdentifier) {
+        if (active?.instanceIdentifier && !isLegacyLocalInstanceIdentifier(active.instanceIdentifier)) {
             return active.instanceIdentifier;
         }
         const apiKey = active ? this.manager.getApiKey(active.id) : this.getApiKey(host, instanceId);

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -8,7 +8,7 @@ import {
     type N8nInstanceVerification,
     type N8nInstanceVerificationStatus,
 } from '@n8n-as-code/n8n-manager-core';
-import { N8nApiClient, createInstanceIdentifier, createProjectSlug, isCanonicalUserInstanceIdentifier, isReusableInstanceIdentifier, resolveInstanceIdentifier } from '../core/index.js';
+import { N8nApiClient, createInstanceIdentifier, createProjectSlug, isCanonicalUserInstanceIdentifier, resolveInstanceIdentifier } from '../core/index.js';
 
 export interface ILocalConfig {
     host?: string;
@@ -143,7 +143,7 @@ export class ConfigService {
         }
         return {
             ...prepared.context,
-            instanceIdentifier: this.reusableInstanceIdentifier(prepared.context.instanceIdentifier),
+            instanceIdentifier: this.canonicalInstanceIdentifier(prepared.context.instanceIdentifier),
         };
     }
 
@@ -280,7 +280,7 @@ export class ConfigService {
             : undefined;
         const instanceIdentifier = input.host && input.apiKey
             ? await this.resolveInstanceIdentifier(input.host, input.apiKey, options.client)
-            : this.reusableInstanceIdentifier(input.instanceIdentifier);
+            : this.canonicalInstanceIdentifier(input.instanceIdentifier);
         const profile = this.saveLocalConfig({
             ...input,
             instanceIdentifier,
@@ -323,7 +323,7 @@ export class ConfigService {
             mode: current?.mode || 'existing',
             baseUrl: host,
             apiKey: options.apiKey,
-            instanceIdentifier: this.reusableInstanceIdentifier(config.instanceIdentifier || current?.instanceIdentifier),
+            instanceIdentifier: this.canonicalInstanceIdentifier(config.instanceIdentifier || current?.instanceIdentifier),
             verification: options.verification || current?.verification,
             defaultProject: current?.defaultProject,
         }, {
@@ -408,11 +408,18 @@ export class ConfigService {
         const target = instanceId
             ? this.manager.getInstance(instanceId)
             : this.manager.listInstances().find((candidate) => this.normalizeHost(candidate.baseUrl || '') === this.normalizeHost(host));
+        const instanceIdentifier = this.resolveInstanceIdentifierFromApiKey(apiKey);
+        if (!instanceIdentifier) {
+            throw new Error('Unable to resolve the n8n user ID from the API key.');
+        }
         if (target) {
             this.manager.saveApiKey(target.id, apiKey);
+            this.manager.upsertInstance({
+                id: target.id,
+                instanceIdentifier,
+            }, { setActive: false });
             return;
         }
-        const instanceIdentifier = this.resolveInstanceIdentifierFromApiKey(apiKey) || undefined;
         const saved = this.manager.upsertInstance({ baseUrl: host, apiKey, instanceIdentifier }, { setActive: true });
         this.manager.saveApiKey(saved.id, apiKey);
     }
@@ -460,8 +467,8 @@ export class ConfigService {
             : path.resolve(this.workspaceRoot, targetPath);
     }
 
-    private reusableInstanceIdentifier(identifier?: string): string | undefined {
-        return isReusableInstanceIdentifier(identifier) ? identifier : undefined;
+    private canonicalInstanceIdentifier(identifier?: string): string | undefined {
+        return isCanonicalUserInstanceIdentifier(identifier) ? identifier : undefined;
     }
 
     private resolveInstanceIdentifierFromApiKey(apiKey: string): string | undefined {
@@ -470,7 +477,7 @@ export class ConfigService {
             if (parts.length !== 3) return undefined;
             const payload = JSON.parse(Buffer.from(parts[1], 'base64url' as BufferEncoding).toString('utf8'));
             return typeof payload.sub === 'string' && payload.sub
-                ? createInstanceIdentifier('', { id: payload.sub })
+                ? createInstanceIdentifier({ id: payload.sub })
                 : undefined;
         } catch {
             return undefined;
@@ -506,7 +513,7 @@ export class ConfigService {
         });
         return {
             ...context,
-            instanceIdentifier: this.reusableInstanceIdentifier(context.instanceIdentifier),
+            instanceIdentifier: this.canonicalInstanceIdentifier(context.instanceIdentifier),
         };
     }
 
@@ -518,7 +525,7 @@ export class ConfigService {
             syncFolder: overrides?.syncFolder,
             projectId: overrides?.projectId || instance.defaultProject?.id,
             projectName: overrides?.projectName || instance.defaultProject?.name,
-            instanceIdentifier: this.reusableInstanceIdentifier(instance.instanceIdentifier),
+            instanceIdentifier: this.canonicalInstanceIdentifier(instance.instanceIdentifier),
             customNodesPath: overrides?.customNodesPath,
             folderSync: overrides?.folderSync,
             verification: instance.verification,
@@ -526,7 +533,7 @@ export class ConfigService {
     }
 
     private contextToInstanceProfile(context: EffectiveN8nContext): IInstanceProfile {
-        const instanceIdentifier = this.reusableInstanceIdentifier(context.instanceIdentifier);
+        const instanceIdentifier = this.canonicalInstanceIdentifier(context.instanceIdentifier);
         return {
             ...this.toInstanceProfile(context.instance),
             host: context.host,

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -147,7 +147,6 @@ export class ConfigService {
         }
         return {
             ...prepared.context,
-            instanceIdentifier: this.canonicalInstanceIdentifier(prepared.context.instanceIdentifier),
         };
     }
 
@@ -517,7 +516,6 @@ export class ConfigService {
         });
         return {
             ...context,
-            instanceIdentifier: this.canonicalInstanceIdentifier(context.instanceIdentifier),
         };
     }
 

--- a/packages/cli/tests/integration/config-library.integration.test.ts
+++ b/packages/cli/tests/integration/config-library.integration.test.ts
@@ -36,6 +36,10 @@ function createService(workspaceDir: string): ConfigService {
     return new ConfigService(workspaceDir);
 }
 
+function apiKeyForUser(userId: string): string {
+    return `header.${Buffer.from(JSON.stringify({ sub: userId })).toString('base64url')}.signature`;
+}
+
 describe('ConfigService filesystem integration', () => {
     it('persists global instances and rehydrates the effective workspace context from disk', () => {
         const workspaceDir = createWorkspaceDir();
@@ -47,23 +51,25 @@ describe('ConfigService filesystem integration', () => {
             syncFolder: 'workflows-test',
             projectId: 'project-test',
             projectName: 'Test',
-            instanceIdentifier: 'test_instance'
+            instanceIdentifier: 'n8n_f85ac825d1'
         }, {
             instanceName: 'Test'
         });
-        configService.saveApiKey('https://shared.example.com', 'test-key', testProfile.id);
+        const testApiKey = apiKeyForUser('test-user');
+        const prodApiKey = apiKeyForUser('prod-user');
+        configService.saveApiKey('https://shared.example.com', testApiKey, testProfile.id);
 
         const prodProfile = configService.saveLocalConfig({
             host: 'https://shared.example.com',
             syncFolder: 'workflows-prod',
             projectId: 'project-prod',
             projectName: 'Production',
-            instanceIdentifier: 'prod_instance'
+            instanceIdentifier: 'n8n_1bfdd27c80'
         }, {
             instanceName: 'Production',
             createNew: true,
         });
-        configService.saveApiKey('https://shared.example.com', 'prod-key', prodProfile.id);
+        configService.saveApiKey('https://shared.example.com', prodApiKey, prodProfile.id);
 
         const reloaded = createService(workspaceDir);
         expect(reloaded.listInstances().map((instance) => instance.name).sort()).toEqual(['Production', 'Test']);
@@ -73,10 +79,10 @@ describe('ConfigService filesystem integration', () => {
             syncFolder: path.join(workspaceDir, 'workflows-prod'),
             projectId: 'project-prod',
             projectName: 'Production',
-            workflowDir: path.join(workspaceDir, 'workflows-prod', 'prod_instance', 'production')
+            workflowDir: path.join(workspaceDir, 'workflows-prod', 'n8n_1bfdd27c80', 'production')
         });
-        expect(reloaded.getApiKey('https://shared.example.com', testProfile.id)).toBe('test-key');
-        expect(reloaded.getApiKey('https://shared.example.com', prodProfile.id)).toBe('prod-key');
+        expect(reloaded.getApiKey('https://shared.example.com', testProfile.id)).toBe(testApiKey);
+        expect(reloaded.getApiKey('https://shared.example.com', prodProfile.id)).toBe(prodApiKey);
 
         reloaded.pinWorkspaceInstance(testProfile.id);
 
@@ -86,7 +92,7 @@ describe('ConfigService filesystem integration', () => {
             syncFolder: path.join(workspaceDir, 'workflows-prod'),
             projectId: 'project-prod',
             projectName: 'Production',
-            workflowDir: path.join(workspaceDir, 'workflows-prod', 'test_instance', 'production')
+            workflowDir: path.join(workspaceDir, 'workflows-prod', 'n8n_f85ac825d1', 'production')
         });
 
         const rawConfig = JSON.parse(fs.readFileSync(path.join(workspaceDir, 'n8nac-config.json'), 'utf-8'));
@@ -114,7 +120,9 @@ describe('ConfigService filesystem integration', () => {
         }, {
             instanceName: 'Test'
         });
-        configService.saveApiKey('https://shared.example.com', 'test-key', testProfile.id);
+        const testApiKey = apiKeyForUser('test-user');
+        const prodApiKey = apiKeyForUser('prod-user');
+        configService.saveApiKey('https://shared.example.com', testApiKey, testProfile.id);
 
         const prodProfile = configService.saveLocalConfig({
             host: 'https://prod.example.com',
@@ -125,13 +133,13 @@ describe('ConfigService filesystem integration', () => {
             instanceName: 'Production',
             createNew: true,
         });
-        configService.saveApiKey('https://prod.example.com', 'prod-key', prodProfile.id);
+        configService.saveApiKey('https://prod.example.com', prodApiKey, prodProfile.id);
 
         const deletion = configService.deleteInstance(prodProfile.id);
 
         expect(deletion.deletedInstance.id).toBe(prodProfile.id);
         expect(deletion.activeInstance?.id).toBe(testProfile.id);
-        expect(configService.getApiKey('https://shared.example.com', testProfile.id)).toBe('test-key');
+        expect(configService.getApiKey('https://shared.example.com', testProfile.id)).toBe(testApiKey);
         expect(configService.getApiKey('https://prod.example.com', prodProfile.id)).toBeUndefined();
 
         const reloaded = createService(workspaceDir);

--- a/packages/cli/tests/integration/list-archived.integration.test.ts
+++ b/packages/cli/tests/integration/list-archived.integration.test.ts
@@ -47,6 +47,7 @@ class MockN8nApiClientForArchive extends EventEmitter {
 // ---------------------------------------------------------------------------
 
 const tempDirs: string[] = [];
+const previousManagerHome = process.env.N8N_MANAGER_HOME;
 
 function createTempDir(prefix: string): string {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -55,15 +56,16 @@ function createTempDir(prefix: string): string {
 }
 
 function createSyncManagerWithMockClient(workspaceDir: string): SyncManager {
+    process.env.N8N_MANAGER_HOME = createTempDir('n8nac-it-archive-manager-');
     const configService = new ConfigService(workspaceDir);
     configService.saveLocalConfig({
         host: 'http://localhost:5678',
         syncFolder: workspaceDir,
         projectId: 'personal-project',
         projectName: 'Personal',
-        instanceIdentifier: 'local_1234_etienne_test',
+        instanceIdentifier: 'n8n_c6c289e49e',
     }, { instanceName: 'Test' });
-    configService.saveApiKey('http://localhost:5678', 'test-api-key');
+    configService.saveApiKey('http://localhost:5678', `header.${Buffer.from(JSON.stringify({ sub: 'user-1' })).toString('base64url')}.signature`);
 
     const mockClient = new MockN8nApiClientForArchive();
     return new SyncManager(mockClient as any, {
@@ -72,7 +74,7 @@ function createSyncManagerWithMockClient(workspaceDir: string): SyncManager {
         ignoredTags: [],
         projectId: 'personal-project',
         projectName: 'Personal',
-        instanceIdentifier: 'test_instance',
+        instanceIdentifier: 'n8n_c6c289e49e',
     });
 }
 
@@ -89,6 +91,11 @@ afterEach(() => {
         fs.rmSync(dir, { recursive: true, force: true });
     }
     tempDirs.length = 0;
+    if (previousManagerHome === undefined) {
+        delete process.env.N8N_MANAGER_HOME;
+    } else {
+        process.env.N8N_MANAGER_HOME = previousManagerHome;
+    }
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/tests/integration/update-ai.integration.test.ts
+++ b/packages/cli/tests/integration/update-ai.integration.test.ts
@@ -126,7 +126,7 @@ describe('CLI update-ai integration', () => {
     it('refreshes n8n-workflows.d.ts for all configured instance directories', () => {
         const workspaceDir = createTempDir('n8nac-update-ai-dts-');
 
-        const instanceIdentifier = 'local_5678_testuser';
+        const instanceIdentifier = 'n8n_c6c289e49e';
         const syncFolder = 'workflows';
         const projectName = 'My Project';
         const projectSlug = 'my_project';

--- a/packages/cli/tests/unit/config-service.test.ts
+++ b/packages/cli/tests/unit/config-service.test.ts
@@ -105,7 +105,7 @@ describe('ConfigService', () => {
             host: 'https://prod.example.test',
             projectId: 'personal',
             projectName: 'Personal',
-            instanceIdentifier: 'local_1234_etienne_test',
+            instanceIdentifier: 'invalid_identifier',
         }, {
             instanceId: 'prod',
             instanceName: 'Production',
@@ -123,7 +123,7 @@ describe('ConfigService', () => {
             apiKey: 'test-key',
             projectId: 'personal',
             projectName: 'Personal',
-            instanceIdentifier: 'local_1234_etienne_test',
+            instanceIdentifier: 'invalid_identifier',
         }, {
             instanceId: 'prod',
             instanceName: 'Production',

--- a/packages/cli/tests/unit/config-service.test.ts
+++ b/packages/cli/tests/unit/config-service.test.ts
@@ -83,7 +83,7 @@ describe('ConfigService', () => {
             host: 'https://prod.example.test',
             projectId: 'personal',
             projectName: 'Personal',
-            instanceIdentifier: 'prod_instance',
+            instanceIdentifier: 'n8n_1234567890',
         }, {
             instanceId: 'prod',
             instanceName: 'Production',
@@ -92,11 +92,55 @@ describe('ConfigService', () => {
         const effective = configService.getEffectiveInstanceConfig('prod');
 
         expect(effective?.syncFolder).toBe(path.join(workspaceRoot, 'workflows'));
-        expect(effective?.workflowDir).toBe(path.join(workspaceRoot, 'workflows', 'prod_instance', 'personal'));
+        expect(effective?.workflowDir).toBe(path.join(workspaceRoot, 'workflows', 'n8n_1234567890', 'personal'));
         expect(configService.getLocalConfig()).toMatchObject({
             syncFolder: path.join(workspaceRoot, 'workflows'),
-            workflowDir: path.join(workspaceRoot, 'workflows', 'prod_instance', 'personal'),
+            workflowDir: path.join(workspaceRoot, 'workflows', 'n8n_1234567890', 'personal'),
         });
+    });
+
+    it('does not expose non-canonical stored instance identifiers', () => {
+        const configService = new ConfigService(workspaceRoot);
+        configService.saveLocalConfig({
+            host: 'https://prod.example.test',
+            projectId: 'personal',
+            projectName: 'Personal',
+            instanceIdentifier: 'local_1234_etienne_test',
+        }, {
+            instanceId: 'prod',
+            instanceName: 'Production',
+        });
+
+        expect(configService.getEffectiveInstanceConfig('prod')?.instanceIdentifier).toBeUndefined();
+        expect(configService.getEffectiveInstanceConfig('prod')?.workflowDir).toBeUndefined();
+    });
+
+    it('resolves canonical identifiers from API key user identity during verified upsert', async () => {
+        const configService = new ConfigService(workspaceRoot);
+
+        const result = await configService.upsertInstanceConfigWithVerification({
+            host: 'https://prod.example.test',
+            apiKey: 'test-key',
+            projectId: 'personal',
+            projectName: 'Personal',
+            instanceIdentifier: 'local_1234_etienne_test',
+        }, {
+            instanceId: 'prod',
+            instanceName: 'Production',
+            client: {
+                async getCurrentUser() {
+                    return {
+                        id: 'user-1',
+                        email: 'etienne@example.com',
+                        firstName: 'Etienne',
+                        lastName: 'Lescot',
+                    };
+                },
+            },
+        });
+
+        expect(result.profile.instanceIdentifier).toBe('n8n_c6c289e49e');
+        expect(configService.getEffectiveInstanceConfig('prod')?.instanceIdentifier).toBe('n8n_c6c289e49e');
     });
 
     it('prepares effective workspace context through n8n-manager runtime service', async () => {

--- a/packages/cli/tests/unit/directory-utils.test.ts
+++ b/packages/cli/tests/unit/directory-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { createApiKeyInstanceIdentifier, createHostSlug, createInstanceIdentifier, isLegacyLocalInstanceIdentifier } from '../../src/core/services/directory-utils.js';
+import { createApiKeyInstanceIdentifier, createHostSlug, createInstanceIdentifier, isLegacyLocalInstanceIdentifier, isReusableInstanceIdentifier } from '../../src/core/services/directory-utils.js';
 
 afterEach(() => {
     vi.restoreAllMocks();
@@ -55,20 +55,27 @@ describe('directory-utils', () => {
                 email: 'etienne@example.com',
                 firstName: 'Etienne',
                 lastName: 'Lescot',
-            })).toBe('n8n_c6c289e49e_etienne_l');
+            })).toBe('n8n_c6c289e49e');
 
             expect(createInstanceIdentifier('https://changed.example.com', {
                 id: 'user-1',
                 email: 'etienne@example.com',
                 firstName: 'Etienne',
                 lastName: 'Lescot',
-            })).toBe('n8n_c6c289e49e_etienne_l');
+            })).toBe('n8n_c6c289e49e');
         });
 
         it('detects legacy local instance identifiers', () => {
             expect(isLegacyLocalInstanceIdentifier('local_1234_etienne_test')).toBe(true);
-            expect(isLegacyLocalInstanceIdentifier('n8n_c6c289e49e_etienne_l')).toBe(false);
+            expect(isLegacyLocalInstanceIdentifier('n8n_c6c289e49e')).toBe(false);
             expect(isLegacyLocalInstanceIdentifier('key_62af870476')).toBe(false);
+        });
+
+        it('only reuses canonical identifiers', () => {
+            expect(isReusableInstanceIdentifier('n8n_c6c289e49e')).toBe(true);
+            expect(isReusableInstanceIdentifier('key_62af870476')).toBe(true);
+            expect(isReusableInstanceIdentifier('local_1234_etienne_test')).toBe(false);
+            expect(isReusableInstanceIdentifier('n8n_c6c289e49e_etienne_l')).toBe(false);
         });
 
         it('fails when the stable n8n user ID is unavailable', () => {

--- a/packages/cli/tests/unit/directory-utils.test.ts
+++ b/packages/cli/tests/unit/directory-utils.test.ts
@@ -1,63 +1,17 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { createApiKeyInstanceIdentifier, createHostSlug, createInstanceIdentifier, isLegacyLocalInstanceIdentifier, isReusableInstanceIdentifier } from '../../src/core/services/directory-utils.js';
-
-afterEach(() => {
-    vi.restoreAllMocks();
-});
+import { describe, it, expect } from 'vitest';
+import { createInstanceIdentifier, isCanonicalUserInstanceIdentifier } from '../../src/core/services/directory-utils.js';
 
 describe('directory-utils', () => {
-    describe('createHostSlug', () => {
-        it('creates slug for local ip address', () => {
-            expect(createHostSlug('192.168.1.1')).toBe('192_168_1_1');
-        });
-
-        it('normalizes localhost with port', () => {
-            expect(createHostSlug('localhost:5678')).toBe('local_5678');
-            expect(createHostSlug('http://localhost:5678')).toBe('local_5678');
-        });
-
-        it('keeps known domain simplification behavior', () => {
-            expect(createHostSlug('etiennel.app.n8n.cloud')).toBe('etiennel_cloud');
-            expect(createHostSlug('prod.example.com')).toBe('prod_example');
-        });
-
-        it('strips common tlds and normalizes separators', () => {
-            expect(createHostSlug('https://my-test.domain.io/')).toBe('my_test_domain');
-            expect(createHostSlug('https://service-name.example.net')).toBe('service_name_example');
-            expect(createHostSlug('ACME-TEAM.ORG')).toBe('acme_team_org');
-        });
-
-        it('preserves non-localhost ports on linux/mac behavior', () => {
-            vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
-
-            expect(createHostSlug('http://192.168.1.1:5679')).toBe('192_168_1_1:5679');
-            expect(createHostSlug('https://demo.example.com:5679')).toBe('demo_example_com:5679');
-        });
-
-        it('replaces colon on windows for non-localhost hosts', () => {
-            vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
-
-            expect(createHostSlug('http://192.168.1.1:5679')).toBe('192_168_1_1_5679');
-            expect(createHostSlug('https://demo.example.com:5679')).toBe('demo_example_com_5679');
-        });
-
-        it('keeps localhost shortcut behavior on windows', () => {
-            vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
-
-            expect(createHostSlug('localhost:9999')).toBe('local_9999');
-        });
-    });
-
     describe('createInstanceIdentifier', () => {
-        it('uses a stable n8n user ID hash instead of the host slug when available', () => {
-            expect(createInstanceIdentifier('http://localhost:5678', {
+        it('uses a stable n8n user ID hash', () => {
+            expect(createInstanceIdentifier({
                 id: 'user-1',
                 email: 'etienne@example.com',
                 firstName: 'Etienne',
                 lastName: 'Lescot',
             })).toBe('n8n_c6c289e49e');
 
-            expect(createInstanceIdentifier('https://changed.example.com', {
+            expect(createInstanceIdentifier({
                 id: 'user-1',
                 email: 'etienne@example.com',
                 firstName: 'Etienne',
@@ -65,27 +19,17 @@ describe('directory-utils', () => {
             })).toBe('n8n_c6c289e49e');
         });
 
-        it('detects legacy local instance identifiers', () => {
-            expect(isLegacyLocalInstanceIdentifier('local_1234_etienne_test')).toBe(true);
-            expect(isLegacyLocalInstanceIdentifier('n8n_c6c289e49e')).toBe(false);
-            expect(isLegacyLocalInstanceIdentifier('key_62af870476')).toBe(false);
-        });
-
-        it('only reuses canonical identifiers', () => {
-            expect(isReusableInstanceIdentifier('n8n_c6c289e49e')).toBe(true);
-            expect(isReusableInstanceIdentifier('key_62af870476')).toBe(true);
-            expect(isReusableInstanceIdentifier('local_1234_etienne_test')).toBe(false);
-            expect(isReusableInstanceIdentifier('n8n_c6c289e49e_etienne_l')).toBe(false);
+        it('accepts only canonical user identity identifiers', () => {
+            expect(isCanonicalUserInstanceIdentifier('n8n_c6c289e49e')).toBe(true);
+            expect(isCanonicalUserInstanceIdentifier('key_62af870476')).toBe(false);
+            expect(isCanonicalUserInstanceIdentifier('invalid_identifier')).toBe(false);
+            expect(isCanonicalUserInstanceIdentifier('n8n_c6c289e49e_etienne_l')).toBe(false);
         });
 
         it('fails when the stable n8n user ID is unavailable', () => {
-            expect(() => createInstanceIdentifier('http://localhost:5678', {
+            expect(() => createInstanceIdentifier({
                 email: 'etienne@example.com',
             })).toThrow('n8n user ID is missing');
-        });
-
-        it('creates a hostless API-key fallback identifier', () => {
-            expect(createApiKeyInstanceIdentifier('test-key')).toBe('key_62af870476');
         });
     });
 });

--- a/packages/cli/tests/unit/directory-utils.test.ts
+++ b/packages/cli/tests/unit/directory-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { createApiKeyInstanceIdentifier, createHostSlug, createInstanceIdentifier } from '../../src/core/services/directory-utils.js';
+import { createApiKeyInstanceIdentifier, createHostSlug, createInstanceIdentifier, isLegacyLocalInstanceIdentifier } from '../../src/core/services/directory-utils.js';
 
 afterEach(() => {
     vi.restoreAllMocks();
@@ -63,6 +63,12 @@ describe('directory-utils', () => {
                 firstName: 'Etienne',
                 lastName: 'Lescot',
             })).toBe('n8n_c6c289e49e_etienne_l');
+        });
+
+        it('detects legacy local instance identifiers', () => {
+            expect(isLegacyLocalInstanceIdentifier('local_1234_etienne_test')).toBe(true);
+            expect(isLegacyLocalInstanceIdentifier('n8n_c6c289e49e_etienne_l')).toBe(false);
+            expect(isLegacyLocalInstanceIdentifier('key_62af870476')).toBe(false);
         });
 
         it('fails when the stable n8n user ID is unavailable', () => {

--- a/packages/cli/tests/unit/n8n-api-client.test.ts
+++ b/packages/cli/tests/unit/n8n-api-client.test.ts
@@ -527,15 +527,14 @@ describe('N8nApiClient test workflow support', () => {
             expect(mockAxiosGet).toHaveBeenCalledWith('/api/v1/users/user-123');
         });
 
-        it('returns the JWT sub claim when user detail lookup has a connection error', async () => {
+        it('propagates transport errors from user detail lookup', async () => {
             const mockJwt = 'header.eyJzdWIiOiJ1c2VyLTEyMyJ9.signature';
             const client = new N8nApiClient({ host: 'https://n8n.local', apiKey: mockJwt });
+            const error = { code: 'ECONNREFUSED' };
 
-            mockAxiosGet.mockRejectedValueOnce({ code: 'ECONNREFUSED' });
+            mockAxiosGet.mockRejectedValueOnce(error);
 
-            const user = await client.getCurrentUser();
-
-            expect(user).toEqual({ id: 'user-123' });
+            await expect(client.getCurrentUser()).rejects.toBe(error);
             expect(mockAxiosGet).toHaveBeenCalledWith('/api/v1/users/user-123');
         });
 

--- a/packages/cli/tests/unit/n8n-api-client.test.ts
+++ b/packages/cli/tests/unit/n8n-api-client.test.ts
@@ -539,46 +539,13 @@ describe('N8nApiClient test workflow support', () => {
             expect(mockAxiosGet).toHaveBeenCalledWith('/api/v1/users/user-123');
         });
 
-        it('falls back to /api/v1/users/me when API key is not a JWT', async () => {
+        it('returns null when API key has no JWT sub claim', async () => {
             const client = new N8nApiClient({ host: 'https://n8n.local', apiKey: 'not-a-jwt' });
-
-            mockAxiosGet.mockResolvedValueOnce({
-                data: {
-                    id: 'me-id',
-                    email: 'me@example.com'
-                }
-            });
 
             const user = await client.getCurrentUser();
 
-            expect(user).toEqual({
-                id: 'me-id',
-                email: 'me@example.com'
-            });
-            expect(mockAxiosGet).toHaveBeenCalledWith('/api/v1/users/me');
-        });
-
-        it('falls back to listing all users when /me and JWT both fail', async () => {
-            const client = new N8nApiClient({ host: 'https://n8n.local', apiKey: 'not-a-jwt' });
-
-            mockAxiosGet
-                .mockRejectedValueOnce({ response: { status: 404 } }) // /me fails
-                .mockResolvedValueOnce({ // /users succeeds
-                    data: {
-                        data: [
-                            { id: 'first-user', email: 'first@example.com' }
-                        ]
-                    }
-                });
-
-            const user = await client.getCurrentUser();
-
-            expect(user).toEqual({
-                id: 'first-user',
-                email: 'first@example.com'
-            });
-            expect(mockAxiosGet).toHaveBeenNthCalledWith(1, '/api/v1/users/me');
-            expect(mockAxiosGet).toHaveBeenNthCalledWith(2, '/api/v1/users');
+            expect(user).toBeNull();
+            expect(mockAxiosGet).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/cli/tests/unit/n8n-api-client.test.ts
+++ b/packages/cli/tests/unit/n8n-api-client.test.ts
@@ -527,6 +527,18 @@ describe('N8nApiClient test workflow support', () => {
             expect(mockAxiosGet).toHaveBeenCalledWith('/api/v1/users/user-123');
         });
 
+        it('returns the JWT sub claim when user detail lookup has a connection error', async () => {
+            const mockJwt = 'header.eyJzdWIiOiJ1c2VyLTEyMyJ9.signature';
+            const client = new N8nApiClient({ host: 'https://n8n.local', apiKey: mockJwt });
+
+            mockAxiosGet.mockRejectedValueOnce({ code: 'ECONNREFUSED' });
+
+            const user = await client.getCurrentUser();
+
+            expect(user).toEqual({ id: 'user-123' });
+            expect(mockAxiosGet).toHaveBeenCalledWith('/api/v1/users/user-123');
+        });
+
         it('falls back to /api/v1/users/me when API key is not a JWT', async () => {
             const client = new N8nApiClient({ host: 'https://n8n.local', apiKey: 'not-a-jwt' });
 

--- a/packages/cli/tests/unit/sync-manager.test.ts
+++ b/packages/cli/tests/unit/sync-manager.test.ts
@@ -17,7 +17,7 @@ describe('SyncManager push filename contract', () => {
             ignoredTags: [],
             projectId: 'project-1',
             projectName: 'Personal',
-            instanceIdentifier: 'local_5678_test',
+            instanceIdentifier: 'n8n_c6c289e49e',
         });
     }
 

--- a/packages/manager-adapter/package.json
+++ b/packages/manager-adapter/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@n8n-as-code/n8n-credentials-manager": "^0.1.3",
-    "@n8n-as-code/n8n-manager-core": "^0.5.2",
+    "@n8n-as-code/n8n-manager-core": "^0.5.3",
     "@n8n-as-code/workflow-core": "0.1.0"
   },
   "devDependencies": {

--- a/packages/manager-adapter/package.json
+++ b/packages/manager-adapter/package.json
@@ -24,8 +24,8 @@
     "clean": "rm -rf dist tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "@n8n-as-code/n8n-credentials-manager": "^0.1.3",
-    "@n8n-as-code/n8n-manager-core": "^0.5.3",
+    "@n8n-as-code/n8n-credentials-manager": "^0.1.4",
+    "@n8n-as-code/n8n-manager-core": "^0.6.0",
     "@n8n-as-code/workflow-core": "0.1.0"
   },
   "devDependencies": {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -21,7 +21,7 @@
     "directory": "packages/telemetry"
   },
   "scripts": {
-    "build": "tsc -b",
+    "build": "tsc -b && node scripts/embed-build-config.mjs",
     "clean": "rm -rf dist tsconfig.tsbuildinfo"
   },
   "devDependencies": {

--- a/packages/telemetry/scripts/embed-build-config.mjs
+++ b/packages/telemetry/scripts/embed-build-config.mjs
@@ -1,0 +1,43 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const distIndexPath = resolve(here, '..', 'dist', 'index.js');
+
+function readBuildEnvironment() {
+  const explicit = process.env.N8NAC_TELEMETRY_ENV || process.env.N8NAC_ENV;
+  if (explicit?.trim()) return explicit.trim();
+
+  const refName = process.env.GITHUB_REF_NAME || process.env.GITHUB_REF?.replace(/^refs\/heads\//, '').replace(/^refs\/tags\//, '');
+  if (refName === 'main') return 'prod';
+  if (refName === 'next') return 'next';
+
+  return '';
+}
+
+function replaceConst(source, name, value) {
+  const pattern = new RegExp(`const ${name} = ['\"][^'\"]*['\"];`);
+  const replacement = `const ${name} = ${JSON.stringify(value)};`;
+  if (!pattern.test(source)) {
+    throw new Error(`Unable to find build config constant ${name} in ${distIndexPath}`);
+  }
+  return source.replace(pattern, replacement);
+}
+
+const values = {
+  BUILD_POSTHOG_KEY: (process.env.N8NAC_POSTHOG_KEY || process.env.POSTHOG_KEY || '').trim(),
+  BUILD_POSTHOG_HOST: (process.env.N8NAC_POSTHOG_HOST || process.env.POSTHOG_HOST || '').trim(),
+  BUILD_TELEMETRY_ENVIRONMENT: readBuildEnvironment(),
+};
+
+let source = readFileSync(distIndexPath, 'utf8');
+for (const [name, value] of Object.entries(values)) {
+  source = replaceConst(source, name, value);
+}
+writeFileSync(distIndexPath, source, 'utf8');
+
+const configured = Boolean(values.BUILD_POSTHOG_KEY);
+const host = values.BUILD_POSTHOG_HOST || '(runtime default)';
+const environment = values.BUILD_TELEMETRY_ENVIRONMENT || '(runtime default)';
+console.log(`[telemetry] build config embedded: configured=${configured} host=${host} environment=${environment}`);

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -4,6 +4,7 @@ import { homedir, platform } from 'node:os';
 import { dirname, join } from 'node:path';
 
 export type TelemetryFacade = 'cli' | 'vscode' | 'mcp' | 'skills' | 'openclaw' | 'claude' | 'docs' | 'yagr';
+export type TelemetryEnvironment = 'dev' | 'test' | 'next' | 'prod' | 'ci';
 export type TelemetryOutcome = 'success' | 'failure' | 'cancelled' | 'skipped';
 export type ErrorCategory =
     | 'configuration_error'
@@ -70,6 +71,7 @@ export interface TelemetryStatus {
     configPath: string;
     anonymousId?: string;
     posthogHost: string;
+    telemetryEnvironment: TelemetryEnvironment;
     noticeShownAt?: string;
 }
 
@@ -98,6 +100,9 @@ interface QueuedEvent {
 
 const TELEMETRY_SCHEMA_VERSION = 1;
 const DEFAULT_POSTHOG_HOST = 'https://eu.i.posthog.com';
+const BUILD_POSTHOG_KEY = 'N8NAC_BUILD_POSTHOG_KEY_PLACEHOLDER';
+const BUILD_POSTHOG_HOST = 'N8NAC_BUILD_POSTHOG_HOST_PLACEHOLDER';
+const BUILD_TELEMETRY_ENVIRONMENT = 'N8NAC_BUILD_TELEMETRY_ENVIRONMENT_PLACEHOLDER';
 
 const ALLOWED_PROPERTY_KEYS = new Set([
     'activation_source_event',
@@ -146,6 +151,7 @@ const ALLOWED_PROPERTY_KEYS = new Set([
     'subcommand',
     'target',
     'telemetry_schema_version',
+    'telemetry_environment',
     'tool_name',
     'tracked_count',
     'transport',
@@ -225,11 +231,56 @@ function getNodeMajor(): number | undefined {
 }
 
 function getPostHogKey(): string | undefined {
-    return process.env.N8NAC_POSTHOG_KEY?.trim() || process.env.POSTHOG_KEY?.trim() || undefined;
+    return process.env.N8NAC_POSTHOG_KEY?.trim() || process.env.POSTHOG_KEY?.trim() || getBuildValue(BUILD_POSTHOG_KEY);
 }
 
 function getPostHogHost(): string {
-    return (process.env.N8NAC_POSTHOG_HOST?.trim() || process.env.POSTHOG_HOST?.trim() || DEFAULT_POSTHOG_HOST).replace(/\/$/, '');
+    return (process.env.N8NAC_POSTHOG_HOST?.trim() || process.env.POSTHOG_HOST?.trim() || getBuildValue(BUILD_POSTHOG_HOST) || DEFAULT_POSTHOG_HOST).replace(/\/$/, '');
+}
+
+function getBuildValue(value: string): string | undefined {
+    const trimmed = value.trim();
+    if (!trimmed || trimmed.startsWith('N8NAC_BUILD_')) return undefined;
+    return trimmed;
+}
+
+function normalizeTelemetryEnvironment(value?: string): TelemetryEnvironment | undefined {
+    const normalized = value?.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    if (!normalized) return undefined;
+    if (normalized === 'production' || normalized === 'prod' || normalized === 'main' || normalized === 'stable') return 'prod';
+    if (normalized === 'next' || normalized === 'preview' || normalized === 'prerelease' || normalized === 'pre_release') return 'next';
+    if (normalized === 'development' || normalized === 'dev' || normalized === 'local') return 'dev';
+    if (normalized === 'test' || normalized === 'testing') return 'test';
+    if (normalized === 'ci') return 'ci';
+    return undefined;
+}
+
+function getGitHubRefName(): string | undefined {
+    const refName = process.env.GITHUB_REF_NAME?.trim();
+    if (refName) return refName;
+
+    const ref = process.env.GITHUB_REF?.trim();
+    return ref?.replace(/^refs\/heads\//, '').replace(/^refs\/tags\//, '') || undefined;
+}
+
+function getTelemetryEnvironment(): TelemetryEnvironment {
+    const explicit = normalizeTelemetryEnvironment(process.env.N8NAC_TELEMETRY_ENV || process.env.N8NAC_ENV);
+    if (explicit) return explicit;
+
+    const branchEnvironment = normalizeTelemetryEnvironment(getGitHubRefName());
+    if (branchEnvironment === 'prod' || branchEnvironment === 'next') return branchEnvironment;
+
+    const nodeEnvironment = normalizeTelemetryEnvironment(process.env.NODE_ENV);
+    if (nodeEnvironment === 'test') return 'test';
+
+    const lifecycleEvent = process.env.npm_lifecycle_event?.toLowerCase() || '';
+    if (lifecycleEvent.includes('test')) return 'test';
+
+    const buildEnvironment = normalizeTelemetryEnvironment(getBuildValue(BUILD_TELEMETRY_ENVIRONMENT));
+    if (buildEnvironment) return buildEnvironment;
+
+    if (process.env.CI === 'true') return 'ci';
+    return 'dev';
 }
 
 function sanitizeProperties(properties: TelemetryProperties): TelemetryProperties {
@@ -317,6 +368,7 @@ export function getTelemetryStatus(context?: Pick<TelemetryContext, 'forceDisabl
         configPath: path,
         anonymousId: config.anonymousId,
         posthogHost: getPostHogHost(),
+        telemetryEnvironment: getTelemetryEnvironment(),
         noticeShownAt: config.noticeShownAt,
     };
 }
@@ -355,6 +407,7 @@ export function createTelemetryClient(context: TelemetryContext): TelemetryClien
         app: 'n8n-as-code',
         facade: context.facade,
         telemetry_schema_version: TELEMETRY_SCHEMA_VERSION,
+        telemetry_environment: getTelemetryEnvironment(),
         package_version: context.version,
         session_id: sessionId,
         workspace_id: context.workspaceId,

--- a/packages/vscode-extension/esbuild.config.js
+++ b/packages/vscode-extension/esbuild.config.js
@@ -13,12 +13,16 @@ const managerCoreAgentToolingPath = path.resolve(
     'dist',
     'agent-tooling.js'
 );
+const managerCoreAgentToolingPaths = new Set([
+    managerCoreAgentToolingPath,
+    fs.existsSync(managerCoreAgentToolingPath) ? fs.realpathSync(managerCoreAgentToolingPath) : managerCoreAgentToolingPath,
+]);
 
 const preserveManagerCoreEntrypointResolution = {
     name: 'preserve-manager-core-entrypoint-resolution',
     setup(build) {
         build.onLoad({ filter: /agent-tooling\.js$/ }, async (args) => {
-            if (path.resolve(args.path) !== managerCoreAgentToolingPath) {
+            if (!managerCoreAgentToolingPaths.has(path.resolve(args.path))) {
                 return undefined;
             }
             const source = await fs.promises.readFile(args.path, 'utf8');

--- a/packages/vscode-extension/esbuild.config.js
+++ b/packages/vscode-extension/esbuild.config.js
@@ -157,7 +157,7 @@ const extensionBuild = esbuild.build({
     entryPoints: ['./src/extension.ts'],
     bundle: true,
     outfile: 'out/extension.js',
-    external: ['vscode', 'prettier', '@yagr/runtime'],
+    external: ['vscode', 'prettier', '@yagr/agent'],
     format: 'cjs',
     platform: 'node',
     logOverride: {

--- a/packages/vscode-extension/esbuild.config.js
+++ b/packages/vscode-extension/esbuild.config.js
@@ -157,7 +157,7 @@ const extensionBuild = esbuild.build({
     entryPoints: ['./src/extension.ts'],
     bundle: true,
     outfile: 'out/extension.js',
-    external: ['vscode', 'prettier'],
+    external: ['vscode', 'prettier', '@yagr/runtime'],
     format: 'cjs',
     platform: 'node',
     logOverride: {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -368,7 +368,7 @@
   ],
   "dependencies": {
     "@n8n-as-code/manager-adapter": "0.1.0",
-    "@n8n-as-code/n8n-manager-core": "^0.5.2",
+    "@n8n-as-code/n8n-manager-core": "^0.5.3",
     "@n8n-as-code/skills": "1.10.0",
     "@n8n-as-code/telemetry": "0.1.0",
     "@n8n-as-code/workflow-core": "0.1.0",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -106,6 +106,16 @@
         "icon": "$(split-horizontal)"
       },
       {
+        "command": "n8n.openAgentWorkbench",
+        "title": "Open Agent Workbench",
+        "icon": "$(hubot)"
+      },
+      {
+        "command": "n8n.openAgentManager",
+        "title": "n8n: Open Agent Manager",
+        "icon": "$(account)"
+      },
+      {
         "command": "n8n.pushWorkflow",
         "title": "Push",
         "icon": "$(cloud-upload)"
@@ -134,6 +144,11 @@
         "command": "n8n.initializeAI",
         "title": "Initialize AI Context",
         "icon": "$(sparkle)"
+      },
+      {
+        "command": "n8n.agent.setApiKey",
+        "title": "n8n Agent: Set Provider API Key",
+        "icon": "$(key)"
       },
       {
         "command": "n8n.applySettings",
@@ -241,6 +256,11 @@
           "when": "viewItem =~ /^workflow-(tracked|local-only)$/"
         },
         {
+          "command": "n8n.openAgentWorkbench",
+          "group": "1_open@4",
+          "when": "viewItem =~ /^workflow-(tracked|tracked-archived|cloud-only)$/"
+        },
+        {
           "command": "n8n.pushWorkflow",
           "group": "2_sync@1",
           "when": "viewItem =~ /^workflow-(tracked|local-only)$/"
@@ -275,6 +295,29 @@
         "n8n.projectName": {
           "type": "string",
           "description": "Project name to display (managed by the extension; use the Configure command to select)"
+        },
+        "n8n.agent.provider": {
+          "type": "string",
+          "enum": [
+            "anthropic",
+            "openai",
+            "google",
+            "mistral",
+            "openrouter",
+            "openai-compatible"
+          ],
+          "default": "openai",
+          "description": "Provider used by the embedded n8n Agent Workbench. API keys are stored in VS Code Secret Storage, not settings."
+        },
+        "n8n.agent.model": {
+          "type": "string",
+          "default": "",
+          "description": "Optional model override for the embedded n8n Agent Workbench. Leave empty to use the provider default."
+        },
+        "n8n.agent.baseUrl": {
+          "type": "string",
+          "default": "",
+          "description": "Optional OpenAI-compatible base URL for the embedded n8n Agent Workbench."
         }
       }
     }
@@ -304,6 +347,7 @@
     "@n8n-as-code/skills": "1.10.0",
     "@n8n-as-code/telemetry": "0.1.0",
     "@n8n-as-code/workflow-core": "0.1.0",
+    "@yagr/runtime": "0.1.1-next.226.1",
     "@reduxjs/toolkit": "^2.11.2",
     "http-proxy": "^1.18.1",
     "n8nac": "1.8.1",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -151,6 +151,16 @@
         "icon": "$(key)"
       },
       {
+        "command": "n8n.agent.setupProvider",
+        "title": "n8n Agent: Set Up Provider",
+        "icon": "$(key)"
+      },
+      {
+        "command": "n8n.agent.selectModel",
+        "title": "n8n Agent: Select Provider Model",
+        "icon": "$(symbol-enum)"
+      },
+      {
         "command": "n8n.applySettings",
         "title": "Apply n8n Settings",
         "icon": "$(check)"
@@ -214,8 +224,28 @@
           "when": "view == n8n-explorer.workflows && n8n.state == initialized"
         },
         {
-          "command": "n8n.configure",
+          "command": "n8n.openAgentWorkbench",
+          "group": "navigation@6",
+          "when": "view == n8n-explorer.workflows && n8n.state == initialized"
+        },
+        {
+          "command": "n8n.openAgentManager",
           "group": "navigation@7",
+          "when": "view == n8n-explorer.workflows"
+        },
+        {
+          "command": "n8n.agent.setupProvider",
+          "group": "navigation@8",
+          "when": "view == n8n-explorer.workflows"
+        },
+        {
+          "command": "n8n.agent.selectModel",
+          "group": "navigation@9",
+          "when": "view == n8n-explorer.workflows"
+        },
+        {
+          "command": "n8n.configure",
+          "group": "navigation@10",
           "when": "view == n8n-explorer.workflows"
         }
       ],
@@ -304,6 +334,11 @@
             "google",
             "mistral",
             "openrouter",
+            "openai-oauth",
+            "anthropic-proxy",
+            "copilot-proxy",
+            "minimax",
+            "minimax-token-plan",
             "openai-compatible"
           ],
           "default": "openai",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -112,7 +112,7 @@
       },
       {
         "command": "n8n.openAgentManager",
-        "title": "n8n: Open Agent Manager",
+        "title": "n8n: Agent Providers",
         "icon": "$(account)"
       },
       {
@@ -229,23 +229,8 @@
           "when": "view == n8n-explorer.workflows && n8n.state == initialized"
         },
         {
-          "command": "n8n.openAgentManager",
-          "group": "navigation@7",
-          "when": "view == n8n-explorer.workflows"
-        },
-        {
-          "command": "n8n.agent.setupProvider",
-          "group": "navigation@8",
-          "when": "view == n8n-explorer.workflows"
-        },
-        {
-          "command": "n8n.agent.selectModel",
-          "group": "navigation@9",
-          "when": "view == n8n-explorer.workflows"
-        },
-        {
           "command": "n8n.configure",
-          "group": "navigation@10",
+          "group": "navigation@7",
           "when": "view == n8n-explorer.workflows"
         }
       ],
@@ -261,13 +246,18 @@
           "when": "viewItem =~ /^workflow-(tracked|tracked-archived|cloud-only)$/"
         },
         {
-          "command": "n8n.pushWorkflow",
+          "command": "n8n.openAgentWorkbench",
           "group": "inline@3",
+          "when": "viewItem =~ /^workflow-(tracked|tracked-archived|cloud-only)$/"
+        },
+        {
+          "command": "n8n.pushWorkflow",
+          "group": "inline@4",
           "when": "viewItem =~ /^workflow-(tracked|local-only)$/"
         },
         {
           "command": "n8n.pullWorkflow",
-          "group": "inline@4",
+          "group": "inline@5",
           "when": "viewItem =~ /^workflow-(tracked|tracked-archived|cloud-only)$/"
         },
         {
@@ -382,8 +372,8 @@
     "@n8n-as-code/skills": "1.10.0",
     "@n8n-as-code/telemetry": "0.1.0",
     "@n8n-as-code/workflow-core": "0.1.0",
-    "@yagr/runtime": "0.1.1-next.226.1",
     "@reduxjs/toolkit": "^2.11.2",
+    "@yagr/agent": "file:../../../yagr",
     "http-proxy": "^1.18.1",
     "n8nac": "1.8.1",
     "ws": "^8.19.0"

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -391,7 +391,7 @@
     "@n8n-as-code/telemetry": "0.1.0",
     "@n8n-as-code/workflow-core": "0.1.0",
     "@reduxjs/toolkit": "^2.11.2",
-    "@yagr/agent": "file:../../../yagr",
+    "@yagr/agent": "^0.2.31",
     "http-proxy": "^1.18.1",
     "n8nac": "1.8.1",
     "ws": "^8.19.0"

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -161,6 +161,11 @@
         "icon": "$(symbol-enum)"
       },
       {
+        "command": "n8n.agent.selectReasoningEffort",
+        "title": "n8n Agent: Select Reasoning Effort",
+        "icon": "$(settings-gear)"
+      },
+      {
         "command": "n8n.applySettings",
         "title": "Apply n8n Settings",
         "icon": "$(check)"
@@ -343,6 +348,19 @@
           "type": "string",
           "default": "",
           "description": "Optional OpenAI-compatible base URL for the embedded n8n Agent Workbench."
+        },
+        "n8n.agent.reasoningEffort": {
+          "type": "string",
+          "enum": [
+            "none",
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "default": "",
+          "description": "Optional reasoning effort override for eligible OpenAI account models used by the embedded n8n Agent Workbench. Leave empty to use the Yagr default."
         }
       }
     }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -368,7 +368,7 @@
   ],
   "dependencies": {
     "@n8n-as-code/manager-adapter": "0.1.0",
-    "@n8n-as-code/n8n-manager-core": "^0.5.3",
+    "@n8n-as-code/n8n-manager-core": "^0.6.0",
     "@n8n-as-code/skills": "1.10.0",
     "@n8n-as-code/telemetry": "0.1.0",
     "@n8n-as-code/workflow-core": "0.1.0",

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -24,9 +24,12 @@ import type { AgentWorkflowContext } from './services/agent-runtime-controller.j
 import {
     YagrProviderService,
     YAGR_PROVIDER_DEFINITIONS,
+    YAGR_REASONING_EFFORTS,
     YAGR_SELECTABLE_PROVIDERS,
     normalizeYagrProviderId,
+    providerSupportsReasoningEffort,
     type YagrModelProvider,
+    type YagrReasoningEffort,
 } from './services/yagr-provider-service.js';
 import {
     N8nConfigurationController,
@@ -838,6 +841,10 @@ async function openAgentWorkbench(context: vscode.ExtensionContext, workflow?: I
                 listWorkflows: listAgentWorkflowOptions,
                 resolveWorkflow: resolveAgentWorkflowTarget,
                 listWorkflowNodes: listAgentWorkflowNodes,
+                listProviderOptions: listAgentProviderOptions,
+                listModelOptions: listAgentModelOptions,
+                selectProviderModel: selectAgentProviderModel,
+                selectReasoningEffort: selectInlineAgentReasoningEffort,
             },
             initialSessionId,
             vscode.ViewColumn.One,
@@ -925,6 +932,60 @@ async function listAgentWorkflowNodes(workflowContext: AgentWorkflowContext): Pr
         result.push({ name, type: type || undefined, id: id || undefined });
     }
     return result;
+}
+
+async function listAgentProviderOptions(): Promise<Array<Record<string, unknown>>> {
+    const states = await requireYagrProviderService().listProviderConnectionStates();
+    return states.filter((state) => state.connected || state.selected).map((state) => ({
+        id: state.id,
+        label: state.label,
+        description: state.description,
+        connected: state.connected,
+        selected: state.selected,
+        model: state.model,
+        defaultModel: state.defaultModel,
+        supportsReasoningEffort: state.supportsReasoningEffort,
+    }));
+}
+
+async function listAgentModelOptions(providerId: string): Promise<Array<Record<string, unknown>>> {
+    const provider = normalizeYagrProviderId(providerId) || 'openai';
+    const definition = YAGR_PROVIDER_DEFINITIONS[provider];
+    const config = vscode.workspace.getConfiguration('n8n.agent');
+    const selectedProvider = normalizeYagrProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
+    const currentModel = String(config.get<string>('model') || '').trim() || definition.defaultModel;
+    const liveModels = await requireYagrProviderService().fetchAvailableModels(provider).catch(() => []);
+    return [...new Set([...(liveModels.length ? liveModels : []), definition.defaultModel, currentModel].filter(Boolean))]
+        .map((model) => ({
+            id: model,
+            label: model,
+            provider,
+            providerLabel: definition.label,
+            selected: provider === selectedProvider && model === currentModel,
+            fallback: !liveModels.length,
+        }));
+}
+
+async function selectAgentProviderModel(providerId: string, model: string): Promise<void> {
+    const provider = normalizeYagrProviderId(providerId) || 'openai';
+    const trimmedModel = model.trim() || YAGR_PROVIDER_DEFINITIONS[provider].defaultModel;
+    const config = vscode.workspace.getConfiguration('n8n.agent');
+    await config.update('provider', provider, vscode.ConfigurationTarget.Global);
+    await config.update('model', trimmedModel, vscode.ConfigurationTarget.Global);
+    await requireYagrProviderService().syncReasoningEffortConfiguration(provider, trimmedModel);
+}
+
+async function selectInlineAgentReasoningEffort(effort: string): Promise<void> {
+    const normalized = YAGR_REASONING_EFFORTS.includes(effort as YagrReasoningEffort) ? effort as YagrReasoningEffort : undefined;
+    if (!normalized) return;
+    const config = vscode.workspace.getConfiguration('n8n.agent');
+    const provider = normalizeYagrProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
+    const model = String(config.get<string>('model') || '').trim() || undefined;
+    if (!providerSupportsReasoningEffort(provider, model)) {
+        await config.update('reasoningEffort', undefined, vscode.ConfigurationTarget.Global);
+        return;
+    }
+    await config.update('reasoningEffort', normalized, vscode.ConfigurationTarget.Global);
 }
 
 function getSelectedAgentProviderModelLabel(): string {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -838,11 +838,15 @@ async function resolveWorkflowWebviewTarget(workflow: IWorkflowStatus): Promise<
         throw new Error(prepared.runtime.blocked.message);
     }
     const effective = prepared.context;
-    const proxyUrl = await proxyService.start(effective.apiBaseUrl ?? effective.host);
+    const n8nBaseUrl = effective.apiBaseUrl ?? effective.host;
+    const proxyUrl = await proxyService.start(n8nBaseUrl);
+    const workflowUrl = new URL(`/workflow/${encodeURIComponent(workflow.id)}`, n8nBaseUrl.endsWith('/') ? n8nBaseUrl : `${n8nBaseUrl}/`);
+    workflowUrl.searchParams.set('_n8nacBridge', String(Date.now()));
     const openTarget = await facade.resolveWorkflowWebviewOpen({
         workflowId: workflow.id,
         proxyBaseUrl: proxyUrl,
         workspaceRoot,
+        workflowUrl: workflowUrl.toString(),
     });
 
     if (openTarget.routePath && openTarget.autoLoginPageHtml) {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -14,14 +14,18 @@ import { AiContextGenerator, getN8nacDevConfigFilenames } from '@n8n-as-code/ski
 import { StatusBar } from './ui/status-bar.js';
 import { EnhancedWorkflowTreeProvider } from './ui/enhanced-workflow-tree-provider.js';
 import { WorkflowWebview } from './ui/workflow-webview.js';
+import { AgentWorkbenchWebview } from './ui/agent-workbench-webview.js';
+import { AgentManagerWebview } from './ui/agent-manager-webview.js';
 import { ConfigurationWebview } from './ui/configuration-webview.js';
 import { WorkflowDecorationProvider } from './ui/workflow-decoration-provider.js';
 
 import { ProxyService } from './services/proxy-service.js';
+import { AgentRuntimeController, getAgentProviderSecretKey } from './services/agent-runtime-controller.js';
 import {
     N8nConfigurationController,
     type N8nConfigurationChangeEvent,
 } from './services/n8n-configuration-controller.js';
+import { workflowWebviewRegistry } from './services/workflow-webview-registry.js';
 import { createN8nManagerFacade } from '@n8n-as-code/manager-adapter';
 import { createTelemetryClient, type TelemetryClient } from '@n8n-as-code/telemetry';
 import { ExtensionState } from './types.js';
@@ -75,6 +79,7 @@ let cli: CliApi | undefined;
 let initializingPromise: Promise<void> | undefined;
 let runtimeDisposables: vscode.Disposable[] = [];
 let configurationController: N8nConfigurationController | undefined;
+let agentRuntimeController: AgentRuntimeController | undefined;
 let suppressNextConfigurationReaction = false;
 let failedAutoInitRuntimeSignature: string | undefined;
 let failedAutoInitConnectionKey: string | undefined;
@@ -183,6 +188,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
     proxyService.setOutputChannel(outputChannel);
     proxyService.setSecrets(context.secrets);
+    agentRuntimeController = new AgentRuntimeController(context, outputChannel);
+    context.subscriptions.push(agentRuntimeController);
     configurationController = new N8nConfigurationController(outputChannel);
     context.subscriptions.push(
         configurationController,
@@ -284,6 +291,17 @@ export async function activate(context: vscode.ExtensionContext) {
             await openWorkflowBoard(wf, vscode.ViewColumn.Two);
         }),
 
+        registerTelemetryCommand('n8n.openAgentWorkbench', async (arg: any) => {
+            const wf = await resolveWorkflowForAgentWorkbench(arg);
+            if (!wf) return;
+            telemetryClient?.track('vscode_workflow_view_opened', { mode: 'agent-workbench', workflow_state: 'unknown' });
+            await openAgentWorkbench(context, wf);
+        }),
+
+        registerTelemetryCommand('n8n.openAgentManager', async () => {
+            AgentManagerWebview.createOrShow(context);
+        }),
+
         // n8nac push <path>
         registerTelemetryCommand('n8n.pushWorkflow', async (arg: any) => {
             if (enhancedTreeProvider.getExtensionState() === ExtensionState.SETTINGS_CHANGED) {
@@ -312,7 +330,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 const workflowId = updatedWorkflow?.id ?? pushedId ?? wf.id;
 
                 if (workflowId) {
-                    WorkflowWebview.reloadIfMatching(workflowId, outputChannel);
+                    workflowWebviewRegistry.reloadIfMatching(workflowId);
                 }
 
                 outputChannel.appendLine(`[n8n] Push successful: ${wf.name} (${workflowId ?? 'unknown id'})`);
@@ -512,6 +530,10 @@ export async function activate(context: vscode.ExtensionContext) {
             }
         }),
 
+        registerTelemetryCommand('n8n.agent.setApiKey', async () => {
+            await setAgentProviderApiKey(context);
+        }),
+
         registerTelemetryCommand('n8n.openSettings', () => {
             vscode.commands.executeCommand('workbench.action.openSettings', 'n8n');
         }),
@@ -556,7 +578,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 await new Promise(r => setTimeout(r, 500));
                 store.dispatch(setWorkflows(await cli.list()));
                 store.dispatch(removeConflict(id));
-                WorkflowWebview.reloadIfMatching(id, outputChannel);
+                workflowWebviewRegistry.reloadIfMatching(id);
                 vscode.window.showInformationMessage('✅ Pushed — remote overwritten with your local version.');
                 enhancedTreeProvider.refresh();
             } else if (choice === 'Keep Incoming (remote)') {
@@ -665,44 +687,107 @@ async function openWorkflowFromFinder(workflow: IWorkflowStatus): Promise<void> 
     vscode.window.showWarningMessage(`Cannot open workflow "${workflow.name}": no local file or remote ID is available.`);
 }
 
+async function resolveWorkflowForAgentWorkbench(arg: any): Promise<IWorkflowStatus | undefined> {
+    const workflow = findWorkflowByCommandArg(arg);
+    if (workflow) {
+        return workflow;
+    }
+
+    if (!cli) {
+        vscode.window.showWarningMessage('n8n as code is not initialized. Configure and initialize n8n before opening the Agent Workbench.');
+        return undefined;
+    }
+
+    const workflows = await cli.list({ fetchRemote: true, includeArchived: true });
+    if (!workflows.length) {
+        vscode.window.showInformationMessage('No workflows available for the Agent Workbench.');
+        return undefined;
+    }
+
+    store.dispatch(setWorkflows(workflows));
+    enhancedTreeProvider.refresh();
+
+    const picked = await vscode.window.showQuickPick(
+        buildWorkflowQuickPickItems(workflows),
+        {
+            title: `Open Agent Workbench (${workflows.length})`,
+            placeHolder: 'Select the workflow to inspect with the n8n agent',
+            ignoreFocusOut: true,
+            matchOnDescription: true,
+            matchOnDetail: true,
+        },
+    );
+
+    return picked?.workflow;
+}
+
 async function openWorkflowBoard(workflow: IWorkflowStatus, viewColumn?: vscode.ViewColumn): Promise<void> {
     if (!workflow.id) {
         vscode.window.showWarningMessage(`Cannot open workflow "${workflow.name}": no remote ID is available.`);
         return;
     }
 
-    const workspaceRoot = getWorkspaceRoot();
-    const facade = createN8nManagerFacade({ workspaceRoot });
     try {
-        const prepared = await facade.prepareEffectiveContext({
-            workspaceRoot,
-            syncFolderDefault: workspaceRoot ? 'workspace' : 'global',
-            consumer: 'vscode',
-            autoStart: true,
-        });
-        if (prepared.runtime.blocked) {
-            throw new Error(prepared.runtime.blocked.message);
-        }
-        const effective = prepared.context;
-        const proxyUrl = await proxyService.start(effective.apiBaseUrl ?? effective.host);
-        const openTarget = await facade.resolveWorkflowWebviewOpen({
-            workflowId: workflow.id,
-            proxyBaseUrl: proxyUrl,
-            workspaceRoot,
-        });
-
-        if (openTarget.routePath && openTarget.autoLoginPageHtml) {
-            proxyService.registerHtmlRoute(openTarget.routePath, openTarget.autoLoginPageHtml);
-            outputChannel.appendLine(`[n8n] Opening workflow ${workflow.id} through managed auto-login webview route.`);
-        } else {
-            outputChannel.appendLine(`[n8n] Opening workflow ${workflow.id} through direct webview route.`);
-        }
-
+        const openTarget = await resolveWorkflowWebviewTarget(workflow);
         WorkflowWebview.createOrShow(workflow, openTarget.url, viewColumn);
         registerClipboardHandler();
     } catch (e: any) {
         vscode.window.showErrorMessage(`Failed to open n8n workflow: ${e.message}`);
     }
+}
+
+async function openAgentWorkbench(context: vscode.ExtensionContext, workflow: IWorkflowStatus): Promise<void> {
+    if (!workflow.id) {
+        vscode.window.showWarningMessage(`Cannot open Agent Workbench for "${workflow.name}": no remote workflow ID is available.`);
+        return;
+    }
+
+    try {
+        const openTarget = await resolveWorkflowWebviewTarget(workflow);
+        AgentWorkbenchWebview.createOrShow(
+            context,
+            workflow,
+            openTarget.url,
+            requireAgentRuntimeController(),
+            vscode.ViewColumn.One,
+        );
+    } catch (e: any) {
+        vscode.window.showErrorMessage(`Failed to open n8n Agent Workbench: ${e.message}`);
+    }
+}
+
+async function resolveWorkflowWebviewTarget(workflow: IWorkflowStatus): Promise<{ url: string }> {
+    if (!workflow.id) {
+        throw new Error(`Workflow "${workflow.name}" does not have a remote ID.`);
+    }
+
+    const workspaceRoot = getWorkspaceRoot();
+    const facade = createN8nManagerFacade({ workspaceRoot });
+    const prepared = await facade.prepareEffectiveContext({
+        workspaceRoot,
+        syncFolderDefault: workspaceRoot ? 'workspace' : 'global',
+        consumer: 'vscode',
+        autoStart: true,
+    });
+    if (prepared.runtime.blocked) {
+        throw new Error(prepared.runtime.blocked.message);
+    }
+    const effective = prepared.context;
+    const proxyUrl = await proxyService.start(effective.apiBaseUrl ?? effective.host);
+    const openTarget = await facade.resolveWorkflowWebviewOpen({
+        workflowId: workflow.id,
+        proxyBaseUrl: proxyUrl,
+        workspaceRoot,
+    });
+
+    if (openTarget.routePath && openTarget.autoLoginPageHtml) {
+        proxyService.registerHtmlRoute(openTarget.routePath, openTarget.autoLoginPageHtml);
+        outputChannel.appendLine(`[n8n] Opening workflow ${workflow.id} through managed auto-login webview route.`);
+    } else {
+        outputChannel.appendLine(`[n8n] Opening workflow ${workflow.id} through direct webview route.`);
+    }
+
+    return { url: openTarget.url };
 }
 
 function updateContextKeys() {
@@ -716,6 +801,66 @@ function requireConfigurationController(): N8nConfigurationController {
         throw new Error('n8n configuration controller is not initialized.');
     }
     return configurationController;
+}
+
+function requireAgentRuntimeController(): AgentRuntimeController {
+    if (!agentRuntimeController) {
+        throw new Error('n8n agent runtime controller is not initialized.');
+    }
+    return agentRuntimeController;
+}
+
+type AgentProviderId = 'anthropic' | 'openai' | 'google' | 'mistral' | 'openrouter' | 'openai-compatible';
+
+const AGENT_PROVIDER_ITEMS: Array<vscode.QuickPickItem & { provider: AgentProviderId }> = [
+    { provider: 'anthropic', label: 'Anthropic', description: 'ANTHROPIC_API_KEY' },
+    { provider: 'openai', label: 'OpenAI', description: 'OPENAI_API_KEY' },
+    { provider: 'google', label: 'Google Gemini', description: 'GOOGLE_GENERATIVE_AI_API_KEY' },
+    { provider: 'mistral', label: 'Mistral', description: 'MISTRAL_API_KEY' },
+    { provider: 'openrouter', label: 'OpenRouter', description: 'OPENROUTER_API_KEY' },
+    { provider: 'openai-compatible', label: 'OpenAI Compatible', description: 'OPENAI_COMPATIBLE_API_KEY' },
+];
+
+async function setAgentProviderApiKey(context: vscode.ExtensionContext): Promise<void> {
+    const config = vscode.workspace.getConfiguration('n8n.agent');
+    const currentProvider = String(config.get<string>('provider') || 'openai');
+    const picked = await vscode.window.showQuickPick(
+        AGENT_PROVIDER_ITEMS.map((item) => ({
+            ...item,
+            picked: item.provider === currentProvider,
+        })),
+        {
+            title: 'Select n8n Agent provider',
+            placeHolder: 'Provider API keys are stored in VS Code Secret Storage',
+            ignoreFocusOut: true,
+        },
+    );
+
+    if (!picked) {
+        return;
+    }
+
+    const apiKey = await vscode.window.showInputBox({
+        title: `Set ${picked.label} API key for n8n Agent`,
+        prompt: 'The key is stored in VS Code Secret Storage and is never sent to the webview.',
+        password: true,
+        ignoreFocusOut: true,
+    });
+
+    if (apiKey === undefined) {
+        return;
+    }
+
+    const trimmed = apiKey.trim();
+    if (!trimmed) {
+        await context.secrets.delete(getAgentProviderSecretKey(picked.provider));
+        vscode.window.showInformationMessage(`Cleared n8n Agent API key for ${picked.label}.`);
+        return;
+    }
+
+    await context.secrets.store(getAgentProviderSecretKey(picked.provider), trimmed);
+    await config.update('provider', picked.provider, vscode.ConfigurationTarget.Global);
+    vscode.window.showInformationMessage(`Stored n8n Agent API key for ${picked.label}.`);
 }
 
 function getAutoInitConnectionKey(workspaceRoot?: string): string {
@@ -1461,7 +1606,7 @@ async function initializeSyncManager(context: vscode.ExtensionContext) {
     });
 
     syncManager.on('remote-updated', (data: { workflowId: string; filename: string }) => {
-        WorkflowWebview.reloadIfMatching(data.workflowId, outputChannel);
+        workflowWebviewRegistry.reloadIfMatching(data.workflowId);
     });
 
     // ── Lightweight UI watchers ──────────────────────────────────────────────
@@ -1521,7 +1666,7 @@ async function initializeSyncManager(context: vscode.ExtensionContext) {
                 for (const [id, entry] of Object.entries(state.workflows ?? {})) {
                     if (entry.lastSyncedAt && entry.lastSyncedAt !== stateSnapshot.get(id)) {
                         stateSnapshot.set(id, entry.lastSyncedAt);
-                        WorkflowWebview.reloadIfMatching(id, outputChannel);
+                        workflowWebviewRegistry.reloadIfMatching(id);
                     }
                 }
             } catch (err) {
@@ -1597,6 +1742,8 @@ async function reinitializeSyncManager(
 
 export async function deactivate(): Promise<void> {
     await telemetryClient?.flush(1000);
+    agentRuntimeController?.dispose();
+    agentRuntimeController = undefined;
     disposeRuntimeDisposables();
     proxyService.stop();
 }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -809,6 +809,7 @@ async function openAgentWorkbench(context: vscode.ExtensionContext, workflow?: I
             context,
             workflow,
             openTarget?.url,
+            openTarget?.targetUrl,
             requireAgentRuntimeController(),
             vscode.ViewColumn.One,
         );
@@ -820,7 +821,7 @@ async function openAgentWorkbench(context: vscode.ExtensionContext, workflow?: I
     }
 }
 
-async function resolveWorkflowWebviewTarget(workflow: IWorkflowStatus): Promise<{ url: string }> {
+async function resolveWorkflowWebviewTarget(workflow: IWorkflowStatus): Promise<{ url: string; targetUrl: string }> {
     if (!workflow.id) {
         throw new Error(`Workflow "${workflow.name}" does not have a remote ID.`);
     }
@@ -851,7 +852,7 @@ async function resolveWorkflowWebviewTarget(workflow: IWorkflowStatus): Promise<
         outputChannel.appendLine(`[n8n] Opening workflow ${workflow.id} through direct webview route.`);
     }
 
-    return { url: openTarget.url };
+    return { url: openTarget.url, targetUrl: openTarget.targetUrl };
 }
 
 function updateContextKeys() {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1634,14 +1634,9 @@ async function initializeSyncManager(context: vscode.ExtensionContext) {
     try {
         const resolution = await resolveInstanceIdentifier(credentials, {
             client,
-            throwOnConnectionError: true
         });
         instanceIdentifier = resolution.identifier;
-        outputChannel.appendLine(
-            resolution.usedFallback
-                ? `[n8n] Instance identifier (fallback): ${instanceIdentifier}`
-                : `[n8n] Instance identifier: ${instanceIdentifier}`
-        );
+        outputChannel.appendLine(`[n8n] Instance identifier: ${instanceIdentifier}`);
         const currentIdentifier = effective.instance.instanceIdentifier;
         if (!isCanonicalUserInstanceIdentifier(currentIdentifier)) {
             await facade.upsertInstance({

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -805,11 +805,13 @@ async function resolveWorkflowForSplitView(arg: any): Promise<IWorkflowStatus | 
 async function openAgentWorkbench(context: vscode.ExtensionContext, workflow?: IWorkflowStatus): Promise<void> {
     try {
         const openTarget = workflow?.id ? await resolveWorkflowWebviewTarget(workflow) : undefined;
+        const providerModelLabel = getSelectedAgentProviderModelLabel();
         AgentWorkbenchWebview.createOrShow(
             context,
             workflow,
             openTarget?.url,
             openTarget?.targetUrl,
+            providerModelLabel,
             requireAgentRuntimeController(),
             vscode.ViewColumn.One,
         );
@@ -819,6 +821,13 @@ async function openAgentWorkbench(context: vscode.ExtensionContext, workflow?: I
     } catch (e: any) {
         vscode.window.showErrorMessage(`Failed to open n8n Agent Workbench: ${e.message}`);
     }
+}
+
+function getSelectedAgentProviderModelLabel(): string {
+    const config = vscode.workspace.getConfiguration('n8n.agent');
+    const provider = String(config.get<string>('provider') || 'openai').trim() || 'openai';
+    const model = String(config.get<string>('model') || '').trim();
+    return model ? `${provider} / ${model}` : provider;
 }
 
 async function resolveWorkflowWebviewTarget(workflow: IWorkflowStatus): Promise<{ url: string; targetUrl: string }> {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -7,7 +7,7 @@ declare const __N8NAC_VERSION__: string;
 declare const __N8NAC_CLI_SEMVER__: string;
 import {
     SyncManager, CliApi, N8nApiClient, IN8nCredentials, WorkflowSyncStatus, ConfigService,
-    resolveInstanceIdentifier
+    resolveInstanceIdentifier, isLegacyLocalInstanceIdentifier
 } from 'n8nac';
 import { AiContextGenerator, getN8nacDevConfigFilenames } from '@n8n-as-code/skills';
 
@@ -15,7 +15,6 @@ import { StatusBar } from './ui/status-bar.js';
 import { EnhancedWorkflowTreeProvider } from './ui/enhanced-workflow-tree-provider.js';
 import { WorkflowWebview } from './ui/workflow-webview.js';
 import { AgentWorkbenchWebview } from './ui/agent-workbench-webview.js';
-import { AgentManagerWebview } from './ui/agent-manager-webview.js';
 import { ConfigurationWebview } from './ui/configuration-webview.js';
 import { WorkflowDecorationProvider } from './ui/workflow-decoration-provider.js';
 
@@ -312,12 +311,12 @@ export async function activate(context: vscode.ExtensionContext) {
         registerTelemetryCommand('n8n.openAgentWorkbench', async (arg: any) => {
             const wf = await resolveWorkflowForAgentWorkbench(arg);
             if (!wf) return;
-            telemetryClient?.track('vscode_workflow_view_opened', { mode: 'agent-workbench', workflow_state: 'unknown' });
-            await openAgentWorkbench(context, wf);
+            telemetryClient?.track('vscode_workflow_view_opened', { mode: 'agent-workbench', workflow_state: wf === 'new' ? 'new' : 'unknown' });
+            await openAgentWorkbench(context, wf === 'new' ? undefined : wf);
         }),
 
         registerTelemetryCommand('n8n.openAgentManager', async () => {
-            AgentManagerWebview.createOrShow(context);
+            ConfigurationWebview.createOrShow(context, requireConfigurationController(), 'agent-providers');
         }),
 
         registerTelemetryCommand('n8n.agent.setupProvider', async () => {
@@ -713,7 +712,9 @@ async function openWorkflowFromFinder(workflow: IWorkflowStatus): Promise<void> 
     vscode.window.showWarningMessage(`Cannot open workflow "${workflow.name}": no local file or remote ID is available.`);
 }
 
-async function resolveWorkflowForAgentWorkbench(arg: any): Promise<IWorkflowStatus | undefined> {
+type AgentWorkbenchTarget = IWorkflowStatus | 'new';
+
+async function resolveWorkflowForAgentWorkbench(arg: any): Promise<AgentWorkbenchTarget | undefined> {
     const workflow = findWorkflowByCommandArg(arg);
     if (workflow) {
         return workflow;
@@ -725,19 +726,24 @@ async function resolveWorkflowForAgentWorkbench(arg: any): Promise<IWorkflowStat
     }
 
     const workflows = await cli.list({ fetchRemote: true, includeArchived: true });
-    if (!workflows.length) {
-        vscode.window.showInformationMessage('No workflows available for the Agent Workbench.');
-        return undefined;
+    if (workflows.length) {
+        store.dispatch(setWorkflows(workflows));
+        enhancedTreeProvider.refresh();
     }
 
-    store.dispatch(setWorkflows(workflows));
-    enhancedTreeProvider.refresh();
-
     const picked = await vscode.window.showQuickPick(
-        buildWorkflowQuickPickItems(workflows),
+        [
+            {
+                label: 'New workflow chat',
+                description: 'Start without an attached workflow',
+                detail: 'Use this to design and create a new n8n workflow with the agent.',
+                workflow: 'new' as const,
+            },
+            ...buildWorkflowQuickPickItems(workflows),
+        ],
         {
-            title: `Open Agent Workbench (${workflows.length})`,
-            placeHolder: 'Select the workflow to inspect with the n8n agent',
+            title: `Open Agent Workbench${workflows.length ? ` (${workflows.length})` : ''}`,
+            placeHolder: 'Start new workflow chat or select an existing workflow',
             ignoreFocusOut: true,
             matchOnDescription: true,
             matchOnDetail: true,
@@ -796,22 +802,19 @@ async function resolveWorkflowForSplitView(arg: any): Promise<IWorkflowStatus | 
     return picked?.workflow;
 }
 
-async function openAgentWorkbench(context: vscode.ExtensionContext, workflow: IWorkflowStatus): Promise<void> {
-    if (!workflow.id) {
-        vscode.window.showWarningMessage(`Cannot open Agent Workbench for "${workflow.name}": no remote workflow ID is available.`);
-        return;
-    }
-
+async function openAgentWorkbench(context: vscode.ExtensionContext, workflow?: IWorkflowStatus): Promise<void> {
     try {
-        const openTarget = await resolveWorkflowWebviewTarget(workflow);
+        const openTarget = workflow?.id ? await resolveWorkflowWebviewTarget(workflow) : undefined;
         AgentWorkbenchWebview.createOrShow(
             context,
             workflow,
-            openTarget.url,
+            openTarget?.url,
             requireAgentRuntimeController(),
             vscode.ViewColumn.One,
         );
-        registerClipboardHandler();
+        if (openTarget?.url) {
+            registerClipboardHandler();
+        }
     } catch (e: any) {
         vscode.window.showErrorMessage(`Failed to open n8n Agent Workbench: ${e.message}`);
     }
@@ -1639,6 +1642,13 @@ async function initializeSyncManager(context: vscode.ExtensionContext) {
                 ? `[n8n] Instance identifier (fallback): ${instanceIdentifier}`
                 : `[n8n] Instance identifier: ${instanceIdentifier}`
         );
+        const currentIdentifier = effective.instance.instanceIdentifier;
+        if (!currentIdentifier || isLegacyLocalInstanceIdentifier(currentIdentifier)) {
+            await facade.upsertInstance({
+                id: effective.activeInstanceId,
+                instanceIdentifier,
+            }, { setActive: false });
+        }
     } catch (error: any) {
         throw new Error(`Cannot connect to n8n instance at "${host}". Please check if n8n is running.`);
     }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -20,7 +20,14 @@ import { ConfigurationWebview } from './ui/configuration-webview.js';
 import { WorkflowDecorationProvider } from './ui/workflow-decoration-provider.js';
 
 import { ProxyService } from './services/proxy-service.js';
-import { AgentRuntimeController, getAgentProviderSecretKey } from './services/agent-runtime-controller.js';
+import { AgentRuntimeController } from './services/agent-runtime-controller.js';
+import {
+    YagrProviderService,
+    YAGR_PROVIDER_DEFINITIONS,
+    YAGR_SELECTABLE_PROVIDERS,
+    normalizeYagrProviderId,
+    type YagrModelProvider,
+} from './services/yagr-provider-service.js';
 import {
     N8nConfigurationController,
     type N8nConfigurationChangeEvent,
@@ -89,6 +96,7 @@ let initializingPromise: Promise<void> | undefined;
 let runtimeDisposables: vscode.Disposable[] = [];
 let configurationController: N8nConfigurationController | undefined;
 let agentRuntimeController: AgentRuntimeController | undefined;
+let yagrProviderService: YagrProviderService | undefined;
 let suppressNextConfigurationReaction = false;
 let failedAutoInitRuntimeSignature: string | undefined;
 let failedAutoInitConnectionKey: string | undefined;
@@ -198,6 +206,7 @@ export async function activate(context: vscode.ExtensionContext) {
     proxyService.setOutputChannel(outputChannel);
     proxyService.setSecrets(context.secrets);
     agentRuntimeController = new AgentRuntimeController(context, outputChannel);
+    yagrProviderService = new YagrProviderService(context);
     context.subscriptions.push(agentRuntimeController);
     configurationController = new N8nConfigurationController(outputChannel);
     context.subscriptions.push(
@@ -285,7 +294,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }),
 
         registerTelemetryCommand('n8n.openSplit', async (arg: any) => {
-            const wf = arg?.workflow ? arg.workflow : arg;
+            const wf = await resolveWorkflowForSplitView(arg);
             if (!wf || !syncManager) return;
             telemetryClient?.track('vscode_workflow_view_opened', { mode: 'split', workflow_state: 'unknown' });
             const uri = getExistingWorkflowFileUri(wf);
@@ -309,6 +318,14 @@ export async function activate(context: vscode.ExtensionContext) {
 
         registerTelemetryCommand('n8n.openAgentManager', async () => {
             AgentManagerWebview.createOrShow(context);
+        }),
+
+        registerTelemetryCommand('n8n.agent.setupProvider', async () => {
+            await setupAgentProvider(context);
+        }),
+
+        registerTelemetryCommand('n8n.agent.selectModel', async () => {
+            await selectAgentModel();
         }),
 
         // n8nac push <path>
@@ -745,6 +762,40 @@ async function openWorkflowBoard(workflow: IWorkflowStatus, viewColumn?: vscode.
     }
 }
 
+async function resolveWorkflowForSplitView(arg: any): Promise<IWorkflowStatus | undefined> {
+    const workflow = findWorkflowByCommandArg(arg);
+    if (workflow) {
+        return workflow;
+    }
+
+    if (!cli) {
+        vscode.window.showWarningMessage('n8n as code is not initialized. Configure and initialize n8n before opening Split View.');
+        return undefined;
+    }
+
+    const workflows = await cli.list({ fetchRemote: true, includeArchived: true });
+    if (!workflows.length) {
+        vscode.window.showInformationMessage('No workflows available for Split View.');
+        return undefined;
+    }
+
+    store.dispatch(setWorkflows(workflows));
+    enhancedTreeProvider.refresh();
+
+    const picked = await vscode.window.showQuickPick(
+        buildWorkflowQuickPickItems(workflows),
+        {
+            title: `Open Split View (${workflows.length})`,
+            placeHolder: 'Select the workflow to open as JSON plus n8n board',
+            ignoreFocusOut: true,
+            matchOnDescription: true,
+            matchOnDetail: true,
+        },
+    );
+
+    return picked?.workflow;
+}
+
 async function openAgentWorkbench(context: vscode.ExtensionContext, workflow: IWorkflowStatus): Promise<void> {
     if (!workflow.id) {
         vscode.window.showWarningMessage(`Cannot open Agent Workbench for "${workflow.name}": no remote workflow ID is available.`);
@@ -820,28 +871,36 @@ function requireAgentRuntimeController(): AgentRuntimeController {
     return agentRuntimeController;
 }
 
-type AgentProviderId = 'anthropic' | 'openai' | 'google' | 'mistral' | 'openrouter' | 'openai-compatible';
-
-const AGENT_PROVIDER_ITEMS: Array<vscode.QuickPickItem & { provider: AgentProviderId }> = [
-    { provider: 'anthropic', label: 'Anthropic', description: 'ANTHROPIC_API_KEY' },
-    { provider: 'openai', label: 'OpenAI', description: 'OPENAI_API_KEY' },
-    { provider: 'google', label: 'Google Gemini', description: 'GOOGLE_GENERATIVE_AI_API_KEY' },
-    { provider: 'mistral', label: 'Mistral', description: 'MISTRAL_API_KEY' },
-    { provider: 'openrouter', label: 'OpenRouter', description: 'OPENROUTER_API_KEY' },
-    { provider: 'openai-compatible', label: 'OpenAI Compatible', description: 'OPENAI_COMPATIBLE_API_KEY' },
-];
+function requireYagrProviderService(): YagrProviderService {
+    if (!yagrProviderService) {
+        throw new Error('n8n Yagr provider service is not initialized.');
+    }
+    return yagrProviderService;
+}
 
 async function setAgentProviderApiKey(context: vscode.ExtensionContext): Promise<void> {
+    await setupAgentProvider(context);
+}
+
+async function setupAgentProvider(context: vscode.ExtensionContext): Promise<void> {
+    const service = requireYagrProviderService();
     const config = vscode.workspace.getConfiguration('n8n.agent');
-    const currentProvider = String(config.get<string>('provider') || 'openai');
+    const currentProvider = normalizeYagrProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
     const picked = await vscode.window.showQuickPick(
-        AGENT_PROVIDER_ITEMS.map((item) => ({
-            ...item,
-            picked: item.provider === currentProvider,
+        YAGR_SELECTABLE_PROVIDERS.map((provider) => ({
+            provider,
+            label: YAGR_PROVIDER_DEFINITIONS[provider].label,
+            description: YAGR_PROVIDER_DEFINITIONS[provider].description,
+            detail: YAGR_PROVIDER_DEFINITIONS[provider].authKind === 'oauth-device'
+                ? 'OAuth device flow'
+                : YAGR_PROVIDER_DEFINITIONS[provider].requiresApiKey
+                    ? 'API key'
+                    : 'Account credential',
+            picked: provider === currentProvider,
         })),
         {
-            title: 'Select n8n Agent provider',
-            placeHolder: 'Provider API keys are stored in VS Code Secret Storage',
+            title: 'Set up n8n Agent provider',
+            placeHolder: 'Providers and credentials are stored separately; model selection is fetched live.',
             ignoreFocusOut: true,
         },
     );
@@ -850,27 +909,41 @@ async function setAgentProviderApiKey(context: vscode.ExtensionContext): Promise
         return;
     }
 
-    const apiKey = await vscode.window.showInputBox({
-        title: `Set ${picked.label} API key for n8n Agent`,
-        prompt: 'The key is stored in VS Code Secret Storage and is never sent to the webview.',
-        password: true,
-        ignoreFocusOut: true,
-    });
-
-    if (apiKey === undefined) {
-        return;
+    try {
+        const configured = await service.setupProvider(picked.provider as YagrModelProvider);
+        if (!configured) return;
+        await service.selectModel(picked.provider as YagrModelProvider);
+        vscode.window.showInformationMessage(`Configured n8n Agent provider: ${picked.label}.`);
+    } catch (error: any) {
+        vscode.window.showErrorMessage(`Provider setup failed: ${error?.message || String(error)}`);
     }
+}
 
-    const trimmed = apiKey.trim();
-    await config.update('provider', picked.provider, vscode.ConfigurationTarget.Global);
-    if (!trimmed) {
-        await context.secrets.delete(getAgentProviderSecretKey(picked.provider));
-        vscode.window.showInformationMessage(`Cleared n8n Agent API key for ${picked.label}.`);
-        return;
+async function selectAgentModel(): Promise<void> {
+    const service = requireYagrProviderService();
+    const config = vscode.workspace.getConfiguration('n8n.agent');
+    const currentProvider = normalizeYagrProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
+    const pickedProvider = await vscode.window.showQuickPick(
+        YAGR_SELECTABLE_PROVIDERS.map((provider) => ({
+            provider,
+            label: YAGR_PROVIDER_DEFINITIONS[provider].label,
+            description: YAGR_PROVIDER_DEFINITIONS[provider].description,
+            picked: provider === currentProvider,
+        })),
+        {
+            title: 'Select provider for this n8n Agent session',
+            placeHolder: 'Choose a configured provider, then choose a live model.',
+            ignoreFocusOut: true,
+        },
+    );
+    if (!pickedProvider) return;
+    const provider = pickedProvider.provider as YagrModelProvider;
+    try {
+        await config.update('provider', provider, vscode.ConfigurationTarget.Global);
+        await service.selectModel(provider);
+    } catch (error: any) {
+        vscode.window.showErrorMessage(`Model selection failed: ${error?.message || String(error)}`);
     }
-
-    await context.secrets.store(getAgentProviderSecretKey(picked.provider), trimmed);
-    vscode.window.showInformationMessage(`Stored n8n Agent API key for ${picked.label}.`);
 }
 
 function getAutoInitConnectionKey(workspaceRoot?: string): string {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -359,7 +359,8 @@ export async function activate(context: vscode.ExtensionContext) {
                 const workflowId = updatedWorkflow?.id ?? pushedId ?? wf.id;
 
                 if (workflowId) {
-                    workflowWebviewRegistry.reloadIfMatching(workflowId);
+                    const reloaded = workflowWebviewRegistry.reloadIfMatching(workflowId);
+                    outputChannel.appendLine(`[n8n-agent-debug] command push reload workflowId=${workflowId} filename=${wf.filename} reloaded=${reloaded}`);
                 }
 
                 outputChannel.appendLine(`[n8n] Push successful: ${wf.name} (${workflowId ?? 'unknown id'})`);
@@ -819,6 +820,7 @@ async function openAgentWorkbench(context: vscode.ExtensionContext, workflow?: I
             openTarget?.targetUrl,
             providerModelLabel,
             requireAgentRuntimeController(),
+            outputChannel,
             vscode.ViewColumn.One,
         );
         if (openTarget?.url) {
@@ -1726,7 +1728,8 @@ async function initializeSyncManager(context: vscode.ExtensionContext) {
     });
 
     syncManager.on('remote-updated', (data: { workflowId: string; filename: string }) => {
-        workflowWebviewRegistry.reloadIfMatching(data.workflowId);
+        const reloaded = workflowWebviewRegistry.reloadIfMatching(data.workflowId);
+        outputChannel.appendLine(`[n8n-agent-debug] syncManager remote-updated workflowId=${data.workflowId} filename=${data.filename} reloaded=${reloaded}`);
     });
 
     // ── Lightweight UI watchers ──────────────────────────────────────────────
@@ -1775,6 +1778,7 @@ async function initializeSyncManager(context: vscode.ExtensionContext) {
         stateWatcher.onDidChange(async (changedUri) => {
             if (!cli) return;
             try {
+                outputChannel.appendLine(`[n8n-agent-debug] stateWatcher change path=${changedUri.fsPath}`);
                 store.dispatch(setWorkflows(await cli.list()));
                 enhancedTreeProvider.refresh();
                 // Only reload the webview if the currently displayed workflow was affected.
@@ -1786,7 +1790,8 @@ async function initializeSyncManager(context: vscode.ExtensionContext) {
                 for (const [id, entry] of Object.entries(state.workflows ?? {})) {
                     if (entry.lastSyncedAt && entry.lastSyncedAt !== stateSnapshot.get(id)) {
                         stateSnapshot.set(id, entry.lastSyncedAt);
-                        workflowWebviewRegistry.reloadIfMatching(id);
+                        const reloaded = workflowWebviewRegistry.reloadIfMatching(id);
+                        outputChannel.appendLine(`[n8n-agent-debug] stateWatcher changed workflowId=${id} lastSyncedAt=${entry.lastSyncedAt} reloaded=${reloaded}`);
                     }
                 }
             } catch (err) {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -7,7 +7,7 @@ declare const __N8NAC_VERSION__: string;
 declare const __N8NAC_CLI_SEMVER__: string;
 import {
     SyncManager, CliApi, N8nApiClient, IN8nCredentials, WorkflowSyncStatus, ConfigService,
-    resolveInstanceIdentifier, isLegacyLocalInstanceIdentifier
+    resolveInstanceIdentifier, isCanonicalUserInstanceIdentifier
 } from 'n8nac';
 import { AiContextGenerator, getN8nacDevConfigFilenames } from '@n8n-as-code/skills';
 
@@ -1643,7 +1643,7 @@ async function initializeSyncManager(context: vscode.ExtensionContext) {
                 : `[n8n] Instance identifier: ${instanceIdentifier}`
         );
         const currentIdentifier = effective.instance.instanceIdentifier;
-        if (!currentIdentifier || isLegacyLocalInstanceIdentifier(currentIdentifier)) {
+        if (!isCanonicalUserInstanceIdentifier(currentIdentifier)) {
             await facade.upsertInstance({
                 id: effective.activeInstanceId,
                 instanceIdentifier,

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -52,7 +52,7 @@ import {
 
 // ------- Clipboard bridge for macOS -------
 /**
- * Register the clipboard paste handler on the current WorkflowWebview panel.
+ * Register the clipboard paste handler on n8n iframe host panels.
  * Only active on macOS where Electron intercepts Cmd+V at the native menu level.
  * When the n8n iframe intercepts Cmd+V, it sends a postMessage chain up to the
  * extension host. This handler reads the system clipboard and sends the text
@@ -61,6 +61,15 @@ import {
 function registerClipboardHandler(): void {
     if (!isClipboardBridgeRequired()) return;
     WorkflowWebview.onClipboardPasteRequest(async (panel, grantToken) => {
+        try {
+            const text = await vscode.env.clipboard.readText();
+            panel.webview.postMessage({ type: 'clipboard-paste', text, grantToken });
+        } catch (error) {
+            console.error('[Clipboard] Failed to read clipboard for paste request', error);
+            panel.webview.postMessage({ type: 'clipboard-error', grantToken });
+        }
+    });
+    AgentWorkbenchWebview.onClipboardPasteRequest(async (panel, grantToken) => {
         try {
             const text = await vscode.env.clipboard.readText();
             panel.webview.postMessage({ type: 'clipboard-paste', text, grantToken });
@@ -751,6 +760,7 @@ async function openAgentWorkbench(context: vscode.ExtensionContext, workflow: IW
             requireAgentRuntimeController(),
             vscode.ViewColumn.One,
         );
+        registerClipboardHandler();
     } catch (e: any) {
         vscode.window.showErrorMessage(`Failed to open n8n Agent Workbench: ${e.message}`);
     }
@@ -852,6 +862,7 @@ async function setAgentProviderApiKey(context: vscode.ExtensionContext): Promise
     }
 
     const trimmed = apiKey.trim();
+    await config.update('provider', picked.provider, vscode.ConfigurationTarget.Global);
     if (!trimmed) {
         await context.secrets.delete(getAgentProviderSecretKey(picked.provider));
         vscode.window.showInformationMessage(`Cleared n8n Agent API key for ${picked.label}.`);
@@ -859,7 +870,6 @@ async function setAgentProviderApiKey(context: vscode.ExtensionContext): Promise
     }
 
     await context.secrets.store(getAgentProviderSecretKey(picked.provider), trimmed);
-    await config.update('provider', picked.provider, vscode.ConfigurationTarget.Global);
     vscode.window.showInformationMessage(`Stored n8n Agent API key for ${picked.label}.`);
 }
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -20,6 +20,7 @@ import { WorkflowDecorationProvider } from './ui/workflow-decoration-provider.js
 
 import { ProxyService } from './services/proxy-service.js';
 import { AgentRuntimeController } from './services/agent-runtime-controller.js';
+import type { AgentWorkflowContext } from './services/agent-runtime-controller.js';
 import {
     YagrProviderService,
     YAGR_PROVIDER_DEFINITIONS,
@@ -309,10 +310,22 @@ export async function activate(context: vscode.ExtensionContext) {
         }),
 
         registerTelemetryCommand('n8n.openAgentWorkbench', async (arg: any) => {
-            const wf = await resolveWorkflowForAgentWorkbench(arg);
-            if (!wf) return;
-            telemetryClient?.track('vscode_workflow_view_opened', { mode: 'agent-workbench', workflow_state: wf === 'new' ? 'new' : 'unknown' });
-            await openAgentWorkbench(context, wf === 'new' ? undefined : wf);
+            const runtime = requireAgentRuntimeController();
+            const wf = findWorkflowByCommandArg(arg);
+            if (wf) {
+                const sessionId = await getOrCreateAgentSessionForWorkflow(wf);
+                telemetryClient?.track('vscode_workflow_view_opened', { mode: 'agent-workbench', workflow_state: 'workflow-context' });
+                await openAgentWorkbench(context, wf, sessionId);
+                return;
+            }
+            if (arg === 'new') {
+                const state = await runtime.createSession({ workspaceRoot: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath });
+                telemetryClient?.track('vscode_workflow_view_opened', { mode: 'agent-workbench', workflow_state: 'new' });
+                await openAgentWorkbench(context, undefined, state.activeSessionId);
+                return;
+            }
+            telemetryClient?.track('vscode_workflow_view_opened', { mode: 'agent-workbench', workflow_state: 'latest' });
+            await openAgentWorkbench(context, undefined, await runtime.getLatestSessionId());
         }),
 
         registerTelemetryCommand('n8n.openAgentManager', async () => {
@@ -807,7 +820,7 @@ async function resolveWorkflowForSplitView(arg: any): Promise<IWorkflowStatus | 
     return picked?.workflow;
 }
 
-async function openAgentWorkbench(context: vscode.ExtensionContext, workflow?: IWorkflowStatus): Promise<void> {
+async function openAgentWorkbench(context: vscode.ExtensionContext, workflow?: IWorkflowStatus, initialSessionId?: string): Promise<void> {
     try {
         const openTarget = workflow?.id ? await resolveWorkflowWebviewTarget(workflow) : undefined;
         const workflowFilePath = workflow ? getExistingWorkflowFileUri(workflow)?.fsPath : undefined;
@@ -821,6 +834,12 @@ async function openAgentWorkbench(context: vscode.ExtensionContext, workflow?: I
             providerModelLabel,
             requireAgentRuntimeController(),
             outputChannel,
+            {
+                listWorkflows: listAgentWorkflowOptions,
+                resolveWorkflow: resolveAgentWorkflowTarget,
+                listWorkflowNodes: listAgentWorkflowNodes,
+            },
+            initialSessionId,
             vscode.ViewColumn.One,
         );
         if (openTarget?.url) {
@@ -829,6 +848,83 @@ async function openAgentWorkbench(context: vscode.ExtensionContext, workflow?: I
     } catch (e: any) {
         vscode.window.showErrorMessage(`Failed to open n8n Agent Workbench: ${e.message}`);
     }
+}
+
+async function getOrCreateAgentSessionForWorkflow(workflow: IWorkflowStatus): Promise<string> {
+    const workflowFilePath = getExistingWorkflowFileUri(workflow)?.fsPath;
+    const workflowContext: AgentWorkflowContext = {
+        id: workflow.id || undefined,
+        name: workflow.name || workflow.id || workflow.filename || 'Workflow',
+        filename: workflow.filename || undefined,
+        filePath: workflowFilePath,
+    };
+    const runtime = requireAgentRuntimeController();
+    const existingSessionId = await runtime.getLatestSessionIdForWorkflow(workflowContext);
+    if (existingSessionId) return existingSessionId;
+    return runtime.createSessionForWorkflow(workflowContext, {
+        workflowId: workflow.id || undefined,
+        workflowName: workflow.name,
+        workflowFilename: workflow.filename,
+        workflowFilePath,
+        workspaceRoot: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+    });
+}
+
+async function listAgentWorkflowOptions(): Promise<IWorkflowStatus[]> {
+    if (cli) {
+        const workflows = await cli.list({ fetchRemote: true, includeArchived: true });
+        store.dispatch(setWorkflows(workflows));
+        enhancedTreeProvider.refresh();
+        return workflows;
+    }
+    return selectAllWorkflows(store.getState());
+}
+
+async function resolveAgentWorkflowTarget(workflowContext: AgentWorkflowContext): Promise<{ workflow?: IWorkflowStatus; workflowFilePath?: string; workflowUrl?: string; workflowReloadUrl?: string }> {
+    const workflows = await listAgentWorkflowOptions();
+    const workflow = workflows.find((candidate) => (
+        Boolean(workflowContext.id && candidate.id === workflowContext.id)
+        || Boolean(workflowContext.filename && candidate.filename === workflowContext.filename)
+        || candidate.name === workflowContext.name
+    ));
+    const effectiveWorkflow = workflow || ({
+        id: workflowContext.id || '',
+        name: workflowContext.name,
+        filename: workflowContext.filename || '',
+    } as IWorkflowStatus);
+    const workflowFilePath = getExistingWorkflowFileUri(effectiveWorkflow)?.fsPath || workflowContext.filePath;
+    if (!effectiveWorkflow.id) {
+        return { workflow: effectiveWorkflow, workflowFilePath };
+    }
+    try {
+        const openTarget = await resolveWorkflowWebviewTarget(effectiveWorkflow);
+        return {
+            workflow: effectiveWorkflow,
+            workflowFilePath,
+            workflowUrl: openTarget.url,
+            workflowReloadUrl: openTarget.targetUrl,
+        };
+    } catch {
+        return { workflow: effectiveWorkflow, workflowFilePath };
+    }
+}
+
+async function listAgentWorkflowNodes(workflowContext: AgentWorkflowContext): Promise<Array<{ name: string; type?: string; id?: string }>> {
+    if (!workflowContext.id) return [];
+    const config = getN8nConfig();
+    if (!config.host || !config.apiKey) return [];
+    const client = new N8nApiClient(config);
+    const workflow = await client.getWorkflow(workflowContext.id);
+    const nodes = Array.isArray(workflow?.nodes) ? workflow.nodes : [];
+    const result: Array<{ name: string; type?: string; id?: string }> = [];
+    for (const node of nodes) {
+        const name = typeof node?.name === 'string' ? node.name.trim() : '';
+        if (!name) continue;
+        const type = typeof node.type === 'string' ? node.type.trim() : '';
+        const id = typeof node.id === 'string' ? node.id.trim() : '';
+        result.push({ name, type: type || undefined, id: id || undefined });
+    }
+    return result;
 }
 
 function getSelectedAgentProviderModelLabel(): string {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -327,6 +327,10 @@ export async function activate(context: vscode.ExtensionContext) {
             await selectAgentModel();
         }),
 
+        registerTelemetryCommand('n8n.agent.selectReasoningEffort', async () => {
+            await selectAgentReasoningEffort();
+        }),
+
         // n8nac push <path>
         registerTelemetryCommand('n8n.pushWorkflow', async (arg: any) => {
             if (enhancedTreeProvider.getExtensionState() === ExtensionState.SETTINGS_CHANGED) {
@@ -805,10 +809,12 @@ async function resolveWorkflowForSplitView(arg: any): Promise<IWorkflowStatus | 
 async function openAgentWorkbench(context: vscode.ExtensionContext, workflow?: IWorkflowStatus): Promise<void> {
     try {
         const openTarget = workflow?.id ? await resolveWorkflowWebviewTarget(workflow) : undefined;
+        const workflowFilePath = workflow ? getExistingWorkflowFileUri(workflow)?.fsPath : undefined;
         const providerModelLabel = getSelectedAgentProviderModelLabel();
         AgentWorkbenchWebview.createOrShow(
             context,
             workflow,
+            workflowFilePath,
             openTarget?.url,
             openTarget?.targetUrl,
             providerModelLabel,
@@ -960,6 +966,18 @@ async function selectAgentModel(): Promise<void> {
         await service.selectModel(provider);
     } catch (error: any) {
         vscode.window.showErrorMessage(`Model selection failed: ${error?.message || String(error)}`);
+    }
+}
+
+async function selectAgentReasoningEffort(): Promise<void> {
+    const service = requireYagrProviderService();
+    const config = vscode.workspace.getConfiguration('n8n.agent');
+    const provider = normalizeYagrProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
+    const model = String(config.get<string>('model') || '').trim() || undefined;
+    try {
+        await service.selectReasoningEffort(provider, model);
+    } catch (error: any) {
+        vscode.window.showErrorMessage(`Reasoning effort selection failed: ${error?.message || String(error)}`);
     }
 }
 

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -48,6 +48,9 @@ export interface AgentCheckpointSummary {
     createdAt: string;
     messageCount: number;
     summary?: string;
+    reason?: CheckpointReason;
+    label?: string;
+    restoredAt?: string;
 }
 
 export interface AgentCompactionSummary {
@@ -201,6 +204,42 @@ type SessionCheckpointMetadata = {
     createdAt: string;
     messageCount: number;
     summary?: string;
+    reason?: CheckpointReason;
+    label?: string;
+    restoredAt?: string;
+};
+
+type CheckpointReason = 'manual' | 'auto' | 'before-tool' | 'after-tool' | 'before-compaction' | 'after-compaction';
+
+type SaveCheckpointOptions = {
+    reason?: CheckpointReason;
+    label?: string;
+    summary?: string;
+    payloads?: Record<string, unknown>;
+    payloadState?: unknown | null;
+};
+
+type RestoreCheckpointResult = {
+    sessionId: string;
+    checkpointId: string;
+    restoredAt: string;
+    langGraphRestored?: boolean;
+    pendingWritesRestored?: boolean;
+    payloads?: Record<string, unknown>;
+    payloadsRestored?: string[];
+    displayThreadRestored?: boolean;
+    warnings?: string[];
+    payloadState?: unknown | null;
+};
+
+type AgentWorkbenchCheckpointSurfacePayload = {
+    version: 1;
+    displayThread: AgentTimelineEntry[];
+    contextMarkers: AgentTimelineEntry[];
+    selectedWorkflow?: AgentWorkflowContext;
+    selectedNodes: AgentNodeContext[];
+    title: string;
+    scope?: DeepAgentSessionScope;
 };
 
 type WebUiSession = {
@@ -224,8 +263,9 @@ type SessionServiceHandle = {
     setCheckpointer(checkpointer: unknown): void;
     buildSessionConfig(sessionId: string): Record<string, unknown>;
     listCheckpoints(sessionId: string): Promise<SessionCheckpointMetadata[]>;
-    saveCheckpoint(sessionId: string, options?: { payloadState?: unknown | null }): Promise<SessionCheckpointMetadata>;
-    restoreCheckpoint(sessionId: string, checkpointId: string): Promise<{ payloadState: unknown | null }>;
+    saveCheckpoint(sessionId: string, options?: SaveCheckpointOptions): Promise<SessionCheckpointMetadata>;
+    maybeSaveCheckpoint?(sessionId: string, reason: CheckpointReason, options?: Omit<SaveCheckpointOptions, 'reason'>): Promise<SessionCheckpointMetadata | undefined>;
+    restoreCheckpoint(sessionId: string, checkpointId: string): Promise<RestoreCheckpointResult>;
     deleteCheckpoint(sessionId: string, checkpointId: string): Promise<void>;
     syncDisplayThread(sessionId: string, displayThread: unknown[]): void;
     clearDisplayThread(sessionId: string): void;
@@ -423,37 +463,72 @@ export class AgentRuntimeController implements vscode.Disposable {
     async saveCheckpoint(sessionId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
         const sessions = await this.getSessionRuntime();
         const handle = await this.ensureAgentHandleWithCheckpoint(input);
-        await sessions.service.saveCheckpoint(sessionId, {
-            payloadState: handle.compactionService.getState(sessionId),
+        const surface = this.buildCheckpointSurfacePayload(sessions.service, sessionId);
+        const compaction = handle.compactionService?.getState?.(sessionId);
+        const label = surface.selectedWorkflow ? 'Before workflow edit' : 'Manual checkpoint';
+        await this.saveYagrCheckpoint(sessions.service, sessionId, {
+            reason: 'manual',
+            label,
+            summary: this.buildCheckpointSummary(surface),
+            payloads: {
+                surface,
+                ...(compaction ? { compaction } : {}),
+            },
         });
         const entries = this.readSessionEntries(sessions.service, sessionId);
         this.writeSessionEntries(sessions.service, sessionId, [
             ...entries,
-            this.createSystemNotice('Checkpoint saved.'),
+            this.createSystemNotice(`Checkpoint saved: ${label}.`),
         ]);
-        return this.getWorkbenchState(input);
+        return this.getWorkbenchState({ ...input, sessionId });
     }
 
     async restoreCheckpoint(sessionId: string, checkpointId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
         const sessions = await this.getSessionRuntime();
         const handle = await this.ensureAgentHandleWithCheckpoint(input);
         const result = await sessions.service.restoreCheckpoint(sessionId, checkpointId);
-        sessions.service.clearDisplayThread(sessionId);
-        if (this.isCompactionState(result.payloadState)) {
-            handle.compactionService.setState(sessionId, result.payloadState);
+        const payloads = this.extractCheckpointPayloads(result);
+        const notices: AgentTimelineEntry[] = [];
+        const surface = payloads.surface;
+        if (this.isWorkbenchSurfacePayload(surface)) {
+            const entries = this.normalizeEntries(surface.displayThread);
+            const title = surface.title.trim() || sessions.service.get(sessionId)?.title || this.getDefaultSessionTitle(input.workflowName);
+            sessions.service.touch(sessionId, { title });
+            sessions.service.setTitle(sessionId, title);
+            this.writeSessionEntries(sessions.service, sessionId, [
+                ...entries,
+                this.createSystemNotice(`Restored checkpoint ${checkpointId}.`),
+            ]);
         } else {
-            handle.compactionService.reset(sessionId);
+            notices.push(this.createSystemNotice(`Restored checkpoint ${checkpointId}. Runtime state was restored, but this checkpoint does not include Workbench surface state, so the visible conversation was kept.`));
         }
-        this.writeSessionEntries(sessions.service, sessionId, [
-            this.createSystemNotice(`Restored checkpoint ${checkpointId}.`),
-        ]);
-        return this.getWorkbenchState(input);
+        if (this.isCompactionState(payloads.compaction) && typeof handle.compactionService?.setState === 'function') {
+            handle.compactionService.setState(sessionId, payloads.compaction);
+        }
+        for (const warning of result.warnings || []) {
+            const message = typeof warning === 'string' ? warning : String(warning);
+            this.outputChannel.appendLine(`[n8n-agent] Checkpoint restore warning: ${message}`);
+            notices.push(this.createSystemNotice(`Checkpoint warning: ${message}`));
+        }
+        if (notices.length) {
+            this.writeSessionEntries(sessions.service, sessionId, [
+                ...this.readSessionEntries(sessions.service, sessionId),
+                ...notices,
+            ]);
+        }
+        return this.getWorkbenchState({ ...input, sessionId });
     }
 
     async deleteCheckpoint(sessionId: string, checkpointId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
         const sessions = await this.getSessionRuntime();
         await sessions.service.deleteCheckpoint(sessionId, checkpointId);
-        return this.getWorkbenchState(input);
+        if ((input.sessionId || sessionId) === sessionId) {
+            this.writeSessionEntries(sessions.service, sessionId, [
+                ...this.readSessionEntries(sessions.service, sessionId),
+                this.createSystemNotice('Checkpoint deleted.'),
+            ]);
+        }
+        return this.getWorkbenchState({ ...input, sessionId });
     }
 
     async compactSession(sessionId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
@@ -495,8 +570,15 @@ export class AgentRuntimeController implements vscode.Disposable {
                     ];
                 }
                 this.writeSessionEntries(sessions.service, sessionId, entries);
-                await sessions.service.saveCheckpoint(sessionId, {
-                    payloadState: handle.compactionService.getState(sessionId),
+                const surface = this.buildCheckpointSurfacePayload(sessions.service, sessionId, entries);
+                await this.saveYagrCheckpoint(sessions.service, sessionId, {
+                    reason: 'after-compaction',
+                    label: 'After context compaction',
+                    summary: 'Workbench checkpoint after context compaction',
+                    payloads: {
+                        surface,
+                        compaction: handle.compactionService.getState(sessionId),
+                    },
                 }).catch((error: any) => {
                     this.outputChannel.appendLine(`[n8n-agent] Manual compaction checkpoint failed: ${error?.message || String(error)}`);
                 });
@@ -739,17 +821,6 @@ export class AgentRuntimeController implements vscode.Disposable {
                 });
             }
 
-            if (accumulator.fileModificationDetected) {
-                this.outputChannel.appendLine(`[n8n-agent-debug] agent runtime detected local workflow modification sessionId=${input.sessionId || 'none'} workflowId=${input.workflowId || 'none'} workflowFilePath=${input.workflowFilePath || 'none'}`);
-                try {
-                    await sessions.service.saveCheckpoint(input.sessionId || '', {
-                        payloadState: handle.compactionService.getState(input.sessionId || ''),
-                    });
-                } catch (error: any) {
-                    this.outputChannel.appendLine(`[n8n-agent] Auto-checkpoint failed: ${error?.message || String(error)}`);
-                }
-            }
-
             const finalEvent: AgentStreamEvent = {
                 type: 'final',
                 sessionId: input.sessionId || '',
@@ -758,6 +829,21 @@ export class AgentRuntimeController implements vscode.Disposable {
             };
             entries = this.applyStreamEvent(entries, finalEvent);
             await postMessage({ type: 'agent.streamEvent', event: finalEvent });
+            if (accumulator.fileModificationDetected) {
+                this.outputChannel.appendLine(`[n8n-agent-debug] agent runtime detected local workflow modification sessionId=${input.sessionId || 'none'} workflowId=${input.workflowId || 'none'} workflowFilePath=${input.workflowFilePath || 'none'}`);
+                try {
+                    await this.maybeSaveYagrCheckpoint(sessions.service, input.sessionId || '', 'after-tool', {
+                        label: 'After file modifications',
+                        summary: 'Saved after file modifications',
+                        payloads: {
+                            surface: this.buildCheckpointSurfacePayload(sessions.service, input.sessionId || '', entries),
+                            compaction: handle.compactionService?.getState?.(input.sessionId || ''),
+                        },
+                    });
+                } catch (error: any) {
+                    this.outputChannel.appendLine(`[n8n-agent] Auto-checkpoint failed: ${error?.message || String(error)}`);
+                }
+            }
             this.outputChannel.appendLine(`[n8n-agent-debug] agent runtime completed sessionId=${input.sessionId || 'none'} workflowId=${input.workflowId || 'none'} workflowChanged=${String(Boolean(accumulator.fileModificationDetected))}`);
             return { entries, workflowChanged: Boolean(accumulator.fileModificationDetected) };
         }
@@ -1138,7 +1224,15 @@ export class AgentRuntimeController implements vscode.Disposable {
                 const service = new module.SessionService({
                     sessionsDir: path.join(sessionsRoot, 'records'),
                     webUiSessionsDir,
-                }) as SessionServiceHandle;
+                    checkpointPolicy: {
+                        enabled: true,
+                        afterFileModifications: true,
+                        beforeToolCalls: false,
+                        beforeCompaction: false,
+                        afterCompaction: false,
+                        maxCheckpointsPerSession: 20,
+                    },
+                } as any) as SessionServiceHandle;
                 return {
                     service,
                     deriveSessionTitle: module.deriveSessionTitle as SessionRuntime['deriveSessionTitle'],
@@ -1225,6 +1319,9 @@ export class AgentRuntimeController implements vscode.Disposable {
                 createdAt: checkpoint.createdAt,
                 messageCount: checkpoint.messageCount,
                 summary: checkpoint.summary,
+                reason: checkpoint.reason,
+                label: checkpoint.label,
+                restoredAt: checkpoint.restoredAt,
             })),
             contextUsage: latestUsageEntry?.usage,
             lastCompaction: compactionState.lastCompaction || undefined,
@@ -1634,6 +1731,98 @@ export class AgentRuntimeController implements vscode.Disposable {
 
     private withoutContextUsage(entries: AgentTimelineEntry[]): AgentTimelineEntry[] {
         return entries.filter((entry) => entry.kind !== 'context-usage');
+    }
+
+    private buildCheckpointSurfacePayload(
+        service: SessionServiceHandle,
+        sessionId: string,
+        entriesOverride?: AgentTimelineEntry[],
+    ): AgentWorkbenchCheckpointSurfacePayload {
+        const displaySession = service.readDisplaySession(sessionId);
+        const record = service.get(sessionId);
+        const displayThread = this.normalizeEntries(entriesOverride || displaySession?.displayThread);
+        const selectedWorkflow = this.getLatestWorkflowContext(displayThread, record);
+        const selectedNodes = selectedWorkflow ? this.getLatestNodeContexts(displayThread) : [];
+        return {
+            version: 1,
+            displayThread,
+            contextMarkers: displayThread.filter((entry) => entry.kind === 'workflow-context' || entry.kind === 'node-context'),
+            selectedWorkflow,
+            selectedNodes,
+            title: displaySession?.title || record?.title || this.getDefaultSessionTitle(),
+            scope: record?.scope,
+        };
+    }
+
+    private buildCheckpointSummary(surface: AgentWorkbenchCheckpointSurfacePayload): string {
+        if (surface.selectedWorkflow && surface.selectedNodes.length) {
+            return `Workbench checkpoint for ${surface.selectedWorkflow.name} with ${surface.selectedNodes.length} selected node${surface.selectedNodes.length === 1 ? '' : 's'}`;
+        }
+        if (surface.selectedWorkflow) {
+            return `Workbench checkpoint for ${surface.selectedWorkflow.name}`;
+        }
+        return 'Workbench checkpoint';
+    }
+
+    private async saveYagrCheckpoint(
+        service: SessionServiceHandle,
+        sessionId: string,
+        options: SaveCheckpointOptions,
+    ): Promise<SessionCheckpointMetadata> {
+        return service.saveCheckpoint(sessionId, this.withLegacyCheckpointPayload(options));
+    }
+
+    private async maybeSaveYagrCheckpoint(
+        service: SessionServiceHandle,
+        sessionId: string,
+        reason: CheckpointReason,
+        options: Omit<SaveCheckpointOptions, 'reason'>,
+    ): Promise<SessionCheckpointMetadata | undefined> {
+        if (typeof service.maybeSaveCheckpoint !== 'function') {
+            return undefined;
+        }
+        return service.maybeSaveCheckpoint(sessionId, reason, this.withLegacyCheckpointPayload(options));
+    }
+
+    private withLegacyCheckpointPayload<T extends SaveCheckpointOptions>(options: T): T {
+        if (!options.payloads || options.payloadState !== undefined) {
+            return options;
+        }
+        return {
+            ...options,
+            payloadState: { payloads: options.payloads },
+        };
+    }
+
+    private extractCheckpointPayloads(result: RestoreCheckpointResult): Record<string, unknown> {
+        if (this.isRecord(result.payloads)) {
+            return result.payloads;
+        }
+        const payloadState = result.payloadState;
+        if (this.isRecord(payloadState)) {
+            if (this.isRecord(payloadState.payloads)) {
+                return payloadState.payloads;
+            }
+            if (this.isRecord(payloadState.surface) || this.isRecord(payloadState.compaction)) {
+                return payloadState;
+            }
+        }
+        if (this.isCompactionState(payloadState)) {
+            return { compaction: payloadState };
+        }
+        return {};
+    }
+
+    private isWorkbenchSurfacePayload(value: unknown): value is AgentWorkbenchCheckpointSurfacePayload {
+        if (!this.isRecord(value)) return false;
+        if (value.version !== 1) return false;
+        if (!Array.isArray(value.displayThread)) return false;
+        if (typeof value.title !== 'string') return false;
+        return true;
+    }
+
+    private isRecord(value: unknown): value is Record<string, unknown> {
+        return Boolean(value && typeof value === 'object' && !Array.isArray(value));
     }
 
     private toCompactionSummary(value: unknown): AgentCompactionSummary | undefined {

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -116,6 +116,10 @@ export interface AgentWorkbenchState {
     isRunning: boolean;
 }
 
+export interface AgentRunResult {
+    workflowChanged: boolean;
+}
+
 export type AgentStreamEvent =
     | { type: 'start'; sessionId: string; message: string }
     | { type: 'progress'; tone: 'info' | 'success' | 'error'; title: string; detail?: string; phase?: string }
@@ -365,18 +369,54 @@ export class AgentRuntimeController implements vscode.Disposable {
         return this.getWorkbenchState(input);
     }
 
-    async sendPrompt(input: AgentPromptInput, postMessage: AgentWorkbenchPostMessage): Promise<void> {
+    async compactSession(sessionId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
+        const sessions = await this.getSessionRuntime();
+        const handle = await this.ensureAgentHandleWithCheckpoint(input);
+        const entries = this.readSessionEntries(sessions.service, sessionId);
+        const compactableEntries = entries.filter((entry) => entry.kind !== 'context-usage' && entry.kind !== 'compaction');
+        if (compactableEntries.length <= 8) {
+            return this.getWorkbenchState(input);
+        }
+
+        const preservedRecentMessages = 8;
+        const retained = compactableEntries.slice(-preservedRecentMessages);
+        const compacted = compactableEntries.slice(0, -preservedRecentMessages);
+        const summary = this.buildFallbackCompactionSummary(compacted);
+        const event: AgentCompactionSummary = {
+            summary,
+            source: 'fallback',
+            messagesCompacted: compacted.length,
+            preservedRecentMessages: retained.length,
+            estimatedTokens: Math.ceil(compacted.map((entry) => this.getEntryText(entry)).join('\n').length / 4),
+        };
+
+        await handle.compactionService.notifyCompaction(sessionId, event);
+        const latestUsage = [...entries].reverse().find((entry): entry is Extract<AgentTimelineEntry, { kind: 'context-usage' }> => entry.kind === 'context-usage');
+        this.writeSessionEntries(sessions.service, sessionId, [
+            ...(latestUsage ? [latestUsage] : []),
+            { kind: 'compaction', id: randomUUID(), timestamp: Date.now(), event },
+            ...retained,
+        ]);
+        await sessions.service.saveCheckpoint(sessionId, {
+            payloadState: handle.compactionService.getState(sessionId),
+        }).catch((error: any) => {
+            this.outputChannel.appendLine(`[n8n-agent] Manual compaction checkpoint failed: ${error?.message || String(error)}`);
+        });
+        return this.getWorkbenchState(input);
+    }
+
+    async sendPrompt(input: AgentPromptInput, postMessage: AgentWorkbenchPostMessage): Promise<AgentRunResult> {
         if (this.activeRun) {
             await postMessage({
                 type: 'agent.error',
                 message: 'An agent run is already in progress. Stop it before sending another prompt.',
             });
-            return;
+            return { workflowChanged: false };
         }
 
         const prompt = input.prompt.trim();
         if (!prompt) {
-            return;
+            return { workflowChanged: false };
         }
 
         const sessions = await this.getSessionRuntime();
@@ -403,10 +443,12 @@ export class AgentRuntimeController implements vscode.Disposable {
         await postMessage({ type: 'agent.streamEvent', event: { type: 'start', sessionId: activeRecord.id, message: prompt } });
 
         try {
-            entries = await this.runInitialAgentTurn({ ...input, sessionId: activeRecord.id }, entries, postMessage, abortController.signal);
+            const runResult = await this.runInitialAgentTurn({ ...input, sessionId: activeRecord.id }, entries, postMessage, abortController.signal);
+            entries = runResult.entries;
             this.writeSessionEntries(sessions.service, activeRecord.id, entries);
             await postMessage({ type: 'agent.state', state: await this.getWorkbenchState({ ...input, sessionId: activeRecord.id }) });
             await postMessage({ type: 'agent.done' });
+            return { workflowChanged: runResult.workflowChanged };
         } catch (error: any) {
             const message = error?.message || String(error);
             this.outputChannel.appendLine(`[n8n-agent] Run failed: ${message}`);
@@ -415,6 +457,7 @@ export class AgentRuntimeController implements vscode.Disposable {
             await postMessage({ type: 'agent.streamEvent', event: { type: 'error', error: message } });
             await postMessage({ type: 'agent.error', message });
             await postMessage({ type: 'agent.state', state: await this.getWorkbenchState({ ...input, sessionId: activeRecord.id }) });
+            return { workflowChanged: false };
         } finally {
             if (this.activeRun?.abortController === abortController) {
                 this.activeRun = undefined;
@@ -443,23 +486,29 @@ export class AgentRuntimeController implements vscode.Disposable {
         initialEntries: AgentTimelineEntry[],
         postMessage: AgentWorkbenchPostMessage,
         signal: AbortSignal,
-    ): Promise<AgentTimelineEntry[]> {
+    ): Promise<{ entries: AgentTimelineEntry[]; workflowChanged: boolean }> {
         await this.throwIfAborted(signal);
 
         const providerRegistry = await this.loadYagrProviderRegistry().catch((error: any) => ({ error: error?.message || String(error) }));
         if ('error' in providerRegistry) {
-            return [
-                ...initialEntries,
-                this.createSystemNotice(await this.buildScaffoldResponse(input, providerRegistry.error)),
-            ];
+            return {
+                entries: [
+                    ...initialEntries,
+                    this.createSystemNotice(await this.buildScaffoldResponse(input, providerRegistry.error)),
+                ],
+                workflowChanged: false,
+            };
         }
 
         const providerConfig = await this.getProviderRuntimeConfig(providerRegistry);
         if (!providerConfig.ready) {
-            return [
-                ...initialEntries,
-                this.createSystemNotice(await this.buildScaffoldResponse(input, providerConfig.reason)),
-            ];
+            return {
+                entries: [
+                    ...initialEntries,
+                    this.createSystemNotice(await this.buildScaffoldResponse(input, providerConfig.reason)),
+                ],
+                workflowChanged: false,
+            };
         }
 
         const handle = await this.getYagrAgentHandle(providerConfig, input);
@@ -578,7 +627,7 @@ export class AgentRuntimeController implements vscode.Disposable {
             };
             entries = this.applyStreamEvent(entries, finalEvent);
             await postMessage({ type: 'agent.streamEvent', event: finalEvent });
-            return entries;
+            return { entries, workflowChanged: Boolean(accumulator.fileModificationDetected) };
         }
 
         const result = await (agent as any).invoke({ messages }, config);
@@ -591,7 +640,7 @@ export class AgentRuntimeController implements vscode.Disposable {
         };
         entries = this.applyStreamEvent(entries, finalEvent);
         await postMessage({ type: 'agent.streamEvent', event: finalEvent });
-        return entries;
+        return { entries, workflowChanged: false };
     }
 
     private truncateOperationDetail(value: unknown): string | undefined {
@@ -1002,7 +1051,7 @@ export class AgentRuntimeController implements vscode.Disposable {
                 isClosed: Boolean(record?.closedAt),
                 checkpointCount: checkpoints.length,
                 workflowId,
-                workflowLabel: workflowId ? workflowId : 'Unattached',
+                workflowLabel: workflowId ? workflowId : 'New workflow chat',
                 totalCompactions: compactionState.totalCompactions,
             };
         }));
@@ -1048,8 +1097,35 @@ export class AgentRuntimeController implements vscode.Disposable {
             lastCompaction: compactionState.lastCompaction || undefined,
             totalCompactions: compactionState.totalCompactions,
             workflowId,
-            workflowLabel: workflowId || 'Unattached',
+            workflowLabel: workflowId || 'New workflow chat',
         };
+    }
+
+    private buildFallbackCompactionSummary(entries: AgentTimelineEntry[]): string {
+        const snippets = entries
+            .map((entry) => this.getEntryText(entry).trim())
+            .filter(Boolean)
+            .slice(-6)
+            .map((text) => text.length > 140 ? `${text.slice(0, 140)}...` : text);
+        return snippets.length
+            ? `Manual context compaction preserved recent conversation and summarized prior context: ${snippets.join(' | ')}`
+            : 'Manual context compaction preserved recent conversation and removed older low-signal context.';
+    }
+
+    private getEntryText(entry: AgentTimelineEntry): string {
+        if (entry.kind === 'user-message' || entry.kind === 'system-notice' || entry.kind === 'assistant-body') {
+            return entry.text;
+        }
+        if (entry.kind === 'operation') {
+            return [entry.title, entry.detail, entry.summary, entry.body].filter(Boolean).join(' ');
+        }
+        if (entry.kind === 'compaction') {
+            return entry.event.summary;
+        }
+        if (entry.kind === 'context-usage') {
+            return `${entry.usage.fillPercent}% context usage`;
+        }
+        return '';
     }
 
     private readSessionEntries(service: SessionServiceHandle, sessionId: string): AgentTimelineEntry[] {
@@ -1061,7 +1137,16 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     private normalizeEntries(value: unknown[] | undefined): AgentTimelineEntry[] {
-        return Array.isArray(value) ? value as AgentTimelineEntry[] : [];
+        return Array.isArray(value)
+            ? (value as AgentTimelineEntry[]).filter((entry) => !this.isNoiseOperation(entry))
+            : [];
+    }
+
+    private isNoiseOperation(entry: AgentTimelineEntry): boolean {
+        if (entry.kind !== 'operation') return false;
+        const title = entry.title.toLowerCase();
+        const detail = (entry.detail || entry.summary || '').toLowerCase();
+        return title === 'agent runtime' || detail === 'run completed' || title.includes('run completed');
     }
 
     private applyStreamEvent(entries: AgentTimelineEntry[], event: AgentStreamEvent): AgentTimelineEntry[] {

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -1,0 +1,284 @@
+import * as vscode from 'vscode';
+
+export interface AgentPromptInput {
+    prompt: string;
+    workflowId?: string;
+    workflowName?: string;
+    workspaceRoot?: string;
+}
+
+export type AgentWorkbenchMessage =
+    | { type: 'agent.status'; status: 'idle' | 'running' | 'stopping'; detail?: string }
+    | { type: 'agent.message'; role: 'assistant' | 'system' | 'user'; content: string }
+    | { type: 'agent.delta'; content: string }
+    | { type: 'agent.operation'; label: string; status: 'running' | 'done' | 'error'; detail?: string }
+    | { type: 'agent.error'; message: string }
+    | { type: 'agent.done' };
+
+export type AgentWorkbenchPostMessage = (message: AgentWorkbenchMessage) => Thenable<boolean>;
+
+export const N8N_AGENT_PROVIDER_SECRET_PREFIX = 'n8n.agent.providerApiKey.';
+
+export function getAgentProviderSecretKey(provider: string): string {
+    return `${N8N_AGENT_PROVIDER_SECRET_PREFIX}${provider}`;
+}
+
+export class AgentRuntimeController implements vscode.Disposable {
+    private activeAbortController: AbortController | undefined;
+    private cachedRuntime: Awaited<ReturnType<typeof this.loadYagrRuntime>> | undefined;
+
+    constructor(
+        private readonly _context: vscode.ExtensionContext,
+        private readonly outputChannel: vscode.OutputChannel,
+    ) {}
+
+    async sendPrompt(input: AgentPromptInput, postMessage: AgentWorkbenchPostMessage): Promise<void> {
+        if (this.activeAbortController) {
+            await postMessage({
+                type: 'agent.error',
+                message: 'An agent run is already in progress. Stop it before sending another prompt.',
+            });
+            return;
+        }
+
+        const prompt = input.prompt.trim();
+        if (!prompt) {
+            return;
+        }
+
+        const abortController = new AbortController();
+        this.activeAbortController = abortController;
+
+        await postMessage({ type: 'agent.status', status: 'running', detail: 'Preparing n8n agent runtime...' });
+        await postMessage({ type: 'agent.operation', label: 'Agent runtime', status: 'running', detail: 'Loading embedded Yagr runtime' });
+
+        try {
+            await this.runInitialAgentTurn(input, postMessage, abortController.signal);
+            await postMessage({ type: 'agent.operation', label: 'Agent runtime', status: 'done', detail: 'Run completed' });
+            await postMessage({ type: 'agent.done' });
+        } catch (error: any) {
+            const message = error?.message || String(error);
+            this.outputChannel.appendLine(`[n8n-agent] Run failed: ${message}`);
+            await postMessage({ type: 'agent.operation', label: 'Agent runtime', status: 'error', detail: message });
+            await postMessage({ type: 'agent.error', message });
+        } finally {
+            if (this.activeAbortController === abortController) {
+                this.activeAbortController = undefined;
+            }
+            await postMessage({ type: 'agent.status', status: 'idle' });
+        }
+    }
+
+    async stop(postMessage: AgentWorkbenchPostMessage): Promise<void> {
+        const controller = this.activeAbortController;
+        if (!controller) {
+            await postMessage({ type: 'agent.status', status: 'idle' });
+            return;
+        }
+        await postMessage({ type: 'agent.status', status: 'stopping', detail: 'Stopping current run...' });
+        controller.abort();
+    }
+
+    dispose(): void {
+        this.activeAbortController?.abort();
+        this.activeAbortController = undefined;
+    }
+
+    private async runInitialAgentTurn(
+        input: AgentPromptInput,
+        postMessage: AgentWorkbenchPostMessage,
+        signal: AbortSignal,
+    ): Promise<void> {
+        await this.throwIfAborted(signal);
+
+        const runtime = await this.loadYagrRuntime().catch((error: any) => ({ error: error?.message || String(error) }));
+        if ('error' in runtime) {
+            await postMessage({
+                type: 'agent.message',
+                role: 'assistant',
+                content: await this.buildScaffoldResponse(input, runtime.error),
+            });
+            return;
+        }
+
+        await this.throwIfAborted(signal);
+
+        const providerConfig = await this.getProviderRuntimeConfig(runtime);
+        if (!providerConfig.ready) {
+            await postMessage({
+                type: 'agent.message',
+                role: 'assistant',
+                content: await this.buildScaffoldResponse(input, providerConfig.reason),
+            });
+            return;
+        }
+
+        await postMessage({ type: 'agent.operation', label: 'Provider', status: 'done', detail: `${providerConfig.provider}${providerConfig.model ? ` / ${providerConfig.model}` : ''}` });
+        await postMessage({ type: 'agent.operation', label: 'DeepAgents runtime', status: 'running', detail: 'Streaming response' });
+
+        const model = runtime.createLangChainChatModel(providerConfig);
+        const agent = runtime.createDeepAgentRuntime({
+            model,
+            tools: [],
+            systemPrompt: this.buildSystemPrompt(input),
+        });
+
+        const messages = [{ role: 'user', content: input.prompt }];
+        const config = { version: 'v2', signal } as Record<string, unknown>;
+
+        if (typeof (agent as any).streamEvents === 'function') {
+            const stream = (agent as any).streamEvents({ messages }, config);
+            const accumulator = await runtime.consumeLangGraphStream(stream, {
+                onTextDelta: async (delta: string) => {
+                    await this.throwIfAborted(signal);
+                    await postMessage({ type: 'agent.delta', content: delta });
+                },
+                onOperation: async (event: any) => {
+                    await postMessage({
+                        type: 'agent.operation',
+                        label: String(event.label || event.operationId || 'Operation'),
+                        status: event.status === 'error' ? 'error' : event.status === 'done' ? 'done' : 'running',
+                        detail: event.summary || event.body,
+                    });
+                },
+            });
+            if (!accumulator.responseText) {
+                await postMessage({ type: 'agent.message', role: 'assistant', content: 'The agent completed without producing text.' });
+            }
+            return;
+        }
+
+        const result = await (agent as any).invoke({ messages }, config);
+        await postMessage({ type: 'agent.message', role: 'assistant', content: this.extractAgentText(result) });
+    }
+
+    private async loadYagrRuntime(): Promise<typeof import('@yagr/runtime')> {
+        if (!this.cachedRuntime) {
+            this.cachedRuntime = await import('@yagr/runtime');
+        }
+        return this.cachedRuntime;
+    }
+
+    private async getProviderRuntimeConfig(runtime: typeof import('@yagr/runtime')): Promise<{
+        ready: boolean;
+        reason?: string;
+        provider: string;
+        model?: string;
+        apiKey?: string;
+        baseUrl?: string;
+        temperature: number;
+    }> {
+        const config = vscode.workspace.getConfiguration('n8n.agent');
+        const provider = String(config.get<string>('provider') || 'openai');
+        const normalizedProvider = runtime.normalizeProviderId(provider) || 'openai';
+        const model = String(config.get<string>('model') || '').trim() || undefined;
+        const baseUrl = String(config.get<string>('baseUrl') || '').trim() || undefined;
+        const apiKey = await this._context.secrets.get(getAgentProviderSecretKey(normalizedProvider));
+        const resolved = runtime.resolveProviderRuntimeConfig({
+            provider: normalizedProvider,
+            model,
+            baseUrl,
+            apiKey,
+            temperature: 0,
+        });
+
+        if (runtime.providerRequiresApiKey(resolved.provider) && !resolved.apiKey) {
+            return {
+                ...resolved,
+                ready: false,
+                reason: `Missing API key for ${runtime.getRuntimeProviderLabel(resolved.provider)}. Run "n8n Agent: Set Provider API Key" or configure the provider environment variable.`,
+            };
+        }
+
+        return { ...resolved, ready: true };
+    }
+
+    private buildSystemPrompt(input: AgentPromptInput): string {
+        return [
+            'You are the embedded n8n-as-code VS Code agent.',
+            'You help users design, inspect, validate, and operate n8n workflows from the current workspace.',
+            'This runtime phase is chat-only: do not claim to have edited files, pushed workflows, provisioned credentials, run commands, or changed n8n runtime state.',
+            'When the user asks for an action that requires tools, explain the intended safe next steps and mention that tool execution will require approval once enabled.',
+            input.workspaceRoot ? `Workspace root: ${input.workspaceRoot}` : undefined,
+            input.workflowId ? `Current workflow: ${input.workflowName || input.workflowId} (${input.workflowId})` : undefined,
+        ].filter(Boolean).join('\n');
+    }
+
+    private extractAgentText(result: unknown): string {
+        if (!result || typeof result !== 'object') {
+            return typeof result === 'string' ? result : 'The agent completed without producing text.';
+        }
+        const record = result as Record<string, unknown>;
+        const messages = Array.isArray(record.messages) ? record.messages : [];
+        const last = messages[messages.length - 1] as Record<string, unknown> | undefined;
+        const content = last?.content ?? record.content ?? record.output;
+        if (typeof content === 'string') {
+            return content;
+        }
+        if (Array.isArray(content)) {
+            return content.map((part) => {
+                if (typeof part === 'string') return part;
+                if (part && typeof part === 'object' && typeof (part as Record<string, unknown>).text === 'string') {
+                    return (part as Record<string, string>).text;
+                }
+                return '';
+            }).join('');
+        }
+        return 'The agent completed without producing text.';
+    }
+
+    private async buildProviderStatusLine(): Promise<string> {
+        const config = vscode.workspace.getConfiguration('n8n.agent');
+        const provider = String(config.get<string>('provider') || 'openai');
+        const model = String(config.get<string>('model') || '').trim();
+        const baseUrl = String(config.get<string>('baseUrl') || '').trim();
+        const storedSecret = await this._context.secrets.get(getAgentProviderSecretKey(provider));
+        const hasEnvSecret = this.hasProviderEnvironmentSecret(provider);
+        const secretState = storedSecret
+            ? 'API key stored in VS Code Secret Storage'
+            : hasEnvSecret
+                ? 'API key available from environment'
+                : 'API key not configured yet';
+        return `Agent provider: ${provider}${model ? ` / ${model}` : ''}${baseUrl ? ` / ${baseUrl}` : ''}. ${secretState}.`;
+    }
+
+    private hasProviderEnvironmentSecret(provider: string): boolean {
+        const envKeys: Record<string, string[]> = {
+            anthropic: ['ANTHROPIC_API_KEY'],
+            openai: ['OPENAI_API_KEY'],
+            google: ['GOOGLE_GENERATIVE_AI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY'],
+            mistral: ['MISTRAL_API_KEY'],
+            openrouter: ['OPENROUTER_API_KEY'],
+            'openai-compatible': ['OPENAI_COMPATIBLE_API_KEY'],
+        };
+        return (envKeys[provider] ?? []).some((key) => Boolean(process.env[key]?.trim()));
+    }
+
+    private async buildScaffoldResponse(input: AgentPromptInput, runtimeError?: string): Promise<string> {
+        const workflowLine = input.workflowId
+            ? `Current workflow: ${input.workflowName || input.workflowId} (${input.workflowId}).`
+            : 'No remote workflow is selected yet.';
+        const workspaceLine = input.workspaceRoot
+            ? `Workspace: ${input.workspaceRoot}.`
+            : 'No workspace root was provided.';
+        const runtimeLine = runtimeError
+            ? `Embedded Yagr runtime is not loadable yet: ${runtimeError}`
+            : 'Embedded Yagr runtime package was detected. Tool and provider execution will be enabled in the next implementation phase.';
+
+        return [
+            'The n8n Agent Workbench is wired into the VS Code extension host.',
+            workflowLine,
+            workspaceLine,
+            await this.buildProviderStatusLine(),
+            runtimeLine,
+            '',
+            'This first run intentionally stays read-only: no workflow files, credentials, runtime state, or shell commands were changed.',
+        ].join('\n');
+    }
+
+    private async throwIfAborted(signal: AbortSignal): Promise<void> {
+        if (signal.aborted) {
+            throw new Error('Agent run cancelled.');
+        }
+    }
+}

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -8,6 +8,13 @@ export interface AgentPromptInput {
     workflowName?: string;
     workflowFilename?: string;
     workspaceRoot?: string;
+    nodeContext?: AgentNodeContext;
+}
+
+export interface AgentNodeContext {
+    name: string;
+    type?: string;
+    id?: string;
 }
 
 export type AgentWorkbenchMessage =
@@ -259,6 +266,9 @@ export class AgentRuntimeController implements vscode.Disposable {
             baseUrl: providerConfig.baseUrl,
             workflowId: input.workflowId || '',
             workflowFilename: input.workflowFilename || '',
+            nodeContextName: input.nodeContext?.name || '',
+            nodeContextType: input.nodeContext?.type || '',
+            nodeContextId: input.nodeContext?.id || '',
             memorySources,
             skillSourcePaths,
         });
@@ -306,7 +316,21 @@ export class AgentRuntimeController implements vscode.Disposable {
             input.workspaceRoot ? `Workspace root: ${input.workspaceRoot}` : undefined,
             input.workflowId ? `Current workflow: ${input.workflowName || input.workflowId} (${input.workflowId})` : undefined,
             input.workflowFilename ? `Current workflow file: ${input.workflowFilename}` : undefined,
+            this.formatNodeContext(input.nodeContext),
             workflowContext,
+        ].filter(Boolean).join('\n');
+    }
+
+    private formatNodeContext(nodeContext: AgentNodeContext | undefined): string | undefined {
+        if (!nodeContext?.name) {
+            return undefined;
+        }
+        return [
+            'Current n8n node detail panel context:',
+            `Node name: ${nodeContext.name}`,
+            nodeContext.type ? `Node type: ${nodeContext.type}` : undefined,
+            nodeContext.id ? `Node ID: ${nodeContext.id}` : undefined,
+            'When the user makes an ambiguous node-specific request, assume it refers to this node unless they name another node.',
         ].filter(Boolean).join('\n');
     }
 

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -289,11 +289,22 @@ type ProviderRuntimeConfig = {
     temperature: number;
 };
 
+type YagrProviderRegistryModule = {
+    YAGR_MODEL_PROVIDERS: string[];
+    normalizeProviderId(provider: string): string | undefined;
+    providerRequiresApiKey(provider: string): boolean;
+    getProviderDisplayName(provider: string): string;
+};
+
 type CompactionState = {
     lastCompaction: AgentCompactionSummary | null;
     compactionHistory: AgentCompactionSummary[];
     totalCompactions: number;
 };
+
+function importRuntimeModule<T = any>(specifier: string): Promise<T> {
+    return import(specifier) as Promise<T>;
+}
 
 export class AgentRuntimeController implements vscode.Disposable {
     private activeRun: { abortController: AbortController; sessionId: string } | undefined;
@@ -747,7 +758,7 @@ export class AgentRuntimeController implements vscode.Disposable {
 
         if (typeof (agent as any).streamEvents === 'function') {
             const stream = (agent as any).streamEvents({ messages }, config);
-            const eventRuntime = await import('@yagr/agent/dist/gateway/langgraph-events.js');
+            const eventRuntime = await importRuntimeModule('@yagr/agent/dist/gateway/langgraph-events.js');
             const accumulator = eventRuntime.createRunAccumulator();
             const lastProgressKeys = new Set<string>();
 
@@ -870,8 +881,8 @@ export class AgentRuntimeController implements vscode.Disposable {
         return normalized.length > 500 ? `${normalized.slice(0, 500)}...` : normalized;
     }
 
-    private async loadYagrProviderRegistry(): Promise<typeof import('@yagr/agent/dist/llm/provider-registry.js')> {
-        return import('@yagr/agent/dist/llm/provider-registry.js');
+    private async loadYagrProviderRegistry(): Promise<YagrProviderRegistryModule> {
+        return importRuntimeModule<YagrProviderRegistryModule>('@yagr/agent/dist/llm/provider-registry.js');
     }
 
     private async describeProviderRuntimeConfig(): Promise<ProviderRuntimeConfig> {
@@ -890,7 +901,7 @@ export class AgentRuntimeController implements vscode.Disposable {
         return this.getProviderRuntimeConfig(providerRegistry);
     }
 
-    private async getProviderRuntimeConfig(providerRegistry: typeof import('@yagr/agent/dist/llm/provider-registry.js')): Promise<ProviderRuntimeConfig> {
+    private async getProviderRuntimeConfig(providerRegistry: YagrProviderRegistryModule): Promise<ProviderRuntimeConfig> {
         const config = vscode.workspace.getConfiguration('n8n.agent');
         const provider = String(config.get<string>('provider') || 'openai');
         const normalizedProvider = providerRegistry.normalizeProviderId(provider);
@@ -910,7 +921,7 @@ export class AgentRuntimeController implements vscode.Disposable {
         const baseUrl = String(config.get<string>('baseUrl') || '').trim() || undefined;
         const apiKey = await this._context.secrets.get(getAgentProviderSecretKey(normalizedProvider));
         if (normalizedProvider === 'openai-oauth') {
-            const accountRuntime = await import('@yagr/agent/dist/llm/openai-account.js');
+            const accountRuntime = await importRuntimeModule('@yagr/agent/dist/llm/openai-account.js');
             const session = await accountRuntime.ensureOpenAiAccountSession().catch(() => undefined);
             if (!session?.accessToken) {
                 return {
@@ -951,8 +962,8 @@ export class AgentRuntimeController implements vscode.Disposable {
     private async getYagrAgentHandle(providerConfig: ProviderRuntimeConfig, input: AgentPromptInput): Promise<any> {
         const rootDir = input.workspaceRoot || process.cwd();
         const [agentFactory, providerRegistry] = await Promise.all([
-            import('@yagr/agent/dist/agent-factory.js'),
-            import('@yagr/agent/dist/llm/provider-registry.js'),
+            importRuntimeModule('@yagr/agent/dist/agent-factory.js'),
+            importRuntimeModule<YagrProviderRegistryModule>('@yagr/agent/dist/llm/provider-registry.js'),
         ]);
         const memorySources = await this.getWorkspaceMemorySources(rootDir);
         const skillSourcePaths = await this.getWorkspaceSkillSources(rootDir);
@@ -970,7 +981,7 @@ export class AgentRuntimeController implements vscode.Disposable {
         }
 
         const credentials = new Map<string, string>();
-        await Promise.all(providerRegistry.YAGR_MODEL_PROVIDERS.map(async (provider) => {
+        await Promise.all(providerRegistry.YAGR_MODEL_PROVIDERS.map(async (provider: string) => {
             const value = await this._context.secrets.get(getAgentProviderSecretKey(provider));
             if (value) credentials.set(provider, value);
         }));
@@ -1219,7 +1230,7 @@ export class AgentRuntimeController implements vscode.Disposable {
     private async getSessionRuntime(): Promise<SessionRuntime> {
         if (!this.sessionRuntimePromise) {
             this.sessionRuntimePromise = (async () => {
-                const module = await import('@yagr/agent/packages/session-service/dist/index.js');
+                const module = await importRuntimeModule('@yagr/agent/packages/session-service/dist/index.js');
                 const sessionsRoot = path.join(this._context.globalStorageUri.fsPath, 'agent-sessions');
                 const webUiSessionsDir = path.join(sessionsRoot, 'display');
                 await fs.promises.mkdir(webUiSessionsDir, { recursive: true });
@@ -1873,7 +1884,7 @@ export class AgentRuntimeController implements vscode.Disposable {
             return DEFAULT_CONTEXT_WINDOW_TOKENS;
         }
         try {
-            const metadata = await import('@yagr/agent/dist/llm/provider-metadata.js');
+            const metadata = await importRuntimeModule('@yagr/agent/dist/llm/provider-metadata.js');
             const entry = await metadata.primeProviderModelMetadata(provider as any, model, apiKey, baseUrl);
             return Number(entry?.contextWindow || metadata.getSnapshotContextWindow(provider as any, model) || DEFAULT_CONTEXT_WINDOW_TOKENS);
         } catch {

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -457,39 +457,68 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     async compactSession(sessionId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
+        if (this.activeRun) {
+            throw new Error(this.activeRun.sessionId === sessionId
+                ? 'An agent run is already active for this conversation.'
+                : 'An agent run is already active. Stop it before compacting context.');
+        }
         const sessions = await this.getSessionRuntime();
         const handle = await this.ensureAgentHandleWithCheckpoint(input);
-        const entries = this.readSessionEntries(sessions.service, sessionId);
-        const compactableEntries = entries.filter((entry) => entry.kind !== 'context-usage' && entry.kind !== 'compaction');
-        if (compactableEntries.length <= 8) {
-            return this.getWorkbenchState(input);
+        if (typeof handle.compactionService?.compactSession !== 'function') {
+            const entries = this.readSessionEntries(sessions.service, sessionId);
+            this.writeSessionEntries(sessions.service, sessionId, [
+                ...entries,
+                this.createSystemNotice('Manual context compaction is not supported by the installed Yagr runtime.'),
+            ]);
+            return this.getWorkbenchState({ ...input, sessionId });
         }
 
-        const preservedRecentMessages = 8;
-        const retained = compactableEntries.slice(-preservedRecentMessages);
-        const compacted = compactableEntries.slice(0, -preservedRecentMessages);
-        const summary = this.buildFallbackCompactionSummary(compacted);
-        const event: AgentCompactionSummary = {
-            summary,
-            source: 'fallback',
-            messagesCompacted: compacted.length,
-            preservedRecentMessages: retained.length,
-            estimatedTokens: Math.ceil(compacted.map((entry) => this.getEntryText(entry)).join('\n').length / 4),
-        };
+        const abortController = new AbortController();
+        this.activeRun = { abortController, sessionId };
+        try {
+            const result = await handle.compactionService.compactSession(sessionId, {
+                abortSignal: abortController.signal,
+            });
+            let entries = this.readSessionEntries(sessions.service, sessionId);
+            const status = String(result?.status || 'failed');
+            if (status === 'completed') {
+                const event = this.toCompactionSummary(result?.event);
+                if (event) {
+                    entries = [
+                        ...this.withoutContextUsage(entries),
+                        { kind: 'compaction', id: randomUUID(), timestamp: Date.now(), event },
+                    ];
+                } else {
+                    entries = [
+                        ...this.withoutContextUsage(entries),
+                        this.createSystemNotice('Context compacted, but the runtime did not return compaction details.'),
+                    ];
+                }
+                this.writeSessionEntries(sessions.service, sessionId, entries);
+                await sessions.service.saveCheckpoint(sessionId, {
+                    payloadState: handle.compactionService.getState(sessionId),
+                }).catch((error: any) => {
+                    this.outputChannel.appendLine(`[n8n-agent] Manual compaction checkpoint failed: ${error?.message || String(error)}`);
+                });
+                return this.getWorkbenchState({ ...input, sessionId });
+            }
 
-        await handle.compactionService.notifyCompaction(sessionId, event);
-        const latestUsage = [...entries].reverse().find((entry): entry is Extract<AgentTimelineEntry, { kind: 'context-usage' }> => entry.kind === 'context-usage');
-        this.writeSessionEntries(sessions.service, sessionId, [
-            ...(latestUsage ? [latestUsage] : []),
-            { kind: 'compaction', id: randomUUID(), timestamp: Date.now(), event },
-            ...retained,
-        ]);
-        await sessions.service.saveCheckpoint(sessionId, {
-            payloadState: handle.compactionService.getState(sessionId),
-        }).catch((error: any) => {
-            this.outputChannel.appendLine(`[n8n-agent] Manual compaction checkpoint failed: ${error?.message || String(error)}`);
-        });
-        return this.getWorkbenchState(input);
+            const reason = typeof result?.reason === 'string' && result.reason.trim() ? result.reason.trim() : undefined;
+            const message = status === 'skipped'
+                ? (reason || 'Nothing to compact.')
+                : status === 'unavailable'
+                    ? (reason || 'Manual context compaction is not available for this runtime.')
+                    : (reason || 'Context compaction failed.');
+            this.writeSessionEntries(sessions.service, sessionId, [
+                ...entries,
+                this.createSystemNotice(message),
+            ]);
+            return this.getWorkbenchState({ ...input, sessionId });
+        } finally {
+            if (this.activeRun?.abortController === abortController) {
+                this.activeRun = undefined;
+            }
+        }
     }
 
     async sendPrompt(input: AgentPromptInput, postMessage: AgentWorkbenchPostMessage): Promise<AgentRunResult> {
@@ -538,7 +567,7 @@ export class AgentRuntimeController implements vscode.Disposable {
         sessions.service.touch(activeRecord.id, { title: derivedTitle });
         sessions.service.setTitle(activeRecord.id, derivedTitle);
 
-        let entries = this.readSessionEntries(sessions.service, activeRecord.id);
+        let entries = this.withoutContextUsage(this.readSessionEntries(sessions.service, activeRecord.id));
         entries = [...entries, { kind: 'user-message', id: randomUUID(), text: prompt, timestamp: Date.now() }];
 
         await postMessage({ type: 'agent.status', status: 'running', detail: 'Preparing n8n agent runtime...' });
@@ -624,24 +653,13 @@ export class AgentRuntimeController implements vscode.Disposable {
         sessions.service.setCheckpointer(handle.checkpointer);
         const agent = handle.agent;
         const messages = [{ role: 'user', content: await this.buildInvocationPrompt(input) }];
+        const contextWindowTokens = await this.resolveContextWindow(providerConfig.provider, providerConfig.model, providerConfig.apiKey, providerConfig.baseUrl);
         const config = {
             ...sessions.service.buildSessionConfig(input.sessionId || ''),
             signal,
         } as Record<string, unknown>;
 
         let entries = [...initialEntries];
-        const contextWindow = await this.resolveContextWindow(providerConfig.provider, providerConfig.model, providerConfig.apiKey, providerConfig.baseUrl);
-        const estimatedPromptTokens = Math.ceil(messages[0].content.length / 4);
-        const initialUsage: AgentContextUsageEvent = {
-            type: 'context-usage',
-            promptTokens: estimatedPromptTokens,
-            completionTokens: 0,
-            contextWindowTokens: contextWindow,
-            fillPercent: Math.round((estimatedPromptTokens / contextWindow) * 100),
-            source: 'estimated',
-        };
-        entries = this.applyStreamEvent(entries, initialUsage);
-        await postMessage({ type: 'agent.streamEvent', event: initialUsage });
 
         if (typeof (agent as any).streamEvents === 'function') {
             const stream = (agent as any).streamEvents({ messages }, config);
@@ -652,6 +670,7 @@ export class AgentRuntimeController implements vscode.Disposable {
             for await (const event of stream) {
                 await this.throwIfAborted(signal);
                 await eventRuntime.processStreamEvent(event, accumulator, {
+                    contextWindowTokens,
                     onTextDelta: async (delta: string) => {
                         entries = this.applyStreamEvent(entries, { type: 'text-delta', delta });
                         await postMessage({ type: 'agent.streamEvent', event: { type: 'text-delta', delta } });
@@ -702,6 +721,21 @@ export class AgentRuntimeController implements vscode.Disposable {
                         entries = this.applyStreamEvent(entries, streamEvent);
                         await postMessage({ type: 'agent.streamEvent', event: streamEvent });
                     },
+                    onContextUsage: async (usage: any) => {
+                        if (usage?.source !== 'api') {
+                            return;
+                        }
+                        const streamEvent: AgentStreamEvent = {
+                            type: 'context-usage',
+                            promptTokens: Number(usage.promptTokens || 0),
+                            completionTokens: Number(usage.completionTokens || 0),
+                            contextWindowTokens: Number(usage.contextWindowTokens || contextWindowTokens),
+                            fillPercent: Number(usage.fillPercent || 0),
+                            source: 'api',
+                        };
+                        entries = this.applyStreamEvent(entries, streamEvent);
+                        await postMessage({ type: 'agent.streamEvent', event: streamEvent });
+                    },
                 });
             }
 
@@ -715,18 +749,6 @@ export class AgentRuntimeController implements vscode.Disposable {
                     this.outputChannel.appendLine(`[n8n-agent] Auto-checkpoint failed: ${error?.message || String(error)}`);
                 }
             }
-
-            const estimatedCompletionTokens = Math.ceil(accumulator.responseText.length / 4);
-            const finalUsage: AgentContextUsageEvent = {
-                type: 'context-usage',
-                promptTokens: estimatedPromptTokens,
-                completionTokens: estimatedCompletionTokens,
-                contextWindowTokens: contextWindow,
-                fillPercent: Math.min(100, Math.round(((estimatedPromptTokens + estimatedCompletionTokens) / contextWindow) * 100)),
-                source: 'estimated',
-            };
-            entries = this.applyStreamEvent(entries, finalUsage);
-            await postMessage({ type: 'agent.streamEvent', event: finalUsage });
 
             const finalEvent: AgentStreamEvent = {
                 type: 'final',
@@ -1192,7 +1214,7 @@ export class AgentRuntimeController implements vscode.Disposable {
         const record = sessions.service.get(sessionId);
         const workflowContext = this.getLatestWorkflowContext(entries, record);
         const nodeContexts = workflowContext ? this.getLatestNodeContexts(entries) : [];
-        const latestUsageEntry = [...entries].reverse().find((entry): entry is Extract<AgentTimelineEntry, { kind: 'context-usage' }> => entry.kind === 'context-usage');
+        const latestUsageEntry = [...entries].reverse().find((entry): entry is Extract<AgentTimelineEntry, { kind: 'context-usage' }> => entry.kind === 'context-usage' && entry.usage.source === 'api');
         return {
             sessionId,
             title: displaySession?.title || record?.title || this.getDefaultSessionTitle(input.workflowName),
@@ -1212,17 +1234,6 @@ export class AgentRuntimeController implements vscode.Disposable {
             workflowContext,
             nodeContexts,
         };
-    }
-
-    private buildFallbackCompactionSummary(entries: AgentTimelineEntry[]): string {
-        const snippets = entries
-            .map((entry) => this.getEntryText(entry).trim())
-            .filter(Boolean)
-            .slice(-6)
-            .map((text) => text.length > 140 ? `${text.slice(0, 140)}...` : text);
-        return snippets.length
-            ? `Manual context compaction preserved recent conversation and summarized prior context: ${snippets.join(' | ')}`
-            : 'Manual context compaction preserved recent conversation and removed older low-signal context.';
     }
 
     private withWorkflowContext(entries: AgentTimelineEntry[], workflow: AgentWorkflowContext): AgentTimelineEntry[] {
@@ -1502,7 +1513,7 @@ export class AgentRuntimeController implements vscode.Disposable {
                     source: event.source,
                 },
             };
-            const withoutPrevious = entries.filter((entry) => entry.kind !== 'context-usage');
+            const withoutPrevious = this.withoutContextUsage(entries);
             return [...withoutPrevious, usageEntry];
         }
         if (event.type === 'error') {
@@ -1619,6 +1630,39 @@ export class AgentRuntimeController implements vscode.Disposable {
 
     private createSystemNotice(text: string): AgentTimelineEntry {
         return { kind: 'system-notice', id: randomUUID(), text, timestamp: Date.now() };
+    }
+
+    private withoutContextUsage(entries: AgentTimelineEntry[]): AgentTimelineEntry[] {
+        return entries.filter((entry) => entry.kind !== 'context-usage');
+    }
+
+    private toCompactionSummary(value: unknown): AgentCompactionSummary | undefined {
+        if (!value || typeof value !== 'object') return undefined;
+        const event = value as Record<string, unknown>;
+        const summary = typeof event.summary === 'string' && event.summary.trim()
+            ? event.summary.trim()
+            : 'Context compacted';
+        return {
+            summary,
+            source: event.source === 'fallback' ? 'fallback' : 'llm',
+            messagesCompacted: this.numberOrZero(event.messagesCompacted),
+            preservedRecentMessages: this.numberOrZero(event.preservedRecentMessages),
+            estimatedTokens: this.optionalNumber(event.estimatedTokens),
+            thresholdTokens: this.optionalNumber(event.thresholdTokens),
+            fallbackReason: typeof event.fallbackReason === 'string' && event.fallbackReason.trim()
+                ? event.fallbackReason.trim()
+                : undefined,
+        };
+    }
+
+    private numberOrZero(value: unknown): number {
+        const number = typeof value === 'number' ? value : Number(value || 0);
+        return Number.isFinite(number) ? number : 0;
+    }
+
+    private optionalNumber(value: unknown): number | undefined {
+        const number = typeof value === 'number' ? value : Number(value);
+        return Number.isFinite(number) ? number : undefined;
     }
 
     private async ensureAgentHandleWithCheckpoint(input: Omit<AgentPromptInput, 'prompt'>): Promise<any> {

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import { randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 
 export interface AgentPromptInput {
     prompt: string;
@@ -365,18 +365,18 @@ export class AgentRuntimeController implements vscode.Disposable {
         return this.getWorkbenchState(input);
     }
 
-    async sendPrompt(input: AgentPromptInput, postMessage: AgentWorkbenchPostMessage): Promise<void> {
+    async sendPrompt(input: AgentPromptInput, postMessage: AgentWorkbenchPostMessage): Promise<boolean> {
         if (this.activeRun) {
             await postMessage({
                 type: 'agent.error',
                 message: 'An agent run is already in progress. Stop it before sending another prompt.',
             });
-            return;
+            return false;
         }
 
         const prompt = input.prompt.trim();
         if (!prompt) {
-            return;
+            return false;
         }
 
         const sessions = await this.getSessionRuntime();
@@ -389,6 +389,8 @@ export class AgentRuntimeController implements vscode.Disposable {
 
         const abortController = new AbortController();
         this.activeRun = { abortController, sessionId: activeRecord.id };
+        const workflowSnapshot = await this.captureWorkflowSnapshot(input.workflowFilePath);
+        let workflowChanged = false;
 
         const derivedTitle = activeRecord.title === 'New conversation'
             ? sessions.deriveSessionTitle(prompt, this.getDefaultSessionTitle(input.workflowName))
@@ -416,11 +418,14 @@ export class AgentRuntimeController implements vscode.Disposable {
             await postMessage({ type: 'agent.error', message });
             await postMessage({ type: 'agent.state', state: await this.getWorkbenchState({ ...input, sessionId: activeRecord.id }) });
         } finally {
+            workflowChanged = await this.hasWorkflowSnapshotChanged(input.workflowFilePath, workflowSnapshot);
             if (this.activeRun?.abortController === abortController) {
                 this.activeRun = undefined;
             }
             await postMessage({ type: 'agent.status', status: 'idle' });
         }
+
+        return workflowChanged;
     }
 
     async stop(postMessage: AgentWorkbenchPostMessage): Promise<void> {
@@ -436,6 +441,36 @@ export class AgentRuntimeController implements vscode.Disposable {
     dispose(): void {
         this.activeRun?.abortController.abort();
         this.activeRun = undefined;
+    }
+
+    private async captureWorkflowSnapshot(workflowFilePath: string | undefined): Promise<string | undefined> {
+        if (!workflowFilePath) {
+            return undefined;
+        }
+
+        try {
+            const [stats, content] = await Promise.all([
+                fs.promises.stat(workflowFilePath),
+                fs.promises.readFile(workflowFilePath),
+            ]);
+            const digest = createHash('sha1').update(content).digest('hex');
+            return `${stats.size}:${stats.mtimeMs}:${digest}`;
+        } catch (error: any) {
+            if (error?.code === 'ENOENT') {
+                return 'missing';
+            }
+            this.outputChannel.appendLine(`[n8n-agent] Workflow snapshot failed for ${workflowFilePath}: ${error?.message || String(error)}`);
+            return undefined;
+        }
+    }
+
+    private async hasWorkflowSnapshotChanged(workflowFilePath: string | undefined, previousSnapshot: string | undefined): Promise<boolean> {
+        if (!workflowFilePath || previousSnapshot === undefined) {
+            return false;
+        }
+
+        const nextSnapshot = await this.captureWorkflowSnapshot(workflowFilePath);
+        return nextSnapshot !== previousSnapshot;
     }
 
     private async runInitialAgentTurn(

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -252,7 +252,9 @@ export class AgentRuntimeController implements vscode.Disposable {
     async getWorkbenchState(input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
         const scope = this.getSessionScope(input);
         const sessions = await this.getSessionRuntime();
-        const activeRecord = sessions.service.getActiveForScope(scope) || sessions.service.getOrCreateForScope(scope, {
+        const activeRecord = input.sessionId
+            ? sessions.service.ensure(input.sessionId, { scope, title: this.getDefaultSessionTitle(input.workflowName) })
+            : sessions.service.getActiveForScope(scope) || sessions.service.getOrCreateForScope(scope, {
             title: this.getDefaultSessionTitle(input.workflowName),
         });
         const session = await this.buildSessionState(activeRecord.id, input);
@@ -598,6 +600,7 @@ export class AgentRuntimeController implements vscode.Disposable {
             }
 
             if (accumulator.fileModificationDetected) {
+                this.outputChannel.appendLine(`[n8n-agent-debug] agent runtime detected local workflow modification sessionId=${input.sessionId || 'none'} workflowId=${input.workflowId || 'none'} workflowFilePath=${input.workflowFilePath || 'none'}`);
                 try {
                     await sessions.service.saveCheckpoint(input.sessionId || '', {
                         payloadState: handle.compactionService.getState(input.sessionId || ''),
@@ -627,6 +630,7 @@ export class AgentRuntimeController implements vscode.Disposable {
             };
             entries = this.applyStreamEvent(entries, finalEvent);
             await postMessage({ type: 'agent.streamEvent', event: finalEvent });
+            this.outputChannel.appendLine(`[n8n-agent-debug] agent runtime completed sessionId=${input.sessionId || 'none'} workflowId=${input.workflowId || 'none'} workflowChanged=${String(Boolean(accumulator.fileModificationDetected))}`);
             return { entries, workflowChanged: Boolean(accumulator.fileModificationDetected) };
         }
 
@@ -1155,31 +1159,24 @@ export class AgentRuntimeController implements vscode.Disposable {
         }
         if (event.type === 'text-delta') {
             const next = [...entries];
-            const last = next[next.length - 1];
-            if (last?.kind === 'assistant-body' && last.streaming) {
-                last.text += event.delta;
+            const streamingIndex = this.findLastAssistantBodyIndex(next, true);
+            if (streamingIndex >= 0) {
+                const entry = next[streamingIndex];
+                if (entry.kind === 'assistant-body') {
+                    entry.text += event.delta;
+                }
                 return next;
             }
             next.push({ kind: 'assistant-body', id: randomUUID(), text: event.delta, streaming: true });
             return next;
         }
         if (event.type === 'final') {
-            const next = [...entries];
-            const last = next[next.length - 1];
-            if (last?.kind === 'assistant-body') {
-                last.streaming = false;
-                if (!last.text) {
-                    last.text = event.response;
-                }
-                last.finalState = event.finalState;
-                return next;
-            }
-            next.push({ kind: 'assistant-body', id: randomUUID(), text: event.response, streaming: false, finalState: event.finalState });
-            return next;
+            const next = this.finalizePendingOperations([...entries], 'done');
+            return this.consolidateFinalAssistant(next, event.response, event.finalState);
         }
         if (event.type === 'operation') {
             const next = [...entries];
-            const existingIndex = next.findIndex((entry) => entry.kind === 'operation' && entry.id === event.operationId);
+            const existingIndex = this.findMatchingPendingOperationIndex(next, event.operationId, event.label, event.category);
             const operationEntry: AgentTimelineEntry = {
                 kind: 'operation',
                 id: event.operationId,
@@ -1201,17 +1198,24 @@ export class AgentRuntimeController implements vscode.Disposable {
             return next;
         }
         if (event.type === 'progress') {
+            const next = [...entries];
+            const existingIndex = this.findMatchingPendingOperationIndex(next, undefined, event.title, event.phase || 'phase');
+            const progressEntry: AgentTimelineEntry = {
+                kind: 'operation',
+                id: existingIndex >= 0 ? next[existingIndex].id : randomUUID(),
+                tone: event.tone,
+                title: event.title,
+                detail: event.detail,
+                category: event.phase || 'phase',
+                status: event.tone === 'error' ? 'error' : 'running',
+            };
+            if (existingIndex >= 0) {
+                next[existingIndex] = progressEntry;
+                return next;
+            }
             return [
-                ...entries,
-                {
-                    kind: 'operation',
-                    id: randomUUID(),
-                    tone: event.tone,
-                    title: event.title,
-                    detail: event.detail,
-                    category: event.phase || 'phase',
-                    status: event.tone === 'error' ? 'error' : 'running',
-                },
+                ...next,
+                progressEntry,
             ];
         }
         if (event.type === 'compaction') {
@@ -1250,9 +1254,115 @@ export class AgentRuntimeController implements vscode.Disposable {
             return [...withoutPrevious, usageEntry];
         }
         if (event.type === 'error') {
-            return [...entries, this.createSystemNotice(`Error: ${event.error}`)];
+            return [...this.finalizePendingOperations(entries, 'error'), this.createSystemNotice(`Error: ${event.error}`)];
         }
         return entries;
+    }
+
+    private finalizePendingOperations(entries: AgentTimelineEntry[], status: 'done' | 'error'): AgentTimelineEntry[] {
+        return entries.map((entry) => {
+            if (entry.kind !== 'operation' || entry.status !== 'running') return entry;
+            return {
+                ...entry,
+                tone: status === 'error' ? 'error' : 'success',
+                status,
+                endedAt: entry.endedAt || Date.now(),
+            };
+        });
+    }
+
+    private consolidateFinalAssistant(entries: AgentTimelineEntry[], response: string, finalState: string): AgentTimelineEntry[] {
+        const userIndex = this.findLastUserMessageIndex(entries);
+        const finalText = this.sanitizeAssistantText(response);
+        let chosenText = finalText;
+        let firstAssistantIndex = -1;
+
+        for (let idx = userIndex + 1; idx < entries.length; idx += 1) {
+            const entry = entries[idx];
+            if (entry.kind !== 'assistant-body') continue;
+            const text = this.sanitizeAssistantText(entry.text);
+            if (text && firstAssistantIndex < 0) {
+                firstAssistantIndex = idx;
+            }
+            if (text && finalText.includes(text) && text.length >= Math.max(80, finalText.length * 0.6)) {
+                chosenText = text;
+            }
+        }
+
+        const result: AgentTimelineEntry[] = [];
+        let inserted = false;
+        for (let idx = 0; idx < entries.length; idx += 1) {
+            const entry = entries[idx];
+            if (idx > userIndex && entry.kind === 'assistant-body') {
+                if (!inserted && chosenText && idx === firstAssistantIndex) {
+                    result.push({ kind: 'assistant-body', id: entry.id || randomUUID(), text: chosenText, streaming: false, finalState });
+                    inserted = true;
+                }
+                continue;
+            }
+            result.push(entry);
+        }
+        if (!inserted && chosenText) {
+            result.push({ kind: 'assistant-body', id: randomUUID(), text: chosenText, streaming: false, finalState });
+        }
+        return result;
+    }
+
+    private findLastUserMessageIndex(entries: AgentTimelineEntry[]): number {
+        for (let idx = entries.length - 1; idx >= 0; idx -= 1) {
+            if (entries[idx].kind === 'user-message') return idx;
+        }
+        return -1;
+    }
+
+    private findLastAssistantBodyIndex(entries: AgentTimelineEntry[], streamingOnly: boolean): number {
+        for (let idx = entries.length - 1; idx >= 0; idx -= 1) {
+            const entry = entries[idx];
+            if (entry.kind !== 'assistant-body') continue;
+            if (streamingOnly && !entry.streaming) continue;
+            return idx;
+        }
+        return -1;
+    }
+
+    private findMatchingPendingOperationIndex(entries: AgentTimelineEntry[], operationId: string | undefined, title: string, category: string): number {
+        if (operationId) {
+            const exactIndex = entries.findIndex((entry) => entry.kind === 'operation' && entry.id === operationId);
+            if (exactIndex >= 0) {
+                return exactIndex;
+            }
+        }
+
+        const targetKind = this.normalizeOperationKind(category, title);
+        for (let idx = entries.length - 1; idx >= 0; idx -= 1) {
+            const entry = entries[idx];
+            if (entry.kind !== 'operation') continue;
+            if (entry.status !== 'running') continue;
+
+            const entryKind = this.normalizeOperationKind(entry.category, entry.title);
+            if (entryKind && targetKind && entryKind === targetKind) {
+                return idx;
+            }
+
+            if (entry.title !== title) continue;
+
+            const entryCategory = String(entry.category || '').toLowerCase();
+            const targetCategory = String(category || '').toLowerCase();
+            if (entryCategory && targetCategory && entryCategory !== targetCategory && entryCategory !== 'phase') continue;
+
+            return idx;
+        }
+
+        return -1;
+    }
+
+    private normalizeOperationKind(category: string | undefined, title: string | undefined): string {
+        const value = String(category || title || '').toLowerCase().replace(/_/g, '-');
+        if (value === 'read-file' || value === 'file-read' || value === 'read') return 'file-read';
+        if (value === 'write-file' || value === 'file-write' || value === 'write') return 'file-write';
+        if (value.includes('shell')) return 'shell';
+        if (value.includes('web')) return 'web';
+        return value;
     }
 
     private createSystemNotice(text: string): AgentTimelineEntry {

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -11,6 +11,7 @@ export interface AgentPromptInput {
     workflowFilePath?: string;
     workspaceRoot?: string;
     nodeContext?: AgentNodeContext;
+    nodeContexts?: AgentNodeContext[];
     sessionId?: string;
 }
 
@@ -22,6 +23,13 @@ export interface AgentNodeContext {
     name: string;
     type?: string;
     id?: string;
+}
+
+export interface AgentWorkflowContext {
+    id?: string;
+    name: string;
+    filename?: string;
+    filePath?: string;
 }
 
 export type AgentReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
@@ -63,12 +71,16 @@ export interface AgentSessionSummary {
     checkpointCount: number;
     workflowId?: string;
     workflowLabel: string;
+    workflowContext?: AgentWorkflowContext;
     totalCompactions: number;
 }
 
 export type AgentTimelineEntry =
     | { kind: 'user-message'; id: string; text: string; timestamp: number }
     | { kind: 'system-notice'; id: string; text: string; timestamp: number }
+    | { kind: 'workflow-context'; id: string; timestamp: number; action: 'set'; workflow: AgentWorkflowContext }
+    | { kind: 'workflow-context'; id: string; timestamp: number; action: 'clear' }
+    | { kind: 'node-context'; id: string; timestamp: number; nodes: AgentNodeContext[] }
     | { kind: 'assistant-body'; id: string; text: string; streaming: boolean; finalState?: string }
     | {
         kind: 'operation';
@@ -96,6 +108,8 @@ export interface AgentSessionState {
     totalCompactions: number;
     workflowId?: string;
     workflowLabel: string;
+    workflowContext?: AgentWorkflowContext;
+    nodeContexts: AgentNodeContext[];
 }
 
 export interface AgentWorkbenchState {
@@ -104,12 +118,14 @@ export interface AgentWorkbenchState {
         name?: string;
         filename?: string;
     };
+    workflowContext?: AgentWorkflowContext;
     provider: string;
     model?: string;
     baseUrl?: string;
     reasoningEffort?: AgentReasoningEffort;
     supportsReasoningEffort: boolean;
     currentNodeContext?: AgentNodeContext;
+    currentNodeContexts: AgentNodeContext[];
     activeSessionId: string;
     sessions: AgentSessionSummary[];
     session: AgentSessionState;
@@ -253,24 +269,28 @@ export class AgentRuntimeController implements vscode.Disposable {
         const scope = this.getSessionScope(input);
         const sessions = await this.getSessionRuntime();
         const activeRecord = input.sessionId
-            ? sessions.service.ensure(input.sessionId, { scope, title: this.getDefaultSessionTitle(input.workflowName) })
+            ? sessions.service.ensure(input.sessionId, { title: this.getDefaultSessionTitle(input.workflowName) })
             : sessions.service.getActiveForScope(scope) || sessions.service.getOrCreateForScope(scope, {
             title: this.getDefaultSessionTitle(input.workflowName),
         });
         const session = await this.buildSessionState(activeRecord.id, input);
+        const workflowContext = session.workflowContext;
+        const nodeContexts = session.nodeContexts.length ? session.nodeContexts : this.normalizeNodeContexts(input.nodeContexts || input.nodeContext);
         const providerConfig = await this.describeProviderRuntimeConfig();
         return {
             workflow: {
-                id: input.workflowId,
-                name: input.workflowName,
-                filename: input.workflowFilename,
+                id: workflowContext?.id,
+                name: workflowContext?.name,
+                filename: workflowContext?.filename,
             },
+            workflowContext,
             provider: providerConfig.provider,
             model: providerConfig.model,
             baseUrl: providerConfig.baseUrl,
             reasoningEffort: providerConfig.reasoningEffort,
             supportsReasoningEffort: providerConfig.provider === 'openai-oauth',
-            currentNodeContext: input.nodeContext,
+            currentNodeContext: nodeContexts[0],
+            currentNodeContexts: nodeContexts,
             activeSessionId: activeRecord.id,
             sessions: await this.listSessionSummaries(scope, activeRecord.id),
             session,
@@ -279,18 +299,50 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     async createSession(input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
-        const scope = this.getSessionScope(input);
+        const scope = this.getUnattachedSessionScope();
         const sessions = await this.getSessionRuntime();
         sessions.service.rotateForScope(scope, {
-            title: this.getDefaultSessionTitle(input.workflowName),
+            title: this.getDefaultSessionTitle(),
         });
-        return this.getWorkbenchState(input);
+        return this.getWorkbenchState({ ...input, workflowId: undefined, workflowName: undefined, workflowFilename: undefined, workflowFilePath: undefined, nodeContext: undefined, nodeContexts: undefined, sessionId: undefined });
+    }
+
+    async getLatestSessionId(): Promise<string | undefined> {
+        const sessions = await this.getSessionRuntime();
+        return [...sessions.service.list()]
+            .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))[0]?.id;
+    }
+
+    async getLatestSessionIdForWorkflow(workflow: AgentWorkflowContext): Promise<string | undefined> {
+        const sessions = await this.getSessionRuntime();
+        const summaries = sessions.service.list();
+        let latest: { id: string; updatedAt: string } | undefined;
+        for (const summary of summaries) {
+            const record = sessions.service.get(summary.id);
+            const context = this.getLatestWorkflowContext(this.readSessionEntries(sessions.service, summary.id), record);
+            if (!context || !this.workflowContextsMatch(context, workflow)) continue;
+            if (!latest || summary.updatedAt.localeCompare(latest.updatedAt) > 0) {
+                latest = { id: summary.id, updatedAt: summary.updatedAt };
+            }
+        }
+        return latest?.id;
+    }
+
+    async createSessionForWorkflow(workflow: AgentWorkflowContext, input: Omit<AgentPromptInput, 'prompt'>): Promise<string> {
+        const name = workflow.name?.trim() || workflow.id || workflow.filename || 'Workflow';
+        const sessions = await this.getSessionRuntime();
+        const record = sessions.service.rotateForScope(this.getUnattachedSessionScope(), {
+            title: this.getDefaultSessionTitle(name),
+        });
+        this.writeSessionEntries(sessions.service, record.id, this.withWorkflowContext([], { ...workflow, name }));
+        await this.getWorkbenchState({ ...input, sessionId: record.id });
+        return record.id;
     }
 
     async selectSession(sessionId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
         const sessions = await this.getSessionRuntime();
-        sessions.service.ensure(sessionId, { scope: this.getSessionScope(input) });
-        return this.getWorkbenchState(input);
+        sessions.service.ensure(sessionId);
+        return this.getWorkbenchState({ ...input, sessionId });
     }
 
     async renameSession(sessionId: string, title: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
@@ -316,23 +368,56 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     async attachSessionToCurrentWorkflow(sessionId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
-        const scope = this.getSessionScope(input);
         if (!input.workflowId) {
             throw new Error('Open a workflow before attaching a session.');
         }
-        const sessions = await this.getSessionRuntime();
-        sessions.service.ensure(sessionId, { scope });
-        return this.getWorkbenchState(input);
+        return this.setWorkflowContext(sessionId, {
+            id: input.workflowId,
+            name: input.workflowName || input.workflowId,
+            filename: input.workflowFilename,
+            filePath: input.workflowFilePath,
+        }, input);
     }
 
     async detachSession(sessionId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
-        const currentScope = this.getSessionScope(input);
+        return this.clearWorkflowContext(sessionId, input);
+    }
+
+    async setWorkflowContext(sessionId: string, workflow: AgentWorkflowContext, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
+        const name = workflow.name?.trim() || workflow.id || workflow.filename || 'Workflow';
         const sessions = await this.getSessionRuntime();
-        sessions.service.ensure(sessionId, { scope: this.getUnattachedSessionScope() });
-        if (sessions.service.getActiveForScope(currentScope)?.id === sessionId) {
-            sessions.service.getOrCreateForScope(currentScope, { title: this.getDefaultSessionTitle(input.workflowName) });
+        sessions.service.ensure(sessionId);
+        const entries = this.withWorkflowContext(this.readSessionEntries(sessions.service, sessionId), {
+            ...workflow,
+            name,
+        });
+        this.writeSessionEntries(sessions.service, sessionId, entries);
+        return this.getWorkbenchState({ ...input, sessionId });
+    }
+
+    async clearWorkflowContext(sessionId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
+        const sessions = await this.getSessionRuntime();
+        sessions.service.ensure(sessionId);
+        this.writeSessionEntries(sessions.service, sessionId, [
+            ...this.readSessionEntries(sessions.service, sessionId),
+            { kind: 'workflow-context', id: randomUUID(), timestamp: Date.now(), action: 'clear' },
+            { kind: 'node-context', id: randomUUID(), timestamp: Date.now(), nodes: [] },
+        ]);
+        return this.getWorkbenchState({ ...input, sessionId, workflowId: undefined, workflowName: undefined, workflowFilename: undefined, workflowFilePath: undefined, nodeContext: undefined, nodeContexts: undefined });
+    }
+
+    async setNodeContexts(sessionId: string, nodes: AgentNodeContext[], input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
+        const sessions = await this.getSessionRuntime();
+        sessions.service.ensure(sessionId);
+        const workflowContext = this.getLatestWorkflowContext(this.readSessionEntries(sessions.service, sessionId), sessions.service.get(sessionId));
+        if (!workflowContext) {
+            return this.getWorkbenchState({ ...input, sessionId, nodeContext: undefined, nodeContexts: undefined });
         }
-        return this.getWorkbenchState(input);
+        this.writeSessionEntries(sessions.service, sessionId, [
+            ...this.readSessionEntries(sessions.service, sessionId),
+            { kind: 'node-context', id: randomUUID(), timestamp: Date.now(), nodes: this.normalizeNodeContexts(nodes) },
+        ]);
+        return this.getWorkbenchState({ ...input, sessionId });
     }
 
     async saveCheckpoint(sessionId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
@@ -424,10 +509,25 @@ export class AgentRuntimeController implements vscode.Disposable {
         const sessions = await this.getSessionRuntime();
         const scope = this.getSessionScope(input);
         const activeRecord = input.sessionId
-            ? sessions.service.ensure(input.sessionId, { scope, title: this.getDefaultSessionTitle(input.workflowName) })
+            ? sessions.service.ensure(input.sessionId, { title: this.getDefaultSessionTitle(input.workflowName) })
             : (sessions.service.getActiveForScope(scope) || sessions.service.getOrCreateForScope(scope, {
                 title: this.getDefaultSessionTitle(input.workflowName),
             }));
+        const sessionContext = await this.buildSessionState(activeRecord.id, input);
+        const promptWorkflowContext = sessionContext.workflowContext;
+        const promptNodeContexts = sessionContext.nodeContexts.length
+            ? sessionContext.nodeContexts
+            : this.normalizeNodeContexts(input.nodeContexts || input.nodeContext);
+        const promptInput: AgentPromptInput = {
+            ...input,
+            sessionId: activeRecord.id,
+            workflowId: promptWorkflowContext?.id,
+            workflowName: promptWorkflowContext?.name,
+            workflowFilename: promptWorkflowContext?.filename,
+            workflowFilePath: promptWorkflowContext?.filePath || input.workflowFilePath,
+            nodeContext: promptNodeContexts[0],
+            nodeContexts: promptNodeContexts,
+        };
 
         const abortController = new AbortController();
         this.activeRun = { abortController, sessionId: activeRecord.id };
@@ -445,8 +545,14 @@ export class AgentRuntimeController implements vscode.Disposable {
         await postMessage({ type: 'agent.streamEvent', event: { type: 'start', sessionId: activeRecord.id, message: prompt } });
 
         try {
-            const runResult = await this.runInitialAgentTurn({ ...input, sessionId: activeRecord.id }, entries, postMessage, abortController.signal);
+            const runResult = await this.runInitialAgentTurn(promptInput, entries, postMessage, abortController.signal);
             entries = runResult.entries;
+            if (runResult.workflowChanged && !promptWorkflowContext) {
+                const inferredWorkflow = await this.inferWorkflowContextFromWorkspace(input.workspaceRoot);
+                if (inferredWorkflow) {
+                    entries = this.withWorkflowContext(entries, inferredWorkflow);
+                }
+            }
             this.writeSessionEntries(sessions.service, activeRecord.id, entries);
             await postMessage({ type: 'agent.state', state: await this.getWorkbenchState({ ...input, sessionId: activeRecord.id }) });
             await postMessage({ type: 'agent.done' });
@@ -796,10 +902,11 @@ export class AgentRuntimeController implements vscode.Disposable {
 
     private async buildInvocationPrompt(input: AgentPromptInput): Promise<string> {
         const workflowContext = await this.loadWorkflowContext(input);
+        const nodeContexts = this.normalizeNodeContexts(input.nodeContexts || input.nodeContext);
         const blocks = [
             input.workflowId ? `Current workflow: ${input.workflowName || input.workflowId} (${input.workflowId})` : 'No workflow is attached. The user may be designing a new workflow.',
             input.workflowFilename ? `Current workflow file: ${input.workflowFilename}` : undefined,
-            this.formatNodeContext(input.nodeContext),
+            this.formatNodeContexts(nodeContexts),
             workflowContext,
             'User request:',
             input.prompt.trim(),
@@ -807,16 +914,18 @@ export class AgentRuntimeController implements vscode.Disposable {
         return blocks.join('\n\n');
     }
 
-    private formatNodeContext(nodeContext: AgentNodeContext | undefined): string | undefined {
-        if (!nodeContext?.name) {
+    private formatNodeContexts(nodeContexts: AgentNodeContext[]): string | undefined {
+        if (!nodeContexts.length) {
             return undefined;
         }
         return [
-            'Current n8n node detail panel context:',
-            `Node name: ${nodeContext.name}`,
-            nodeContext.type ? `Node type: ${nodeContext.type}` : undefined,
-            nodeContext.id ? `Node ID: ${nodeContext.id}` : undefined,
-            'When the user makes an ambiguous node-specific request, assume it refers to this node unless they name another node.',
+            nodeContexts.length === 1 ? 'Current n8n node context:' : 'Current n8n node contexts:',
+            ...nodeContexts.map((node, index) => [
+                `${index + 1}. Node name: ${node.name}`,
+                node.type ? `   Node type: ${node.type}` : undefined,
+                node.id ? `   Node ID: ${node.id}` : undefined,
+            ].filter(Boolean).join('\n')),
+            'When the user makes an ambiguous node-specific request, assume it refers to these selected nodes unless they name another node.',
         ].filter(Boolean).join('\n');
     }
 
@@ -1037,10 +1146,8 @@ export class AgentRuntimeController implements vscode.Disposable {
         const handle = this.cachedAgentHandle?.handle;
         const summaries = await Promise.all(sessions.service.list().map(async (summary) => {
             const record = sessions.service.get(summary.id);
-            const recordScope = record?.scope;
-            const workflowId = recordScope?.kind === 'vscode-workflow' && recordScope.key !== UNATTACHED_WORKFLOW_SCOPE_KEY
-                ? recordScope.key
-                : undefined;
+            const entries = this.readSessionEntries(sessions.service, summary.id);
+            const workflowContext = this.getLatestWorkflowContext(entries, record);
             const compactionState = handle?.compactionService?.getState
                 ? handle.compactionService.getState(summary.id) as CompactionState
                 : { lastCompaction: null, compactionHistory: [], totalCompactions: 0 };
@@ -1054,8 +1161,9 @@ export class AgentRuntimeController implements vscode.Disposable {
                 isActive: summary.id === activeSessionId,
                 isClosed: Boolean(record?.closedAt),
                 checkpointCount: checkpoints.length,
-                workflowId,
-                workflowLabel: workflowId ? workflowId : 'New workflow chat',
+                workflowId: workflowContext?.id,
+                workflowLabel: workflowContext?.name || workflowContext?.id || workflowContext?.filename || 'New workflow chat',
+                workflowContext,
                 totalCompactions: compactionState.totalCompactions,
             };
         }));
@@ -1063,8 +1171,8 @@ export class AgentRuntimeController implements vscode.Disposable {
             if (left.isActive !== right.isActive) {
                 return left.isActive ? -1 : 1;
             }
-            const leftMatchesScope = left.workflowId === scope.key || (!left.workflowId && scope.key === UNATTACHED_WORKFLOW_SCOPE_KEY);
-            const rightMatchesScope = right.workflowId === scope.key || (!right.workflowId && scope.key === UNATTACHED_WORKFLOW_SCOPE_KEY);
+            const leftMatchesScope = left.workflowId === scope.key || (!left.workflowContext && scope.key === UNATTACHED_WORKFLOW_SCOPE_KEY);
+            const rightMatchesScope = right.workflowId === scope.key || (!right.workflowContext && scope.key === UNATTACHED_WORKFLOW_SCOPE_KEY);
             if (leftMatchesScope !== rightMatchesScope) {
                 return leftMatchesScope ? -1 : 1;
             }
@@ -1082,9 +1190,8 @@ export class AgentRuntimeController implements vscode.Disposable {
             ? handle.compactionService.getState(sessionId)
             : { lastCompaction: null, compactionHistory: [], totalCompactions: 0 };
         const record = sessions.service.get(sessionId);
-        const workflowId = record?.scope?.kind === 'vscode-workflow' && record.scope.key !== UNATTACHED_WORKFLOW_SCOPE_KEY
-            ? record.scope.key
-            : undefined;
+        const workflowContext = this.getLatestWorkflowContext(entries, record);
+        const nodeContexts = workflowContext ? this.getLatestNodeContexts(entries) : [];
         const latestUsageEntry = [...entries].reverse().find((entry): entry is Extract<AgentTimelineEntry, { kind: 'context-usage' }> => entry.kind === 'context-usage');
         return {
             sessionId,
@@ -1100,8 +1207,10 @@ export class AgentRuntimeController implements vscode.Disposable {
             contextUsage: latestUsageEntry?.usage,
             lastCompaction: compactionState.lastCompaction || undefined,
             totalCompactions: compactionState.totalCompactions,
-            workflowId,
-            workflowLabel: workflowId || 'New workflow chat',
+            workflowId: workflowContext?.id,
+            workflowLabel: workflowContext?.name || workflowContext?.id || workflowContext?.filename || 'New workflow chat',
+            workflowContext,
+            nodeContexts,
         };
     }
 
@@ -1116,9 +1225,152 @@ export class AgentRuntimeController implements vscode.Disposable {
             : 'Manual context compaction preserved recent conversation and removed older low-signal context.';
     }
 
+    private withWorkflowContext(entries: AgentTimelineEntry[], workflow: AgentWorkflowContext): AgentTimelineEntry[] {
+        const name = workflow.name?.trim() || workflow.id || workflow.filename || 'Workflow';
+        return [
+            ...entries,
+            {
+                kind: 'workflow-context',
+                id: randomUUID(),
+                timestamp: Date.now(),
+                action: 'set',
+                workflow: {
+                    id: workflow.id?.trim() || undefined,
+                    name,
+                    filename: workflow.filename?.trim() || undefined,
+                    filePath: workflow.filePath?.trim() || undefined,
+                },
+            },
+        ];
+    }
+
+    private getLatestWorkflowContext(entries: AgentTimelineEntry[], record?: DeepAgentSessionRecord): AgentWorkflowContext | undefined {
+        for (let idx = entries.length - 1; idx >= 0; idx -= 1) {
+            const entry = entries[idx];
+            if (entry.kind !== 'workflow-context') continue;
+            if (entry.action === 'clear') return undefined;
+            return entry.workflow;
+        }
+        const workflowId = record?.scope?.kind === 'vscode-workflow' && record.scope.key !== UNATTACHED_WORKFLOW_SCOPE_KEY
+            ? record.scope.key
+            : undefined;
+        return workflowId ? { id: workflowId, name: workflowId } : undefined;
+    }
+
+    private workflowContextsMatch(left: AgentWorkflowContext, right: AgentWorkflowContext): boolean {
+        if (left.id && right.id && left.id === right.id) return true;
+        if (left.filename && right.filename && left.filename === right.filename) return true;
+        return Boolean(left.name && right.name && left.name === right.name);
+    }
+
+    private getLatestNodeContexts(entries: AgentTimelineEntry[]): AgentNodeContext[] {
+        for (let idx = entries.length - 1; idx >= 0; idx -= 1) {
+            const entry = entries[idx];
+            if (entry.kind !== 'node-context') continue;
+            return this.normalizeNodeContexts(entry.nodes);
+        }
+        return [];
+    }
+
+    private normalizeNodeContexts(value: AgentNodeContext | AgentNodeContext[] | undefined): AgentNodeContext[] {
+        const values = Array.isArray(value) ? value : value ? [value] : [];
+        const seen = new Set<string>();
+        const result: AgentNodeContext[] = [];
+        for (const candidate of values) {
+            const name = typeof candidate?.name === 'string' ? candidate.name.trim() : '';
+            if (!name) continue;
+            const type = typeof candidate.type === 'string' ? candidate.type.trim() : '';
+            const id = typeof candidate.id === 'string' ? candidate.id.trim() : '';
+            const key = [name, type, id].join('|');
+            if (seen.has(key)) continue;
+            seen.add(key);
+            result.push({ name, type: type || undefined, id: id || undefined });
+        }
+        return result;
+    }
+
+    private async inferWorkflowContextFromWorkspace(workspaceRoot?: string): Promise<AgentWorkflowContext | undefined> {
+        if (!workspaceRoot) return undefined;
+        const candidates = await this.listWorkflowSourceCandidates(workspaceRoot);
+        candidates.sort((left, right) => right.mtimeMs - left.mtimeMs);
+        for (const candidate of candidates.slice(0, 12)) {
+            const context = await this.readWorkflowContextFromTypeScriptFile(candidate.filePath, workspaceRoot);
+            if (context) return context;
+        }
+        return undefined;
+    }
+
+    private async listWorkflowSourceCandidates(workspaceRoot: string): Promise<Array<{ filePath: string; mtimeMs: number }>> {
+        const results: Array<{ filePath: string; mtimeMs: number }> = [];
+        await this.collectWorkflowSourceCandidates(workspaceRoot, results, workspaceRoot, 0);
+        return results;
+    }
+
+    private async collectWorkflowSourceCandidates(
+        directory: string,
+        results: Array<{ filePath: string; mtimeMs: number }>,
+        workspaceRoot: string,
+        depth: number,
+    ): Promise<void> {
+        if (depth > 4) return;
+        const relative = path.relative(workspaceRoot, directory).replace(/\\/g, '/');
+        if (relative && /(^|\/)(node_modules|dist|out|\.git|\.kilo|\.yagr)(\/|$)/.test(relative)) {
+            return;
+        }
+        let entries: fs.Dirent[];
+        try {
+            entries = await fs.promises.readdir(directory, { withFileTypes: true });
+        } catch {
+            return;
+        }
+        for (const entry of entries) {
+            const filePath = path.join(directory, entry.name);
+            if (entry.isDirectory()) {
+                await this.collectWorkflowSourceCandidates(filePath, results, workspaceRoot, depth + 1);
+                continue;
+            }
+            if (!entry.isFile() || !entry.name.endsWith('.workflow.ts')) continue;
+            const stat = await fs.promises.stat(filePath).catch(() => undefined);
+            if (stat?.isFile()) results.push({ filePath, mtimeMs: stat.mtimeMs });
+        }
+    }
+
+    private async readWorkflowContextFromTypeScriptFile(filePath: string, workspaceRoot: string): Promise<AgentWorkflowContext | undefined> {
+        try {
+            const raw = await fs.promises.readFile(filePath, 'utf8');
+            const metadata = this.extractWorkflowDecoratorMetadata(raw);
+            const filename = path.relative(workspaceRoot, filePath).replace(/\\/g, '/');
+            return {
+                id: metadata.id,
+                name: metadata.name || path.basename(filePath, '.workflow.ts'),
+                filename,
+                filePath,
+            };
+        } catch {
+            return undefined;
+        }
+    }
+
+    private extractWorkflowDecoratorMetadata(source: string): { id?: string; name?: string } {
+        const decoratorMatch = source.match(/@workflow\s*\(\s*\{([\s\S]*?)\}\s*\)/);
+        const decoratorContent = decoratorMatch?.[1] || '';
+        return {
+            id: this.extractStringProperty(decoratorContent, 'id'),
+            name: this.extractStringProperty(decoratorContent, 'name'),
+        };
+    }
+
+    private extractStringProperty(source: string, property: string): string | undefined {
+        const match = source.match(new RegExp(`${property}\\s*:\\s*(["'])((?:\\\\.|(?!\\1)[\\s\\S])*?)\\1`));
+        return match?.[2]?.trim() || undefined;
+    }
+
     private getEntryText(entry: AgentTimelineEntry): string {
         if (entry.kind === 'user-message' || entry.kind === 'system-notice' || entry.kind === 'assistant-body') {
             return entry.text;
+        }
+        if (entry.kind === 'workflow-context' || entry.kind === 'node-context') {
+            return '';
         }
         if (entry.kind === 'operation') {
             return [entry.title, entry.detail, entry.summary, entry.body].filter(Boolean).join(' ');

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -11,6 +11,8 @@ export interface AgentPromptInput {
     nodeContext?: AgentNodeContext;
 }
 
+const ENVIRONMENT_DETAILS_BLOCK_PATTERN = /<environment_details>[\s\S]*?<\/environment_details>/gi;
+
 export interface AgentNodeContext {
     name: string;
     type?: string;
@@ -435,18 +437,22 @@ export class AgentRuntimeController implements vscode.Disposable {
         const last = messages[messages.length - 1] as Record<string, unknown> | undefined;
         const content = last?.content ?? record.content ?? record.output;
         if (typeof content === 'string') {
-            return content;
+            return this.sanitizeAssistantText(content);
         }
         if (Array.isArray(content)) {
-            return content.map((part) => {
+            return this.sanitizeAssistantText(content.map((part) => {
                 if (typeof part === 'string') return part;
                 if (part && typeof part === 'object' && typeof (part as Record<string, unknown>).text === 'string') {
                     return (part as Record<string, string>).text;
                 }
                 return '';
-            }).join('');
+            }).join(''));
         }
         return 'The agent completed without producing text.';
+    }
+
+    private sanitizeAssistantText(value: string): string {
+        return value.replace(ENVIRONMENT_DETAILS_BLOCK_PATTERN, '').trim();
     }
 
     private async buildProviderStatusLine(): Promise<string> {

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import { createHash, randomUUID } from 'crypto';
+import { randomUUID } from 'crypto';
 
 export interface AgentPromptInput {
     prompt: string;
@@ -365,18 +365,18 @@ export class AgentRuntimeController implements vscode.Disposable {
         return this.getWorkbenchState(input);
     }
 
-    async sendPrompt(input: AgentPromptInput, postMessage: AgentWorkbenchPostMessage): Promise<boolean> {
+    async sendPrompt(input: AgentPromptInput, postMessage: AgentWorkbenchPostMessage): Promise<void> {
         if (this.activeRun) {
             await postMessage({
                 type: 'agent.error',
                 message: 'An agent run is already in progress. Stop it before sending another prompt.',
             });
-            return false;
+            return;
         }
 
         const prompt = input.prompt.trim();
         if (!prompt) {
-            return false;
+            return;
         }
 
         const sessions = await this.getSessionRuntime();
@@ -389,8 +389,6 @@ export class AgentRuntimeController implements vscode.Disposable {
 
         const abortController = new AbortController();
         this.activeRun = { abortController, sessionId: activeRecord.id };
-        const workflowSnapshot = await this.captureWorkflowSnapshot(input.workflowFilePath);
-        let workflowChanged = false;
 
         const derivedTitle = activeRecord.title === 'New conversation'
             ? sessions.deriveSessionTitle(prompt, this.getDefaultSessionTitle(input.workflowName))
@@ -418,14 +416,11 @@ export class AgentRuntimeController implements vscode.Disposable {
             await postMessage({ type: 'agent.error', message });
             await postMessage({ type: 'agent.state', state: await this.getWorkbenchState({ ...input, sessionId: activeRecord.id }) });
         } finally {
-            workflowChanged = await this.hasWorkflowSnapshotChanged(input.workflowFilePath, workflowSnapshot);
             if (this.activeRun?.abortController === abortController) {
                 this.activeRun = undefined;
             }
             await postMessage({ type: 'agent.status', status: 'idle' });
         }
-
-        return workflowChanged;
     }
 
     async stop(postMessage: AgentWorkbenchPostMessage): Promise<void> {
@@ -441,36 +436,6 @@ export class AgentRuntimeController implements vscode.Disposable {
     dispose(): void {
         this.activeRun?.abortController.abort();
         this.activeRun = undefined;
-    }
-
-    private async captureWorkflowSnapshot(workflowFilePath: string | undefined): Promise<string | undefined> {
-        if (!workflowFilePath) {
-            return undefined;
-        }
-
-        try {
-            const [stats, content] = await Promise.all([
-                fs.promises.stat(workflowFilePath),
-                fs.promises.readFile(workflowFilePath),
-            ]);
-            const digest = createHash('sha1').update(content).digest('hex');
-            return `${stats.size}:${stats.mtimeMs}:${digest}`;
-        } catch (error: any) {
-            if (error?.code === 'ENOENT') {
-                return 'missing';
-            }
-            this.outputChannel.appendLine(`[n8n-agent] Workflow snapshot failed for ${workflowFilePath}: ${error?.message || String(error)}`);
-            return undefined;
-        }
-    }
-
-    private async hasWorkflowSnapshotChanged(workflowFilePath: string | undefined, previousSnapshot: string | undefined): Promise<boolean> {
-        if (!workflowFilePath || previousSnapshot === undefined) {
-            return false;
-        }
-
-        const nextSnapshot = await this.captureWorkflowSnapshot(workflowFilePath);
-        return nextSnapshot !== previousSnapshot;
     }
 
     private async runInitialAgentTurn(

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -504,6 +504,8 @@ export class AgentRuntimeController implements vscode.Disposable {
         }
         if (this.isCompactionState(payloads.compaction) && typeof handle.compactionService?.setState === 'function') {
             handle.compactionService.setState(sessionId, payloads.compaction);
+        } else if (typeof handle.compactionService?.reset === 'function') {
+            handle.compactionService.reset(sessionId);
         }
         for (const warning of result.warnings || []) {
             const message = typeof warning === 'string' ? warning : String(warning);
@@ -1779,7 +1781,7 @@ export class AgentRuntimeController implements vscode.Disposable {
         options: Omit<SaveCheckpointOptions, 'reason'>,
     ): Promise<SessionCheckpointMetadata | undefined> {
         if (typeof service.maybeSaveCheckpoint !== 'function') {
-            return undefined;
+            return this.saveYagrCheckpoint(service, sessionId, { ...options, reason });
         }
         return service.maybeSaveCheckpoint(sessionId, reason, this.withLegacyCheckpointPayload(options));
     }

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -1,17 +1,22 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import { randomUUID } from 'crypto';
 
 export interface AgentPromptInput {
     prompt: string;
     workflowId?: string;
     workflowName?: string;
     workflowFilename?: string;
+    workflowFilePath?: string;
     workspaceRoot?: string;
     nodeContext?: AgentNodeContext;
+    sessionId?: string;
 }
 
 const ENVIRONMENT_DETAILS_BLOCK_PATTERN = /<environment_details>[\s\S]*?<\/environment_details>/gi;
+const UNATTACHED_WORKFLOW_SCOPE_KEY = '__unattached__';
+const DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000;
 
 export interface AgentNodeContext {
     name: string;
@@ -19,11 +24,124 @@ export interface AgentNodeContext {
     id?: string;
 }
 
+export type AgentReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+
+export interface AgentContextUsage {
+    promptTokens: number;
+    completionTokens: number;
+    contextWindowTokens: number;
+    fillPercent: number;
+    source: 'api' | 'estimated';
+}
+
+export interface AgentCheckpointSummary {
+    id: string;
+    sessionId: string;
+    createdAt: string;
+    messageCount: number;
+    summary?: string;
+}
+
+export interface AgentCompactionSummary {
+    summary: string;
+    source: 'llm' | 'fallback';
+    messagesCompacted: number;
+    preservedRecentMessages: number;
+    estimatedTokens?: number;
+    thresholdTokens?: number;
+    fallbackReason?: string;
+}
+
+export interface AgentSessionSummary {
+    id: string;
+    title: string;
+    createdAt: string;
+    updatedAt: string;
+    messageCount: number;
+    isActive: boolean;
+    isClosed: boolean;
+    checkpointCount: number;
+    workflowId?: string;
+    workflowLabel: string;
+    totalCompactions: number;
+}
+
+export type AgentTimelineEntry =
+    | { kind: 'user-message'; id: string; text: string; timestamp: number }
+    | { kind: 'system-notice'; id: string; text: string; timestamp: number }
+    | { kind: 'assistant-body'; id: string; text: string; streaming: boolean; finalState?: string }
+    | {
+        kind: 'operation';
+        id: string;
+        tone: 'info' | 'success' | 'error';
+        title: string;
+        detail?: string;
+        category?: string;
+        status?: 'running' | 'done' | 'error';
+        body?: string;
+        summary?: string;
+        startedAt?: number;
+        endedAt?: number;
+    }
+    | { kind: 'compaction'; id: string; timestamp: number; event: AgentCompactionSummary }
+    | { kind: 'context-usage'; id: string; timestamp: number; usage: AgentContextUsage };
+
+export interface AgentSessionState {
+    sessionId: string;
+    title: string;
+    entries: AgentTimelineEntry[];
+    checkpoints: AgentCheckpointSummary[];
+    contextUsage?: AgentContextUsage;
+    lastCompaction?: AgentCompactionSummary;
+    totalCompactions: number;
+    workflowId?: string;
+    workflowLabel: string;
+}
+
+export interface AgentWorkbenchState {
+    workflow: {
+        id?: string;
+        name?: string;
+        filename?: string;
+    };
+    provider: string;
+    model?: string;
+    baseUrl?: string;
+    reasoningEffort?: AgentReasoningEffort;
+    supportsReasoningEffort: boolean;
+    currentNodeContext?: AgentNodeContext;
+    activeSessionId: string;
+    sessions: AgentSessionSummary[];
+    session: AgentSessionState;
+    isRunning: boolean;
+}
+
+export type AgentStreamEvent =
+    | { type: 'start'; sessionId: string; message: string }
+    | { type: 'progress'; tone: 'info' | 'success' | 'error'; title: string; detail?: string; phase?: string }
+    | {
+        type: 'operation';
+        operationId: string;
+        label: string;
+        category: string;
+        status: 'running' | 'done' | 'error';
+        body?: string;
+        summary?: string;
+        startedAt: number;
+        endedAt?: number;
+    }
+    | { type: 'text-delta'; delta: string }
+    | { type: 'compaction'; summary: string; source: 'llm' | 'fallback'; messagesCompacted: number; preservedRecentMessages: number; estimatedTokens?: number; thresholdTokens?: number; fallbackReason?: string }
+    | AgentContextUsageEvent
+    | { type: 'final'; sessionId: string; response: string; finalState: string }
+    | { type: 'error'; error: string };
+
+type AgentContextUsageEvent = { type: 'context-usage'; promptTokens: number; completionTokens: number; contextWindowTokens: number; fillPercent: number; source: 'api' | 'estimated' };
+
 export type AgentWorkbenchMessage =
     | { type: 'agent.status'; status: 'idle' | 'running' | 'stopping'; detail?: string }
-    | { type: 'agent.message'; role: 'assistant' | 'system' | 'user'; content: string }
-    | { type: 'agent.delta'; content: string }
-    | { type: 'agent.operation'; label: string; status: 'running' | 'done' | 'error'; detail?: string }
+    | { type: 'agent.state'; state: AgentWorkbenchState }
+    | { type: 'agent.streamEvent'; event: AgentStreamEvent }
     | { type: 'agent.error'; message: string }
     | { type: 'agent.done' };
 
@@ -35,17 +153,220 @@ export function getAgentProviderSecretKey(provider: string): string {
     return `${N8N_AGENT_PROVIDER_SECRET_PREFIX}${provider}`;
 }
 
+type DeepAgentSessionScope = {
+    kind: string;
+    key: string;
+};
+
+type DeepAgentSessionRecord = {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    title: string;
+    closedAt?: string;
+    scope?: DeepAgentSessionScope;
+};
+
+type SessionSummary = {
+    id: string;
+    title: string;
+    createdAt: string;
+    updatedAt: string;
+    messageCount: number;
+};
+
+type SessionCheckpointMetadata = {
+    id: string;
+    sessionId: string;
+    createdAt: string;
+    messageCount: number;
+    summary?: string;
+};
+
+type WebUiSession = {
+    id: string;
+    title: string;
+    createdAt: string;
+    updatedAt: string;
+    displayThread?: unknown[];
+};
+
+type SessionServiceHandle = {
+    list(): SessionSummary[];
+    get(id: string): DeepAgentSessionRecord | undefined;
+    getOrCreateForScope(scope: DeepAgentSessionScope, options?: { title?: string }): DeepAgentSessionRecord;
+    rotateForScope(scope: DeepAgentSessionScope, options?: { title?: string }): DeepAgentSessionRecord;
+    getActiveForScope(scope: DeepAgentSessionScope): DeepAgentSessionRecord | undefined;
+    listForScope(scope: DeepAgentSessionScope): DeepAgentSessionRecord[];
+    ensure(sessionId: string, options?: { title?: string; scope?: DeepAgentSessionScope }): DeepAgentSessionRecord;
+    touch(sessionId: string, options?: { title?: string; closed?: boolean }): DeepAgentSessionRecord | undefined;
+    delete(id: string): Promise<void>;
+    setCheckpointer(checkpointer: unknown): void;
+    buildSessionConfig(sessionId: string): Record<string, unknown>;
+    listCheckpoints(sessionId: string): Promise<SessionCheckpointMetadata[]>;
+    saveCheckpoint(sessionId: string, options?: { payloadState?: unknown | null }): Promise<SessionCheckpointMetadata>;
+    restoreCheckpoint(sessionId: string, checkpointId: string): Promise<{ payloadState: unknown | null }>;
+    deleteCheckpoint(sessionId: string, checkpointId: string): Promise<void>;
+    syncDisplayThread(sessionId: string, displayThread: unknown[]): void;
+    clearDisplayThread(sessionId: string): void;
+    setTitle(sessionId: string, title: string): void;
+    readDisplaySession(sessionId: string): WebUiSession | undefined;
+};
+
+type SessionRuntime = {
+    service: SessionServiceHandle;
+    deriveSessionTitle: (text: string, fallback?: string) => string;
+};
+
+type ProviderRuntimeConfig = {
+    ready: boolean;
+    reason?: string;
+    provider: string;
+    model?: string;
+    apiKey?: string;
+    baseUrl?: string;
+    reasoningEffort?: AgentReasoningEffort;
+    temperature: number;
+};
+
+type CompactionState = {
+    lastCompaction: AgentCompactionSummary | null;
+    compactionHistory: AgentCompactionSummary[];
+    totalCompactions: number;
+};
+
 export class AgentRuntimeController implements vscode.Disposable {
-    private activeAbortController: AbortController | undefined;
+    private activeRun: { abortController: AbortController; sessionId: string } | undefined;
     private cachedAgentHandle: { key: string; handle: any } | undefined;
+    private sessionRuntimePromise: Promise<SessionRuntime> | undefined;
 
     constructor(
         private readonly _context: vscode.ExtensionContext,
         private readonly outputChannel: vscode.OutputChannel,
     ) {}
 
+    async getWorkbenchState(input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
+        const scope = this.getSessionScope(input);
+        const sessions = await this.getSessionRuntime();
+        const activeRecord = sessions.service.getActiveForScope(scope) || sessions.service.getOrCreateForScope(scope, {
+            title: this.getDefaultSessionTitle(input.workflowName),
+        });
+        const session = await this.buildSessionState(activeRecord.id, input);
+        const providerConfig = await this.describeProviderRuntimeConfig();
+        return {
+            workflow: {
+                id: input.workflowId,
+                name: input.workflowName,
+                filename: input.workflowFilename,
+            },
+            provider: providerConfig.provider,
+            model: providerConfig.model,
+            baseUrl: providerConfig.baseUrl,
+            reasoningEffort: providerConfig.reasoningEffort,
+            supportsReasoningEffort: providerConfig.provider === 'openai-oauth',
+            currentNodeContext: input.nodeContext,
+            activeSessionId: activeRecord.id,
+            sessions: await this.listSessionSummaries(scope, activeRecord.id),
+            session,
+            isRunning: this.activeRun?.sessionId === activeRecord.id,
+        };
+    }
+
+    async createSession(input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
+        const scope = this.getSessionScope(input);
+        const sessions = await this.getSessionRuntime();
+        sessions.service.rotateForScope(scope, {
+            title: this.getDefaultSessionTitle(input.workflowName),
+        });
+        return this.getWorkbenchState(input);
+    }
+
+    async selectSession(sessionId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
+        const sessions = await this.getSessionRuntime();
+        sessions.service.ensure(sessionId, { scope: this.getSessionScope(input) });
+        return this.getWorkbenchState(input);
+    }
+
+    async renameSession(sessionId: string, title: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
+        const trimmed = title.trim();
+        if (!trimmed) {
+            throw new Error('Session title is required.');
+        }
+        const sessions = await this.getSessionRuntime();
+        sessions.service.touch(sessionId, { title: trimmed });
+        sessions.service.setTitle(sessionId, trimmed);
+        return this.getWorkbenchState(input);
+    }
+
+    async deleteSession(sessionId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
+        const scope = this.getSessionScope(input);
+        const sessions = await this.getSessionRuntime();
+        const active = sessions.service.getActiveForScope(scope)?.id;
+        await sessions.service.delete(sessionId);
+        if (active === sessionId) {
+            sessions.service.getOrCreateForScope(scope, { title: this.getDefaultSessionTitle(input.workflowName) });
+        }
+        return this.getWorkbenchState(input);
+    }
+
+    async attachSessionToCurrentWorkflow(sessionId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
+        const scope = this.getSessionScope(input);
+        if (!input.workflowId) {
+            throw new Error('Open a workflow before attaching a session.');
+        }
+        const sessions = await this.getSessionRuntime();
+        sessions.service.ensure(sessionId, { scope });
+        return this.getWorkbenchState(input);
+    }
+
+    async detachSession(sessionId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
+        const currentScope = this.getSessionScope(input);
+        const sessions = await this.getSessionRuntime();
+        sessions.service.ensure(sessionId, { scope: this.getUnattachedSessionScope() });
+        if (sessions.service.getActiveForScope(currentScope)?.id === sessionId) {
+            sessions.service.getOrCreateForScope(currentScope, { title: this.getDefaultSessionTitle(input.workflowName) });
+        }
+        return this.getWorkbenchState(input);
+    }
+
+    async saveCheckpoint(sessionId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
+        const sessions = await this.getSessionRuntime();
+        const handle = await this.ensureAgentHandleWithCheckpoint(input);
+        await sessions.service.saveCheckpoint(sessionId, {
+            payloadState: handle.compactionService.getState(sessionId),
+        });
+        const entries = this.readSessionEntries(sessions.service, sessionId);
+        this.writeSessionEntries(sessions.service, sessionId, [
+            ...entries,
+            this.createSystemNotice('Checkpoint saved.'),
+        ]);
+        return this.getWorkbenchState(input);
+    }
+
+    async restoreCheckpoint(sessionId: string, checkpointId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
+        const sessions = await this.getSessionRuntime();
+        const handle = await this.ensureAgentHandleWithCheckpoint(input);
+        const result = await sessions.service.restoreCheckpoint(sessionId, checkpointId);
+        sessions.service.clearDisplayThread(sessionId);
+        if (this.isCompactionState(result.payloadState)) {
+            handle.compactionService.setState(sessionId, result.payloadState);
+        } else {
+            handle.compactionService.reset(sessionId);
+        }
+        this.writeSessionEntries(sessions.service, sessionId, [
+            this.createSystemNotice(`Restored checkpoint ${checkpointId}.`),
+        ]);
+        return this.getWorkbenchState(input);
+    }
+
+    async deleteCheckpoint(sessionId: string, checkpointId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
+        const sessions = await this.getSessionRuntime();
+        await sessions.service.deleteCheckpoint(sessionId, checkpointId);
+        return this.getWorkbenchState(input);
+    }
+
     async sendPrompt(input: AgentPromptInput, postMessage: AgentWorkbenchPostMessage): Promise<void> {
-        if (this.activeAbortController) {
+        if (this.activeRun) {
             await postMessage({
                 type: 'agent.error',
                 message: 'An agent run is already in progress. Stop it before sending another prompt.',
@@ -58,123 +379,219 @@ export class AgentRuntimeController implements vscode.Disposable {
             return;
         }
 
+        const sessions = await this.getSessionRuntime();
+        const scope = this.getSessionScope(input);
+        const activeRecord = input.sessionId
+            ? sessions.service.ensure(input.sessionId, { scope, title: this.getDefaultSessionTitle(input.workflowName) })
+            : (sessions.service.getActiveForScope(scope) || sessions.service.getOrCreateForScope(scope, {
+                title: this.getDefaultSessionTitle(input.workflowName),
+            }));
+
         const abortController = new AbortController();
-        this.activeAbortController = abortController;
+        this.activeRun = { abortController, sessionId: activeRecord.id };
+
+        const derivedTitle = activeRecord.title === 'New conversation'
+            ? sessions.deriveSessionTitle(prompt, this.getDefaultSessionTitle(input.workflowName))
+            : activeRecord.title;
+        sessions.service.touch(activeRecord.id, { title: derivedTitle });
+        sessions.service.setTitle(activeRecord.id, derivedTitle);
+
+        let entries = this.readSessionEntries(sessions.service, activeRecord.id);
+        entries = [...entries, { kind: 'user-message', id: randomUUID(), text: prompt, timestamp: Date.now() }];
 
         await postMessage({ type: 'agent.status', status: 'running', detail: 'Preparing n8n agent runtime...' });
-        await postMessage({ type: 'agent.operation', label: 'Agent runtime', status: 'running', detail: 'Loading embedded Yagr runtime' });
+        await postMessage({ type: 'agent.streamEvent', event: { type: 'start', sessionId: activeRecord.id, message: prompt } });
 
         try {
-            await this.runInitialAgentTurn(input, postMessage, abortController.signal);
-            await postMessage({ type: 'agent.operation', label: 'Agent runtime', status: 'done', detail: 'Run completed' });
+            entries = await this.runInitialAgentTurn({ ...input, sessionId: activeRecord.id }, entries, postMessage, abortController.signal);
+            this.writeSessionEntries(sessions.service, activeRecord.id, entries);
+            await postMessage({ type: 'agent.state', state: await this.getWorkbenchState({ ...input, sessionId: activeRecord.id }) });
             await postMessage({ type: 'agent.done' });
         } catch (error: any) {
             const message = error?.message || String(error);
             this.outputChannel.appendLine(`[n8n-agent] Run failed: ${message}`);
-            await postMessage({ type: 'agent.operation', label: 'Agent runtime', status: 'error', detail: message });
+            const failedEntries = [...entries, this.createSystemNotice(`Run failed: ${message}`)];
+            this.writeSessionEntries(sessions.service, activeRecord.id, failedEntries);
+            await postMessage({ type: 'agent.streamEvent', event: { type: 'error', error: message } });
             await postMessage({ type: 'agent.error', message });
+            await postMessage({ type: 'agent.state', state: await this.getWorkbenchState({ ...input, sessionId: activeRecord.id }) });
         } finally {
-            if (this.activeAbortController === abortController) {
-                this.activeAbortController = undefined;
+            if (this.activeRun?.abortController === abortController) {
+                this.activeRun = undefined;
             }
             await postMessage({ type: 'agent.status', status: 'idle' });
         }
     }
 
     async stop(postMessage: AgentWorkbenchPostMessage): Promise<void> {
-        const controller = this.activeAbortController;
-        if (!controller) {
+        const activeRun = this.activeRun;
+        if (!activeRun) {
             await postMessage({ type: 'agent.status', status: 'idle' });
             return;
         }
         await postMessage({ type: 'agent.status', status: 'stopping', detail: 'Stopping current run...' });
-        controller.abort();
+        activeRun.abortController.abort();
     }
 
     dispose(): void {
-        this.activeAbortController?.abort();
-        this.activeAbortController = undefined;
+        this.activeRun?.abortController.abort();
+        this.activeRun = undefined;
     }
 
     private async runInitialAgentTurn(
         input: AgentPromptInput,
+        initialEntries: AgentTimelineEntry[],
         postMessage: AgentWorkbenchPostMessage,
         signal: AbortSignal,
-    ): Promise<void> {
+    ): Promise<AgentTimelineEntry[]> {
         await this.throwIfAborted(signal);
 
         const providerRegistry = await this.loadYagrProviderRegistry().catch((error: any) => ({ error: error?.message || String(error) }));
         if ('error' in providerRegistry) {
-            await postMessage({
-                type: 'agent.message',
-                role: 'assistant',
-                content: await this.buildScaffoldResponse(input, providerRegistry.error),
-            });
-            return;
+            return [
+                ...initialEntries,
+                this.createSystemNotice(await this.buildScaffoldResponse(input, providerRegistry.error)),
+            ];
         }
 
         const providerConfig = await this.getProviderRuntimeConfig(providerRegistry);
         if (!providerConfig.ready) {
-            await postMessage({
-                type: 'agent.message',
-                role: 'assistant',
-                content: await this.buildScaffoldResponse(input, providerConfig.reason),
-            });
-            return;
+            return [
+                ...initialEntries,
+                this.createSystemNotice(await this.buildScaffoldResponse(input, providerConfig.reason)),
+            ];
         }
 
-        await postMessage({ type: 'agent.operation', label: 'Provider', status: 'done', detail: `${providerConfig.provider}${providerConfig.model ? ` / ${providerConfig.model}` : ''}` });
-        await postMessage({ type: 'agent.operation', label: 'DeepAgents runtime', status: 'running', detail: `Workspace root: ${input.workspaceRoot || process.cwd()}` });
-
         const handle = await this.getYagrAgentHandle(providerConfig, input);
+        const sessions = await this.getSessionRuntime();
+        sessions.service.setCheckpointer(handle.checkpointer);
         const agent = handle.agent;
-
-        const messages = [{ role: 'user', content: input.prompt }];
+        const messages = [{ role: 'user', content: await this.buildInvocationPrompt(input) }];
         const config = {
-            version: 'v2',
+            ...sessions.service.buildSessionConfig(input.sessionId || ''),
             signal,
-            configurable: {
-                thread_id: input.workflowId ? `workflow:${input.workflowId}` : 'workflow:new',
-            },
         } as Record<string, unknown>;
+
+        let entries = [...initialEntries];
+        const contextWindow = await this.resolveContextWindow(providerConfig.provider, providerConfig.model, providerConfig.apiKey, providerConfig.baseUrl);
+        const estimatedPromptTokens = Math.ceil(messages[0].content.length / 4);
+        const initialUsage: AgentContextUsageEvent = {
+            type: 'context-usage',
+            promptTokens: estimatedPromptTokens,
+            completionTokens: 0,
+            contextWindowTokens: contextWindow,
+            fillPercent: Math.round((estimatedPromptTokens / contextWindow) * 100),
+            source: 'estimated',
+        };
+        entries = this.applyStreamEvent(entries, initialUsage);
+        await postMessage({ type: 'agent.streamEvent', event: initialUsage });
 
         if (typeof (agent as any).streamEvents === 'function') {
             const stream = (agent as any).streamEvents({ messages }, config);
             const eventRuntime = await import('@yagr/agent/dist/gateway/langgraph-events.js');
             const accumulator = eventRuntime.createRunAccumulator();
+            const lastProgressKeys = new Set<string>();
+
             for await (const event of stream) {
                 await this.throwIfAborted(signal);
                 await eventRuntime.processStreamEvent(event, accumulator, {
                     onTextDelta: async (delta: string) => {
-                        await this.throwIfAborted(signal);
-                        await postMessage({ type: 'agent.delta', content: delta });
+                        entries = this.applyStreamEvent(entries, { type: 'text-delta', delta });
+                        await postMessage({ type: 'agent.streamEvent', event: { type: 'text-delta', delta } });
                     },
-                    onOperation: async (event: any) => {
-                        await postMessage({
-                            type: 'agent.operation',
-                            label: String(event.label || event.operationId || 'Operation'),
-                            status: event.status === 'error' ? 'error' : event.status === 'done' ? 'done' : 'running',
-                            detail: this.truncateOperationDetail(event.summary || event.body),
-                        });
+                    onOperation: async (operation: any) => {
+                        const streamEvent: AgentStreamEvent = {
+                            type: 'operation',
+                            operationId: String(operation.operationId || randomUUID()),
+                            label: String(operation.label || 'Operation'),
+                            category: String(operation.category || 'tool'),
+                            status: operation.status === 'error' ? 'error' : operation.status === 'done' ? 'done' : 'running',
+                            body: typeof operation.body === 'string' ? operation.body : undefined,
+                            summary: typeof operation.summary === 'string' ? operation.summary : undefined,
+                            startedAt: Number(operation.startedAt || Date.now()),
+                            endedAt: typeof operation.endedAt === 'number' ? operation.endedAt : undefined,
+                        };
+                        entries = this.applyStreamEvent(entries, streamEvent);
+                        await postMessage({ type: 'agent.streamEvent', event: streamEvent });
                     },
                     onUserVisibleUpdate: async (update: any) => {
-                        await postMessage({
-                            type: 'agent.operation',
-                            label: String(update.title || update.phase || 'Progress'),
-                            status: update.tone === 'error' ? 'error' : 'running',
+                        const dedupeKey = String(update.dedupeKey || `${update.title || 'progress'}:${update.detail || ''}`);
+                        if (lastProgressKeys.has(dedupeKey)) {
+                            return;
+                        }
+                        lastProgressKeys.add(dedupeKey);
+                        const streamEvent: AgentStreamEvent = {
+                            type: 'progress',
+                            tone: update.tone === 'error' ? 'error' : update.tone === 'success' ? 'success' : 'info',
+                            title: String(update.title || update.phase || 'Progress'),
                             detail: this.truncateOperationDetail(update.detail),
-                        });
+                            phase: typeof update.phase === 'string' ? update.phase : undefined,
+                        };
+                        entries = this.applyStreamEvent(entries, streamEvent);
+                        await postMessage({ type: 'agent.streamEvent', event: streamEvent });
+                    },
+                    onCompaction: async (compaction: any) => {
+                        const streamEvent: AgentStreamEvent = {
+                            type: 'compaction',
+                            summary: String(compaction.summary || 'Context compacted'),
+                            source: compaction.source === 'fallback' ? 'fallback' : 'llm',
+                            messagesCompacted: Number(compaction.messagesCompacted || 0),
+                            preservedRecentMessages: Number(compaction.preservedRecentMessages || 0),
+                            estimatedTokens: typeof compaction.estimatedTokens === 'number' ? compaction.estimatedTokens : undefined,
+                            thresholdTokens: typeof compaction.thresholdTokens === 'number' ? compaction.thresholdTokens : undefined,
+                            fallbackReason: typeof compaction.fallbackReason === 'string' ? compaction.fallbackReason : undefined,
+                        };
+                        await handle.compactionService.notifyCompaction(input.sessionId || '', streamEvent);
+                        entries = this.applyStreamEvent(entries, streamEvent);
+                        await postMessage({ type: 'agent.streamEvent', event: streamEvent });
                     },
                 });
             }
-            if (!accumulator.responseText) {
-                await postMessage({ type: 'agent.message', role: 'assistant', content: 'The agent completed without producing text.' });
+
+            if (accumulator.fileModificationDetected) {
+                try {
+                    await sessions.service.saveCheckpoint(input.sessionId || '', {
+                        payloadState: handle.compactionService.getState(input.sessionId || ''),
+                    });
+                } catch (error: any) {
+                    this.outputChannel.appendLine(`[n8n-agent] Auto-checkpoint failed: ${error?.message || String(error)}`);
+                }
             }
-            return;
+
+            const estimatedCompletionTokens = Math.ceil(accumulator.responseText.length / 4);
+            const finalUsage: AgentContextUsageEvent = {
+                type: 'context-usage',
+                promptTokens: estimatedPromptTokens,
+                completionTokens: estimatedCompletionTokens,
+                contextWindowTokens: contextWindow,
+                fillPercent: Math.min(100, Math.round(((estimatedPromptTokens + estimatedCompletionTokens) / contextWindow) * 100)),
+                source: 'estimated',
+            };
+            entries = this.applyStreamEvent(entries, finalUsage);
+            await postMessage({ type: 'agent.streamEvent', event: finalUsage });
+
+            const finalEvent: AgentStreamEvent = {
+                type: 'final',
+                sessionId: input.sessionId || '',
+                response: accumulator.responseText,
+                finalState: 'done',
+            };
+            entries = this.applyStreamEvent(entries, finalEvent);
+            await postMessage({ type: 'agent.streamEvent', event: finalEvent });
+            return entries;
         }
 
         const result = await (agent as any).invoke({ messages }, config);
-        await postMessage({ type: 'agent.message', role: 'assistant', content: this.extractAgentText(result) });
+        const response = this.extractAgentText(result);
+        const finalEvent: AgentStreamEvent = {
+            type: 'final',
+            sessionId: input.sessionId || '',
+            response,
+            finalState: 'done',
+        };
+        entries = this.applyStreamEvent(entries, finalEvent);
+        await postMessage({ type: 'agent.streamEvent', event: finalEvent });
+        return entries;
     }
 
     private truncateOperationDetail(value: unknown): string | undefined {
@@ -188,24 +605,35 @@ export class AgentRuntimeController implements vscode.Disposable {
         return import('@yagr/agent/dist/llm/provider-registry.js');
     }
 
-    private async getProviderRuntimeConfig(providerRegistry: typeof import('@yagr/agent/dist/llm/provider-registry.js')): Promise<{
-        ready: boolean;
-        reason?: string;
-        provider: string;
-        model?: string;
-        apiKey?: string;
-        baseUrl?: string;
-        temperature: number;
-    }> {
+    private async describeProviderRuntimeConfig(): Promise<ProviderRuntimeConfig> {
+        const providerRegistry = await this.loadYagrProviderRegistry().catch(() => undefined);
+        if (!providerRegistry) {
+            const config = vscode.workspace.getConfiguration('n8n.agent');
+            return {
+                ready: false,
+                provider: String(config.get<string>('provider') || 'openai'),
+                model: String(config.get<string>('model') || '').trim() || undefined,
+                baseUrl: String(config.get<string>('baseUrl') || '').trim() || undefined,
+                reasoningEffort: this.readReasoningEffort(),
+                temperature: 0,
+            };
+        }
+        return this.getProviderRuntimeConfig(providerRegistry);
+    }
+
+    private async getProviderRuntimeConfig(providerRegistry: typeof import('@yagr/agent/dist/llm/provider-registry.js')): Promise<ProviderRuntimeConfig> {
         const config = vscode.workspace.getConfiguration('n8n.agent');
         const provider = String(config.get<string>('provider') || 'openai');
         const normalizedProvider = providerRegistry.normalizeProviderId(provider);
+        const reasoningEffort = this.readReasoningEffort();
         if (!normalizedProvider) {
             return {
                 ready: false,
                 reason: `Provider ${provider} is not supported by the installed Yagr runtime.`,
                 provider,
                 model: String(config.get<string>('model') || '').trim() || undefined,
+                baseUrl: String(config.get<string>('baseUrl') || '').trim() || undefined,
+                reasoningEffort,
                 temperature: 0,
             };
         }
@@ -223,6 +651,7 @@ export class AgentRuntimeController implements vscode.Disposable {
                     model,
                     baseUrl,
                     apiKey,
+                    reasoningEffort,
                     temperature: 0,
                 };
             }
@@ -235,6 +664,7 @@ export class AgentRuntimeController implements vscode.Disposable {
                 model,
                 baseUrl,
                 apiKey,
+                reasoningEffort,
                 temperature: 0,
             };
         }
@@ -244,16 +674,12 @@ export class AgentRuntimeController implements vscode.Disposable {
             model,
             baseUrl,
             apiKey,
+            reasoningEffort: normalizedProvider === 'openai-oauth' ? reasoningEffort : undefined,
             temperature: 0,
         };
     }
 
-    private async getYagrAgentHandle(providerConfig: {
-        provider: string;
-        model?: string;
-        apiKey?: string;
-        baseUrl?: string;
-    }, input: AgentPromptInput): Promise<any> {
+    private async getYagrAgentHandle(providerConfig: ProviderRuntimeConfig, input: AgentPromptInput): Promise<any> {
         const rootDir = input.workspaceRoot || process.cwd();
         const [agentFactory, providerRegistry] = await Promise.all([
             import('@yagr/agent/dist/agent-factory.js'),
@@ -266,11 +692,7 @@ export class AgentRuntimeController implements vscode.Disposable {
             provider: providerConfig.provider,
             model: providerConfig.model,
             baseUrl: providerConfig.baseUrl,
-            workflowId: input.workflowId || '',
-            workflowFilename: input.workflowFilename || '',
-            nodeContextName: input.nodeContext?.name || '',
-            nodeContextType: input.nodeContext?.type || '',
-            nodeContextId: input.nodeContext?.id || '',
+            reasoningEffort: providerConfig.reasoningEffort || '',
             memorySources,
             skillSourcePaths,
         });
@@ -287,6 +709,7 @@ export class AgentRuntimeController implements vscode.Disposable {
             provider: providerConfig.provider,
             model: providerConfig.model,
             baseUrl: providerConfig.baseUrl,
+            reasoningEffort: providerConfig.reasoningEffort,
         } as any;
         const configStore = {
             getLocalConfig: () => localConfig,
@@ -301,26 +724,34 @@ export class AgentRuntimeController implements vscode.Disposable {
             rootDir,
             memorySources,
             skillSourcePaths,
-            systemPrompt: await this.buildSystemPrompt(input),
+            systemPrompt: this.buildStaticSystemPrompt(input.workspaceRoot),
         });
         this.cachedAgentHandle = { key, handle };
         return handle;
     }
 
-    private async buildSystemPrompt(input: AgentPromptInput): Promise<string> {
-        const workflowContext = await this.loadWorkflowContext(input);
+    private buildStaticSystemPrompt(workspaceRoot?: string): string {
         return [
             'You are the embedded n8n-as-code VS Code agent.',
             'You help users design, inspect, validate, and operate n8n workflows from the current workspace.',
             'Your DeepAgents backend working directory is the VS Code workspace root. Treat all relative filesystem tool paths as relative to that home directory.',
-            'Use tools only when useful. For questions about the currently selected workflow, first use the provided workflow context below as authoritative.',
+            'Use tools only when useful. For workflow-specific questions, use the inline workflow and node context supplied with each user turn as authoritative.',
             'Do not claim to push workflows, provision credentials, or change n8n runtime state unless a tool explicitly performs that action successfully.',
-            input.workspaceRoot ? `Workspace root: ${input.workspaceRoot}` : undefined,
-            input.workflowId ? `Current workflow: ${input.workflowName || input.workflowId} (${input.workflowId})` : undefined,
+            workspaceRoot ? `Workspace root: ${workspaceRoot}` : undefined,
+        ].filter(Boolean).join('\n');
+    }
+
+    private async buildInvocationPrompt(input: AgentPromptInput): Promise<string> {
+        const workflowContext = await this.loadWorkflowContext(input);
+        const blocks = [
+            input.workflowId ? `Current workflow: ${input.workflowName || input.workflowId} (${input.workflowId})` : 'No workflow is attached. The user may be designing a new workflow.',
             input.workflowFilename ? `Current workflow file: ${input.workflowFilename}` : undefined,
             this.formatNodeContext(input.nodeContext),
             workflowContext,
-        ].filter(Boolean).join('\n');
+            'User request:',
+            input.prompt.trim(),
+        ].filter(Boolean);
+        return blocks.join('\n\n');
     }
 
     private formatNodeContext(nodeContext: AgentNodeContext | undefined): string | undefined {
@@ -395,7 +826,7 @@ export class AgentRuntimeController implements vscode.Disposable {
 
     private async loadWorkflowContext(input: AgentPromptInput): Promise<string | undefined> {
         if (!input.workflowId && !input.workflowFilename) {
-            return 'No workflow is attached. The user may be designing a new workflow.';
+            return undefined;
         }
         const candidates: string[] = [];
         if (input.workspaceRoot && input.workflowFilename) {
@@ -460,6 +891,7 @@ export class AgentRuntimeController implements vscode.Disposable {
         const provider = String(config.get<string>('provider') || 'openai');
         const model = String(config.get<string>('model') || '').trim();
         const baseUrl = String(config.get<string>('baseUrl') || '').trim();
+        const reasoningEffort = this.readReasoningEffort();
         const storedSecret = await this._context.secrets.get(getAgentProviderSecretKey(provider));
         const hasEnvSecret = this.hasProviderEnvironmentSecret(provider);
         const secretState = storedSecret
@@ -467,7 +899,7 @@ export class AgentRuntimeController implements vscode.Disposable {
             : hasEnvSecret
                 ? 'API key available from environment'
                 : 'API key not configured yet';
-        return `Agent provider: ${provider}${model ? ` / ${model}` : ''}${baseUrl ? ` / ${baseUrl}` : ''}. ${secretState}.`;
+        return `Agent provider: ${provider}${model ? ` / ${model}` : ''}${reasoningEffort ? ` / reasoning ${reasoningEffort}` : ''}${baseUrl ? ` / ${baseUrl}` : ''}. ${secretState}.`;
     }
 
     private hasProviderEnvironmentSecret(provider: string): boolean {
@@ -500,13 +932,285 @@ export class AgentRuntimeController implements vscode.Disposable {
             await this.buildProviderStatusLine(),
             runtimeLine,
             '',
-            'This first run intentionally stays read-only: no workflow files, credentials, runtime state, or shell commands were changed.',
+            'No workflow files, credentials, runtime state, or shell commands were changed unless the runtime explicitly reported success.',
         ].join('\n');
     }
 
     private async throwIfAborted(signal: AbortSignal): Promise<void> {
         if (signal.aborted) {
-            throw new Error('Agent run cancelled.');
+            const error = new Error('Agent run cancelled.');
+            error.name = 'AbortError';
+            throw error;
         }
+    }
+
+    private async getSessionRuntime(): Promise<SessionRuntime> {
+        if (!this.sessionRuntimePromise) {
+            this.sessionRuntimePromise = (async () => {
+                const module = await import('@yagr/agent/packages/session-service/dist/index.js');
+                const sessionsRoot = path.join(this._context.globalStorageUri.fsPath, 'agent-sessions');
+                const webUiSessionsDir = path.join(sessionsRoot, 'display');
+                await fs.promises.mkdir(webUiSessionsDir, { recursive: true });
+                const service = new module.SessionService({
+                    sessionsDir: path.join(sessionsRoot, 'records'),
+                    webUiSessionsDir,
+                }) as SessionServiceHandle;
+                return {
+                    service,
+                    deriveSessionTitle: module.deriveSessionTitle as SessionRuntime['deriveSessionTitle'],
+                };
+            })();
+        }
+        return this.sessionRuntimePromise;
+    }
+
+    private getSessionScope(input: Omit<AgentPromptInput, 'prompt'>): DeepAgentSessionScope {
+        if (input.workflowId) {
+            return { kind: 'vscode-workflow', key: input.workflowId };
+        }
+        return this.getUnattachedSessionScope();
+    }
+
+    private getUnattachedSessionScope(): DeepAgentSessionScope {
+        return { kind: 'vscode-workflow', key: UNATTACHED_WORKFLOW_SCOPE_KEY };
+    }
+
+    private getDefaultSessionTitle(workflowName?: string): string {
+        return workflowName ? `${workflowName} conversation` : 'New conversation';
+    }
+
+    private async listSessionSummaries(scope: DeepAgentSessionScope, activeSessionId: string): Promise<AgentSessionSummary[]> {
+        const sessions = await this.getSessionRuntime();
+        const handle = this.cachedAgentHandle?.handle;
+        const summaries = await Promise.all(sessions.service.list().map(async (summary) => {
+            const record = sessions.service.get(summary.id);
+            const recordScope = record?.scope;
+            const workflowId = recordScope?.kind === 'vscode-workflow' && recordScope.key !== UNATTACHED_WORKFLOW_SCOPE_KEY
+                ? recordScope.key
+                : undefined;
+            const compactionState = handle?.compactionService?.getState
+                ? handle.compactionService.getState(summary.id) as CompactionState
+                : { lastCompaction: null, compactionHistory: [], totalCompactions: 0 };
+            const checkpoints = await sessions.service.listCheckpoints(summary.id).catch(() => []);
+            return {
+                id: summary.id,
+                title: summary.title,
+                createdAt: summary.createdAt,
+                updatedAt: summary.updatedAt,
+                messageCount: summary.messageCount,
+                isActive: summary.id === activeSessionId,
+                isClosed: Boolean(record?.closedAt),
+                checkpointCount: checkpoints.length,
+                workflowId,
+                workflowLabel: workflowId ? workflowId : 'Unattached',
+                totalCompactions: compactionState.totalCompactions,
+            };
+        }));
+        return summaries.sort((left, right) => {
+            if (left.isActive !== right.isActive) {
+                return left.isActive ? -1 : 1;
+            }
+            const leftMatchesScope = left.workflowId === scope.key || (!left.workflowId && scope.key === UNATTACHED_WORKFLOW_SCOPE_KEY);
+            const rightMatchesScope = right.workflowId === scope.key || (!right.workflowId && scope.key === UNATTACHED_WORKFLOW_SCOPE_KEY);
+            if (leftMatchesScope !== rightMatchesScope) {
+                return leftMatchesScope ? -1 : 1;
+            }
+            return right.updatedAt.localeCompare(left.updatedAt);
+        });
+    }
+
+    private async buildSessionState(sessionId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentSessionState> {
+        const sessions = await this.getSessionRuntime();
+        const displaySession = sessions.service.readDisplaySession(sessionId);
+        const entries = this.normalizeEntries(displaySession?.displayThread);
+        const checkpoints = await sessions.service.listCheckpoints(sessionId).catch(() => []);
+        const handle = this.cachedAgentHandle?.handle;
+        const compactionState: CompactionState = handle?.compactionService?.getState
+            ? handle.compactionService.getState(sessionId)
+            : { lastCompaction: null, compactionHistory: [], totalCompactions: 0 };
+        const record = sessions.service.get(sessionId);
+        const workflowId = record?.scope?.kind === 'vscode-workflow' && record.scope.key !== UNATTACHED_WORKFLOW_SCOPE_KEY
+            ? record.scope.key
+            : undefined;
+        const latestUsageEntry = [...entries].reverse().find((entry): entry is Extract<AgentTimelineEntry, { kind: 'context-usage' }> => entry.kind === 'context-usage');
+        return {
+            sessionId,
+            title: displaySession?.title || record?.title || this.getDefaultSessionTitle(input.workflowName),
+            entries,
+            checkpoints: checkpoints.map((checkpoint) => ({
+                id: checkpoint.id,
+                sessionId: checkpoint.sessionId,
+                createdAt: checkpoint.createdAt,
+                messageCount: checkpoint.messageCount,
+                summary: checkpoint.summary,
+            })),
+            contextUsage: latestUsageEntry?.usage,
+            lastCompaction: compactionState.lastCompaction || undefined,
+            totalCompactions: compactionState.totalCompactions,
+            workflowId,
+            workflowLabel: workflowId || 'Unattached',
+        };
+    }
+
+    private readSessionEntries(service: SessionServiceHandle, sessionId: string): AgentTimelineEntry[] {
+        return this.normalizeEntries(service.readDisplaySession(sessionId)?.displayThread);
+    }
+
+    private writeSessionEntries(service: SessionServiceHandle, sessionId: string, entries: AgentTimelineEntry[]): void {
+        service.syncDisplayThread(sessionId, entries);
+    }
+
+    private normalizeEntries(value: unknown[] | undefined): AgentTimelineEntry[] {
+        return Array.isArray(value) ? value as AgentTimelineEntry[] : [];
+    }
+
+    private applyStreamEvent(entries: AgentTimelineEntry[], event: AgentStreamEvent): AgentTimelineEntry[] {
+        if (event.type === 'start') {
+            return entries;
+        }
+        if (event.type === 'text-delta') {
+            const next = [...entries];
+            const last = next[next.length - 1];
+            if (last?.kind === 'assistant-body' && last.streaming) {
+                last.text += event.delta;
+                return next;
+            }
+            next.push({ kind: 'assistant-body', id: randomUUID(), text: event.delta, streaming: true });
+            return next;
+        }
+        if (event.type === 'final') {
+            const next = [...entries];
+            const last = next[next.length - 1];
+            if (last?.kind === 'assistant-body') {
+                last.streaming = false;
+                if (!last.text) {
+                    last.text = event.response;
+                }
+                last.finalState = event.finalState;
+                return next;
+            }
+            next.push({ kind: 'assistant-body', id: randomUUID(), text: event.response, streaming: false, finalState: event.finalState });
+            return next;
+        }
+        if (event.type === 'operation') {
+            const next = [...entries];
+            const existingIndex = next.findIndex((entry) => entry.kind === 'operation' && entry.id === event.operationId);
+            const operationEntry: AgentTimelineEntry = {
+                kind: 'operation',
+                id: event.operationId,
+                tone: event.status === 'error' ? 'error' : event.status === 'done' ? 'success' : 'info',
+                title: event.label,
+                category: event.category,
+                status: event.status,
+                body: event.body,
+                summary: event.summary,
+                startedAt: event.startedAt,
+                endedAt: event.endedAt,
+                detail: event.summary,
+            };
+            if (existingIndex >= 0) {
+                next[existingIndex] = operationEntry;
+                return next;
+            }
+            next.push(operationEntry);
+            return next;
+        }
+        if (event.type === 'progress') {
+            return [
+                ...entries,
+                {
+                    kind: 'operation',
+                    id: randomUUID(),
+                    tone: event.tone,
+                    title: event.title,
+                    detail: event.detail,
+                    category: event.phase || 'phase',
+                    status: event.tone === 'error' ? 'error' : 'running',
+                },
+            ];
+        }
+        if (event.type === 'compaction') {
+            return [
+                ...entries,
+                {
+                    kind: 'compaction',
+                    id: randomUUID(),
+                    timestamp: Date.now(),
+                    event: {
+                        summary: event.summary,
+                        source: event.source,
+                        messagesCompacted: event.messagesCompacted,
+                        preservedRecentMessages: event.preservedRecentMessages,
+                        estimatedTokens: event.estimatedTokens,
+                        thresholdTokens: event.thresholdTokens,
+                        fallbackReason: event.fallbackReason,
+                    },
+                },
+            ];
+        }
+        if (event.type === 'context-usage') {
+            const usageEntry: AgentTimelineEntry = {
+                kind: 'context-usage',
+                id: randomUUID(),
+                timestamp: Date.now(),
+                usage: {
+                    promptTokens: event.promptTokens,
+                    completionTokens: event.completionTokens,
+                    contextWindowTokens: event.contextWindowTokens,
+                    fillPercent: event.fillPercent,
+                    source: event.source,
+                },
+            };
+            const withoutPrevious = entries.filter((entry) => entry.kind !== 'context-usage');
+            return [...withoutPrevious, usageEntry];
+        }
+        if (event.type === 'error') {
+            return [...entries, this.createSystemNotice(`Error: ${event.error}`)];
+        }
+        return entries;
+    }
+
+    private createSystemNotice(text: string): AgentTimelineEntry {
+        return { kind: 'system-notice', id: randomUUID(), text, timestamp: Date.now() };
+    }
+
+    private async ensureAgentHandleWithCheckpoint(input: Omit<AgentPromptInput, 'prompt'>): Promise<any> {
+        const providerRegistry = await this.loadYagrProviderRegistry();
+        const providerConfig = await this.getProviderRuntimeConfig(providerRegistry);
+        if (!providerConfig.ready) {
+            throw new Error(providerConfig.reason || 'Agent provider is not ready.');
+        }
+        const handle = await this.getYagrAgentHandle(providerConfig, { ...input, prompt: '' });
+        const sessions = await this.getSessionRuntime();
+        sessions.service.setCheckpointer(handle.checkpointer);
+        return handle;
+    }
+
+    private async resolveContextWindow(provider: string, model?: string, apiKey?: string, baseUrl?: string): Promise<number> {
+        if (!model) {
+            return DEFAULT_CONTEXT_WINDOW_TOKENS;
+        }
+        try {
+            const metadata = await import('@yagr/agent/dist/llm/provider-metadata.js');
+            const entry = await metadata.primeProviderModelMetadata(provider as any, model, apiKey, baseUrl);
+            return Number(entry?.contextWindow || metadata.getSnapshotContextWindow(provider as any, model) || DEFAULT_CONTEXT_WINDOW_TOKENS);
+        } catch {
+            return DEFAULT_CONTEXT_WINDOW_TOKENS;
+        }
+    }
+
+    private readReasoningEffort(): AgentReasoningEffort | undefined {
+        const config = vscode.workspace.getConfiguration('n8n.agent');
+        const value = String(config.get<string>('reasoningEffort') || '').trim();
+        return value ? value as AgentReasoningEffort : undefined;
+    }
+
+    private isCompactionState(value: unknown): value is CompactionState {
+        return Boolean(
+            value
+            && typeof value === 'object'
+            && Array.isArray((value as { compactionHistory?: unknown[] }).compactionHistory)
+            && typeof (value as { totalCompactions?: unknown }).totalCompactions === 'number',
+        );
     }
 }

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -1,9 +1,12 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
 
 export interface AgentPromptInput {
     prompt: string;
     workflowId?: string;
     workflowName?: string;
+    workflowFilename?: string;
     workspaceRoot?: string;
 }
 
@@ -25,7 +28,7 @@ export function getAgentProviderSecretKey(provider: string): string {
 
 export class AgentRuntimeController implements vscode.Disposable {
     private activeAbortController: AbortController | undefined;
-    private cachedRuntime: Awaited<ReturnType<typeof this.loadYagrRuntime>> | undefined;
+    private cachedAgentHandle: { key: string; handle: any } | undefined;
 
     constructor(
         private readonly _context: vscode.ExtensionContext,
@@ -91,19 +94,17 @@ export class AgentRuntimeController implements vscode.Disposable {
     ): Promise<void> {
         await this.throwIfAborted(signal);
 
-        const runtime = await this.loadYagrRuntime().catch((error: any) => ({ error: error?.message || String(error) }));
-        if ('error' in runtime) {
+        const providerRegistry = await this.loadYagrProviderRegistry().catch((error: any) => ({ error: error?.message || String(error) }));
+        if ('error' in providerRegistry) {
             await postMessage({
                 type: 'agent.message',
                 role: 'assistant',
-                content: await this.buildScaffoldResponse(input, runtime.error),
+                content: await this.buildScaffoldResponse(input, providerRegistry.error),
             });
             return;
         }
 
-        await this.throwIfAborted(signal);
-
-        const providerConfig = await this.getProviderRuntimeConfig(runtime);
+        const providerConfig = await this.getProviderRuntimeConfig(providerRegistry);
         if (!providerConfig.ready) {
             await postMessage({
                 type: 'agent.message',
@@ -114,34 +115,49 @@ export class AgentRuntimeController implements vscode.Disposable {
         }
 
         await postMessage({ type: 'agent.operation', label: 'Provider', status: 'done', detail: `${providerConfig.provider}${providerConfig.model ? ` / ${providerConfig.model}` : ''}` });
-        await postMessage({ type: 'agent.operation', label: 'DeepAgents runtime', status: 'running', detail: 'Streaming response' });
+        await postMessage({ type: 'agent.operation', label: 'DeepAgents runtime', status: 'running', detail: `Workspace root: ${input.workspaceRoot || process.cwd()}` });
 
-        const model = runtime.createLangChainChatModel(providerConfig);
-        const agent = runtime.createDeepAgentRuntime({
-            model,
-            tools: [],
-            systemPrompt: this.buildSystemPrompt(input),
-        });
+        const handle = await this.getYagrAgentHandle(providerConfig, input);
+        const agent = handle.agent;
 
         const messages = [{ role: 'user', content: input.prompt }];
-        const config = { version: 'v2', signal } as Record<string, unknown>;
+        const config = {
+            version: 'v2',
+            signal,
+            configurable: {
+                thread_id: input.workflowId ? `workflow:${input.workflowId}` : 'workflow:new',
+            },
+        } as Record<string, unknown>;
 
         if (typeof (agent as any).streamEvents === 'function') {
             const stream = (agent as any).streamEvents({ messages }, config);
-            const accumulator = await runtime.consumeLangGraphStream(stream, {
-                onTextDelta: async (delta: string) => {
-                    await this.throwIfAborted(signal);
-                    await postMessage({ type: 'agent.delta', content: delta });
-                },
-                onOperation: async (event: any) => {
-                    await postMessage({
-                        type: 'agent.operation',
-                        label: String(event.label || event.operationId || 'Operation'),
-                        status: event.status === 'error' ? 'error' : event.status === 'done' ? 'done' : 'running',
-                        detail: event.summary || event.body,
-                    });
-                },
-            });
+            const eventRuntime = await import('@yagr/agent/dist/gateway/langgraph-events.js');
+            const accumulator = eventRuntime.createRunAccumulator();
+            for await (const event of stream) {
+                await this.throwIfAborted(signal);
+                await eventRuntime.processStreamEvent(event, accumulator, {
+                    onTextDelta: async (delta: string) => {
+                        await this.throwIfAborted(signal);
+                        await postMessage({ type: 'agent.delta', content: delta });
+                    },
+                    onOperation: async (event: any) => {
+                        await postMessage({
+                            type: 'agent.operation',
+                            label: String(event.label || event.operationId || 'Operation'),
+                            status: event.status === 'error' ? 'error' : event.status === 'done' ? 'done' : 'running',
+                            detail: this.truncateOperationDetail(event.summary || event.body),
+                        });
+                    },
+                    onUserVisibleUpdate: async (update: any) => {
+                        await postMessage({
+                            type: 'agent.operation',
+                            label: String(update.title || update.phase || 'Progress'),
+                            status: update.tone === 'error' ? 'error' : 'running',
+                            detail: this.truncateOperationDetail(update.detail),
+                        });
+                    },
+                });
+            }
             if (!accumulator.responseText) {
                 await postMessage({ type: 'agent.message', role: 'assistant', content: 'The agent completed without producing text.' });
             }
@@ -152,14 +168,18 @@ export class AgentRuntimeController implements vscode.Disposable {
         await postMessage({ type: 'agent.message', role: 'assistant', content: this.extractAgentText(result) });
     }
 
-    private async loadYagrRuntime(): Promise<typeof import('@yagr/runtime')> {
-        if (!this.cachedRuntime) {
-            this.cachedRuntime = await import('@yagr/runtime');
-        }
-        return this.cachedRuntime;
+    private truncateOperationDetail(value: unknown): string | undefined {
+        if (typeof value !== 'string') return undefined;
+        const normalized = value.trim();
+        if (!normalized) return undefined;
+        return normalized.length > 500 ? `${normalized.slice(0, 500)}...` : normalized;
     }
 
-    private async getProviderRuntimeConfig(runtime: typeof import('@yagr/runtime')): Promise<{
+    private async loadYagrProviderRegistry(): Promise<typeof import('@yagr/agent/dist/llm/provider-registry.js')> {
+        return import('@yagr/agent/dist/llm/provider-registry.js');
+    }
+
+    private async getProviderRuntimeConfig(providerRegistry: typeof import('@yagr/agent/dist/llm/provider-registry.js')): Promise<{
         ready: boolean;
         reason?: string;
         provider: string;
@@ -170,11 +190,11 @@ export class AgentRuntimeController implements vscode.Disposable {
     }> {
         const config = vscode.workspace.getConfiguration('n8n.agent');
         const provider = String(config.get<string>('provider') || 'openai');
-        const normalizedProvider = runtime.normalizeProviderId(provider);
+        const normalizedProvider = providerRegistry.normalizeProviderId(provider);
         if (!normalizedProvider) {
             return {
                 ready: false,
-                reason: `Provider ${provider} can be configured in the VS Code UI, but the bundled @yagr/runtime package does not expose execution support for it yet. Select an API provider supported by the embedded runtime or update @yagr/runtime.`,
+                reason: `Provider ${provider} is not supported by the installed Yagr runtime.`,
                 provider,
                 model: String(config.get<string>('model') || '').trim() || undefined,
                 temperature: 0,
@@ -183,34 +203,203 @@ export class AgentRuntimeController implements vscode.Disposable {
         const model = String(config.get<string>('model') || '').trim() || undefined;
         const baseUrl = String(config.get<string>('baseUrl') || '').trim() || undefined;
         const apiKey = await this._context.secrets.get(getAgentProviderSecretKey(normalizedProvider));
-        const resolved = runtime.resolveProviderRuntimeConfig({
+        if (normalizedProvider === 'openai-oauth') {
+            const accountRuntime = await import('@yagr/agent/dist/llm/openai-account.js');
+            const session = await accountRuntime.ensureOpenAiAccountSession().catch(() => undefined);
+            if (!session?.accessToken) {
+                return {
+                    ready: false,
+                    reason: 'OpenAI OAuth needs to be reconnected once so n8n-as-code can persist the Codex account session used by the Yagr runtime. Open Settings > Agent Providers, disconnect OpenAI ChatGPT OAuth, then connect it again.',
+                    provider: normalizedProvider,
+                    model,
+                    baseUrl,
+                    apiKey,
+                    temperature: 0,
+                };
+            }
+        }
+        if (providerRegistry.providerRequiresApiKey(normalizedProvider) && !apiKey && normalizedProvider !== 'openai-oauth' && normalizedProvider !== 'copilot-proxy' && normalizedProvider !== 'anthropic-proxy') {
+            return {
+                ready: false,
+                reason: `Missing API key for ${providerRegistry.getProviderDisplayName(normalizedProvider)}. Open Settings > Agent Providers to connect it.`,
+                provider: normalizedProvider,
+                model,
+                baseUrl,
+                apiKey,
+                temperature: 0,
+            };
+        }
+        return {
+            ready: true,
             provider: normalizedProvider,
             model,
             baseUrl,
             apiKey,
             temperature: 0,
-        });
-
-        if (runtime.providerRequiresApiKey(resolved.provider) && !resolved.apiKey) {
-            return {
-                ...resolved,
-                ready: false,
-                reason: `Missing API key for ${runtime.getRuntimeProviderLabel(resolved.provider)}. Run "n8n Agent: Set Provider API Key" or configure the provider environment variable.`,
-            };
-        }
-
-        return { ...resolved, ready: true };
+        };
     }
 
-    private buildSystemPrompt(input: AgentPromptInput): string {
+    private async getYagrAgentHandle(providerConfig: {
+        provider: string;
+        model?: string;
+        apiKey?: string;
+        baseUrl?: string;
+    }, input: AgentPromptInput): Promise<any> {
+        const rootDir = input.workspaceRoot || process.cwd();
+        const [agentFactory, providerRegistry] = await Promise.all([
+            import('@yagr/agent/dist/agent-factory.js'),
+            import('@yagr/agent/dist/llm/provider-registry.js'),
+        ]);
+        const memorySources = await this.getWorkspaceMemorySources(rootDir);
+        const skillSourcePaths = await this.getWorkspaceSkillSources(rootDir);
+        const key = JSON.stringify({
+            rootDir,
+            provider: providerConfig.provider,
+            model: providerConfig.model,
+            baseUrl: providerConfig.baseUrl,
+            workflowId: input.workflowId || '',
+            workflowFilename: input.workflowFilename || '',
+            memorySources,
+            skillSourcePaths,
+        });
+        if (this.cachedAgentHandle?.key === key) {
+            return this.cachedAgentHandle.handle;
+        }
+
+        const credentials = new Map<string, string>();
+        await Promise.all(providerRegistry.YAGR_MODEL_PROVIDERS.map(async (provider) => {
+            const value = await this._context.secrets.get(getAgentProviderSecretKey(provider));
+            if (value) credentials.set(provider, value);
+        }));
+        const localConfig = {
+            provider: providerConfig.provider,
+            model: providerConfig.model,
+            baseUrl: providerConfig.baseUrl,
+        } as any;
+        const configStore = {
+            getLocalConfig: () => localConfig,
+            getApiKey: (provider: string) => credentials.get(provider),
+        };
+        const handle = await agentFactory.createYagrDeepAgent(configStore as any, {
+            provider: providerConfig.provider,
+            model: providerConfig.model,
+            apiKey: providerConfig.apiKey,
+            baseUrl: providerConfig.baseUrl,
+        }, undefined, undefined, {
+            rootDir,
+            memorySources,
+            skillSourcePaths,
+            systemPrompt: await this.buildSystemPrompt(input),
+        });
+        this.cachedAgentHandle = { key, handle };
+        return handle;
+    }
+
+    private async buildSystemPrompt(input: AgentPromptInput): Promise<string> {
+        const workflowContext = await this.loadWorkflowContext(input);
         return [
             'You are the embedded n8n-as-code VS Code agent.',
             'You help users design, inspect, validate, and operate n8n workflows from the current workspace.',
-            'This runtime phase is chat-only: do not claim to have edited files, pushed workflows, provisioned credentials, run commands, or changed n8n runtime state.',
-            'When the user asks for an action that requires tools, explain the intended safe next steps and mention that tool execution will require approval once enabled.',
+            'Your DeepAgents backend working directory is the VS Code workspace root. Treat all relative filesystem tool paths as relative to that home directory.',
+            'Use tools only when useful. For questions about the currently selected workflow, first use the provided workflow context below as authoritative.',
+            'Do not claim to push workflows, provision credentials, or change n8n runtime state unless a tool explicitly performs that action successfully.',
             input.workspaceRoot ? `Workspace root: ${input.workspaceRoot}` : undefined,
             input.workflowId ? `Current workflow: ${input.workflowName || input.workflowId} (${input.workflowId})` : undefined,
+            input.workflowFilename ? `Current workflow file: ${input.workflowFilename}` : undefined,
+            workflowContext,
         ].filter(Boolean).join('\n');
+    }
+
+    private async getWorkspaceMemorySources(rootDir: string): Promise<string[]> {
+        const candidates = [
+            path.join(rootDir, 'AGENTS.md'),
+            path.join(rootDir, 'README.md'),
+            path.join(rootDir, 'readme.md'),
+            path.join(rootDir, '.agents', 'AGENTS.md'),
+            path.join(rootDir, '.yagr', 'AGENTS.md'),
+        ];
+        const existing = await Promise.all(candidates.map(async (candidate) => {
+            try {
+                const stat = await fs.promises.stat(candidate);
+                return stat.isFile() ? candidate : undefined;
+            } catch {
+                return undefined;
+            }
+        }));
+        return existing.filter((candidate): candidate is string => Boolean(candidate));
+    }
+
+    private async getWorkspaceSkillSources(rootDir: string): Promise<string[]> {
+        const candidates = [
+            path.join(rootDir, '.agents', 'skills'),
+            path.join(rootDir, 'skills'),
+            path.join(rootDir, 'agent-skills'),
+        ];
+        const existing = await Promise.all(candidates.map(async (candidate) => {
+            try {
+                const stat = await fs.promises.stat(candidate);
+                return stat.isDirectory() && await this.directoryHasSkill(candidate) ? candidate : undefined;
+            } catch {
+                return undefined;
+            }
+        }));
+        return existing.filter((candidate): candidate is string => Boolean(candidate));
+    }
+
+    private async directoryHasSkill(directoryPath: string): Promise<boolean> {
+        const directSkill = path.join(directoryPath, 'SKILL.md');
+        try {
+            const stat = await fs.promises.stat(directSkill);
+            if (stat.isFile()) return true;
+        } catch {
+            // Check child skill directories below.
+        }
+        try {
+            const entries = await fs.promises.readdir(directoryPath, { withFileTypes: true });
+            for (const entry of entries) {
+                if (!entry.isDirectory()) continue;
+                const stat = await fs.promises.stat(path.join(directoryPath, entry.name, 'SKILL.md')).catch(() => undefined);
+                if (stat?.isFile()) return true;
+            }
+        } catch {
+            return false;
+        }
+        return false;
+    }
+
+    private async loadWorkflowContext(input: AgentPromptInput): Promise<string | undefined> {
+        if (!input.workflowId && !input.workflowFilename) {
+            return 'No workflow is attached. The user may be designing a new workflow.';
+        }
+        const candidates: string[] = [];
+        if (input.workspaceRoot && input.workflowFilename) {
+            candidates.push(path.join(input.workspaceRoot, input.workflowFilename));
+            candidates.push(path.join(input.workspaceRoot, 'workflows', input.workflowFilename));
+        }
+        if (input.workspaceRoot && input.workflowId) {
+            candidates.push(path.join(input.workspaceRoot, 'workflows', `${input.workflowId}.json`));
+        }
+        for (const candidate of [...new Set(candidates)]) {
+            try {
+                const stat = await fs.promises.stat(candidate);
+                if (!stat.isFile() || stat.size > 400_000) continue;
+                const content = await fs.promises.readFile(candidate, 'utf8');
+                return [
+                    'Selected workflow JSON context:',
+                    '```json',
+                    content,
+                    '```',
+                ].join('\n');
+            } catch {
+                // Try next candidate.
+            }
+        }
+        return [
+            'Selected workflow metadata:',
+            `Name: ${input.workflowName || 'unknown'}`,
+            `ID: ${input.workflowId || 'not yet available'}`,
+            'Workflow JSON was not found in the workspace. Explain only from available metadata and say when JSON details are needed.',
+        ].join('\n');
     }
 
     private extractAgentText(result: unknown): string {

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -170,7 +170,16 @@ export class AgentRuntimeController implements vscode.Disposable {
     }> {
         const config = vscode.workspace.getConfiguration('n8n.agent');
         const provider = String(config.get<string>('provider') || 'openai');
-        const normalizedProvider = runtime.normalizeProviderId(provider) || 'openai';
+        const normalizedProvider = runtime.normalizeProviderId(provider);
+        if (!normalizedProvider) {
+            return {
+                ready: false,
+                reason: `Provider ${provider} can be configured in the VS Code UI, but the bundled @yagr/runtime package does not expose execution support for it yet. Select an API provider supported by the embedded runtime or update @yagr/runtime.`,
+                provider,
+                model: String(config.get<string>('model') || '').trim() || undefined,
+                temperature: 0,
+            };
+        }
         const model = String(config.get<string>('model') || '').trim() || undefined;
         const baseUrl = String(config.get<string>('baseUrl') || '').trim() || undefined;
         const apiKey = await this._context.secrets.get(getAgentProviderSecretKey(normalizedProvider));

--- a/packages/vscode-extension/src/services/n8n-configuration-controller.ts
+++ b/packages/vscode-extension/src/services/n8n-configuration-controller.ts
@@ -141,34 +141,6 @@ export class N8nConfigurationController implements vscode.Disposable {
             },
           };
         }
-        if (prepared.context.instance.publicUrlEnabled) {
-          try {
-            const access = await facade.resolveInstanceAccess({
-              workspaceRoot,
-              instanceId: prepared.context.activeInstanceId,
-              syncFolderDefault: 'workspace',
-              consumer: 'vscode',
-              mode: 'reconcile',
-            });
-            prepared = {
-              ...prepared,
-              context: {
-                ...prepared.context,
-                publicBaseUrl: access.publicN8nUrl || prepared.context.publicBaseUrl,
-                instance: {
-                  ...prepared.context.instance,
-                  tunnelPublicUrl: access.publicN8nUrl || prepared.context.instance.tunnelPublicUrl,
-                },
-              },
-              runtime: {
-                ...prepared.runtime,
-                tunnel: access.tunnel || prepared.runtime.tunnel,
-              },
-            };
-          } catch (error: any) {
-            this.outputChannel?.appendLine(`[n8n] Public URL reconcile skipped: ${error?.message || error}`);
-          }
-        }
         global = await facade.getGlobalConfig();
       }
       const effective = prepared?.context;

--- a/packages/vscode-extension/src/services/n8n-configuration-controller.ts
+++ b/packages/vscode-extension/src/services/n8n-configuration-controller.ts
@@ -141,6 +141,34 @@ export class N8nConfigurationController implements vscode.Disposable {
             },
           };
         }
+        if (prepared.context.instance.publicUrlEnabled) {
+          try {
+            const access = await facade.resolveInstanceAccess({
+              workspaceRoot,
+              instanceId: prepared.context.activeInstanceId,
+              syncFolderDefault: 'workspace',
+              consumer: 'vscode',
+              mode: 'reconcile',
+            });
+            prepared = {
+              ...prepared,
+              context: {
+                ...prepared.context,
+                publicBaseUrl: access.publicN8nUrl || prepared.context.publicBaseUrl,
+                instance: {
+                  ...prepared.context.instance,
+                  tunnelPublicUrl: access.publicN8nUrl || prepared.context.instance.tunnelPublicUrl,
+                },
+              },
+              runtime: {
+                ...prepared.runtime,
+                tunnel: access.tunnel || prepared.runtime.tunnel,
+              },
+            };
+          } catch (error: any) {
+            this.outputChannel?.appendLine(`[n8n] Public URL reconcile skipped: ${error?.message || error}`);
+          }
+        }
         global = await facade.getGlobalConfig();
       }
       const effective = prepared?.context;

--- a/packages/vscode-extension/src/services/n8n-configuration-controller.ts
+++ b/packages/vscode-extension/src/services/n8n-configuration-controller.ts
@@ -5,6 +5,7 @@ import {
   createN8nManagerFacade,
   resolveN8nManagerConfigurationPaths,
 } from '@n8n-as-code/manager-adapter';
+import { isCanonicalUserInstanceIdentifier, resolveInstanceIdentifier } from 'n8nac';
 
 type N8nManagerFacade = ReturnType<typeof createN8nManagerFacade>;
 type N8nGlobalConfig = Awaited<ReturnType<N8nManagerFacade['getGlobalConfig']>>;
@@ -111,13 +112,35 @@ export class N8nConfigurationController implements vscode.Disposable {
     try {
       let global = await facade.getGlobalConfig();
       const workspace = workspaceRoot ? await facade.readWorkspaceOverrides(workspaceRoot) : { version: 3 as const };
-      const prepared = await facade.prepareEffectiveContext({
+      let prepared = await facade.prepareEffectiveContext({
         workspaceRoot,
         syncFolderDefault: 'workspace',
         consumer: 'vscode',
         autoStart: true,
       }).catch(() => undefined);
       if (prepared) {
+        const effectiveHost = prepared.context.apiBaseUrl ?? prepared.context.host;
+        if (effectiveHost && prepared.context.apiKey && !isCanonicalUserInstanceIdentifier(prepared.context.instanceIdentifier)) {
+          const { identifier } = await resolveInstanceIdentifier({
+            host: effectiveHost,
+            apiKey: prepared.context.apiKey,
+          });
+          await facade.upsertInstance({
+            id: prepared.context.activeInstanceId,
+            instanceIdentifier: identifier,
+          }, { setActive: false });
+          prepared = {
+            ...prepared,
+            context: {
+              ...prepared.context,
+              instanceIdentifier: identifier,
+              instance: {
+                ...prepared.context.instance,
+                instanceIdentifier: identifier,
+              },
+            },
+          };
+        }
         global = await facade.getGlobalConfig();
       }
       const effective = prepared?.context;

--- a/packages/vscode-extension/src/services/proxy-service.ts
+++ b/packages/vscode-extension/src/services/proxy-service.ts
@@ -137,8 +137,8 @@ export class ProxyService {
             target: this.target,
             changeOrigin: true,
             secure: false,
-            // Only intercept responses on macOS where we need to inject the clipboard bridge
-            selfHandleResponse: isMacOS,
+            // Intercept HTML responses so we can inject the n8n UI bridge.
+            selfHandleResponse: true,
             cookieDomainRewrite: "", // Rewrite all domains to match localhost
             preserveHeaderKeyCase: true, // Preserve header casing
             autoRewrite: true, // Automatically rewrite redirects
@@ -195,10 +195,6 @@ export class ProxyService {
             proxyRes.headers['access-control-allow-methods'] = 'GET, POST, PUT, DELETE, OPTIONS, PATCH';
             proxyRes.headers['access-control-allow-headers'] = '*';
 
-            // On non-macOS, selfHandleResponse is false so http-proxy pipes automatically.
-            // On macOS, we handle responses ourselves to inject the clipboard bridge.
-            if (!isMacOS) return;
-
             const rawCT = proxyRes.headers['content-type'];
             const contentType = Array.isArray(rawCT) ? rawCT[0] || '' : rawCT || '';
             const isHtml = contentType.includes('text/html');
@@ -215,7 +211,7 @@ export class ProxyService {
                         const charsetMatch = contentType.match(/charset=([^\s;]+)/i);
                         const charset = (charsetMatch?.[1] || 'utf-8') as BufferEncoding;
                         let html = raw.toString(charset);
-                        html = this.injectClipboardBridge(html);
+                        html = this.injectClipboardBridge(html, isMacOS);
                         const encoded = Buffer.from(html, charset);
                         delete proxyRes.headers['content-length'];
                         delete proxyRes.headers['content-encoding'];
@@ -253,7 +249,7 @@ export class ProxyService {
                     'content-type': 'text/html; charset=utf-8',
                     'cache-control': 'no-store',
                 });
-                res.end(routeHtml);
+                res.end(this.injectClipboardBridge(routeHtml, isMacOS, false, 'auth-route'));
                 return;
             }
 
@@ -270,10 +266,8 @@ export class ProxyService {
             }
 
             if (this.proxy) {
-                // On macOS, request uncompressed responses so we can inject the clipboard bridge
-                if (isMacOS) {
-                    delete req.headers['accept-encoding'];
-                }
+                // Request uncompressed responses so HTML bridge injection can safely mutate the body.
+                delete req.headers['accept-encoding'];
 
                 const mergedCookies = this.buildMergedCookieHeader(req.headers.cookie);
                 if (mergedCookies) {
@@ -460,10 +454,411 @@ export class ProxyService {
      *   are all enforced in the parent webview (workflow-webview.ts), which is
      *   extension-controlled and not accessible to iframe scripts.
      */
-    static buildBridgeScript(): string {
+    static buildBridgeScript(clipboardBridgeEnabled = true, nodeBridgeEnabled = true, pageKind = 'n8n'): string {
         return `<script>
 (function(){
+  var CLIPBOARD_BRIDGE_ENABLED = ${JSON.stringify(clipboardBridgeEnabled)};
+  var NODE_BRIDGE_ENABLED = ${JSON.stringify(nodeBridgeEnabled)};
+  var N8NAC_BRIDGE_PAGE_KIND = ${JSON.stringify(pageKind)};
+  var N8NAC_BRIDGE_BUILD = "2026.05.04.8";
   var _pasteInProgress = false;
+  var _lastNodeDetailSignature = "";
+  var _lastCanvasNode = null;
+  var _uiMutationTimer = null;
+  var _uiMutationCount = 0;
+
+  function postBridgeReady() {
+    window.parent.postMessage({ type: "n8n-bridge-ready", build: N8NAC_BRIDGE_BUILD, pageKind: N8NAC_BRIDGE_PAGE_KIND, href: window.location.href }, "*");
+  }
+
+  function asRecord(value) {
+    return value && typeof value === "object" && !Array.isArray(value) ? value : null;
+  }
+
+  function cleanText(value) {
+    if (typeof value !== "string") return "";
+    return value.replace(/\\s+/g, " ").trim();
+  }
+
+  function coerceNode(value) {
+    var record = asRecord(value);
+    if (!record) return null;
+    var name = cleanText(record.name || record.displayName || record.label || record.title || "");
+    if (!name) return null;
+    return {
+      name: name,
+      type: cleanText(record.type || record.nodeType || record.typeVersion || ""),
+      id: cleanText(record.id || record.nodeId || "")
+    };
+  }
+
+  function describeElement(element) {
+    if (!element || element.nodeType !== 1) return "unknown";
+    var tag = cleanText(element.tagName || "element").toLowerCase();
+    var testId = element.getAttribute && cleanText(element.getAttribute("data-test-id") || "");
+    var label = element.getAttribute && cleanText(element.getAttribute("aria-label") || element.getAttribute("title") || "");
+    var text = cleanText(element.textContent || "");
+    if (text.length > 60) text = text.slice(0, 57) + "...";
+    return [tag, testId || label || text].filter(Boolean).join(": ");
+  }
+
+  function postUiClick(event) {
+    var target = event.target;
+    var nodeRoot = findCanvasNodeElement(target);
+    var canvasSurface = isCanvasSurfaceElement(target);
+    var node = null;
+    if (nodeRoot) {
+      try { node = readNodeFromElement(target); } catch (e) {}
+      window.setTimeout(function() {
+        publishNodeDetail(node || readNodeFromStore());
+      }, 50);
+    } else if (canvasSurface) {
+      clearNodeContext();
+    }
+    window.parent.postMessage({
+      type: "n8n-ui-click",
+      build: N8NAC_BRIDGE_BUILD,
+      target: describeElement(event.target),
+      nodeName: node && node.name
+    }, "*");
+  }
+
+  function postUiChangedSoon() {
+    _uiMutationCount += 1;
+    if (_uiMutationTimer) return;
+    _uiMutationTimer = window.setTimeout(function() {
+      _uiMutationTimer = null;
+      window.parent.postMessage({
+        type: "n8n-ui-change",
+        build: N8NAC_BRIDGE_BUILD,
+        count: _uiMutationCount
+      }, "*");
+    }, 250);
+  }
+
+  function firstUsefulText(root) {
+    if (!root) return "";
+    var selectors = ["[data-test-id='node-title']", "[data-test-id*='node-name']", "[data-test-id*='nodeName']", "[class*='node-name']", "[class*='nodeName']", "[class*='node-title']", "[class*='nodeTitle']", "[class*='modal-title']", "[class*='ModalTitle']", ".el-dialog__title", "header [class*='title']", "header [class*='Title']", "[title]", "[aria-label]", "[role='heading']", "h1", "h2", "h3"];
+    for (var i = 0; i < selectors.length; i++) {
+      try {
+        var candidate = root.matches && root.matches(selectors[i]) ? root : root.querySelector && root.querySelector(selectors[i]);
+        var text = cleanText((candidate && (candidate.getAttribute("title") || candidate.getAttribute("aria-label") || candidate.textContent)) || "");
+        if (text && text.length <= 120 && text !== "Parameters" && text !== "Settings") return text;
+      } catch (e) {}
+    }
+    var fallback = cleanText(root.textContent || "");
+    if (!fallback || fallback.length > 160) return "";
+    return fallback;
+  }
+
+  function looksLikeNodeDetailPanel(root) {
+    if (!root || !isVisible(root)) return false;
+    var text = cleanText(root.textContent || "");
+    if (!text) return false;
+    if (/\\b(Parameters|Settings)\\b/.test(text) && /\\b(Execute step|INPUT|OUTPUT|Source for Prompt|Options)\\b/.test(text)) return true;
+    if (/\\b(Node|Credential|Parameter|Execute step)\\b/.test(text) && /\\b(INPUT|OUTPUT|Parameters|Settings)\\b/.test(text)) return true;
+    return false;
+  }
+
+  function isLikelyNodeTitleText(text) {
+    text = cleanText(text);
+    if (!text || text.length < 2 || text.length > 120) return false;
+      if (/^(Parameters|Settings|INPUT|OUTPUT|Docs|Execute step|Execute previous nodes|No input data|No output data|Options|Add Option|Tool|Memory|Chat Model|Logs)$/i.test(text)) return false;
+      if (/^(Tip:|Source for Prompt|Prompt \\(|Require Specific|Enable Fallback|Connected Chat Trigger Node)/i.test(text)) return false;
+    if (/^[+×x\-–—|•·]+$/.test(text)) return false;
+    return true;
+  }
+
+  function readNodeTitleFromPanelTopBand(root) {
+    if (!root || !isVisible(root)) return null;
+    var rootRect = root.getBoundingClientRect();
+    var selectors = "div,span,h1,h2,h3,[role='heading'],[title],[aria-label]";
+    var candidates = [];
+    try { candidates = Array.prototype.slice.call(root.querySelectorAll(selectors)); } catch (e) { candidates = []; }
+    if (root.matches && root.matches(selectors)) candidates.unshift(root);
+
+    var best = null;
+    for (var i = 0; i < candidates.length; i++) {
+      var el = candidates[i];
+      if (!isVisible(el)) continue;
+      var rect = el.getBoundingClientRect();
+      if (rect.top < rootRect.top - 2 || rect.top > rootRect.top + 80) continue;
+      if (rect.left < rootRect.left - 2 || rect.left > rootRect.left + Math.max(220, rootRect.width * 0.45)) continue;
+      var text = cleanText(el.getAttribute && (el.getAttribute("title") || el.getAttribute("aria-label")) || el.textContent || "");
+      if (!isLikelyNodeTitleText(text)) continue;
+      var score = (rect.top - rootRect.top) * 1000 + (rect.left - rootRect.left) + Math.max(0, text.length - 60) * 10;
+      if (!best || score < best.score) best = { score: score, text: text };
+    }
+    return best ? { name: best.text, type: "", id: "" } : null;
+  }
+
+  function findNodeDetailRootByTextScan() {
+    var candidates = [];
+    try { candidates = Array.prototype.slice.call(document.querySelectorAll("[role='dialog'],[aria-modal='true'],section,aside,main,div")); } catch (e) { candidates = []; }
+    var best = null;
+    for (var i = 0; i < candidates.length; i++) {
+      var el = candidates[i];
+      if (!isVisible(el)) continue;
+      var rect = el.getBoundingClientRect();
+      if (rect.width < 300 || rect.height < 180) continue;
+      var text = cleanText(el.textContent || "");
+      if (!/\\bParameters\\b/.test(text) || !/\\bSettings\\b/.test(text) || !/\\bExecute step\\b/.test(text)) continue;
+      var title = readNodeTitleFromPanelTopBand(el);
+      if (!title) continue;
+      var area = rect.width * rect.height;
+      if (!best || area < best.area) best = { area: area, element: el };
+    }
+    return best ? best.element : null;
+  }
+
+  function findNodeDetailTitleByPanelText() {
+    var titleSelectors = ["[data-test-id='node-title']", "[data-test-id*='node-name']", "[data-test-id*='nodeName']", "[class*='node-name']", "[class*='nodeName']", "[class*='modal-title']", "[class*='ModalTitle']", ".el-dialog__title", "header [class*='title']", "header [class*='Title']", "h1", "h2", "h3", "[role='heading']"];
+    for (var i = 0; i < titleSelectors.length; i++) {
+      var titles = [];
+      try { titles = Array.prototype.slice.call(document.querySelectorAll(titleSelectors[i])); } catch (e) { titles = []; }
+      for (var j = 0; j < titles.length; j++) {
+        var title = titles[j];
+        if (!isVisible(title)) continue;
+        var name = cleanText(title.textContent || title.getAttribute("title") || title.getAttribute("aria-label") || "");
+        if (!isLikelyNodeTitleText(name)) continue;
+
+        var cursor = title;
+        for (var depth = 0; cursor && depth < 8; depth++) {
+          var text = cleanText(cursor.textContent || "");
+          if (/\\bParameters\\b/.test(text) && /\\bSettings\\b/.test(text) && /\\bExecute step\\b/.test(text)) {
+            return { name: name, type: "", id: "" };
+          }
+          cursor = cursor.parentElement;
+        }
+      }
+    }
+    return null;
+  }
+
+  function readNodeFromElement(element) {
+    if (!element || !element.closest) return null;
+    var root = findCanvasNodeElement(element);
+    if (!root) return null;
+    var attrHost = root.matches && (root.matches("[data-node-name]") || root.matches("[data-name]"))
+      ? root
+      : root.querySelector && root.querySelector("[data-node-name], [data-name]");
+    var attrName = attrHost && cleanText(attrHost.getAttribute("data-node-name") || attrHost.getAttribute("data-name") || "");
+    var name = attrName || firstUsefulText(root);
+    if (!name) return null;
+    return {
+      name: name,
+      type: cleanText((attrHost && (attrHost.getAttribute("data-node-type") || attrHost.getAttribute("data-type"))) || root.getAttribute && (root.getAttribute("data-node-type") || root.getAttribute("data-type")) || ""),
+      id: cleanText((attrHost && (attrHost.getAttribute("data-node-id") || attrHost.getAttribute("data-id"))) || root.getAttribute && (root.getAttribute("data-node-id") || root.getAttribute("data-id")) || "")
+    };
+  }
+
+  function findCanvasNodeElement(element) {
+    if (!element || !element.closest) return null;
+    var selectors = [
+      "[data-test-id='canvas-node']",
+      "[data-test-id*='canvas-node']",
+      "[data-test-id*='workflow-node']",
+      "[data-test-id*='node-view-node']",
+      "[data-node-name]",
+      "[data-name]",
+      "[class*='canvas-node']",
+      "[class*='CanvasNode']",
+      "[class*='workflow-node']",
+      "[class*='node-box']"
+    ];
+    for (var i = 0; i < selectors.length; i++) {
+      try {
+        var match = element.closest(selectors[i]);
+        if (match && isVisible(match)) return match;
+      } catch (e) {}
+    }
+    return null;
+  }
+
+  function isCanvasSurfaceElement(element) {
+    if (!element || !element.closest) return false;
+    if (findCanvasNodeElement(element)) return false;
+    if (findNodeDetailRoot() && element.closest && element.closest("[role='dialog'],[aria-modal='true'],[class*='node-parameters'],[class*='NodeParameters'],[class*='modal'],[class*='Modal'],[class*='drawer'],[class*='Drawer']")) return false;
+    var selectors = [
+      "[data-test-id='canvas']",
+      "[data-test-id*='canvas']",
+      "[data-test-id*='node-view']",
+      "[data-test-id*='workflow']",
+      "[class*='canvas']",
+      "[class*='Canvas']",
+      "[class*='node-view']",
+      "[class*='NodeView']",
+      ".vue-flow",
+      ".react-flow"
+    ];
+    for (var i = 0; i < selectors.length; i++) {
+      try {
+        var match = element.closest(selectors[i]);
+        if (match && isVisible(match)) return true;
+      } catch (e) {}
+    }
+    return false;
+  }
+
+  function readNodeFromStore() {
+    try {
+      var app = document.querySelector("#app");
+      var vue = app && app.__vue__;
+      var store = vue && vue.$store;
+      if (!store) return null;
+      var getters = store.getters || {};
+      var getterKeys = ["ndv/activeNode", "nodeView/selectedNode", "workflows/getSelectedNode", "workflows/selectedNode"];
+      for (var i = 0; i < getterKeys.length; i++) {
+        var fromGetter = coerceNode(getters[getterKeys[i]]);
+        if (fromGetter) return fromGetter;
+      }
+      var state = store.state || {};
+      var candidates = [
+        state.ndv && state.ndv.activeNode,
+        state.ndv && state.ndv.node,
+        state.nodeView && state.nodeView.selectedNode,
+        state.workflows && state.workflows.selectedNode,
+        state.workflows && state.workflows.activeNode
+      ];
+      for (var j = 0; j < candidates.length; j++) {
+        var fromState = coerceNode(candidates[j]);
+        if (fromState) return fromState;
+      }
+    } catch (e) {}
+    return null;
+  }
+
+  function isVisible(el) {
+    if (!el) return false;
+    var rect = el.getBoundingClientRect && el.getBoundingClientRect();
+    if (!rect || rect.width === 0 || rect.height === 0) return false;
+    var style = window.getComputedStyle ? window.getComputedStyle(el) : null;
+    return !style || (style.visibility !== "hidden" && style.display !== "none");
+  }
+
+  function findNodeDetailRoot() {
+    var selectors = [
+      "[data-test-id='ndv']",
+      "[data-test-id='node-parameters']",
+      "[data-test-id*='node-parameters']",
+      "[data-test-id*='node-creator']",
+      "[data-test-id*='node-detail']",
+      "[data-test-id*='nodeDetail']",
+      "[role='dialog']",
+      "[aria-modal='true']",
+      "[class*='node-parameters']",
+      "[class*='NodeParameters']",
+      "[class*='node-detail']",
+      "[class*='NodeDetail']",
+      "[class*='node-settings']",
+      "[class*='NodeSettings']",
+      "[class*='modal']",
+      "[class*='Modal']",
+      "[class*='dialog']",
+      "[class*='Dialog']",
+      "[class*='drawer']",
+      "[class*='Drawer']",
+      "[class*='ndv']",
+      "[class*='NDV']"
+    ];
+    for (var i = 0; i < selectors.length; i++) {
+      try {
+        var nodes = document.querySelectorAll(selectors[i]);
+        for (var j = 0; j < nodes.length; j++) {
+          if (looksLikeNodeDetailPanel(nodes[j])) return nodes[j];
+        }
+      } catch (e) {}
+    }
+    return null;
+  }
+
+  function readNodeFromDom(root) {
+    if (!root) return null;
+    var attrHost = root.matches && root.matches("[data-node-name]") ? root : root.querySelector && root.querySelector("[data-node-name]");
+    var attrName = attrHost && cleanText(attrHost.getAttribute("data-node-name") || "");
+    if (attrName) {
+      return {
+        name: attrName,
+        type: cleanText((attrHost && attrHost.getAttribute("data-node-type")) || ""),
+        id: cleanText((attrHost && attrHost.getAttribute("data-node-id")) || "")
+      };
+    }
+    var titleSelectors = ["[data-test-id='node-title']", "[data-test-id*='node-name']", "[data-test-id*='nodeName']", "[class*='node-name']", "[class*='nodeName']", "[class*='modal-title']", "[class*='ModalTitle']", ".el-dialog__title", "header [class*='title']", "header [class*='Title']", "h1", "h2", "h3", "[role='heading']"];
+    for (var i = 0; i < titleSelectors.length; i++) {
+      try {
+        var title = root.querySelector(titleSelectors[i]);
+        var text = cleanText(title && title.textContent || "");
+        if (text && text !== "Parameters" && text !== "Settings" && text !== "INPUT" && text !== "OUTPUT" && text.length <= 120) {
+          return { name: text, type: "", id: "" };
+        }
+      } catch (e) {}
+    }
+    return null;
+  }
+
+  function readNodeFromUrl() {
+    try {
+      var url = new URL(window.location.href);
+      var name = cleanText(url.searchParams.get("node") || url.searchParams.get("nodeName") || "");
+      var id = cleanText(url.searchParams.get("nodeId") || url.searchParams.get("selectedNode") || "");
+      return name ? { name: name, type: "", id: id } : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function publishNodeDetailIfOpen() {
+    if (!NODE_BRIDGE_ENABLED) return;
+    var root = findNodeDetailRoot();
+    var node = readNodeFromStore() || (root ? readNodeFromDom(root) : null) || (root ? readNodeTitleFromPanelTopBand(root) : null) || findNodeDetailTitleByPanelText() || readNodeFromUrl() || (root ? _lastCanvasNode : null);
+    publishNodeDetail(node);
+  }
+
+  function publishNodeDetail(node) {
+    if (!NODE_BRIDGE_ENABLED) return;
+    if (!node || !node.name) return;
+    var signature = [node.name, node.type || "", node.id || ""].join("|");
+    if (signature === _lastNodeDetailSignature) return;
+    _lastNodeDetailSignature = signature;
+    window.parent.postMessage({ type: "n8n-node-detail-opened", build: N8NAC_BRIDGE_BUILD, node: node }, "*");
+  }
+
+  function clearNodeContext() {
+    _lastNodeDetailSignature = "";
+    _lastCanvasNode = null;
+    window.parent.postMessage({ type: "n8n-node-context-cleared", build: N8NAC_BRIDGE_BUILD }, "*");
+  }
+
+  function installNodeDetailObserver() {
+    postBridgeReady();
+    if (!NODE_BRIDGE_ENABLED) return;
+    document.addEventListener("pointerdown", function(e) {
+      var node = readNodeFromElement(e.target);
+      if (node) _lastCanvasNode = node;
+    }, true);
+    document.addEventListener("click", function(e) {
+      postUiClick(e);
+    }, true);
+    document.addEventListener("dblclick", function(e) {
+      var node = readNodeFromElement(e.target) || _lastCanvasNode;
+      if (!node) return;
+      _lastCanvasNode = node;
+      window.setTimeout(function() {
+        publishNodeDetail(node || readNodeFromStore());
+      }, 200);
+    }, true);
+    try {
+      var observer = new MutationObserver(function() { postUiChangedSoon(); });
+      observer.observe(document.body || document.documentElement, { childList: true, subtree: true, attributes: true });
+    } catch (e) {}
+    window.setInterval(postBridgeReady, 5000);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", installNodeDetailObserver, { once: true });
+  } else {
+    installNodeDetailObserver();
+  }
 
   function handlePaste(text) {
     var el = document.activeElement;
@@ -526,6 +921,7 @@ export class ProxyService {
   // Intercept Cmd+V only (macOS-specific bridge — no static secret here;
   // origin validation and one-time grant tokens are enforced in the parent webview)
   document.addEventListener("keydown", function(e) {
+    if (!CLIPBOARD_BRIDGE_ENABLED) return;
     if (e.metaKey && e.key === "v") {
       if (_pasteInProgress) return;
       e.preventDefault();
@@ -550,7 +946,7 @@ export class ProxyService {
   window.addEventListener("message", function(e) {
     var msg = e.data;
     if (!msg || typeof msg !== "object") return;
-    if (msg.type === "n8n-clipboard-paste" && typeof msg.text === "string") {
+    if (CLIPBOARD_BRIDGE_ENABLED && msg.type === "n8n-clipboard-paste" && typeof msg.text === "string") {
       handlePaste(msg.text);
     }
   });
@@ -571,8 +967,8 @@ export class ProxyService {
      * 3. Monkey-patches navigator.clipboard.readText so n8n reads our data
      * 4. Dispatches synthetic keyboard and clipboard events to trigger n8n's paste handler
      */
-    private injectClipboardBridge(html: string): string {
-        const bridgeScript = ProxyService.buildBridgeScript();
+    private injectClipboardBridge(html: string, clipboardBridgeEnabled = true, nodeBridgeEnabled = true, pageKind = 'n8n'): string {
+        const bridgeScript = ProxyService.buildBridgeScript(clipboardBridgeEnabled, nodeBridgeEnabled, pageKind);
 
         if (html.includes('</head>')) {
             return html.replace('</head>', bridgeScript + '</head>');

--- a/packages/vscode-extension/src/services/workflow-webview-registry.ts
+++ b/packages/vscode-extension/src/services/workflow-webview-registry.ts
@@ -1,0 +1,33 @@
+export interface WorkflowWebviewReloadTarget {
+    getWorkflowId(): string | undefined;
+    reloadWorkflow(): Thenable<boolean> | Promise<boolean> | boolean;
+}
+
+export class WorkflowWebviewRegistry {
+    private readonly targets = new Set<WorkflowWebviewReloadTarget>();
+
+    register(target: WorkflowWebviewReloadTarget): { dispose(): void } {
+        this.targets.add(target);
+        return {
+            dispose: () => {
+                this.targets.delete(target);
+            },
+        };
+    }
+
+    reloadIfMatching(workflowId: string): boolean {
+        let reloaded = false;
+        for (const target of [...this.targets]) {
+            if (target.getWorkflowId() !== workflowId) {
+                continue;
+            }
+            reloaded = true;
+            void Promise.resolve(target.reloadWorkflow()).catch(() => {
+                // Webview reload is best-effort; stale targets unregister on dispose.
+            });
+        }
+        return reloaded;
+    }
+}
+
+export const workflowWebviewRegistry = new WorkflowWebviewRegistry();

--- a/packages/vscode-extension/src/services/workflow-webview-registry.ts
+++ b/packages/vscode-extension/src/services/workflow-webview-registry.ts
@@ -1,31 +1,44 @@
 export interface WorkflowWebviewReloadTarget {
     getWorkflowId(): string | undefined;
     reloadWorkflow(): Thenable<boolean> | Promise<boolean> | boolean;
+    describeTarget?(): string;
 }
 
 export class WorkflowWebviewRegistry {
     private readonly targets = new Set<WorkflowWebviewReloadTarget>();
+    private debugLogger: ((message: string) => void) | undefined;
+
+    setDebugLogger(logger: ((message: string) => void) | undefined): void {
+        this.debugLogger = logger;
+    }
 
     register(target: WorkflowWebviewReloadTarget): { dispose(): void } {
         this.targets.add(target);
+        this.debugLogger?.(`[workflow-registry] register target=${target.describeTarget?.() || 'unknown'} workflowId=${target.getWorkflowId() || 'none'} total=${this.targets.size}`);
         return {
             dispose: () => {
                 this.targets.delete(target);
+                this.debugLogger?.(`[workflow-registry] dispose target=${target.describeTarget?.() || 'unknown'} total=${this.targets.size}`);
             },
         };
     }
 
     reloadIfMatching(workflowId: string): boolean {
         let reloaded = false;
+        this.debugLogger?.(`[workflow-registry] reloadIfMatching workflowId=${workflowId} targets=${this.targets.size}`);
         for (const target of [...this.targets]) {
-            if (target.getWorkflowId() !== workflowId) {
+            const targetWorkflowId = target.getWorkflowId();
+            if (targetWorkflowId !== workflowId) {
+                this.debugLogger?.(`[workflow-registry] skip target=${target.describeTarget?.() || 'unknown'} targetWorkflowId=${targetWorkflowId || 'none'}`);
                 continue;
             }
             reloaded = true;
+            this.debugLogger?.(`[workflow-registry] reloading target=${target.describeTarget?.() || 'unknown'} workflowId=${workflowId}`);
             void Promise.resolve(target.reloadWorkflow()).catch(() => {
                 // Webview reload is best-effort; stale targets unregister on dispose.
             });
         }
+        this.debugLogger?.(`[workflow-registry] reloadIfMatching result workflowId=${workflowId} reloaded=${reloaded}`);
         return reloaded;
     }
 }

--- a/packages/vscode-extension/src/services/yagr-provider-service.ts
+++ b/packages/vscode-extension/src/services/yagr-provider-service.ts
@@ -62,6 +62,10 @@ const OPENAI_CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 const OPENAI_CODEX_DEVICE_REDIRECT_URI = 'https://auth.openai.com/deviceauth/callback';
 const DISABLED_PROVIDERS_STATE_KEY = 'n8n.agent.disabledProviders';
 
+function importRuntimeModule<T = any>(specifier: string): Promise<T> {
+    return import(specifier) as Promise<T>;
+}
+
 const MODEL_LIST_MAPPER = (payload: Record<string, unknown>): string[] => {
     const data = Array.isArray(payload.data) ? payload.data : [];
     return data
@@ -467,7 +471,7 @@ export class YagrProviderService {
 
     private async getDefaultReasoningEffort(model: string): Promise<YagrReasoningEffort> {
         try {
-            const openAiAccount = await import('@yagr/agent/dist/llm/openai-account.js');
+            const openAiAccount = await importRuntimeModule('@yagr/agent/dist/llm/openai-account.js');
             return openAiAccount.getDefaultCodexReasoningEffort(model || YAGR_PROVIDER_DEFINITIONS['openai-oauth'].defaultModel) as YagrReasoningEffort;
         } catch {
             return 'medium';
@@ -475,7 +479,7 @@ export class YagrProviderService {
     }
 
     private async fetchOpenAiOauthModels(accessToken: string): Promise<string[]> {
-        const accountRuntime = await import('@yagr/agent/dist/llm/openai-account.js').catch(() => undefined);
+        const accountRuntime = await importRuntimeModule('@yagr/agent/dist/llm/openai-account.js').catch(() => undefined);
         if (accountRuntime) {
             const session = await accountRuntime.ensureOpenAiAccountSession().catch(() => undefined);
             const token = session?.accessToken || accessToken;
@@ -691,7 +695,7 @@ export class YagrProviderService {
     }
 
     private async completeOpenAiDeviceAuth(challenge: DeviceChallenge, cancellationToken?: vscode.CancellationToken): Promise<string> {
-        const accountRuntime = await import('@yagr/agent/dist/llm/openai-account.js');
+        const accountRuntime = await importRuntimeModule('@yagr/agent/dist/llm/openai-account.js');
         const wait = accountRuntime.completeCodexDeviceAuth({
             deviceAuthId: challenge.deviceAuthId || '',
             userCode: challenge.userCode,
@@ -784,7 +788,7 @@ export class YagrProviderService {
     }
 
     private async completeGitHubDeviceAuth(challenge: DeviceChallenge, cancellationToken?: vscode.CancellationToken): Promise<string> {
-        const accountRuntime = await import('@yagr/agent/dist/llm/copilot-account.js');
+        const accountRuntime = await importRuntimeModule('@yagr/agent/dist/llm/copilot-account.js');
         const wait = accountRuntime.completeGitHubCopilotAuth({
             deviceCode: challenge.deviceCode || '',
             intervalMs: challenge.intervalMs,

--- a/packages/vscode-extension/src/services/yagr-provider-service.ts
+++ b/packages/vscode-extension/src/services/yagr-provider-service.ts
@@ -1,0 +1,427 @@
+import * as vscode from 'vscode';
+import { getAgentProviderSecretKey } from './agent-runtime-controller.js';
+
+export type YagrModelProvider =
+    | 'anthropic'
+    | 'openai'
+    | 'google'
+    | 'mistral'
+    | 'openrouter'
+    | 'openai-oauth'
+    | 'anthropic-proxy'
+    | 'copilot-proxy'
+    | 'minimax'
+    | 'minimax-token-plan'
+    | 'openai-compatible';
+
+export type ProviderAuthKind = 'api-key' | 'oauth-device' | 'setup-token' | 'none';
+
+export interface YagrProviderDefinition {
+    id: YagrModelProvider;
+    label: string;
+    description: string;
+    defaultModel: string;
+    defaultBaseUrl?: string;
+    requiresApiKey: boolean;
+    authKind: ProviderAuthKind;
+    envKeys: string[];
+    canDiscoverModels: boolean;
+}
+
+type DeviceChallenge = {
+    verificationUri: string;
+    userCode: string;
+    deviceCode?: string;
+    deviceAuthId?: string;
+    intervalMs: number;
+    expiresAt: number;
+};
+
+const MODEL_LIST_MAPPER = (payload: Record<string, unknown>): string[] => {
+    const data = Array.isArray(payload.data) ? payload.data : [];
+    return data
+        .map((entry) => (entry && typeof entry === 'object' ? String((entry as Record<string, unknown>).id || '').trim() : ''))
+        .filter(Boolean)
+        .sort((left, right) => left.localeCompare(right));
+};
+
+export const YAGR_PROVIDER_DEFINITIONS: Record<YagrModelProvider, YagrProviderDefinition> = {
+    anthropic: {
+        id: 'anthropic',
+        label: 'Claude API',
+        description: 'ANTHROPIC_API_KEY',
+        defaultModel: 'claude-haiku-4-5',
+        requiresApiKey: true,
+        authKind: 'api-key',
+        envKeys: ['ANTHROPIC_LLM_API_KEY', 'ANTHROPIC_API_KEY'],
+        canDiscoverModels: true,
+    },
+    openai: {
+        id: 'openai',
+        label: 'OpenAI API',
+        description: 'OPENAI_API_KEY',
+        defaultModel: 'gpt-4o',
+        defaultBaseUrl: 'https://api.openai.com/v1',
+        requiresApiKey: true,
+        authKind: 'api-key',
+        envKeys: ['OPENAI_LLM_API_KEY', 'OPENAI_API_KEY'],
+        canDiscoverModels: true,
+    },
+    google: {
+        id: 'google',
+        label: 'Gemini API',
+        description: 'GOOGLE_GENERATIVE_AI_API_KEY',
+        defaultModel: 'gemini-3-flash-preview',
+        defaultBaseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+        requiresApiKey: true,
+        authKind: 'api-key',
+        envKeys: ['GOOGLE_GENERATIVE_AI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'GEMINI_LLM_API_KEY', 'GOOGLE_LLM_API_KEY'],
+        canDiscoverModels: true,
+    },
+    mistral: {
+        id: 'mistral',
+        label: 'Mistral API',
+        description: 'MISTRAL_API_KEY',
+        defaultModel: 'mistral-large-latest',
+        defaultBaseUrl: 'https://api.mistral.ai/v1',
+        requiresApiKey: true,
+        authKind: 'api-key',
+        envKeys: ['MISTRAL_API_KEY', 'MISTRAL_LLM_API_KEY'],
+        canDiscoverModels: true,
+    },
+    openrouter: {
+        id: 'openrouter',
+        label: 'OpenRouter API',
+        description: 'OPENROUTER_API_KEY',
+        defaultModel: 'anthropic/claude-3.5-sonnet',
+        defaultBaseUrl: 'https://openrouter.ai/api/v1',
+        requiresApiKey: true,
+        authKind: 'api-key',
+        envKeys: ['OPENROUTER_API_KEY', 'OPENROUTER_LLM_API_KEY'],
+        canDiscoverModels: true,
+    },
+    'openai-oauth': {
+        id: 'openai-oauth',
+        label: 'OpenAI ChatGPT OAuth',
+        description: 'ChatGPT subscription, device flow',
+        defaultModel: 'gpt-5.4',
+        defaultBaseUrl: 'https://chatgpt.com/backend-api',
+        requiresApiKey: false,
+        authKind: 'oauth-device',
+        envKeys: [],
+        canDiscoverModels: true,
+    },
+    'anthropic-proxy': {
+        id: 'anthropic-proxy',
+        label: 'Claude Account',
+        description: 'Claude setup-token',
+        defaultModel: 'claude-haiku-4-5',
+        requiresApiKey: false,
+        authKind: 'setup-token',
+        envKeys: ['YAGR_ANTHROPIC_SETUP_TOKEN'],
+        canDiscoverModels: true,
+    },
+    'copilot-proxy': {
+        id: 'copilot-proxy',
+        label: 'GitHub Copilot OAuth',
+        description: 'GitHub Copilot subscription, device flow',
+        defaultModel: 'gpt-4.1',
+        defaultBaseUrl: 'https://api.individual.githubcopilot.com',
+        requiresApiKey: false,
+        authKind: 'oauth-device',
+        envKeys: ['COPILOT_GITHUB_TOKEN', 'GH_TOKEN', 'GITHUB_TOKEN'],
+        canDiscoverModels: true,
+    },
+    minimax: {
+        id: 'minimax',
+        label: 'MiniMax API',
+        description: 'MINIMAX_API_KEY',
+        defaultModel: 'MiniMax-M2.7',
+        defaultBaseUrl: 'https://api.minimax.io/anthropic',
+        requiresApiKey: true,
+        authKind: 'api-key',
+        envKeys: ['MINIMAX_API_KEY'],
+        canDiscoverModels: false,
+    },
+    'minimax-token-plan': {
+        id: 'minimax-token-plan',
+        label: 'MiniMax Token Plan',
+        description: 'MINIMAX_TOKEN_PLAN_API_KEY',
+        defaultModel: 'MiniMax-M2.7',
+        defaultBaseUrl: 'https://api.minimax.io/anthropic',
+        requiresApiKey: true,
+        authKind: 'api-key',
+        envKeys: ['MINIMAX_TOKEN_PLAN_API_KEY'],
+        canDiscoverModels: false,
+    },
+    'openai-compatible': {
+        id: 'openai-compatible',
+        label: 'OpenAI Compatible',
+        description: 'Custom base URL',
+        defaultModel: '',
+        requiresApiKey: false,
+        authKind: 'api-key',
+        envKeys: ['OPENAI_COMPATIBLE_API_KEY'],
+        canDiscoverModels: true,
+    },
+};
+
+export const YAGR_SELECTABLE_PROVIDERS = Object.freeze(Object.keys(YAGR_PROVIDER_DEFINITIONS) as YagrModelProvider[]);
+
+export function normalizeYagrProviderId(provider?: string): YagrModelProvider | undefined {
+    const normalized = provider?.trim().toLowerCase();
+    if (!normalized) return undefined;
+    if (normalized === 'claude') return 'anthropic';
+    if (normalized === 'gemini') return 'google';
+    return normalized in YAGR_PROVIDER_DEFINITIONS ? normalized as YagrModelProvider : undefined;
+}
+
+export function providerNeedsBaseUrlInput(provider: YagrModelProvider): boolean {
+    return provider === 'openai-compatible';
+}
+
+export class YagrProviderService {
+    constructor(private readonly context: vscode.ExtensionContext) {}
+
+    getDefinition(provider: string): YagrProviderDefinition {
+        return YAGR_PROVIDER_DEFINITIONS[normalizeYagrProviderId(provider) || 'openai'];
+    }
+
+    async getStoredCredential(provider: YagrModelProvider): Promise<string | undefined> {
+        return this.context.secrets.get(getAgentProviderSecretKey(provider));
+    }
+
+    hasEnvironmentCredential(provider: YagrModelProvider): boolean {
+        return YAGR_PROVIDER_DEFINITIONS[provider].envKeys.some((key) => Boolean(process.env[key]?.trim()));
+    }
+
+    async setupProvider(provider: YagrModelProvider): Promise<boolean> {
+        const definition = YAGR_PROVIDER_DEFINITIONS[provider];
+        const config = vscode.workspace.getConfiguration('n8n.agent');
+
+        if (providerNeedsBaseUrlInput(provider)) {
+            const baseUrl = await vscode.window.showInputBox({
+                title: 'OpenAI-compatible base URL',
+                prompt: 'Only OpenAI-compatible providers allow a custom base URL.',
+                value: String(config.get<string>('baseUrl') || ''),
+                ignoreFocusOut: true,
+                validateInput: (value) => {
+                    if (!value.trim()) return 'Base URL is required for OpenAI-compatible providers.';
+                    try { new URL(value.trim()); return undefined; } catch { return 'Enter a valid URL.'; }
+                },
+            });
+            if (baseUrl === undefined) return false;
+            await config.update('baseUrl', baseUrl.trim().replace(/\/$/, ''), vscode.ConfigurationTarget.Global);
+        } else {
+            await config.update('baseUrl', '', vscode.ConfigurationTarget.Global);
+        }
+
+        if (definition.authKind === 'api-key') {
+            const apiKey = await vscode.window.showInputBox({
+                title: `Set ${definition.label} API key`,
+                prompt: 'Stored in VS Code Secret Storage. Leave empty to clear the stored key and rely on environment credentials if available.',
+                password: true,
+                ignoreFocusOut: true,
+            });
+            if (apiKey === undefined) return false;
+            const trimmed = apiKey.trim();
+            if (trimmed) {
+                await this.context.secrets.store(getAgentProviderSecretKey(provider), trimmed);
+            } else {
+                await this.context.secrets.delete(getAgentProviderSecretKey(provider));
+            }
+        } else if (definition.authKind === 'setup-token') {
+            const token = await vscode.window.showInputBox({
+                title: 'Connect Claude account',
+                prompt: 'Run `claude setup-token` in a logged-in Claude CLI, then paste the generated setup-token.',
+                password: true,
+                ignoreFocusOut: true,
+            });
+            if (token === undefined) return false;
+            if (token.trim()) await this.context.secrets.store(getAgentProviderSecretKey(provider), token.trim());
+        } else if (definition.authKind === 'oauth-device') {
+            await this.runDeviceFlow(provider);
+        }
+
+        await config.update('provider', provider, vscode.ConfigurationTarget.Global);
+        const currentModel = String(config.get<string>('model') || '').trim();
+        if (!currentModel) {
+            await config.update('model', definition.defaultModel, vscode.ConfigurationTarget.Global);
+        }
+        return true;
+    }
+
+    async selectModel(provider: YagrModelProvider): Promise<string | undefined> {
+        const definition = YAGR_PROVIDER_DEFINITIONS[provider];
+        const models = await this.fetchAvailableModels(provider).catch(() => []);
+        const config = vscode.workspace.getConfiguration('n8n.agent');
+        const currentModel = String(config.get<string>('model') || '').trim() || definition.defaultModel;
+        const items = [...new Set([...(models.length ? models : []), definition.defaultModel, currentModel].filter(Boolean))]
+            .map((model) => ({ label: model, picked: model === currentModel }));
+
+        const picked = await vscode.window.showQuickPick(items, {
+            title: `Select ${definition.label} model`,
+            placeHolder: models.length ? 'Live model list from provider' : 'Live model list unavailable; using known defaults',
+            ignoreFocusOut: true,
+        });
+        if (!picked) return undefined;
+        await config.update('model', picked.label, vscode.ConfigurationTarget.Global);
+        return picked.label;
+    }
+
+    async fetchAvailableModels(provider: YagrModelProvider): Promise<string[]> {
+        const definition = YAGR_PROVIDER_DEFINITIONS[provider];
+        if (!definition.canDiscoverModels) return [];
+        const apiKey = await this.getStoredCredential(provider) || this.readEnvironmentCredential(provider);
+        const config = vscode.workspace.getConfiguration('n8n.agent');
+        const configuredBaseUrl = String(config.get<string>('baseUrl') || '').trim();
+        const baseUrl = provider === 'openai-compatible' ? configuredBaseUrl : definition.defaultBaseUrl;
+
+        if ((definition.requiresApiKey || provider !== 'openai-compatible') && !apiKey && definition.authKind !== 'none') {
+            return [];
+        }
+
+        if (provider === 'anthropic' || provider === 'anthropic-proxy') {
+            return this.fetchJsonModels('https://api.anthropic.com/v1/models', { 'x-api-key': apiKey || '', 'anthropic-version': '2023-06-01' });
+        }
+        if (provider === 'google') {
+            return (await this.fetchJsonModels('https://generativelanguage.googleapis.com/v1beta/openai/models', { Authorization: `Bearer ${apiKey}` }))
+                .map((model) => model.replace(/^models\//, ''))
+                .filter((model) => /^gemini-/i.test(model));
+        }
+        if (provider === 'openai-oauth') {
+            return this.fetchJsonModels('https://chatgpt.com/backend-api/codex/models', { Authorization: `Bearer ${apiKey}` });
+        }
+        if (provider === 'copilot-proxy') {
+            return this.fetchJsonModels(`${definition.defaultBaseUrl}/models`, {
+                Authorization: `Bearer ${apiKey}`,
+                'User-Agent': 'GitHubCopilotChat/0.26.7',
+                'Editor-Version': 'vscode/1.96.2',
+                'Editor-Plugin-Version': 'copilot-chat/0.26.7',
+            });
+        }
+
+        const modelsUrl = provider === 'openai-compatible'
+            ? (baseUrl ? `${baseUrl.replace(/\/$/, '')}/models` : undefined)
+            : `${(baseUrl || '').replace(/\/$/, '')}/models`;
+        if (!modelsUrl) return [];
+        return this.fetchJsonModels(modelsUrl, apiKey ? { Authorization: `Bearer ${apiKey}` } : {});
+    }
+
+    private readEnvironmentCredential(provider: YagrModelProvider): string | undefined {
+        for (const key of YAGR_PROVIDER_DEFINITIONS[provider].envKeys) {
+            const value = process.env[key]?.trim();
+            if (value) return value;
+        }
+        return undefined;
+    }
+
+    private async fetchJsonModels(url: string, headers: Record<string, string>): Promise<string[]> {
+        const response = await fetch(url, { headers: { Accept: 'application/json', ...headers } });
+        if (!response.ok) return [];
+        const payload = await response.json() as Record<string, unknown>;
+        return [...new Set(MODEL_LIST_MAPPER(payload))];
+    }
+
+    private async runDeviceFlow(provider: YagrModelProvider): Promise<void> {
+        const challenge = provider === 'openai-oauth'
+            ? await this.beginOpenAiDeviceAuth()
+            : await this.beginGitHubDeviceAuth();
+        await vscode.env.openExternal(vscode.Uri.parse(challenge.verificationUri));
+        const submitted = await vscode.window.showInputBox({
+            title: provider === 'openai-oauth' ? 'Complete OpenAI device login' : 'Complete GitHub Copilot device login',
+            prompt: `Browser opened. Enter code ${challenge.userCode}, authorize, then press Enter here to continue.`,
+            value: challenge.userCode,
+            ignoreFocusOut: true,
+        });
+        if (submitted === undefined) return;
+        const token = provider === 'openai-oauth'
+            ? await this.completeOpenAiDeviceAuth(challenge)
+            : await this.completeGitHubDeviceAuth(challenge);
+        await this.context.secrets.store(getAgentProviderSecretKey(provider), token);
+    }
+
+    private async beginOpenAiDeviceAuth(): Promise<DeviceChallenge> {
+        const response = await fetch('https://auth.openai.com/api/accounts/deviceauth/usercode', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ client_id: 'app_EMoamEEZ73f0CkXaXp7hrann' }),
+        });
+        if (!response.ok) throw new Error(`OpenAI device login failed: HTTP ${response.status}`);
+        const payload = await response.json() as Record<string, unknown>;
+        const deviceAuthId = String(payload.device_auth_id || '');
+        const userCode = String(payload.user_code || '');
+        if (!deviceAuthId || !userCode) throw new Error('OpenAI device login returned an incomplete challenge.');
+        const intervalSeconds = Number.parseInt(String(payload.interval || '5'), 10);
+        return {
+            verificationUri: 'https://auth.openai.com/codex/device',
+            userCode,
+            deviceAuthId,
+            intervalMs: Math.max(Number.isFinite(intervalSeconds) ? intervalSeconds : 5, 1) * 1000,
+            expiresAt: Date.now() + (Number(payload.expires_in || 600) * 1000),
+        };
+    }
+
+    private async completeOpenAiDeviceAuth(challenge: DeviceChallenge): Promise<string> {
+        while (Date.now() < challenge.expiresAt - 3000) {
+            const response = await fetch('https://auth.openai.com/api/accounts/deviceauth/token', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    client_id: 'app_EMoamEEZ73f0CkXaXp7hrann',
+                    device_auth_id: challenge.deviceAuthId,
+                    user_code: challenge.userCode,
+                }),
+            });
+            const payload = await response.json().catch(() => ({})) as Record<string, unknown>;
+            const accessToken = String(payload.access_token || '');
+            if (response.ok && accessToken) return accessToken;
+            const error = String(payload.error || '');
+            if (error && error !== 'authorization_pending' && error !== 'slow_down') {
+                throw new Error(String(payload.error_description || error));
+            }
+            await new Promise((resolve) => setTimeout(resolve, challenge.intervalMs));
+        }
+        throw new Error('OpenAI device login expired.');
+    }
+
+    private async beginGitHubDeviceAuth(): Promise<DeviceChallenge> {
+        const response = await fetch('https://github.com/login/device/code', {
+            method: 'POST',
+            headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({ client_id: 'Iv1.b507a08c87ecfe98', scope: 'read:user' }),
+        });
+        if (!response.ok) throw new Error(`GitHub device code failed: HTTP ${response.status}`);
+        const payload = await response.json() as Record<string, unknown>;
+        return {
+            verificationUri: String(payload.verification_uri || 'https://github.com/login/device'),
+            userCode: String(payload.user_code || ''),
+            deviceCode: String(payload.device_code || ''),
+            intervalMs: Math.max(1000, Number(payload.interval || 5) * 1000),
+            expiresAt: Date.now() + Number(payload.expires_in || 900) * 1000,
+        };
+    }
+
+    private async completeGitHubDeviceAuth(challenge: DeviceChallenge): Promise<string> {
+        while (Date.now() < challenge.expiresAt) {
+            const response = await fetch('https://github.com/login/oauth/access_token', {
+                method: 'POST',
+                headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: new URLSearchParams({
+                    client_id: 'Iv1.b507a08c87ecfe98',
+                    device_code: challenge.deviceCode || '',
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+                }),
+            });
+            const payload = await response.json().catch(() => ({})) as Record<string, unknown>;
+            const accessToken = String(payload.access_token || '');
+            if (accessToken) return accessToken;
+            const error = String(payload.error || '');
+            if (error && error !== 'authorization_pending' && error !== 'slow_down') {
+                throw new Error(String(payload.error_description || error));
+            }
+            await new Promise((resolve) => setTimeout(resolve, challenge.intervalMs));
+        }
+        throw new Error('GitHub Copilot device login expired.');
+    }
+}

--- a/packages/vscode-extension/src/services/yagr-provider-service.ts
+++ b/packages/vscode-extension/src/services/yagr-provider-service.ts
@@ -16,6 +16,10 @@ export type YagrModelProvider =
 
 export type ProviderAuthKind = 'api-key' | 'oauth-device' | 'setup-token' | 'none';
 
+export type YagrReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+
+export const YAGR_REASONING_EFFORTS: readonly YagrReasoningEffort[] = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'];
+
 export interface YagrProviderDefinition {
     id: YagrModelProvider;
     label: string;
@@ -41,6 +45,8 @@ export interface YagrProviderConnectionState {
     selected: boolean;
     model?: string;
     baseUrl?: string;
+    supportsReasoningEffort?: boolean;
+    reasoningEffort?: YagrReasoningEffort;
 }
 
 type DeviceChallenge = {
@@ -199,6 +205,10 @@ export function providerNeedsBaseUrlInput(provider: YagrModelProvider): boolean 
     return provider === 'openai-compatible';
 }
 
+export function providerSupportsReasoningEffort(provider: YagrModelProvider, _model?: string): boolean {
+    return provider === 'openai-oauth';
+}
+
 export class YagrProviderService {
     constructor(private readonly context: vscode.ExtensionContext) {}
 
@@ -215,6 +225,7 @@ export class YagrProviderService {
         const selectedProvider = normalizeYagrProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
         const selectedModel = String(config.get<string>('model') || '').trim() || undefined;
         const configuredBaseUrl = String(config.get<string>('baseUrl') || '').trim() || undefined;
+        const selectedReasoningEffort = this.readReasoningEffort();
         const disabledProviders = this.getDisabledProviders();
         const states = await Promise.all(YAGR_SELECTABLE_PROVIDERS.map(async (provider) => {
             const definition = YAGR_PROVIDER_DEFINITIONS[provider];
@@ -235,6 +246,8 @@ export class YagrProviderService {
                 selected: provider === selectedProvider,
                 model: provider === selectedProvider ? selectedModel : undefined,
                 baseUrl: provider === 'openai-compatible' ? configuredBaseUrl : definition.defaultBaseUrl,
+                supportsReasoningEffort: providerSupportsReasoningEffort(provider, provider === selectedProvider ? selectedModel : definition.defaultModel),
+                reasoningEffort: provider === selectedProvider && providerSupportsReasoningEffort(provider, selectedModel) ? selectedReasoningEffort : undefined,
             };
         }));
         return states;
@@ -249,6 +262,7 @@ export class YagrProviderService {
             await config.update('provider', 'openai', vscode.ConfigurationTarget.Global);
             await config.update('model', YAGR_PROVIDER_DEFINITIONS.openai.defaultModel, vscode.ConfigurationTarget.Global);
             await config.update('baseUrl', '', vscode.ConfigurationTarget.Global);
+            await config.update('reasoningEffort', undefined, vscode.ConfigurationTarget.Global);
         }
     }
 
@@ -329,7 +343,50 @@ export class YagrProviderService {
         });
         if (!picked) return undefined;
         await config.update('model', picked.label, vscode.ConfigurationTarget.Global);
+        await this.syncReasoningEffortConfiguration(provider, picked.label);
         return picked.label;
+    }
+
+    async selectReasoningEffort(provider: YagrModelProvider, model?: string): Promise<YagrReasoningEffort | undefined> {
+        if (!providerSupportsReasoningEffort(provider, model)) {
+            const config = vscode.workspace.getConfiguration('n8n.agent');
+            await config.update('reasoningEffort', undefined, vscode.ConfigurationTarget.Global);
+            return undefined;
+        }
+
+        const config = vscode.workspace.getConfiguration('n8n.agent');
+        const defaultReasoningEffort = await this.getDefaultReasoningEffort(model || String(config.get<string>('model') || '').trim());
+        const current = this.readReasoningEffort() || defaultReasoningEffort;
+        const picked = await vscode.window.showQuickPick(
+            YAGR_REASONING_EFFORTS.map((effort) => ({
+                label: effort,
+                picked: effort === current,
+                description: effort === defaultReasoningEffort ? 'Yagr default' : undefined,
+            })),
+            {
+                title: 'Select reasoning effort',
+                placeHolder: 'Controls how much reasoning budget eligible OpenAI account models can use.',
+                ignoreFocusOut: true,
+            },
+        );
+        if (!picked) return current;
+        await config.update('reasoningEffort', picked.label as YagrReasoningEffort, vscode.ConfigurationTarget.Global);
+        return picked.label as YagrReasoningEffort;
+    }
+
+    async syncReasoningEffortConfiguration(provider: YagrModelProvider, model?: string): Promise<YagrReasoningEffort | undefined> {
+        if (!providerSupportsReasoningEffort(provider, model)) {
+            const config = vscode.workspace.getConfiguration('n8n.agent');
+            await config.update('reasoningEffort', undefined, vscode.ConfigurationTarget.Global);
+            return undefined;
+        }
+
+        const config = vscode.workspace.getConfiguration('n8n.agent');
+        const current = this.readReasoningEffort();
+        const defaultReasoningEffort = await this.getDefaultReasoningEffort(model || String(config.get<string>('model') || '').trim());
+        const next = current || defaultReasoningEffort;
+        await config.update('reasoningEffort', next, vscode.ConfigurationTarget.Global);
+        return next;
     }
 
     async fetchAvailableModels(provider: YagrModelProvider): Promise<string[]> {
@@ -400,6 +457,21 @@ export class YagrProviderService {
         if (!response.ok) return [];
         const payload = await response.json() as Record<string, unknown>;
         return [...new Set(MODEL_LIST_MAPPER(payload))];
+    }
+
+    private readReasoningEffort(): YagrReasoningEffort | undefined {
+        const config = vscode.workspace.getConfiguration('n8n.agent');
+        const value = String(config.get<string>('reasoningEffort') || '').trim();
+        return YAGR_REASONING_EFFORTS.includes(value as YagrReasoningEffort) ? value as YagrReasoningEffort : undefined;
+    }
+
+    private async getDefaultReasoningEffort(model: string): Promise<YagrReasoningEffort> {
+        try {
+            const openAiAccount = await import('@yagr/agent/dist/llm/openai-account.js');
+            return openAiAccount.getDefaultCodexReasoningEffort(model || YAGR_PROVIDER_DEFINITIONS['openai-oauth'].defaultModel) as YagrReasoningEffort;
+        } catch {
+            return 'medium';
+        }
     }
 
     private async fetchOpenAiOauthModels(accessToken: string): Promise<string[]> {

--- a/packages/vscode-extension/src/services/yagr-provider-service.ts
+++ b/packages/vscode-extension/src/services/yagr-provider-service.ts
@@ -28,6 +28,21 @@ export interface YagrProviderDefinition {
     canDiscoverModels: boolean;
 }
 
+export interface YagrProviderConnectionState {
+    id: YagrModelProvider;
+    label: string;
+    description: string;
+    authKind: ProviderAuthKind;
+    defaultModel: string;
+    defaultBaseUrl?: string;
+    requiresApiKey: boolean;
+    connected: boolean;
+    credentialSource?: 'secret' | 'environment';
+    selected: boolean;
+    model?: string;
+    baseUrl?: string;
+}
+
 type DeviceChallenge = {
     verificationUri: string;
     userCode: string;
@@ -36,6 +51,10 @@ type DeviceChallenge = {
     intervalMs: number;
     expiresAt: number;
 };
+
+const OPENAI_CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+const OPENAI_CODEX_DEVICE_REDIRECT_URI = 'https://auth.openai.com/deviceauth/callback';
+const DISABLED_PROVIDERS_STATE_KEY = 'n8n.agent.disabledProviders';
 
 const MODEL_LIST_MAPPER = (payload: Record<string, unknown>): string[] => {
     const data = Array.isArray(payload.data) ? payload.data : [];
@@ -191,6 +210,48 @@ export class YagrProviderService {
         return this.context.secrets.get(getAgentProviderSecretKey(provider));
     }
 
+    async listProviderConnectionStates(): Promise<YagrProviderConnectionState[]> {
+        const config = vscode.workspace.getConfiguration('n8n.agent');
+        const selectedProvider = normalizeYagrProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
+        const selectedModel = String(config.get<string>('model') || '').trim() || undefined;
+        const configuredBaseUrl = String(config.get<string>('baseUrl') || '').trim() || undefined;
+        const disabledProviders = this.getDisabledProviders();
+        const states = await Promise.all(YAGR_SELECTABLE_PROVIDERS.map(async (provider) => {
+            const definition = YAGR_PROVIDER_DEFINITIONS[provider];
+            const hasStoredCredential = Boolean(await this.getStoredCredential(provider));
+            const providerDisabled = disabledProviders.has(provider);
+            const hasEnvironmentCredential = !providerDisabled && this.hasEnvironmentCredential(provider);
+            const connected = !providerDisabled && (hasStoredCredential || hasEnvironmentCredential || provider === selectedProvider);
+            return {
+                id: provider,
+                label: definition.label,
+                description: definition.description,
+                authKind: definition.authKind,
+                defaultModel: definition.defaultModel,
+                defaultBaseUrl: definition.defaultBaseUrl,
+                requiresApiKey: definition.requiresApiKey,
+                connected,
+                credentialSource: hasStoredCredential ? 'secret' as const : hasEnvironmentCredential ? 'environment' as const : undefined,
+                selected: provider === selectedProvider,
+                model: provider === selectedProvider ? selectedModel : undefined,
+                baseUrl: provider === 'openai-compatible' ? configuredBaseUrl : definition.defaultBaseUrl,
+            };
+        }));
+        return states;
+    }
+
+    async disconnectProvider(provider: YagrModelProvider): Promise<void> {
+        await this.context.secrets.delete(getAgentProviderSecretKey(provider));
+        await this.setProviderDisabled(provider, true);
+        const config = vscode.workspace.getConfiguration('n8n.agent');
+        const selectedProvider = normalizeYagrProviderId(String(config.get<string>('provider') || ''));
+        if (selectedProvider === provider) {
+            await config.update('provider', 'openai', vscode.ConfigurationTarget.Global);
+            await config.update('model', YAGR_PROVIDER_DEFINITIONS.openai.defaultModel, vscode.ConfigurationTarget.Global);
+            await config.update('baseUrl', '', vscode.ConfigurationTarget.Global);
+        }
+    }
+
     hasEnvironmentCredential(provider: YagrModelProvider): boolean {
         return YAGR_PROVIDER_DEFINITIONS[provider].envKeys.some((key) => Boolean(process.env[key]?.trim()));
     }
@@ -198,6 +259,8 @@ export class YagrProviderService {
     async setupProvider(provider: YagrModelProvider): Promise<boolean> {
         const definition = YAGR_PROVIDER_DEFINITIONS[provider];
         const config = vscode.workspace.getConfiguration('n8n.agent');
+        const previousProvider = normalizeYagrProviderId(String(config.get<string>('provider') || ''));
+        await this.setProviderDisabled(provider, false);
 
         if (providerNeedsBaseUrlInput(provider)) {
             const baseUrl = await vscode.window.showInputBox({
@@ -245,7 +308,7 @@ export class YagrProviderService {
 
         await config.update('provider', provider, vscode.ConfigurationTarget.Global);
         const currentModel = String(config.get<string>('model') || '').trim();
-        if (!currentModel) {
+        if (!currentModel || previousProvider !== provider) {
             await config.update('model', definition.defaultModel, vscode.ConfigurationTarget.Global);
         }
         return true;
@@ -290,7 +353,7 @@ export class YagrProviderService {
                 .filter((model) => /^gemini-/i.test(model));
         }
         if (provider === 'openai-oauth') {
-            return this.fetchJsonModels('https://chatgpt.com/backend-api/codex/models', { Authorization: `Bearer ${apiKey}` });
+            return this.fetchOpenAiOauthModels(apiKey || '');
         }
         if (provider === 'copilot-proxy') {
             return this.fetchJsonModels(`${definition.defaultBaseUrl}/models`, {
@@ -309,11 +372,27 @@ export class YagrProviderService {
     }
 
     private readEnvironmentCredential(provider: YagrModelProvider): string | undefined {
+        if (this.getDisabledProviders().has(provider)) return undefined;
         for (const key of YAGR_PROVIDER_DEFINITIONS[provider].envKeys) {
             const value = process.env[key]?.trim();
             if (value) return value;
         }
         return undefined;
+    }
+
+    private getDisabledProviders(): Set<YagrModelProvider> {
+        const disabled = this.context.globalState.get<string[]>(DISABLED_PROVIDERS_STATE_KEY, []);
+        return new Set(disabled.map((provider) => normalizeYagrProviderId(provider)).filter((provider): provider is YagrModelProvider => Boolean(provider)));
+    }
+
+    private async setProviderDisabled(provider: YagrModelProvider, disabled: boolean): Promise<void> {
+        const providers = this.getDisabledProviders();
+        if (disabled) {
+            providers.add(provider);
+        } else {
+            providers.delete(provider);
+        }
+        await this.context.globalState.update(DISABLED_PROVIDERS_STATE_KEY, [...providers]);
     }
 
     private async fetchJsonModels(url: string, headers: Record<string, string>): Promise<string[]> {
@@ -323,29 +402,206 @@ export class YagrProviderService {
         return [...new Set(MODEL_LIST_MAPPER(payload))];
     }
 
+    private async fetchOpenAiOauthModels(accessToken: string): Promise<string[]> {
+        const accountRuntime = await import('@yagr/agent/dist/llm/openai-account.js').catch(() => undefined);
+        if (accountRuntime) {
+            const session = await accountRuntime.ensureOpenAiAccountSession().catch(() => undefined);
+            const token = session?.accessToken || accessToken;
+            return token ? accountRuntime.fetchOpenAiAccountModels(token) : [];
+        }
+        if (!accessToken) return [];
+        const headers: Record<string, string> = {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json',
+        };
+        const accountId = this.extractChatGptAccountId(accessToken);
+        if (accountId) {
+            headers['chatgpt-account-id'] = accountId;
+        }
+        const response = await fetch('https://chatgpt.com/backend-api/codex/models?client_version=1.0.0', { headers });
+        if (!response.ok) return [];
+        const payload = await response.json() as { models?: Array<{ slug?: string; visibility?: string; priority?: number }> };
+        return [...new Set((payload.models ?? [])
+            .filter((model) => typeof model.slug === 'string' && model.slug.trim().length > 0)
+            .filter((model) => (model.visibility ?? 'list') === 'list')
+            .sort((left, right) => (left.priority ?? Number.MAX_SAFE_INTEGER) - (right.priority ?? Number.MAX_SAFE_INTEGER))
+            .map((model) => model.slug!.trim()))];
+    }
+
+    private extractChatGptAccountId(accessToken: string): string | undefined {
+        try {
+            const parts = accessToken.split('.');
+            if (parts.length !== 3) return undefined;
+            const payload = JSON.parse(Buffer.from(parts[1], 'base64').toString('utf8')) as Record<string, unknown>;
+            const claim = payload['https://api.openai.com/auth'] as Record<string, unknown> | undefined;
+            return typeof claim?.chatgpt_account_id === 'string' ? claim.chatgpt_account_id : undefined;
+        } catch {
+            return undefined;
+        }
+    }
+
     private async runDeviceFlow(provider: YagrModelProvider): Promise<void> {
         const challenge = provider === 'openai-oauth'
             ? await this.beginOpenAiDeviceAuth()
             : await this.beginGitHubDeviceAuth();
-        await vscode.env.openExternal(vscode.Uri.parse(challenge.verificationUri));
-        const submitted = await vscode.window.showInputBox({
-            title: provider === 'openai-oauth' ? 'Complete OpenAI device login' : 'Complete GitHub Copilot device login',
-            prompt: `Browser opened. Enter code ${challenge.userCode}, authorize, then press Enter here to continue.`,
-            value: challenge.userCode,
-            ignoreFocusOut: true,
+
+        const cancellationSource = new vscode.CancellationTokenSource();
+        const authPanel = this.showDeviceFlowModal(provider, challenge, cancellationSource);
+
+        try {
+            const token = await vscode.window.withProgress({
+                location: vscode.ProgressLocation.Notification,
+                title: provider === 'openai-oauth' ? 'Waiting for OpenAI authorization' : 'Waiting for GitHub authorization',
+                cancellable: true,
+            }, async (progress, cancellationToken) => {
+                const disposable = cancellationToken.onCancellationRequested(() => cancellationSource.cancel());
+                try {
+                    progress.report({ message: `Code ${challenge.userCode}` });
+                    return provider === 'openai-oauth'
+                        ? this.completeOpenAiDeviceAuth(challenge, cancellationSource.token)
+                        : this.completeGitHubDeviceAuth(challenge, cancellationSource.token);
+                } finally {
+                    disposable.dispose();
+                }
+            });
+
+            await this.context.secrets.store(getAgentProviderSecretKey(provider), token);
+            vscode.window.showInformationMessage(`${YAGR_PROVIDER_DEFINITIONS[provider].label} connected.`);
+        } finally {
+            authPanel.dispose();
+            cancellationSource.dispose();
+        }
+    }
+
+    private showDeviceFlowModal(provider: YagrModelProvider, challenge: DeviceChallenge, cancellationSource: vscode.CancellationTokenSource): vscode.WebviewPanel {
+        const title = provider === 'openai-oauth' ? 'Connect OpenAI account' : 'Connect GitHub Copilot';
+        void vscode.env.clipboard.writeText(challenge.userCode).then(undefined, () => undefined);
+        void vscode.env.openExternal(vscode.Uri.parse(challenge.verificationUri));
+        return this.showDeviceFlowWebview(title, provider, challenge, cancellationSource);
+    }
+
+    private showDeviceFlowWebview(title: string, provider: YagrModelProvider, challenge: DeviceChallenge, cancellationSource: vscode.CancellationTokenSource): vscode.WebviewPanel {
+        const panel = vscode.window.createWebviewPanel(
+            'n8nAgentDeviceAuth',
+            title,
+            vscode.ViewColumn.Active,
+            { enableScripts: true, retainContextWhenHidden: false, localResourceRoots: [] },
+        );
+
+        panel.webview.html = this.buildDeviceFlowHtml(title, provider, challenge);
+        const disposable = panel.webview.onDidReceiveMessage(async (message: unknown) => {
+            if (!message || typeof message !== 'object') return;
+            const payload = message as Record<string, unknown>;
+            if (payload.type === 'copyCode') {
+                await vscode.env.clipboard.writeText(challenge.userCode);
+                await panel.webview.postMessage({ type: 'copied' });
+                return;
+            }
+            if (payload.type === 'openBrowser') {
+                await vscode.env.openExternal(vscode.Uri.parse(challenge.verificationUri));
+                return;
+            }
+            if (payload.type === 'cancel') {
+                cancellationSource.cancel();
+                panel.dispose();
+            }
         });
-        if (submitted === undefined) return;
-        const token = provider === 'openai-oauth'
-            ? await this.completeOpenAiDeviceAuth(challenge)
-            : await this.completeGitHubDeviceAuth(challenge);
-        await this.context.secrets.store(getAgentProviderSecretKey(provider), token);
+        panel.onDidDispose(() => disposable.dispose());
+        return panel;
+    }
+
+    private buildDeviceFlowHtml(title: string, provider: YagrModelProvider, challenge: DeviceChallenge): string {
+        const nonce = this.getNonce();
+        const providerLabel = this.escapeHtml(YAGR_PROVIDER_DEFINITIONS[provider].label);
+        const safeTitle = this.escapeHtml(title);
+        const code = this.escapeHtml(challenge.userCode);
+        const verificationUri = this.escapeHtml(challenge.verificationUri);
+        const expiresInMinutes = Math.max(1, Math.ceil((challenge.expiresAt - Date.now()) / 60000));
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${safeTitle}</title>
+  <style>
+    :root {
+      --bg: var(--vscode-editor-background);
+      --panel: var(--vscode-sideBar-background, var(--vscode-editor-background));
+      --text: var(--vscode-editor-foreground);
+      --muted: var(--vscode-descriptionForeground);
+      --border: var(--vscode-panel-border, var(--vscode-input-border));
+      --accent: var(--vscode-button-background);
+      --accentText: var(--vscode-button-foreground);
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 24px; background: var(--bg); color: var(--text); font-family: var(--vscode-font-family); }
+    main { width: min(560px, 100%); border: 1px solid var(--border); border-radius: 14px; background: var(--panel); padding: 22px; display: grid; gap: 16px; box-shadow: 0 18px 60px rgba(0,0,0,.28); }
+    h1, p { margin: 0; }
+    h1 { font-size: 22px; }
+    .muted { color: var(--muted); line-height: 1.45; }
+    .code { border: 1px solid var(--border); border-radius: 12px; padding: 18px; text-align: center; font-size: 34px; font-weight: 800; letter-spacing: .16em; background: var(--vscode-input-background); user-select: all; }
+    .url { color: var(--vscode-textLink-foreground); overflow-wrap: anywhere; }
+    .actions { display: flex; flex-wrap: wrap; gap: 10px; justify-content: flex-end; }
+    button { min-height: 34px; border: 1px solid transparent; border-radius: 7px; padding: 0 13px; color: var(--accentText); background: var(--accent); font-weight: 650; cursor: pointer; }
+    button.secondary { color: var(--text); background: transparent; border-color: var(--border); }
+    .copied { display: none; color: var(--vscode-testing-iconPassed, var(--text)); font-size: 12px; }
+  </style>
+</head>
+<body>
+  <main>
+    <div>
+      <h1>${safeTitle}</h1>
+      <p class="muted">Authorize ${providerLabel} in your browser. n8n-as-code detects completion automatically.</p>
+    </div>
+    <div class="code" aria-label="Device code">${code}</div>
+    <p class="muted">Open <span class="url">${verificationUri}</span> and enter this code. It expires in about ${expiresInMinutes} minutes.</p>
+    <div id="copied" class="copied">Code copied to clipboard.</div>
+    <div class="actions">
+      <button id="copy" class="secondary" type="button">Copy Code</button>
+      <button id="open" class="secondary" type="button">Open Browser</button>
+      <button id="cancel" class="secondary" type="button">Cancel</button>
+    </div>
+  </main>
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    document.getElementById('copy').addEventListener('click', () => vscode.postMessage({ type: 'copyCode' }));
+    document.getElementById('open').addEventListener('click', () => vscode.postMessage({ type: 'openBrowser' }));
+    document.getElementById('cancel').addEventListener('click', () => vscode.postMessage({ type: 'cancel' }));
+    window.addEventListener('message', (event) => {
+      if (event.data?.type === 'copied') {
+        const copied = document.getElementById('copied');
+        copied.style.display = 'block';
+        setTimeout(() => copied.style.display = 'none', 1400);
+      }
+    });
+  </script>
+</body>
+</html>`;
+    }
+
+    private escapeHtml(value: string): string {
+        return value
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    private getNonce(): string {
+        const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+        let nonce = '';
+        for (let i = 0; i < 32; i++) {
+            nonce += chars.charAt(Math.floor(Math.random() * chars.length));
+        }
+        return nonce;
     }
 
     private async beginOpenAiDeviceAuth(): Promise<DeviceChallenge> {
         const response = await fetch('https://auth.openai.com/api/accounts/deviceauth/usercode', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ client_id: 'app_EMoamEEZ73f0CkXaXp7hrann' }),
+            body: JSON.stringify({ client_id: OPENAI_CODEX_CLIENT_ID }),
         });
         if (!response.ok) throw new Error(`OpenAI device login failed: HTTP ${response.status}`);
         const payload = await response.json() as Record<string, unknown>;
@@ -362,27 +618,80 @@ export class YagrProviderService {
         };
     }
 
-    private async completeOpenAiDeviceAuth(challenge: DeviceChallenge): Promise<string> {
+    private async completeOpenAiDeviceAuth(challenge: DeviceChallenge, cancellationToken?: vscode.CancellationToken): Promise<string> {
+        const accountRuntime = await import('@yagr/agent/dist/llm/openai-account.js');
+        const wait = accountRuntime.completeCodexDeviceAuth({
+            deviceAuthId: challenge.deviceAuthId || '',
+            userCode: challenge.userCode,
+            intervalMs: challenge.intervalMs,
+            expiresAt: challenge.expiresAt,
+        });
+        if (!cancellationToken) {
+            return (await wait).accessToken;
+        }
+        const session = await Promise.race([
+            wait,
+            new Promise<never>((_, reject) => {
+                const disposable = cancellationToken.onCancellationRequested(() => {
+                    disposable.dispose();
+                    reject(new Error('OpenAI device login cancelled.'));
+                });
+            }),
+        ]);
+        return session.accessToken;
+    }
+
+    private async completeOpenAiDeviceAuthLegacy(challenge: DeviceChallenge, cancellationToken?: vscode.CancellationToken): Promise<string> {
         while (Date.now() < challenge.expiresAt - 3000) {
+            if (cancellationToken?.isCancellationRequested) throw new Error('OpenAI device login cancelled.');
             const response = await fetch('https://auth.openai.com/api/accounts/deviceauth/token', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
-                    client_id: 'app_EMoamEEZ73f0CkXaXp7hrann',
                     device_auth_id: challenge.deviceAuthId,
                     user_code: challenge.userCode,
                 }),
             });
-            const payload = await response.json().catch(() => ({})) as Record<string, unknown>;
-            const accessToken = String(payload.access_token || '');
-            if (response.ok && accessToken) return accessToken;
-            const error = String(payload.error || '');
-            if (error && error !== 'authorization_pending' && error !== 'slow_down') {
-                throw new Error(String(payload.error_description || error));
+
+            if (response.ok) {
+                const deviceToken = await response.json() as Record<string, unknown>;
+                const authorizationCode = String(deviceToken.authorization_code || '');
+                const codeVerifier = String(deviceToken.code_verifier || '');
+                if (!authorizationCode || !codeVerifier) {
+                    throw new Error('OpenAI device login returned an incomplete authorization result.');
+                }
+                return this.exchangeOpenAiDeviceCode(authorizationCode, codeVerifier);
             }
-            await new Promise((resolve) => setTimeout(resolve, challenge.intervalMs));
+
+            if (response.status !== 403 && response.status !== 404) {
+                const payload = await response.json().catch(() => ({})) as Record<string, unknown>;
+                throw new Error(String(payload.error_description || payload.message || payload.error || `OpenAI device flow failed: HTTP ${response.status}`));
+            }
+            await this.sleep(challenge.intervalMs + 3000, cancellationToken);
         }
         throw new Error('OpenAI device login expired.');
+    }
+
+    private async exchangeOpenAiDeviceCode(authorizationCode: string, codeVerifier: string): Promise<string> {
+        const body = new URLSearchParams();
+        body.set('grant_type', 'authorization_code');
+        body.set('code', authorizationCode);
+        body.set('redirect_uri', OPENAI_CODEX_DEVICE_REDIRECT_URI);
+        body.set('client_id', OPENAI_CODEX_CLIENT_ID);
+        body.set('code_verifier', codeVerifier);
+
+        const response = await fetch('https://auth.openai.com/oauth/token', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: body.toString(),
+        });
+        if (!response.ok) {
+            throw new Error(`OpenAI token exchange failed: HTTP ${response.status}`);
+        }
+        const tokens = await response.json() as Record<string, unknown>;
+        const accessToken = String(tokens.access_token || '');
+        if (!accessToken) throw new Error('OpenAI device login returned no access token.');
+        return accessToken;
     }
 
     private async beginGitHubDeviceAuth(): Promise<DeviceChallenge> {
@@ -402,8 +711,31 @@ export class YagrProviderService {
         };
     }
 
-    private async completeGitHubDeviceAuth(challenge: DeviceChallenge): Promise<string> {
+    private async completeGitHubDeviceAuth(challenge: DeviceChallenge, cancellationToken?: vscode.CancellationToken): Promise<string> {
+        const accountRuntime = await import('@yagr/agent/dist/llm/copilot-account.js');
+        const wait = accountRuntime.completeGitHubCopilotAuth({
+            deviceCode: challenge.deviceCode || '',
+            intervalMs: challenge.intervalMs,
+            expiresAt: challenge.expiresAt,
+        });
+        if (!cancellationToken) {
+            return (await wait).githubToken;
+        }
+        const session = await Promise.race([
+            wait,
+            new Promise<never>((_, reject) => {
+                const disposable = cancellationToken.onCancellationRequested(() => {
+                    disposable.dispose();
+                    reject(new Error('GitHub Copilot device login cancelled.'));
+                });
+            }),
+        ]);
+        return session.githubToken;
+    }
+
+    private async completeGitHubDeviceAuthLegacy(challenge: DeviceChallenge, cancellationToken?: vscode.CancellationToken): Promise<string> {
         while (Date.now() < challenge.expiresAt) {
+            if (cancellationToken?.isCancellationRequested) throw new Error('GitHub Copilot device login cancelled.');
             const response = await fetch('https://github.com/login/oauth/access_token', {
                 method: 'POST',
                 headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -420,8 +752,26 @@ export class YagrProviderService {
             if (error && error !== 'authorization_pending' && error !== 'slow_down') {
                 throw new Error(String(payload.error_description || error));
             }
-            await new Promise((resolve) => setTimeout(resolve, challenge.intervalMs));
+            await this.sleep(challenge.intervalMs, cancellationToken);
         }
         throw new Error('GitHub Copilot device login expired.');
+    }
+
+    private async sleep(ms: number, cancellationToken?: vscode.CancellationToken): Promise<void> {
+        if (!cancellationToken) {
+            await new Promise((resolve) => setTimeout(resolve, ms));
+            return;
+        }
+        await new Promise<void>((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                disposable.dispose();
+                resolve();
+            }, ms);
+            const disposable = cancellationToken.onCancellationRequested(() => {
+                clearTimeout(timeout);
+                disposable.dispose();
+                reject(new Error('Device login cancelled.'));
+            });
+        });
     }
 }

--- a/packages/vscode-extension/src/ui/agent-manager-html.ts
+++ b/packages/vscode-extension/src/ui/agent-manager-html.ts
@@ -1,0 +1,165 @@
+export interface AgentManagerHtmlInput {
+    provider: string;
+    model?: string;
+    baseUrl?: string;
+    hasStoredApiKey: boolean;
+}
+
+function escapeHtml(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+function getNonce(): string {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let nonce = '';
+    for (let i = 0; i < 32; i++) {
+        nonce += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return nonce;
+}
+
+export function buildAgentManagerHtml(input: AgentManagerHtmlInput): string {
+    const nonce = getNonce();
+    const provider = escapeHtml(input.provider);
+    const model = escapeHtml(input.model || 'provider default');
+    const baseUrl = escapeHtml(input.baseUrl || 'provider default');
+    const keyStatus = input.hasStoredApiKey ? 'Stored in VS Code Secret Storage' : 'Not stored yet';
+    const profiles = [
+        ['Workflow Architect', 'Design, generate, validate, and refactor workflows.'],
+        ['Workflow Operator', 'Push, activate, execute, and inspect workflows after approval.'],
+        ['Workflow Debugger', 'Diagnose failed executions and repair workflow code.'],
+        ['Credential Assistant', 'Guide and provision credentials through n8n-manager APIs.'],
+    ];
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>n8n Agent Manager</title>
+    <style>
+        :root {
+            --bg: var(--vscode-editor-background, #1e1e1e);
+            --panel: var(--vscode-sideBar-background, #181818);
+            --text: var(--vscode-editor-foreground, #d4d4d4);
+            --muted: var(--vscode-descriptionForeground, #8b949e);
+            --border: var(--vscode-panel-border, #2f3337);
+            --accent: var(--vscode-button-background, #0e639c);
+            --accent-text: var(--vscode-button-foreground, #ffffff);
+        }
+        body {
+            margin: 0;
+            background: var(--bg);
+            color: var(--text);
+            font-family: var(--vscode-font-family, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+        }
+        main {
+            max-width: 980px;
+            margin: 0 auto;
+            padding: 28px;
+        }
+        .hero {
+            border: 1px solid var(--border);
+            border-radius: 16px;
+            padding: 22px;
+            background: linear-gradient(135deg, color-mix(in srgb, var(--panel) 84%, var(--accent)), var(--panel));
+        }
+        .kicker {
+            color: var(--muted);
+            font-size: 11px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+        h1 {
+            margin: 8px 0 8px;
+            font-size: 28px;
+        }
+        p {
+            color: var(--muted);
+            line-height: 1.5;
+        }
+        .actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-top: 16px;
+        }
+        button {
+            border: none;
+            border-radius: 8px;
+            padding: 9px 12px;
+            color: var(--accent-text);
+            background: var(--accent);
+            cursor: pointer;
+            font: inherit;
+        }
+        button.secondary {
+            color: var(--vscode-button-secondaryForeground, var(--text));
+            background: var(--vscode-button-secondaryBackground, #3a3d41);
+        }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 12px;
+            margin-top: 18px;
+        }
+        .card {
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            padding: 14px;
+            background: var(--panel);
+        }
+        .card h2 {
+            font-size: 15px;
+            margin: 0 0 8px;
+        }
+        .meta {
+            display: grid;
+            gap: 8px;
+            margin-top: 16px;
+            color: var(--muted);
+            font-size: 13px;
+        }
+        code {
+            color: var(--text);
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <section class="hero">
+            <div class="kicker">n8n Agent Manager</div>
+            <h1>Embedded workflow agents</h1>
+            <p>Manage the first-party agents that power the n8n Agent Workbench. Built-in profiles are read-only for now; custom profile editing will build on this surface.</p>
+            <div class="meta">
+                <div>Provider: <code>${provider}</code></div>
+                <div>Model: <code>${model}</code></div>
+                <div>Base URL: <code>${baseUrl}</code></div>
+                <div>API key: <code>${keyStatus}</code></div>
+            </div>
+            <div class="actions">
+                <button id="set-key" type="button">Set Provider API Key</button>
+                <button id="open-settings" class="secondary" type="button">Open Agent Settings</button>
+            </div>
+        </section>
+        <section class="grid">
+            ${profiles.map(([name, description]) => `
+            <article class="card">
+                <h2>${escapeHtml(name)}</h2>
+                <p>${escapeHtml(description)}</p>
+            </article>`).join('')}
+        </section>
+    </main>
+    <script nonce="${nonce}">
+        const vscode = acquireVsCodeApi();
+        document.getElementById('set-key').addEventListener('click', () => vscode.postMessage({ type: 'setApiKey' }));
+        document.getElementById('open-settings').addEventListener('click', () => vscode.postMessage({ type: 'openSettings' }));
+    </script>
+</body>
+</html>`;
+}

--- a/packages/vscode-extension/src/ui/agent-manager-html.ts
+++ b/packages/vscode-extension/src/ui/agent-manager-html.ts
@@ -3,6 +3,8 @@ export interface AgentManagerHtmlInput {
     providerLabel: string;
     model?: string;
     baseUrl?: string;
+    reasoningEffort?: string;
+    supportsReasoningEffort?: boolean;
     hasStoredApiKey: boolean;
     authKind: string;
 }
@@ -30,6 +32,7 @@ export function buildAgentManagerHtml(input: AgentManagerHtmlInput): string {
     const providerLabel = escapeHtml(input.providerLabel);
     const model = escapeHtml(input.model || 'provider default');
     const baseUrl = escapeHtml(input.baseUrl || (input.provider === 'openai-compatible' ? 'not set' : 'provider default'));
+    const reasoningEffort = escapeHtml(input.reasoningEffort || 'Yagr default');
     const keyStatus = input.hasStoredApiKey ? 'Stored in VS Code Secret Storage' : 'Not stored yet / environment fallback';
     const authKind = escapeHtml(input.authKind);
     const profiles = [
@@ -144,12 +147,14 @@ export function buildAgentManagerHtml(input: AgentManagerHtmlInput): string {
                 <div>Provider: <code>${providerLabel}</code> <code>${provider}</code></div>
                 <div>Model: <code>${model}</code></div>
                 <div>Base URL: <code>${baseUrl}</code></div>
+                <div>Reasoning: <code>${input.supportsReasoningEffort ? reasoningEffort : 'not available for this provider'}</code></div>
                 <div>Auth: <code>${authKind}</code></div>
                 <div>Credential: <code>${keyStatus}</code></div>
             </div>
             <div class="actions">
                 <button id="set-key" type="button">Set Up Provider</button>
                 <button id="select-model" class="secondary" type="button">Select Model</button>
+                <button id="select-reasoning" class="secondary" type="button" ${input.supportsReasoningEffort ? '' : 'disabled'}>Reasoning Effort</button>
                 <button id="open-settings" class="secondary" type="button">Open Agent Settings</button>
             </div>
         </section>
@@ -165,6 +170,7 @@ export function buildAgentManagerHtml(input: AgentManagerHtmlInput): string {
         const vscode = acquireVsCodeApi();
         document.getElementById('set-key').addEventListener('click', () => vscode.postMessage({ type: 'setApiKey' }));
         document.getElementById('select-model').addEventListener('click', () => vscode.postMessage({ type: 'selectModel' }));
+        document.getElementById('select-reasoning').addEventListener('click', () => vscode.postMessage({ type: 'selectReasoningEffort' }));
         document.getElementById('open-settings').addEventListener('click', () => vscode.postMessage({ type: 'openSettings' }));
     </script>
 </body>

--- a/packages/vscode-extension/src/ui/agent-manager-html.ts
+++ b/packages/vscode-extension/src/ui/agent-manager-html.ts
@@ -1,8 +1,10 @@
 export interface AgentManagerHtmlInput {
     provider: string;
+    providerLabel: string;
     model?: string;
     baseUrl?: string;
     hasStoredApiKey: boolean;
+    authKind: string;
 }
 
 function escapeHtml(value: string): string {
@@ -25,9 +27,11 @@ function getNonce(): string {
 export function buildAgentManagerHtml(input: AgentManagerHtmlInput): string {
     const nonce = getNonce();
     const provider = escapeHtml(input.provider);
+    const providerLabel = escapeHtml(input.providerLabel);
     const model = escapeHtml(input.model || 'provider default');
-    const baseUrl = escapeHtml(input.baseUrl || 'provider default');
-    const keyStatus = input.hasStoredApiKey ? 'Stored in VS Code Secret Storage' : 'Not stored yet';
+    const baseUrl = escapeHtml(input.baseUrl || (input.provider === 'openai-compatible' ? 'not set' : 'provider default'));
+    const keyStatus = input.hasStoredApiKey ? 'Stored in VS Code Secret Storage' : 'Not stored yet / environment fallback';
+    const authKind = escapeHtml(input.authKind);
     const profiles = [
         ['Workflow Architect', 'Design, generate, validate, and refactor workflows.'],
         ['Workflow Operator', 'Push, activate, execute, and inspect workflows after approval.'],
@@ -137,13 +141,15 @@ export function buildAgentManagerHtml(input: AgentManagerHtmlInput): string {
             <h1>Embedded workflow agents</h1>
             <p>Manage the first-party agents that power the n8n Agent Workbench. Built-in profiles are read-only for now; custom profile editing will build on this surface.</p>
             <div class="meta">
-                <div>Provider: <code>${provider}</code></div>
+                <div>Provider: <code>${providerLabel}</code> <code>${provider}</code></div>
                 <div>Model: <code>${model}</code></div>
                 <div>Base URL: <code>${baseUrl}</code></div>
-                <div>API key: <code>${keyStatus}</code></div>
+                <div>Auth: <code>${authKind}</code></div>
+                <div>Credential: <code>${keyStatus}</code></div>
             </div>
             <div class="actions">
-                <button id="set-key" type="button">Set Provider API Key</button>
+                <button id="set-key" type="button">Set Up Provider</button>
+                <button id="select-model" class="secondary" type="button">Select Model</button>
                 <button id="open-settings" class="secondary" type="button">Open Agent Settings</button>
             </div>
         </section>
@@ -158,6 +164,7 @@ export function buildAgentManagerHtml(input: AgentManagerHtmlInput): string {
     <script nonce="${nonce}">
         const vscode = acquireVsCodeApi();
         document.getElementById('set-key').addEventListener('click', () => vscode.postMessage({ type: 'setApiKey' }));
+        document.getElementById('select-model').addEventListener('click', () => vscode.postMessage({ type: 'selectModel' }));
         document.getElementById('open-settings').addEventListener('click', () => vscode.postMessage({ type: 'openSettings' }));
     </script>
 </body>

--- a/packages/vscode-extension/src/ui/agent-manager-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-manager-webview.ts
@@ -1,0 +1,74 @@
+import * as vscode from 'vscode';
+import { getAgentProviderSecretKey } from '../services/agent-runtime-controller.js';
+import { buildAgentManagerHtml } from './agent-manager-html.js';
+
+export class AgentManagerWebview {
+    public static currentPanel: AgentManagerWebview | undefined;
+
+    private readonly _panel: vscode.WebviewPanel;
+    private readonly _context: vscode.ExtensionContext;
+    private readonly _disposables: vscode.Disposable[] = [];
+
+    private constructor(panel: vscode.WebviewPanel, context: vscode.ExtensionContext) {
+        this._panel = panel;
+        this._context = context;
+        this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+        this._panel.webview.onDidReceiveMessage((message) => {
+            void this.handleMessage(message);
+        }, null, this._disposables);
+        void this.render();
+    }
+
+    public static createOrShow(context: vscode.ExtensionContext): void {
+        if (AgentManagerWebview.currentPanel) {
+            AgentManagerWebview.currentPanel._panel.reveal(vscode.ViewColumn.One);
+            void AgentManagerWebview.currentPanel.render();
+            return;
+        }
+
+        const panel = vscode.window.createWebviewPanel(
+            'n8nAgentManager',
+            'n8n Agent Manager',
+            vscode.ViewColumn.One,
+            { enableScripts: true, retainContextWhenHidden: true, localResourceRoots: [] },
+        );
+
+        AgentManagerWebview.currentPanel = new AgentManagerWebview(panel, context);
+    }
+
+    public dispose(): void {
+        if (AgentManagerWebview.currentPanel === this) {
+            AgentManagerWebview.currentPanel = undefined;
+        }
+        this._panel.dispose();
+        while (this._disposables.length) {
+            this._disposables.pop()?.dispose();
+        }
+    }
+
+    private async render(): Promise<void> {
+        const config = vscode.workspace.getConfiguration('n8n.agent');
+        const provider = String(config.get<string>('provider') || 'openai');
+        this._panel.webview.html = buildAgentManagerHtml({
+            provider,
+            model: String(config.get<string>('model') || '').trim() || undefined,
+            baseUrl: String(config.get<string>('baseUrl') || '').trim() || undefined,
+            hasStoredApiKey: Boolean(await this._context.secrets.get(getAgentProviderSecretKey(provider))),
+        });
+    }
+
+    private async handleMessage(message: unknown): Promise<void> {
+        if (!message || typeof message !== 'object') {
+            return;
+        }
+        const payload = message as Record<string, unknown>;
+        if (payload.type === 'setApiKey') {
+            await vscode.commands.executeCommand('n8n.agent.setApiKey');
+            await this.render();
+            return;
+        }
+        if (payload.type === 'openSettings') {
+            await vscode.commands.executeCommand('workbench.action.openSettings', 'n8n.agent');
+        }
+    }
+}

--- a/packages/vscode-extension/src/ui/agent-manager-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-manager-webview.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { getAgentProviderSecretKey } from '../services/agent-runtime-controller.js';
-import { YAGR_PROVIDER_DEFINITIONS, normalizeYagrProviderId } from '../services/yagr-provider-service.js';
+import { YAGR_PROVIDER_DEFINITIONS, normalizeYagrProviderId, providerSupportsReasoningEffort } from '../services/yagr-provider-service.js';
 import { buildAgentManagerHtml } from './agent-manager-html.js';
 
 export class AgentManagerWebview {
@@ -56,6 +56,8 @@ export class AgentManagerWebview {
             providerLabel: definition.label,
             model: String(config.get<string>('model') || '').trim() || undefined,
             baseUrl: String(config.get<string>('baseUrl') || '').trim() || undefined,
+            reasoningEffort: String(config.get<string>('reasoningEffort') || '').trim() || undefined,
+            supportsReasoningEffort: providerSupportsReasoningEffort(provider, String(config.get<string>('model') || '').trim() || undefined),
             hasStoredApiKey: Boolean(await this._context.secrets.get(getAgentProviderSecretKey(provider))),
             authKind: definition.authKind,
         });
@@ -73,6 +75,11 @@ export class AgentManagerWebview {
         }
         if (payload.type === 'selectModel') {
             await vscode.commands.executeCommand('n8n.agent.selectModel');
+            await this.render();
+            return;
+        }
+        if (payload.type === 'selectReasoningEffort') {
+            await vscode.commands.executeCommand('n8n.agent.selectReasoningEffort');
             await this.render();
             return;
         }

--- a/packages/vscode-extension/src/ui/agent-manager-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-manager-webview.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { getAgentProviderSecretKey } from '../services/agent-runtime-controller.js';
+import { YAGR_PROVIDER_DEFINITIONS, normalizeYagrProviderId } from '../services/yagr-provider-service.js';
 import { buildAgentManagerHtml } from './agent-manager-html.js';
 
 export class AgentManagerWebview {
@@ -48,12 +49,15 @@ export class AgentManagerWebview {
 
     private async render(): Promise<void> {
         const config = vscode.workspace.getConfiguration('n8n.agent');
-        const provider = String(config.get<string>('provider') || 'openai');
+        const provider = normalizeYagrProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
+        const definition = YAGR_PROVIDER_DEFINITIONS[provider];
         this._panel.webview.html = buildAgentManagerHtml({
             provider,
+            providerLabel: definition.label,
             model: String(config.get<string>('model') || '').trim() || undefined,
             baseUrl: String(config.get<string>('baseUrl') || '').trim() || undefined,
             hasStoredApiKey: Boolean(await this._context.secrets.get(getAgentProviderSecretKey(provider))),
+            authKind: definition.authKind,
         });
     }
 
@@ -63,7 +67,12 @@ export class AgentManagerWebview {
         }
         const payload = message as Record<string, unknown>;
         if (payload.type === 'setApiKey') {
-            await vscode.commands.executeCommand('n8n.agent.setApiKey');
+            await vscode.commands.executeCommand('n8n.agent.setupProvider');
+            await this.render();
+            return;
+        }
+        if (payload.type === 'selectModel') {
+            await vscode.commands.executeCommand('n8n.agent.selectModel');
             await this.render();
             return;
         }

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -48,6 +48,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
     const newConversationIcon = lucideIcon('<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/><path d="M12 7v6"/><path d="M9 10h6"/>');
     const historyIcon = lucideIcon('<path d="M3 12a9 9 0 1 0 9-9 9.8 9.8 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M12 7v5l4 2"/>');
     const compactIcon = lucideIcon('<path d="M6 12h12"/><path d="m8 4 4 4 4-4"/><path d="m8 20 4-4 4 4"/>');
+    const checkpointIcon = lucideIcon('<path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2Z"/><path d="M17 21v-8H7v8"/><path d="M7 3v5h8"/>');
     const sendIcon = lucideIcon('<path d="m22 2-7 20-4-9-9-4Z"/><path d="M22 2 11 13"/>');
 
     return `<!DOCTYPE html>
@@ -211,7 +212,40 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             color: var(--muted);
             font-size: 11px;
         }
-        .history-overlay {
+        .checkpoint-item {
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            background: color-mix(in srgb, var(--bg) 82%, transparent);
+            padding: 10px;
+            display: grid;
+            gap: 8px;
+        }
+        .checkpoint-item-head,
+        .checkpoint-item-foot {
+            display: flex;
+            justify-content: space-between;
+            gap: 8px;
+            align-items: flex-start;
+        }
+        .checkpoint-item-title {
+            font-size: 13px;
+            font-weight: 650;
+            line-height: 1.35;
+            overflow-wrap: anywhere;
+        }
+        .checkpoint-item-meta {
+            color: var(--muted);
+            font-size: 11px;
+            line-height: 1.4;
+        }
+        .checkpoint-actions {
+            display: flex;
+            gap: 7px;
+            justify-content: flex-end;
+            flex-wrap: wrap;
+        }
+        .history-overlay,
+        .checkpoint-overlay {
             position: fixed;
             inset: 0;
             z-index: 10;
@@ -221,8 +255,10 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             padding-top: 42px;
             background: rgba(0, 0, 0, .28);
         }
-        .history-overlay.open { display: flex; }
-        .history-modal {
+        .history-overlay.open,
+        .checkpoint-overlay.open { display: flex; }
+        .history-modal,
+        .checkpoint-modal {
             width: min(560px, calc(100vw - 28px));
             max-height: min(640px, calc(100vh - 84px));
             display: grid;
@@ -233,28 +269,35 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             box-shadow: 0 18px 48px rgba(0, 0, 0, .45);
             overflow: hidden;
         }
+        .checkpoint-modal { grid-template-rows: auto 1fr auto; }
         .history-head,
         .history-controls,
-        .history-foot {
+        .history-foot,
+        .checkpoint-head,
+        .checkpoint-foot {
             padding: 12px;
             border-bottom: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
         }
-        .history-head {
+        .history-head,
+        .checkpoint-head {
             display: flex;
             align-items: center;
             justify-content: space-between;
             gap: 12px;
         }
-        .history-title {
+        .history-title,
+        .checkpoint-title {
             font-size: 14px;
             font-weight: 650;
         }
-        .history-list {
+        .history-list,
+        .checkpoint-list {
             overflow: auto;
             min-height: 0;
             padding: 10px 12px;
         }
-        .history-foot {
+        .history-foot,
+        .checkpoint-foot {
             border-bottom: 0;
             border-top: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
             display: flex;
@@ -853,6 +896,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                         </div>
                     </div>
                     <div class="header-actions">
+                        <button id="checkpoint-open" class="ghost small icon-button" type="button" title="Checkpoints" aria-label="Checkpoints">${checkpointIcon}</button>
                         <button id="history-open" class="ghost small icon-button" type="button" title="Conversation history" aria-label="Conversation history">${historyIcon}</button>
                         <button id="new-session-header" class="ghost small icon-button" type="button" title="New conversation" aria-label="New conversation">${newConversationIcon}</button>
                         <div id="run-indicator" class="run-indicator" aria-label="Agent running" title="Agent running">
@@ -912,6 +956,21 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 </div>
             </div>
         </div>
+        <div id="checkpoint-overlay" class="checkpoint-overlay" role="dialog" aria-modal="true" aria-label="Checkpoints">
+            <div class="checkpoint-modal">
+                <div class="checkpoint-head">
+                    <div>
+                        <div class="checkpoint-title">Checkpoints</div>
+                        <div class="meta-text">Save, restore, or delete checkpoints for this conversation.</div>
+                    </div>
+                    <button id="checkpoint-close" class="ghost small" type="button" aria-label="Close checkpoints">Close</button>
+                </div>
+                <div id="checkpoint-list" class="checkpoint-list sessions"></div>
+                <div class="checkpoint-foot">
+                    <button id="checkpoint-save" class="secondary small" type="button">Save checkpoint</button>
+                </div>
+            </div>
+        </div>
     </main>
     <script nonce="${nonce}">
         const vscode = acquireVsCodeApi();
@@ -968,6 +1027,11 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const contextMeterFill = document.getElementById('context-meter-fill');
         const newSessionButton = document.getElementById('new-session');
         const newSessionHeaderButton = document.getElementById('new-session-header');
+        const checkpointOpenButton = document.getElementById('checkpoint-open');
+        const checkpointCloseButton = document.getElementById('checkpoint-close');
+        const checkpointOverlay = document.getElementById('checkpoint-overlay');
+        const checkpointList = document.getElementById('checkpoint-list');
+        const checkpointSaveButton = document.getElementById('checkpoint-save');
         const historyOpenButton = document.getElementById('history-open');
         const historyCloseButton = document.getElementById('history-close');
         const historyOverlay = document.getElementById('history-overlay');
@@ -990,8 +1054,11 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             stopButton.classList.toggle('active', running);
             newSessionButton.disabled = running;
             newSessionHeaderButton.disabled = running;
+            checkpointOpenButton.disabled = running;
+            checkpointSaveButton.disabled = running;
             compactContextButton.disabled = running;
             if (runIndicator) runIndicator.classList.toggle('active', running);
+            renderCheckpoints();
         }
 
         function escapeText(value) {
@@ -1194,6 +1261,82 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
 
         function closeHistory() {
             historyOverlay.classList.remove('open');
+        }
+
+        function renderCheckpoints() {
+            if (!checkpointList) return;
+            checkpointList.innerHTML = '';
+            const session = getActiveSession();
+            const checkpoints = session && Array.isArray(session.checkpoints) ? session.checkpoints : [];
+            if (!checkpoints.length) {
+                const empty = document.createElement('div');
+                empty.className = 'empty-note';
+                empty.textContent = 'No checkpoints for this conversation yet.';
+                checkpointList.appendChild(empty);
+                return;
+            }
+            for (const checkpoint of checkpoints) {
+                const item = document.createElement('div');
+                item.className = 'checkpoint-item';
+
+                const head = document.createElement('div');
+                head.className = 'checkpoint-item-head';
+                const titleWrap = document.createElement('div');
+                const title = document.createElement('div');
+                title.className = 'checkpoint-item-title';
+                title.textContent = checkpoint.label || checkpoint.summary || 'Checkpoint';
+                const meta = document.createElement('div');
+                meta.className = 'checkpoint-item-meta';
+                const metaParts = [formatDate(checkpoint.createdAt), (checkpoint.messageCount || 0) + ' messages'];
+                if (checkpoint.restoredAt) metaParts.push('Restored ' + formatDate(checkpoint.restoredAt));
+                meta.textContent = metaParts.join(' · ');
+                titleWrap.append(title, meta);
+                head.appendChild(titleWrap);
+                if (checkpoint.reason) head.appendChild(badge(checkpoint.reason, 'success'));
+
+                const foot = document.createElement('div');
+                foot.className = 'checkpoint-item-foot';
+                const summary = document.createElement('div');
+                summary.className = 'checkpoint-item-meta';
+                summary.textContent = checkpoint.summary || '';
+                const actions = document.createElement('div');
+                actions.className = 'checkpoint-actions';
+                const restore = document.createElement('button');
+                restore.type = 'button';
+                restore.className = 'secondary small';
+                restore.textContent = 'Restore';
+                restore.disabled = isRunning;
+                restore.addEventListener('click', () => {
+                    if (!state || !state.activeSessionId) return;
+                    if (!window.confirm('Restore this checkpoint? The agent runtime and saved Workbench surface state will be restored.')) return;
+                    closeCheckpointPanel();
+                    vscode.postMessage({ type: 'agent.checkpoint.restore', sessionId: state.activeSessionId, checkpointId: checkpoint.id });
+                });
+                const del = document.createElement('button');
+                del.type = 'button';
+                del.className = 'ghost small';
+                del.textContent = 'Delete';
+                del.disabled = isRunning;
+                del.addEventListener('click', () => {
+                    if (!state || !state.activeSessionId) return;
+                    if (!window.confirm('Delete this checkpoint? This cannot be undone.')) return;
+                    vscode.postMessage({ type: 'agent.checkpoint.delete', sessionId: state.activeSessionId, checkpointId: checkpoint.id });
+                });
+                actions.append(restore, del);
+                foot.append(summary, actions);
+                item.append(head, foot);
+                checkpointList.appendChild(item);
+            }
+        }
+
+        function openCheckpointPanel() {
+            closeHistory();
+            renderCheckpoints();
+            checkpointOverlay.classList.add('open');
+        }
+
+        function closeCheckpointPanel() {
+            checkpointOverlay.classList.remove('open');
         }
 
         function closeInlineMenus() {
@@ -1502,6 +1645,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             renderChatMeta();
             renderFeed();
             renderMentionMenu();
+            if (checkpointOverlay && checkpointOverlay.classList.contains('open')) renderCheckpoints();
         }
 
         function getMentionQuery() {
@@ -1792,6 +1936,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 closeInlineMenus();
                 if (mentionMenu) mentionMenu.classList.remove('open');
                 if (historyOverlay && historyOverlay.classList.contains('open')) closeHistory();
+                if (checkpointOverlay && checkpointOverlay.classList.contains('open')) closeCheckpointPanel();
             }
         });
         window.addEventListener('pointerdown', (event) => {
@@ -1813,6 +1958,11 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         on(historyOverlay, 'click', (event) => {
             if (event.target === historyOverlay) closeHistory();
         });
+        on(checkpointOpenButton, 'click', openCheckpointPanel);
+        on(checkpointCloseButton, 'click', closeCheckpointPanel);
+        on(checkpointOverlay, 'click', (event) => {
+            if (event.target === checkpointOverlay) closeCheckpointPanel();
+        });
         on(selectModelButton, 'click', () => {
             providerMenuOpen = !providerMenuOpen;
             reasoningMenuOpen = false;
@@ -1831,11 +1981,16 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         });
         function startNewSession() {
             closeHistory();
+            closeCheckpointPanel();
             vscode.postMessage({ type: 'agent.session.new' });
         }
 
         on(newSessionButton, 'click', startNewSession);
         on(newSessionHeaderButton, 'click', startNewSession);
+        on(checkpointSaveButton, 'click', () => {
+            if (!state || !state.activeSessionId || isRunning) return;
+            vscode.postMessage({ type: 'agent.checkpoint.save', sessionId: state.activeSessionId });
+        });
         on(compactContextButton, 'click', () => state && vscode.postMessage({ type: 'agent.context.compact', sessionId: state.activeSessionId }));
         on(sessionFilter, 'change', () => {
             activeFilter = sessionFilter.value || 'current';

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -44,6 +44,11 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         // Fallback to iframe's own source origin behavior if URL parsing fails.
     }
     const iframeAllowPolicy = `clipboard-read ${iframePermissionOrigin}; clipboard-write ${iframePermissionOrigin}; geolocation ${iframePermissionOrigin}; microphone ${iframePermissionOrigin}; camera ${iframePermissionOrigin}`;
+    const lucideIcon = (paths: string) => `<svg viewBox="0 0 24 24" aria-hidden="true">${paths}</svg>`;
+    const newConversationIcon = lucideIcon('<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/><path d="M12 7v6"/><path d="M9 10h6"/>');
+    const historyIcon = lucideIcon('<path d="M3 12a9 9 0 1 0 9-9 9.8 9.8 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M12 7v5l4 2"/>');
+    const compactIcon = lucideIcon('<path d="M6 12h12"/><path d="m8 4 4 4 4-4"/><path d="m8 20 4-4 4 4"/>');
+    const sendIcon = lucideIcon('<path d="m22 2-7 20-4-9-9-4Z"/><path d="M22 2 11 13"/>');
 
     return `<!DOCTYPE html>
 <html lang="en">
@@ -264,12 +269,34 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             display: flex;
             justify-content: space-between;
             gap: 12px;
-            align-items: center;
+            align-items: flex-start;
         }
         .chat-head-main {
             min-width: 0;
             display: grid;
-            gap: 4px;
+            gap: 8px;
+            flex: 1 1 auto;
+        }
+        .chat-title-row {
+            display: flex;
+            align-items: baseline;
+            gap: 10px;
+            min-width: 0;
+        }
+        .conversation-title {
+            min-width: 0;
+            color: var(--muted);
+            font-size: 12px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .context-actions {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+            flex-wrap: wrap;
+            min-width: 0;
         }
         .workflow-selector {
             width: fit-content;
@@ -455,11 +482,128 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             min-height: 30px;
         }
         .composer-provider {
+            position: relative;
             display: flex;
             gap: 8px;
             align-items: center;
             flex-wrap: wrap;
             min-width: 0;
+        }
+        .inline-popover {
+            position: absolute;
+            left: 0;
+            bottom: calc(100% + 8px);
+            z-index: 8;
+            display: none;
+            width: min(390px, calc(100vw - 28px));
+            max-height: min(420px, calc(100vh - 96px));
+            overflow: hidden;
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            background: color-mix(in srgb, var(--panel) 96%, black 6%);
+            box-shadow: 0 16px 42px rgba(0, 0, 0, .42);
+            grid-template-rows: auto auto auto minmax(0, 1fr) auto;
+        }
+        .inline-popover.open { display: grid; }
+        .inline-popover.reasoning {
+            left: auto;
+            right: 0;
+            width: 220px;
+        }
+        .inline-popover-head {
+            display: flex;
+            justify-content: space-between;
+            gap: 8px;
+            align-items: center;
+            padding: 9px 10px;
+            border-bottom: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+            color: var(--muted);
+            font-size: 12px;
+        }
+        .inline-popover-head strong {
+            color: var(--text);
+            font-weight: 650;
+        }
+        .inline-back {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            width: 100%;
+            padding: 9px 10px;
+            border: 0;
+            border-bottom: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+            border-radius: 0;
+            color: var(--text);
+            background: color-mix(in srgb, var(--accent) 16%, transparent);
+            text-align: left;
+            font-size: 12px;
+            font-weight: 650;
+        }
+        .inline-back:hover {
+            background: color-mix(in srgb, var(--accent) 24%, transparent);
+        }
+        .inline-search-wrap {
+            padding: 8px 9px;
+            border-bottom: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+        }
+        .inline-search {
+            min-height: 30px;
+            padding: 6px 8px;
+            border-radius: 7px;
+            font-size: 12px;
+        }
+        .inline-popover-list {
+            overflow: auto;
+            min-height: 0;
+            padding: 4px;
+        }
+        .inline-popover-foot {
+            padding: 7px 10px;
+            border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+        }
+        .inline-link {
+            width: auto;
+            min-height: 0;
+            padding: 0;
+            border: 0;
+            color: var(--muted);
+            background: transparent;
+            font-size: 12px;
+            text-align: left;
+        }
+        .inline-link:hover {
+            color: var(--text);
+            text-decoration: underline;
+        }
+        .inline-option {
+            display: grid;
+            grid-template-columns: 1fr auto;
+            gap: 4px 10px;
+            width: 100%;
+            padding: 8px 9px;
+            border: 0;
+            border-radius: 7px;
+            background: transparent;
+            color: var(--text);
+            text-align: left;
+        }
+        .inline-option:hover,
+        .inline-option.active {
+            background: color-mix(in srgb, var(--accent) 18%, transparent);
+        }
+        .inline-option .main {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .inline-option .sub,
+        .inline-option .mark {
+            color: var(--muted);
+            font-size: 11px;
+        }
+        .inline-option .mark { align-self: center; }
+        .inline-option.provider {
+            font-weight: 650;
         }
         .context-badges {
             display: flex;
@@ -594,9 +738,24 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             border-radius: 6px;
         }
         .send-button {
-            min-width: 30px;
-            font-size: 13px;
+            display: inline-grid;
+            place-items: center;
+            width: 32px;
+            min-width: 32px;
+            height: 32px;
+            padding: 0;
+            border-radius: 9px;
             line-height: 1;
+            box-shadow: 0 1px 0 color-mix(in srgb, white 18%, transparent) inset;
+        }
+        .send-button svg {
+            width: 15px;
+            height: 15px;
+            stroke: currentColor;
+            fill: none;
+            stroke-width: 2;
+            stroke-linecap: round;
+            stroke-linejoin: round;
         }
         .stop-button {
             display: none;
@@ -681,17 +840,21 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             <header class="chat-head">
                 <div class="chat-head-row">
                     <div class="chat-head-main">
-                        <div class="chat-title">Workflow Architect</div>
-                        <div id="workflow-subtitle" class="workflow-selector" title="${initialWorkflowLabel}">${initialWorkflowLabel}${safeWorkflowId ? ` · ${safeWorkflowId}` : ''}</div>
+                        <div class="chat-title-row">
+                            <div class="chat-title">Workflow Architect</div>
+                            <div id="conversation-title" class="conversation-title"></div>
+                        </div>
+                        <div class="context-actions">
+                            <div id="context-pill" class="context-pill" title="Context usage">
+                                <span id="context-label">Context</span>
+                                <span class="context-meter" aria-hidden="true"><span id="context-meter-fill" class="context-meter-fill"></span></span>
+                            </div>
+                            <button id="compact-context" class="ghost small icon-button" type="button" title="Compact context" aria-label="Compact context">${compactIcon}</button>
+                        </div>
                     </div>
                     <div class="header-actions">
-                        <button id="new-session-header" class="ghost small icon-button" type="button" title="New conversation" aria-label="New conversation"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 3v10M3 8h10"/><path d="M2.5 2.5h3M10.5 2.5h3v3M13.5 10.5v3h-3M5.5 13.5h-3v-3"/></svg></button>
-                        <button id="history-open" class="ghost small icon-button" type="button" title="Conversation history" aria-label="Conversation history"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M3 4.5h10M3 8h10M3 11.5h7"/><path d="M2 2.5h12v11H2z"/></svg></button>
-                        <div id="context-pill" class="context-pill" title="Context usage">
-                            <span id="context-label">Context</span>
-                            <span class="context-meter" aria-hidden="true"><span id="context-meter-fill" class="context-meter-fill"></span></span>
-                        </div>
-                        <button id="compact-context" class="ghost small" type="button" title="Compact context" aria-label="Compact context">Compact</button>
+                        <button id="history-open" class="ghost small icon-button" type="button" title="Conversation history" aria-label="Conversation history">${historyIcon}</button>
+                        <button id="new-session-header" class="ghost small icon-button" type="button" title="New conversation" aria-label="New conversation">${newConversationIcon}</button>
                         <div id="run-indicator" class="run-indicator" aria-label="Agent running" title="Agent running">
                             <span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span>
                         </div>
@@ -708,10 +871,12 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                         <div class="composer-provider">
                             <button id="select-model" class="secondary small" type="button" title="${safeProviderModelLabel}">${safeProviderModelLabel}</button>
                             <button id="select-reasoning" class="secondary small" type="button">Reasoning</button>
+                            <div id="provider-menu" class="inline-popover" role="menu"></div>
+                            <div id="reasoning-menu" class="inline-popover reasoning" role="menu"></div>
                         </div>
                         <div class="composer-actions">
                             <button id="stop" class="ghost stop-button" type="button" disabled>Stop</button>
-                            <button id="send" class="send-button" type="submit" title="Send" aria-label="Send">▶</button>
+                            <button id="send" class="send-button" type="submit" title="Send" aria-label="Send">${sendIcon}</button>
                         </div>
                     </div>
                 </div>
@@ -739,7 +904,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                     <select id="session-filter" aria-label="Filter conversations">
                         <option value="current">Current workflow</option>
                         <option value="all">All conversations</option>
-                        <option value="unattached">New workflow chats</option>
                     </select>
                 </div>
                 <div id="session-list" class="sessions history-list"></div>
@@ -764,6 +928,13 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         let currentNodeContexts = [];
         let activeFilter = 'current';
         let state = null;
+        let providerModelCache = {};
+        let providerMenuOpen = false;
+        let providerMenuMode = 'models';
+        let providerMenuProvider = '';
+        let modelSearchQuery = '';
+        let reasoningMenuOpen = false;
+        let autoScrollFeed = true;
 
         const OP_ICONS = {
             'file-read': 'Read',
@@ -783,13 +954,15 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const stopButton = document.getElementById('stop');
         const selectModelButton = document.getElementById('select-model');
         const selectReasoningButton = document.getElementById('select-reasoning');
+        const providerMenu = document.getElementById('provider-menu');
+        const reasoningMenu = document.getElementById('reasoning-menu');
         const frame = document.getElementById('workflow-frame');
         const refreshPill = document.getElementById('refresh-pill');
         const contextBadges = document.getElementById('context-badges');
         const mentionMenu = document.getElementById('mention-menu');
+        const conversationTitle = document.getElementById('conversation-title');
         const sessionList = document.getElementById('session-list');
         const sessionFilter = document.getElementById('session-filter');
-        const workflowSubtitle = document.getElementById('workflow-subtitle');
         const contextPill = document.getElementById('context-pill');
         const contextLabel = document.getElementById('context-label');
         const contextMeterFill = document.getElementById('context-meter-fill');
@@ -803,6 +976,11 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
 
         function on(element, eventName, handler) {
             if (element) element.addEventListener(eventName, handler);
+        }
+
+        function isFeedNearBottom() {
+            if (!feed) return true;
+            return feed.scrollHeight - feed.scrollTop - feed.clientHeight <= 48;
         }
 
         function setRunning(running) {
@@ -987,7 +1165,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 badges.className = 'session-item-badges';
                 if (session.isActive) badges.appendChild(badge('Active', 'active'));
                 if (session.checkpointCount) badges.appendChild(badge(session.checkpointCount + ' cp', 'success'));
-                if (session.totalCompactions) badges.appendChild(badge(session.totalCompactions + ' compact', ''));
                 head.append(title, badges);
 
                 const foot = document.createElement('div');
@@ -1019,18 +1196,215 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             historyOverlay.classList.remove('open');
         }
 
+        function closeInlineMenus() {
+            providerMenuOpen = false;
+            reasoningMenuOpen = false;
+            if (providerMenu) providerMenu.classList.remove('open');
+            if (reasoningMenu) reasoningMenu.classList.remove('open');
+        }
+
+        function connectedProviders() {
+            const providers = Array.isArray(state && state.providerOptions) ? [...state.providerOptions] : [];
+            if (state && state.provider && !providers.some((provider) => provider.id === state.provider)) {
+                providers.unshift({
+                    id: state.provider,
+                    label: state.provider,
+                    description: 'Current provider',
+                    selected: true,
+                    connected: true,
+                    model: state.model,
+                });
+            }
+            return providers.filter((provider) => provider.connected || provider.selected);
+        }
+
+        function renderProviderMenu() {
+            if (!providerMenu || !state) return;
+            const providers = connectedProviders();
+            const selectedProvider = state.provider || '';
+            const activeProvider = providerMenuProvider || selectedProvider;
+            providerMenu.innerHTML = '';
+            if (providerMenuMode === 'providers') {
+                renderProviderPicker(providers, selectedProvider);
+            } else {
+                renderModelPicker(providers, activeProvider, selectedProvider);
+            }
+            providerMenu.classList.toggle('open', providerMenuOpen);
+        }
+
+        function renderProviderPicker(providers, selectedProvider) {
+            const head = document.createElement('div');
+            head.className = 'inline-popover-head';
+            head.innerHTML = '<strong>Connected providers</strong><span>' + escapeHtml(providers.length ? providers.length + ' connected' : 'none connected') + '</span>';
+            providerMenu.appendChild(head);
+            const list = document.createElement('div');
+            list.className = 'inline-popover-list';
+            if (!providers.length) {
+                const empty = document.createElement('div');
+                empty.className = 'empty-note';
+                empty.textContent = 'No connected providers.';
+                list.appendChild(empty);
+            }
+            for (const provider of providers) {
+                const providerButton = inlineOption(provider.label || provider.id, provider.description || '', provider.id === selectedProvider ? 'Selected' : '', 'provider');
+                providerButton.addEventListener('click', () => {
+                    providerMenuMode = 'models';
+                    providerMenuProvider = provider.id;
+                    modelSearchQuery = '';
+                    renderProviderMenu();
+                    vscode.postMessage({ type: 'agent.selectModel', provider: provider.id });
+                });
+                list.appendChild(providerButton);
+            }
+            providerMenu.appendChild(list);
+            appendProviderMenuFooter();
+        }
+
+        function renderModelPicker(providers, activeProvider, selectedProvider) {
+            const provider = providers.find((candidate) => candidate.id === activeProvider) || providers.find((candidate) => candidate.id === selectedProvider) || providers[0] || { id: selectedProvider, label: selectedProvider || 'Provider' };
+            if (!providerMenuProvider && provider.id) providerMenuProvider = provider.id;
+            const back = document.createElement('button');
+            back.type = 'button';
+            back.className = 'inline-back';
+            back.textContent = '← Providers';
+            back.addEventListener('click', () => {
+                providerMenuMode = 'providers';
+                modelSearchQuery = '';
+                renderProviderMenu();
+            });
+            providerMenu.appendChild(back);
+
+            const head = document.createElement('div');
+            head.className = 'inline-popover-head';
+            head.innerHTML = '<strong>' + escapeHtml(provider.label || provider.id || 'Provider') + '</strong><span>Models</span>';
+            providerMenu.appendChild(head);
+
+            const searchWrap = document.createElement('div');
+            searchWrap.className = 'inline-search-wrap';
+            const search = document.createElement('input');
+            search.className = 'inline-search';
+            search.type = 'text';
+            search.placeholder = 'Search models...';
+            search.value = modelSearchQuery;
+            search.addEventListener('input', () => {
+                modelSearchQuery = search.value || '';
+                renderProviderMenu();
+                const nextSearch = providerMenu.querySelector('.inline-search');
+                if (nextSearch) {
+                    nextSearch.focus();
+                    nextSearch.selectionStart = nextSearch.selectionEnd = nextSearch.value.length;
+                }
+            });
+            searchWrap.appendChild(search);
+            providerMenu.appendChild(searchWrap);
+
+            const list = document.createElement('div');
+            list.className = 'inline-popover-list';
+            const allModels = providerModelCache[provider.id] || (provider.id === selectedProvider ? state.modelOptions || [] : []);
+            const query = modelSearchQuery.trim().toLowerCase();
+            const models = allModels.filter((model) => !query || String(model.label || model.id || '').toLowerCase().includes(query));
+            if (!allModels.length) {
+                const loading = document.createElement('div');
+                loading.className = 'empty-note';
+                loading.textContent = 'Loading models...';
+                list.appendChild(loading);
+                if (provider.id) vscode.postMessage({ type: 'agent.selectModel', provider: provider.id });
+            } else if (!models.length) {
+                const empty = document.createElement('div');
+                empty.className = 'empty-note';
+                empty.textContent = 'No models match this search.';
+                list.appendChild(empty);
+            }
+            for (const model of models) {
+                const modelButton = inlineOption(model.label || model.id, model.fallback ? 'Known/default model' : provider.label || provider.id, model.selected ? 'Active' : '', 'model');
+                modelButton.addEventListener('click', () => {
+                    closeInlineMenus();
+                    vscode.postMessage({ type: 'agent.providerModel.select', provider: provider.id, model: model.id || model.label });
+                });
+                list.appendChild(modelButton);
+            }
+            providerMenu.appendChild(list);
+            appendProviderMenuFooter();
+        }
+
+        function appendProviderMenuFooter() {
+            const foot = document.createElement('div');
+            foot.className = 'inline-popover-foot';
+            const add = document.createElement('button');
+            add.type = 'button';
+            add.className = 'inline-link';
+            add.textContent = 'Add more providers...';
+            add.addEventListener('click', () => {
+                closeInlineMenus();
+                vscode.postMessage({ type: 'agent.providers.configure' });
+            });
+            foot.appendChild(add);
+            providerMenu.appendChild(foot);
+        }
+
+        function renderReasoningMenu() {
+            if (!reasoningMenu || !state) return;
+            reasoningMenu.innerHTML = '';
+            const head = document.createElement('div');
+            head.className = 'inline-popover-head';
+            head.textContent = 'Reasoning effort';
+            reasoningMenu.appendChild(head);
+            const list = document.createElement('div');
+            list.className = 'inline-popover-list';
+            const options = Array.isArray(state.reasoningOptions) ? state.reasoningOptions : [];
+            for (const option of options) {
+                const button = inlineOption(option.label || option.id, '', option.selected ? 'Active' : '', '');
+                button.addEventListener('click', () => {
+                    closeInlineMenus();
+                    vscode.postMessage({ type: 'agent.selectReasoningEffort', effort: option.id || option.label });
+                });
+                list.appendChild(button);
+            }
+            reasoningMenu.appendChild(list);
+            reasoningMenu.classList.toggle('open', reasoningMenuOpen && state.supportsReasoningEffort);
+        }
+
+        function inlineOption(label, sub, mark, klass) {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'inline-option' + (klass ? ' ' + klass : '') + (mark ? ' active' : '');
+            const main = document.createElement('span');
+            main.className = 'main';
+            main.textContent = label || '';
+            const marker = document.createElement('span');
+            marker.className = 'mark';
+            marker.textContent = mark || '';
+            button.append(main, marker);
+            if (sub) {
+                const detail = document.createElement('span');
+                detail.className = 'sub';
+                detail.textContent = sub;
+                button.appendChild(detail);
+            }
+            return button;
+        }
+
         function renderChatMeta() {
             if (!state) return;
+            if (conversationTitle) {
+                const title = state.session && state.session.title ? state.session.title : '';
+                conversationTitle.textContent = title;
+                conversationTitle.title = title;
+            }
             const providerLabel = (state.provider || 'provider') + (state.model ? ' / ' + state.model : '');
             selectModelButton.textContent = providerLabel;
             selectModelButton.title = providerLabel;
+            if (state.provider && Array.isArray(state.modelOptions)) providerModelCache[state.provider] = state.modelOptions;
             selectReasoningButton.textContent = state.reasoningEffort ? 'Reasoning ' + state.reasoningEffort : 'Reasoning';
             selectReasoningButton.style.display = state.supportsReasoningEffort ? 'inline-block' : 'none';
+            renderProviderMenu();
+            renderReasoningMenu();
             const usage = state.session && state.session.contextUsage;
-            if (!usage) {
+            if (!usage || usage.source !== 'api') {
                 contextPill.classList.remove('active');
                 contextLabel.textContent = 'Context';
                 contextMeterFill.style.width = '0%';
+                contextPill.title = 'Context usage unavailable';
                 return;
             }
             const percent = Math.max(0, Math.min(100, Number(usage.fillPercent) || 0));
@@ -1041,6 +1415,8 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         }
 
         function renderFeed() {
+            const shouldStickToBottom = autoScrollFeed || isFeedNearBottom();
+            const previousScrollTop = feed.scrollTop;
             feed.innerHTML = '';
             const visibleEntries = state && state.session && Array.isArray(state.session.entries)
                 ? state.session.entries.filter((entry) => entry.kind !== 'context-usage' && entry.kind !== 'workflow-context' && entry.kind !== 'node-context')
@@ -1051,7 +1427,12 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             for (const entry of visibleEntries) {
                 feed.appendChild(renderEntry(entry));
             }
-            feed.scrollTop = feed.scrollHeight;
+            if (shouldStickToBottom) {
+                feed.scrollTop = feed.scrollHeight;
+                autoScrollFeed = true;
+            } else {
+                feed.scrollTop = previousScrollTop;
+            }
         }
 
         function renderEntry(entry) {
@@ -1069,6 +1450,8 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             if (entry.kind === 'compaction') {
                 const el = document.createElement('div');
                 el.className = 'entry compaction';
+                const isFallback = entry.event.source === 'fallback';
+                const title = isFallback ? 'Context compacted with fallback' : 'Context compacted';
                 const details = document.createElement('details');
                 details.className = 'details';
                 details.innerHTML = '<summary>Show compaction details</summary>' +
@@ -1080,7 +1463,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                     (entry.event.thresholdTokens ? '\\nThreshold tokens: ' + escapeHtml(entry.event.thresholdTokens) : '') +
                     (entry.event.fallbackReason ? '\\nFallback reason: ' + escapeHtml(entry.event.fallbackReason) : '') +
                     '</div>';
-                el.innerHTML = '<div class="entry-head"><div class="entry-title">Context compacted</div><div class="entry-subtle">' + escapeHtml(new Date(entry.timestamp).toLocaleTimeString()) + '</div></div><div>' + escapeHtml(entry.event.summary) + '</div>';
+                el.innerHTML = '<div class="entry-head"><div class="entry-title">' + escapeHtml(title) + '</div><div class="entry-subtle">' + escapeHtml(new Date(entry.timestamp).toLocaleTimeString()) + '</div></div><div>' + escapeHtml(entry.event.summary) + '</div>';
                 el.appendChild(details);
                 return el;
             }
@@ -1118,12 +1501,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             renderSessions();
             renderChatMeta();
             renderFeed();
-            if (state && state.workflow && workflowSubtitle) {
-                workflowSubtitle.textContent = state.workflow.name
-                    ? state.workflow.name + (state.workflow.id ? ' · ' + state.workflow.id : '')
-                    : 'New workflow chat';
-                workflowSubtitle.title = workflowSubtitle.textContent;
-            }
             renderMentionMenu();
         }
 
@@ -1311,6 +1688,8 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             if (!state || !state.session) return;
             let entries = Array.isArray(state.session.entries) ? [...state.session.entries] : [];
             if (event.type === 'start') {
+                entries = entries.filter((entry) => entry.kind !== 'context-usage');
+                state.session.contextUsage = undefined;
                 state.activeSessionId = event.sessionId;
                 const last = entries[entries.length - 1];
                 if (!last || last.kind !== 'user-message' || last.text !== event.message) {
@@ -1368,6 +1747,10 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 state.session.lastCompaction = event;
                 state.session.totalCompactions = (state.session.totalCompactions || 0) + 1;
             } else if (event.type === 'context-usage') {
+                if (event.source !== 'api') {
+                    renderAll();
+                    return;
+                }
                 state.session.contextUsage = {
                     promptTokens: event.promptTokens,
                     completionTokens: event.completionTokens,
@@ -1394,6 +1777,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
 
         on(form, 'submit', (event) => {
             event.preventDefault();
+            autoScrollFeed = true;
             sendPrompt();
         });
 
@@ -1403,8 +1787,25 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 sendPrompt();
             }
         });
+        window.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') {
+                closeInlineMenus();
+                if (mentionMenu) mentionMenu.classList.remove('open');
+                if (historyOverlay && historyOverlay.classList.contains('open')) closeHistory();
+            }
+        });
+        window.addEventListener('pointerdown', (event) => {
+            const target = event.target;
+            if (!(target instanceof Node)) return;
+            if (providerMenu && (providerMenu.contains(target) || selectModelButton.contains(target))) return;
+            if (reasoningMenu && (reasoningMenu.contains(target) || selectReasoningButton.contains(target))) return;
+            closeInlineMenus();
+        }, true);
         on(promptInput, 'input', renderMentionMenu);
         on(promptInput, 'keyup', renderMentionMenu);
+        on(feed, 'scroll', () => {
+            autoScrollFeed = isFeedNearBottom();
+        });
 
         on(stopButton, 'click', () => vscode.postMessage({ type: 'agent.stop' }));
         on(historyOpenButton, 'click', openHistory);
@@ -1412,8 +1813,22 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         on(historyOverlay, 'click', (event) => {
             if (event.target === historyOverlay) closeHistory();
         });
-        on(selectModelButton, 'click', () => vscode.postMessage({ type: 'agent.selectModel' }));
-        on(selectReasoningButton, 'click', () => vscode.postMessage({ type: 'agent.selectReasoningEffort' }));
+        on(selectModelButton, 'click', () => {
+            providerMenuOpen = !providerMenuOpen;
+            reasoningMenuOpen = false;
+            providerMenuMode = 'models';
+            providerMenuProvider = state && state.provider ? state.provider : providerMenuProvider;
+            if (providerMenuOpen) modelSearchQuery = '';
+            renderProviderMenu();
+            renderReasoningMenu();
+            if (providerMenuOpen) vscode.postMessage({ type: 'agent.providers.refresh' });
+        });
+        on(selectReasoningButton, 'click', () => {
+            reasoningMenuOpen = !reasoningMenuOpen;
+            providerMenuOpen = false;
+            renderProviderMenu();
+            renderReasoningMenu();
+        });
         function startNewSession() {
             closeHistory();
             vscode.postMessage({ type: 'agent.session.new' });
@@ -1497,6 +1912,13 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             if (message.type === 'agent.state') {
                 state = message.state || null;
                 renderAll();
+                return;
+            }
+
+            if (message.type === 'agent.providerModels') {
+                providerModelCache[String(message.provider || '')] = Array.isArray(message.models) ? message.models : [];
+                providerMenuOpen = true;
+                renderProviderMenu();
                 return;
             }
 

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -5,6 +5,8 @@ export interface AgentWorkbenchHtmlInput {
     workflowReloadUrl?: string;
 }
 
+const AGENT_WORKBENCH_CHAT_BUILD = '2026.05.04.8';
+
 function escapeHtml(value: string): string {
     return value
         .replace(/&/g, '&amp;')
@@ -99,6 +101,21 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             font-weight: 650;
             line-height: 1.35;
         }
+        .build-marker {
+            margin-top: 4px;
+            color: var(--muted);
+            font-size: 11px;
+            font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        }
+        .bridge-status {
+            margin-top: 3px;
+            color: var(--muted);
+            font-size: 11px;
+            font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        }
+        .bridge-status.connected {
+            color: var(--vscode-testing-iconPassed, #73c991);
+        }
         .subtitle {
             margin-top: 6px;
             color: var(--muted);
@@ -149,6 +166,26 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             padding: 12px;
             border-top: 1px solid var(--border);
             background: var(--panel);
+        }
+        .composer-input {
+            display: grid;
+            gap: 6px;
+            min-width: 0;
+        }
+        .node-context-badge {
+            display: none;
+            width: fit-content;
+            max-width: 100%;
+            padding: 3px 8px;
+            border: 1px solid color-mix(in srgb, var(--accent) 55%, var(--border));
+            border-radius: 999px;
+            color: var(--accent-text);
+            background: color-mix(in srgb, var(--accent) 60%, transparent);
+            font-size: 12px;
+            line-height: 1.25;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
         }
         textarea {
             resize: none;
@@ -239,6 +276,8 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             <header class="header">
                 <div class="kicker">n8n Agent Workbench</div>
                 <div class="title">Workflow Architect</div>
+                <div class="build-marker">Chat build ${AGENT_WORKBENCH_CHAT_BUILD}</div>
+                <div id="bridge-status" class="bridge-status">n8n bridge pending</div>
                 <div class="subtitle" title="${safeWorkflowName}">${safeWorkflowName}${safeWorkflowId ? ` · ${safeWorkflowId}` : ' · new workflow chat'}</div>
                 <div class="header-actions"><button id="select-model" class="secondary" type="button">Provider / Model</button></div>
             </header>
@@ -249,7 +288,10 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 </div>
             </div>
             <form id="composer" class="composer">
-                <textarea id="prompt" placeholder="Ask the n8n agent what to do with this workflow..." rows="2"></textarea>
+                <div class="composer-input">
+                    <div id="node-context-badge" class="node-context-badge" title=""></div>
+                    <textarea id="prompt" placeholder="Ask the n8n agent what to do with this workflow..." rows="2"></textarea>
+                </div>
                 <div class="actions">
                     <button id="send" type="submit">Send</button>
                     <button id="stop" class="secondary" type="button" disabled>Stop</button>
@@ -278,6 +320,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const pendingGrants = new Map();
         let isRunning = false;
         let activeAssistantMessage = null;
+        let currentNodeContext = null;
 
         const feed = document.getElementById('feed');
         const form = document.getElementById('composer');
@@ -287,6 +330,8 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const selectModelButton = document.getElementById('select-model');
         const frame = document.getElementById('workflow-frame');
         const refreshPill = document.getElementById('refresh-pill');
+        const nodeContextBadge = document.getElementById('node-context-badge');
+        const bridgeStatus = document.getElementById('bridge-status');
 
         function appendMessage(role, content) {
             const el = document.createElement('div');
@@ -314,6 +359,44 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             isRunning = running;
             sendButton.disabled = running;
             stopButton.disabled = !running;
+        }
+
+        function sanitizeNodeContext(value) {
+            if (!value || typeof value !== 'object') return null;
+            const name = typeof value.name === 'string' ? value.name.trim() : '';
+            if (!name) return null;
+            return {
+                name,
+                type: typeof value.type === 'string' ? value.type.trim() : '',
+                id: typeof value.id === 'string' ? value.id.trim() : '',
+            };
+        }
+
+        function updateNodeContextBadge(node) {
+            currentNodeContext = sanitizeNodeContext(node);
+            if (!nodeContextBadge) return;
+            if (!currentNodeContext) {
+                nodeContextBadge.style.display = 'none';
+                nodeContextBadge.textContent = '';
+                nodeContextBadge.title = '';
+                return;
+            }
+            nodeContextBadge.textContent = '@' + currentNodeContext.name;
+            nodeContextBadge.title = currentNodeContext.type
+                ? currentNodeContext.name + ' · ' + currentNodeContext.type
+                : currentNodeContext.name;
+            nodeContextBadge.style.display = 'block';
+        }
+
+        function updateBridgeStatus(text, connected) {
+            if (!bridgeStatus) return;
+            bridgeStatus.textContent = text;
+            bridgeStatus.classList.toggle('connected', Boolean(connected));
+        }
+
+        function isWorkflowFrameEvent(event) {
+            if (!frame || event.source !== frame.contentWindow) return false;
+            return event.origin === iframeOrigin || event.origin === 'null';
         }
 
         function reloadWorkflowFrame() {
@@ -354,7 +437,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             promptInput.value = '';
             activeAssistantMessage = null;
             appendMessage('user', text);
-            vscode.postMessage({ type: 'agent.send', text, workflowId });
+            vscode.postMessage({ type: 'agent.send', text, workflowId, nodeContext: currentNodeContext });
         });
 
         promptInput.addEventListener('keydown', (event) => {
@@ -385,12 +468,31 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 workflowUrl = message.url;
                 workflowReloadUrl = typeof message.reloadUrl === 'string' && message.reloadUrl ? message.reloadUrl : workflowUrl;
                 try { iframeOrigin = new URL(workflowUrl).origin; } catch (e) { iframeOrigin = 'src'; }
+                updateBridgeStatus('n8n bridge pending', false);
                 if (frame) frame.src = workflowUrl;
                 return;
             }
 
+            if (message.type === 'n8n-bridge-ready') {
+                if (!isWorkflowFrameEvent(event)) return;
+                updateBridgeStatus('n8n bridge ' + (message.build || 'connected') + (message.pageKind ? ' · ' + message.pageKind : '') + (message.nodeName ? ' · saw ' + message.nodeName : ''), true);
+                return;
+            }
+
+            if (message.type === 'n8n-ui-click') {
+                if (!isWorkflowFrameEvent(event)) return;
+                updateBridgeStatus('n8n bridge ' + (message.build || 'connected') + ' · click ' + (message.nodeName || message.target || 'ui'), true);
+                return;
+            }
+
+            if (message.type === 'n8n-ui-change') {
+                if (!isWorkflowFrameEvent(event)) return;
+                updateBridgeStatus('n8n bridge ' + (message.build || 'connected') + ' · ui changed ' + (message.nodeName || message.count || ''), true);
+                return;
+            }
+
             if (message.type === 'n8n-paste-request') {
-                if (event.origin !== iframeOrigin) return;
+                if (!isWorkflowFrameEvent(event)) return;
                 const now = Date.now();
                 if (now - lastPasteMs < PASTE_RATE_LIMIT_MS) return;
                 lastPasteMs = now;
@@ -398,8 +500,24 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 return;
             }
 
+            if (message.type === 'n8n-node-detail-opened') {
+                if (!isWorkflowFrameEvent(event)) return;
+                updateNodeContextBadge(message.node);
+                if (currentNodeContext) {
+                    vscode.postMessage({ type: 'agent.nodeDetailChanged', workflowId, nodeContext: currentNodeContext });
+                }
+                return;
+            }
+
+            if (message.type === 'n8n-node-context-cleared') {
+                if (!isWorkflowFrameEvent(event)) return;
+                updateNodeContextBadge(null);
+                vscode.postMessage({ type: 'agent.nodeDetailChanged', workflowId, nodeContext: null });
+                return;
+            }
+
             if (message.type === 'n8n-clipboard-write' && typeof message.text === 'string') {
-                if (event.origin !== iframeOrigin) return;
+                if (!isWorkflowFrameEvent(event)) return;
                 vscode.postMessage({ type: 'clipboard-write', text: message.text });
                 return;
             }

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -25,14 +25,15 @@ function getNonce(): string {
 
 export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string {
     const nonce = getNonce();
+    const hasWorkflow = Boolean(input.workflowUrl);
     const safeWorkflowName = escapeHtml(input.workflowName);
     const safeWorkflowId = escapeHtml(input.workflowId);
+    const initialWorkflowLabel = hasWorkflow ? safeWorkflowName : 'New workflow chat';
     const safeWorkflowUrl = escapeHtml(input.workflowUrl || '');
     const safeProviderModelLabel = escapeHtml(input.providerModelLabel);
     const workflowIdJs = JSON.stringify(input.workflowId);
     const workflowUrlJs = JSON.stringify(input.workflowUrl || '');
     const workflowReloadUrlJs = JSON.stringify(input.workflowReloadUrl || input.workflowUrl || '');
-    const hasWorkflow = Boolean(input.workflowUrl);
 
     let iframePermissionOrigin = 'src';
     try {
@@ -78,25 +79,20 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         button, input, select, textarea { font: inherit; }
         .workbench {
             display: grid;
-            grid-template-columns: 290px ${hasWorkflow ? 'minmax(360px, .95fr) minmax(420px, 1.05fr)' : 'minmax(420px, 1fr)'};
+            grid-template-columns: ${hasWorkflow ? 'minmax(360px, .95fr) minmax(420px, 1.05fr)' : 'minmax(420px, 1fr)'};
             height: 100vh;
             width: 100vw;
             min-width: 0;
             min-height: 0;
         }
-        .sidebar, .chat {
+        .chat {
             min-width: 0;
             min-height: 0;
             background: var(--panel);
         }
-        .sidebar {
-            display: grid;
-            grid-template-rows: auto auto 1fr auto;
-            border-right: 1px solid var(--border);
-        }
         .chat {
             display: grid;
-            grid-template-rows: auto auto 1fr auto;
+            grid-template-rows: auto 1fr auto;
             border-right: ${hasWorkflow ? '1px solid var(--border)' : '0'};
         }
         .workflow {
@@ -105,17 +101,17 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             min-height: 0;
             background: var(--bg);
         }
-        .section-head, .chat-head, .composer {
+        .chat-head {
             padding: 12px 14px;
         }
-        .section-head, .chat-head {
+        .chat-head {
             border-bottom: 1px solid var(--border);
         }
-        .sidebar-title, .chat-title {
+        .chat-title {
             font-size: 14px;
             font-weight: 700;
         }
-        .sidebar-subtitle, .chat-subtitle, .meta-text {
+        .chat-subtitle, .meta-text {
             color: var(--muted);
             font-size: 12px;
             line-height: 1.4;
@@ -128,14 +124,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         }
         .toolbar.compact {
             margin-top: 0;
-        }
-        .session-filters, .session-actions, .session-meta, .checkpoint-panel {
-            padding: 12px 14px;
-            border-bottom: 1px solid var(--border);
-        }
-        .session-meta, .checkpoint-panel {
-            display: grid;
-            gap: 8px;
         }
         .meta-grid {
             display: grid;
@@ -154,7 +142,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         .sessions {
             overflow: auto;
             min-height: 0;
-            padding: 10px;
+            padding: 8px 0 0;
             display: grid;
             gap: 8px;
         }
@@ -216,6 +204,56 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             color: var(--muted);
             font-size: 11px;
         }
+        .history-overlay {
+            position: fixed;
+            inset: 0;
+            z-index: 10;
+            display: none;
+            align-items: flex-start;
+            justify-content: center;
+            padding-top: 42px;
+            background: rgba(0, 0, 0, .28);
+        }
+        .history-overlay.open { display: flex; }
+        .history-modal {
+            width: min(560px, calc(100vw - 28px));
+            max-height: min(640px, calc(100vh - 84px));
+            display: grid;
+            grid-template-rows: auto auto 1fr auto;
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            background: color-mix(in srgb, var(--panel) 96%, black 8%);
+            box-shadow: 0 18px 48px rgba(0, 0, 0, .45);
+            overflow: hidden;
+        }
+        .history-head,
+        .history-controls,
+        .history-foot {
+            padding: 12px;
+            border-bottom: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
+        }
+        .history-head {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+        }
+        .history-title {
+            font-size: 14px;
+            font-weight: 650;
+        }
+        .history-list {
+            overflow: auto;
+            min-height: 0;
+            padding: 10px 12px;
+        }
+        .history-foot {
+            border-bottom: 0;
+            border-top: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
+            display: flex;
+            justify-content: flex-end;
+            gap: 8px;
+        }
         .chat-head {
             display: grid;
             gap: 10px;
@@ -224,7 +262,68 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             display: flex;
             justify-content: space-between;
             gap: 12px;
-            align-items: flex-start;
+            align-items: center;
+        }
+        .chat-head-main {
+            min-width: 0;
+            display: grid;
+            gap: 4px;
+        }
+        .workflow-selector {
+            width: fit-content;
+            max-width: 100%;
+            min-height: 0;
+            padding: 0;
+            color: var(--muted);
+            background: transparent;
+            border: 0;
+            border-radius: 0;
+            text-align: left;
+            font-size: 12px;
+            line-height: 1.4;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .workflow-selector:hover {
+            color: var(--text);
+            text-decoration: underline;
+        }
+        .header-actions {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+            justify-content: flex-end;
+            min-width: 0;
+        }
+        .run-indicator {
+            display: none;
+            width: 15px;
+            height: 15px;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 2px;
+            align-items: center;
+            margin-top: 2px;
+        }
+        .run-indicator.active { display: grid; }
+        .run-indicator span {
+            width: 3px;
+            height: 3px;
+            background: var(--muted);
+            opacity: .35;
+            animation: pixelPulse 900ms infinite ease-in-out;
+        }
+        .run-indicator span:nth-child(2) { animation-delay: 90ms; }
+        .run-indicator span:nth-child(3) { animation-delay: 180ms; }
+        .run-indicator span:nth-child(4) { animation-delay: 270ms; }
+        .run-indicator span:nth-child(5) { animation-delay: 360ms; background: var(--accent); }
+        .run-indicator span:nth-child(6) { animation-delay: 450ms; }
+        .run-indicator span:nth-child(7) { animation-delay: 540ms; }
+        .run-indicator span:nth-child(8) { animation-delay: 630ms; }
+        .run-indicator span:nth-child(9) { animation-delay: 720ms; }
+        @keyframes pixelPulse {
+            0%, 100% { opacity: .25; transform: scale(.8); }
+            50% { opacity: 1; transform: scale(1.15); }
         }
         .chat-meta {
             display: flex;
@@ -232,10 +331,37 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             flex-wrap: wrap;
             align-items: center;
         }
+        .context-pill {
+            display: none;
+            gap: 7px;
+            align-items: center;
+            max-width: 230px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            padding: 4px 8px;
+            color: var(--muted);
+            font-size: 12px;
+            line-height: 1.2;
+            white-space: nowrap;
+        }
+        .context-pill.active { display: inline-flex; }
+        .context-meter {
+            width: 42px;
+            height: 4px;
+            border-radius: 999px;
+            background: color-mix(in srgb, var(--border) 70%, transparent);
+            overflow: hidden;
+        }
+        .context-meter-fill {
+            display: block;
+            width: 0;
+            height: 100%;
+            background: var(--accent);
+        }
         .feed {
             overflow: auto;
             min-height: 0;
-            padding: 14px;
+            padding: 14px 14px 8px;
             display: grid;
             gap: 10px;
             align-content: start;
@@ -299,14 +425,17 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         }
         .composer {
             display: grid;
-            grid-template-columns: 1fr auto;
-            gap: 8px;
-            border-top: 1px solid var(--border);
-            background: var(--panel);
+            gap: 6px;
+            margin: 8px 12px 12px;
+            padding: 8px;
+            border: 1px solid var(--vscode-input-border, var(--border));
+            border-radius: 8px;
+            background: var(--input);
+            box-shadow: 0 0 0 1px color-mix(in srgb, var(--border) 45%, transparent);
         }
         .composer-input {
             display: grid;
-            gap: 8px;
+            gap: 4px;
             min-width: 0;
         }
         .composer-meta {
@@ -314,6 +443,21 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             gap: 8px;
             align-items: center;
             flex-wrap: wrap;
+        }
+        .composer-toolbar {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+            justify-content: space-between;
+            flex-wrap: wrap;
+            min-height: 30px;
+        }
+        .composer-provider {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+            flex-wrap: wrap;
+            min-width: 0;
         }
         .node-context-badge {
             display: none;
@@ -331,9 +475,10 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             white-space: nowrap;
         }
         .composer-actions {
-            display: grid;
+            display: flex;
             gap: 8px;
-            align-content: end;
+            align-items: center;
+            margin-left: auto;
         }
         textarea, input[type="text"], select {
             width: 100%;
@@ -347,9 +492,13 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         }
         textarea {
             resize: none;
-            min-height: 46px;
+            min-height: 72px;
             max-height: 160px;
             line-height: 1.4;
+            border: 0;
+            border-radius: 0;
+            background: transparent;
+            padding: 4px 2px;
         }
         button {
             border: none;
@@ -372,6 +521,24 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             padding: 5px 8px;
             font-size: 12px;
             min-height: 30px;
+        }
+        .composer button.small,
+        .composer .send-button,
+        .composer .stop-button {
+            min-height: 28px;
+            padding: 4px 8px;
+            border-radius: 6px;
+        }
+        .send-button {
+            min-width: 30px;
+            font-size: 13px;
+            line-height: 1;
+        }
+        .stop-button {
+            display: none;
+        }
+        .stop-button.active {
+            display: inline-block;
         }
         button:disabled {
             cursor: not-allowed;
@@ -420,7 +587,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         }
         @media (max-width: 1200px) {
             .workbench {
-                grid-template-columns: 280px 1fr;
+                grid-template-columns: 1fr;
                 grid-template-rows: ${hasWorkflow ? 'minmax(360px, 48%) 1fr' : '1fr'};
             }
             .chat {
@@ -434,65 +601,37 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         @media (max-width: 900px) {
             .workbench {
                 grid-template-columns: 1fr;
-                grid-template-rows: auto auto ${hasWorkflow ? 'minmax(280px, 42%)' : ''};
+                grid-template-rows: auto ${hasWorkflow ? 'minmax(280px, 42%)' : ''};
             }
-            .sidebar, .chat {
+            .chat {
                 border-right: 0;
                 border-bottom: 1px solid var(--border);
             }
-            .composer {
-                grid-template-columns: 1fr;
-            }
+            .composer { margin: 8px; }
         }
     </style>
 </head>
 <body>
-    <main class="workbench">
-        <aside class="sidebar" aria-label="Agent sessions">
-            <div class="section-head">
-                <div class="sidebar-title">Sessions</div>
-                <div class="sidebar-subtitle">Persisted Yagr-backed conversations, checkpoints, and workflow attachment.</div>
-                <div class="toolbar compact">
-                    <button id="new-session" class="small">New session</button>
-                </div>
-            </div>
-            <div class="session-filters">
-                <div class="meta-text">Filter</div>
-                <select id="session-filter">
-                    <option value="current">Current workflow</option>
-                    <option value="all">All sessions</option>
-                    <option value="unattached">Unattached</option>
-                </select>
-            </div>
-            <div id="session-list" class="sessions"></div>
-            <div class="checkpoint-panel">
-                <div class="meta-grid" id="session-meta"></div>
-                <div class="toolbar compact">
-                    <button id="rename-session" class="secondary small" type="button">Rename</button>
-                    <button id="attach-session" class="secondary small" type="button">Attach</button>
-                    <button id="detach-session" class="secondary small" type="button">Detach</button>
-                    <button id="delete-session" class="ghost small" type="button">Delete</button>
-                </div>
-                <div class="meta-text">Checkpoints</div>
-                <div class="toolbar compact">
-                    <button id="save-checkpoint" class="secondary small" type="button">Save checkpoint</button>
-                </div>
-                <div id="checkpoint-list" class="meta-grid"></div>
-            </div>
-        </aside>
+    <main id="workbench" class="workbench">
         <section class="chat" aria-label="Agent chat">
             <header class="chat-head">
                 <div class="chat-head-row">
-                    <div>
+                    <div class="chat-head-main">
                         <div class="chat-title">Workflow Architect</div>
-                        <div id="chat-subtitle" class="chat-subtitle" title="${safeWorkflowName}">${safeWorkflowName}${safeWorkflowId ? ` · ${safeWorkflowId}` : ' · new workflow chat'}</div>
+                        <button id="workflow-selector" class="workflow-selector" type="button" title="${initialWorkflowLabel}">${initialWorkflowLabel}${safeWorkflowId ? ` · ${safeWorkflowId}` : ''}</button>
                     </div>
-                    <div class="toolbar compact">
-                        <button id="select-model" class="secondary small" type="button" title="${safeProviderModelLabel}">${safeProviderModelLabel}</button>
-                        <button id="select-reasoning" class="secondary small" type="button">Reasoning</button>
+                    <div class="header-actions">
+                        <button id="history-open" class="ghost small" type="button" title="Conversation history">History</button>
+                        <div id="context-pill" class="context-pill" title="Context usage">
+                            <span id="context-label">Context</span>
+                            <span class="context-meter" aria-hidden="true"><span id="context-meter-fill" class="context-meter-fill"></span></span>
+                        </div>
+                        <button id="compact-context" class="ghost small" type="button" title="Compact context" aria-label="Compact context">Compact</button>
+                        <div id="run-indicator" class="run-indicator" aria-label="Agent running" title="Agent running">
+                            <span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span>
+                        </div>
                     </div>
                 </div>
-                <div id="chat-meta" class="chat-meta"></div>
             </header>
             <div id="feed" class="feed"></div>
             <form id="composer" class="composer">
@@ -501,10 +640,16 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                         <div id="node-context-badge" class="node-context-badge" title=""></div>
                     </div>
                     <textarea id="prompt" placeholder="Ask the n8n agent what to do with this workflow..." rows="2"></textarea>
-                </div>
-                <div class="composer-actions">
-                    <button id="send" type="submit">Send</button>
-                    <button id="stop" class="secondary" type="button" disabled>Stop</button>
+                    <div class="composer-toolbar">
+                        <div class="composer-provider">
+                            <button id="select-model" class="secondary small" type="button" title="${safeProviderModelLabel}">${safeProviderModelLabel}</button>
+                            <button id="select-reasoning" class="secondary small" type="button">Reasoning</button>
+                        </div>
+                        <div class="composer-actions">
+                            <button id="stop" class="ghost stop-button" type="button" disabled>Stop</button>
+                            <button id="send" class="send-button" type="submit" title="Send" aria-label="Send">▶</button>
+                        </div>
+                    </div>
                 </div>
             </form>
         </section>
@@ -517,6 +662,28 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 allow="${iframeAllowPolicy}">
             </iframe>
         </section>` : ''}
+        <div id="history-overlay" class="history-overlay" role="dialog" aria-modal="true" aria-label="Conversation history">
+            <div class="history-modal">
+                <div class="history-head">
+                    <div>
+                        <div class="history-title">Conversation History</div>
+                        <div class="meta-text">Open a previous chat or start a new one.</div>
+                    </div>
+                    <button id="history-close" class="ghost small" type="button" aria-label="Close history">Close</button>
+                </div>
+                <div class="history-controls">
+                    <select id="session-filter" aria-label="Filter conversations">
+                        <option value="current">Current workflow</option>
+                        <option value="all">All conversations</option>
+                        <option value="unattached">New workflow chats</option>
+                    </select>
+                </div>
+                <div id="session-list" class="sessions history-list"></div>
+                <div class="history-foot">
+                    <button id="new-session" class="secondary small" type="button">New chat</button>
+                </div>
+            </div>
+        </div>
     </main>
     <script nonce="${nonce}">
         const vscode = acquireVsCodeApi();
@@ -556,27 +723,25 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const nodeContextBadge = document.getElementById('node-context-badge');
         const sessionList = document.getElementById('session-list');
         const sessionFilter = document.getElementById('session-filter');
-        const sessionMeta = document.getElementById('session-meta');
-        const checkpointList = document.getElementById('checkpoint-list');
-        const chatSubtitle = document.getElementById('chat-subtitle');
-        const chatMeta = document.getElementById('chat-meta');
+        const workflowSelector = document.getElementById('workflow-selector');
+        const contextPill = document.getElementById('context-pill');
+        const contextLabel = document.getElementById('context-label');
+        const contextMeterFill = document.getElementById('context-meter-fill');
         const newSessionButton = document.getElementById('new-session');
-        const renameSessionButton = document.getElementById('rename-session');
-        const attachSessionButton = document.getElementById('attach-session');
-        const detachSessionButton = document.getElementById('detach-session');
-        const deleteSessionButton = document.getElementById('delete-session');
-        const saveCheckpointButton = document.getElementById('save-checkpoint');
+        const historyOpenButton = document.getElementById('history-open');
+        const historyCloseButton = document.getElementById('history-close');
+        const historyOverlay = document.getElementById('history-overlay');
+        const runIndicator = document.getElementById('run-indicator');
+        const compactContextButton = document.getElementById('compact-context');
 
         function setRunning(running) {
             isRunning = running;
             sendButton.disabled = running;
             stopButton.disabled = !running;
+            stopButton.classList.toggle('active', running);
             newSessionButton.disabled = running;
-            renameSessionButton.disabled = running;
-            attachSessionButton.disabled = running;
-            detachSessionButton.disabled = running;
-            deleteSessionButton.disabled = running;
-            saveCheckpointButton.disabled = running;
+            compactContextButton.disabled = running;
+            if (runIndicator) runIndicator.classList.toggle('active', running);
         }
 
         function escapeText(value) {
@@ -681,7 +846,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 empty.textContent = activeFilter === 'all'
                     ? 'No sessions yet.'
                     : activeFilter === 'unattached'
-                        ? 'No unattached sessions.'
+                        ? 'No new workflow chats.'
                         : 'No sessions for this workflow yet.';
                 sessionList.appendChild(empty);
                 return;
@@ -691,7 +856,10 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 const item = document.createElement('button');
                 item.type = 'button';
                 item.className = 'session-item' + (session.isActive ? ' active' : '');
-                item.addEventListener('click', () => vscode.postMessage({ type: 'agent.session.select', sessionId: session.id }));
+                item.addEventListener('click', () => {
+                    closeHistory();
+                    vscode.postMessage({ type: 'agent.session.select', sessionId: session.id });
+                });
 
                 const head = document.createElement('div');
                 head.className = 'session-item-head';
@@ -726,104 +894,45 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             return el;
         }
 
-        function renderMeta() {
-            sessionMeta.innerHTML = '';
-            checkpointList.innerHTML = '';
-            if (!state || !state.session) {
-                sessionMeta.textContent = '';
-                return;
-            }
+        function openHistory() {
+            renderSessions();
+            historyOverlay.classList.add('open');
+        }
 
-            const session = state.session;
-            const rows = [
-                ['Session', session.title],
-                ['Attached', session.workflowLabel],
-                ['Checkpoints', String(session.checkpoints.length)],
-                ['Compactions', String(session.totalCompactions)],
-                ['Context', session.contextUsage ? session.contextUsage.fillPercent + '% of ' + session.contextUsage.contextWindowTokens + ' tokens' : 'No estimate yet'],
-            ];
-            for (const [label, value] of rows) {
-                const row = document.createElement('div');
-                row.className = 'meta-row';
-                const left = document.createElement('span');
-                left.className = 'meta-text';
-                left.textContent = label;
-                const right = document.createElement('code');
-                right.textContent = value;
-                row.append(left, right);
-                sessionMeta.appendChild(row);
-            }
-
-            if (!session.checkpoints.length) {
-                const empty = document.createElement('div');
-                empty.className = 'meta-text';
-                empty.textContent = 'No checkpoints saved for this session.';
-                checkpointList.appendChild(empty);
-            } else {
-                for (const checkpoint of session.checkpoints) {
-                    const row = document.createElement('div');
-                    row.className = 'session-item';
-                    const head = document.createElement('div');
-                    head.className = 'session-item-head';
-                    const title = document.createElement('div');
-                    title.className = 'session-item-title';
-                    title.textContent = checkpoint.id;
-                    const summary = document.createElement('div');
-                    summary.className = 'session-item-foot';
-                    const left = document.createElement('span');
-                    left.textContent = checkpoint.messageCount + ' msgs';
-                    const right = document.createElement('span');
-                    right.textContent = formatDate(checkpoint.createdAt);
-                    summary.append(left, right);
-                    head.append(title);
-                    row.append(head, summary);
-
-                    const actions = document.createElement('div');
-                    actions.className = 'toolbar compact';
-                    const restore = document.createElement('button');
-                    restore.className = 'secondary small';
-                    restore.type = 'button';
-                    restore.textContent = 'Restore';
-                    restore.disabled = isRunning;
-                    restore.addEventListener('click', () => vscode.postMessage({ type: 'agent.checkpoint.restore', sessionId: session.sessionId, checkpointId: checkpoint.id }));
-                    const del = document.createElement('button');
-                    del.className = 'ghost small';
-                    del.type = 'button';
-                    del.textContent = 'Delete';
-                    del.disabled = isRunning;
-                    del.addEventListener('click', () => vscode.postMessage({ type: 'agent.checkpoint.delete', sessionId: session.sessionId, checkpointId: checkpoint.id }));
-                    actions.append(restore, del);
-                    row.append(actions);
-                    checkpointList.appendChild(row);
-                }
-            }
-
-            attachSessionButton.disabled = isRunning || !workflowId || session.workflowId === workflowId;
-            detachSessionButton.disabled = isRunning || !session.workflowId;
+        function closeHistory() {
+            historyOverlay.classList.remove('open');
         }
 
         function renderChatMeta() {
-            chatMeta.innerHTML = '';
             if (!state) return;
-            const bits = [];
-            bits.push(badge((state.provider || 'provider') + (state.model ? ' / ' + state.model : ''), ''));
-            if (state.reasoningEffort) bits.push(badge('Reasoning ' + state.reasoningEffort, ''));
-            if (state.session && state.session.workflowLabel) bits.push(badge(state.session.workflowLabel, ''));
-            if (state.session && state.session.lastCompaction) bits.push(badge('Compacted', 'success'));
-            bits.forEach((el) => chatMeta.appendChild(el));
+            const providerLabel = (state.provider || 'provider') + (state.model ? ' / ' + state.model : '');
+            selectModelButton.textContent = providerLabel;
+            selectModelButton.title = providerLabel;
+            selectReasoningButton.textContent = state.reasoningEffort ? 'Reasoning ' + state.reasoningEffort : 'Reasoning';
             selectReasoningButton.style.display = state.supportsReasoningEffort ? 'inline-block' : 'none';
+            const usage = state.session && state.session.contextUsage;
+            if (!usage) {
+                contextPill.classList.remove('active');
+                contextLabel.textContent = 'Context';
+                contextMeterFill.style.width = '0%';
+                return;
+            }
+            const percent = Math.max(0, Math.min(100, Number(usage.fillPercent) || 0));
+            contextPill.classList.add('active');
+            contextLabel.textContent = percent + '% context';
+            contextPill.title = percent + '% of ' + usage.contextWindowTokens + ' tokens · prompt ' + usage.promptTokens + ' · completion ' + usage.completionTokens + ' · ' + usage.source;
+            contextMeterFill.style.width = percent + '%';
         }
 
         function renderFeed() {
             feed.innerHTML = '';
-            if (!state || !state.session || !state.session.entries.length) {
-                const empty = document.createElement('div');
-                empty.className = 'entry system';
-                empty.textContent = 'Ask for a workflow inspection, create a new session, or attach a saved conversation to this workflow.';
-                feed.appendChild(empty);
+            const visibleEntries = state && state.session && Array.isArray(state.session.entries)
+                ? state.session.entries.filter((entry) => entry.kind !== 'context-usage')
+                : [];
+            if (!visibleEntries.length) {
                 return;
             }
-            for (const entry of state.session.entries) {
+            for (const entry of visibleEntries) {
                 feed.appendChild(renderEntry(entry));
             }
             feed.scrollTop = feed.scrollHeight;
@@ -839,13 +948,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             if (entry.kind === 'assistant-body') {
                 return textEntry('assistant' + (entry.streaming ? ' streaming' : ''), entry.text || '');
             }
-            if (entry.kind === 'context-usage') {
-                const el = document.createElement('div');
-                el.className = 'entry context';
-                el.innerHTML = '<div class="entry-head"><div class="entry-title">Context usage</div><div class="entry-subtle">' + escapeHtml(entry.usage.source) + '</div></div>' +
-                    '<div>' + escapeHtml(entry.usage.fillPercent + '% of ' + entry.usage.contextWindowTokens + ' tokens · prompt ' + entry.usage.promptTokens + ' · completion ' + entry.usage.completionTokens) + '</div>';
-                return el;
-            }
+            if (entry.kind === 'context-usage') return document.createComment('context usage');
             if (entry.kind === 'compaction') {
                 const el = document.createElement('div');
                 el.className = 'entry compaction';
@@ -853,12 +956,12 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 details.className = 'details';
                 details.innerHTML = '<summary>Show compaction details</summary>' +
                     '<div class="details-body">' +
-                    'Source: ' + escapeHtml(entry.event.source) + '\n' +
-                    'Messages compacted: ' + escapeHtml(entry.event.messagesCompacted) + '\n' +
+                    'Source: ' + escapeHtml(entry.event.source) + '\\n' +
+                    'Messages compacted: ' + escapeHtml(entry.event.messagesCompacted) + '\\n' +
                     'Preserved recent messages: ' + escapeHtml(entry.event.preservedRecentMessages) +
-                    (entry.event.estimatedTokens ? '\nEstimated tokens: ' + escapeHtml(entry.event.estimatedTokens) : '') +
-                    (entry.event.thresholdTokens ? '\nThreshold tokens: ' + escapeHtml(entry.event.thresholdTokens) : '') +
-                    (entry.event.fallbackReason ? '\nFallback reason: ' + escapeHtml(entry.event.fallbackReason) : '') +
+                    (entry.event.estimatedTokens ? '\\nEstimated tokens: ' + escapeHtml(entry.event.estimatedTokens) : '') +
+                    (entry.event.thresholdTokens ? '\\nThreshold tokens: ' + escapeHtml(entry.event.thresholdTokens) : '') +
+                    (entry.event.fallbackReason ? '\\nFallback reason: ' + escapeHtml(entry.event.fallbackReason) : '') +
                     '</div>';
                 el.innerHTML = '<div class="entry-head"><div class="entry-title">Context compacted</div><div class="entry-subtle">' + escapeHtml(new Date(entry.timestamp).toLocaleTimeString()) + '</div></div><div>' + escapeHtml(entry.event.summary) + '</div>';
                 el.appendChild(details);
@@ -894,13 +997,13 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
 
         function renderAll() {
             renderSessions();
-            renderMeta();
             renderChatMeta();
             renderFeed();
             if (state && state.workflow) {
-                chatSubtitle.textContent = state.workflow.name
+                workflowSelector.textContent = state.workflow.name
                     ? state.workflow.name + (state.workflow.id ? ' · ' + state.workflow.id : '')
                     : 'New workflow chat';
+                workflowSelector.title = workflowSelector.textContent;
             }
         }
 
@@ -957,9 +1060,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                     fillPercent: event.fillPercent,
                     source: event.source,
                 };
-                const filtered = entries.filter((entry) => entry.kind !== 'context-usage');
-                filtered.push({ kind: 'context-usage', id: crypto.randomUUID(), timestamp: Date.now(), usage: state.session.contextUsage });
-                state.session.entries = filtered;
                 renderAll();
                 return;
             } else if (event.type === 'error') {
@@ -985,26 +1085,19 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         });
 
         stopButton.addEventListener('click', () => vscode.postMessage({ type: 'agent.stop' }));
+        workflowSelector.addEventListener('click', () => vscode.postMessage({ type: 'agent.workflow.select' }));
+        historyOpenButton.addEventListener('click', openHistory);
+        historyCloseButton.addEventListener('click', closeHistory);
+        historyOverlay.addEventListener('click', (event) => {
+            if (event.target === historyOverlay) closeHistory();
+        });
         selectModelButton.addEventListener('click', () => vscode.postMessage({ type: 'agent.selectModel' }));
         selectReasoningButton.addEventListener('click', () => vscode.postMessage({ type: 'agent.selectReasoningEffort' }));
-        newSessionButton.addEventListener('click', () => vscode.postMessage({ type: 'agent.session.new' }));
-        saveCheckpointButton.addEventListener('click', () => state && vscode.postMessage({ type: 'agent.checkpoint.save', sessionId: state.activeSessionId }));
-        renameSessionButton.addEventListener('click', () => {
-            if (!state || !state.session) return;
-            const title = window.prompt('Rename session', state.session.title);
-            if (typeof title === 'string' && title.trim()) {
-                vscode.postMessage({ type: 'agent.session.rename', sessionId: state.activeSessionId, title: title.trim() });
-            }
+        newSessionButton.addEventListener('click', () => {
+            closeHistory();
+            vscode.postMessage({ type: 'agent.session.new' });
         });
-        attachSessionButton.addEventListener('click', () => state && vscode.postMessage({ type: 'agent.session.attach', sessionId: state.activeSessionId }));
-        detachSessionButton.addEventListener('click', () => state && vscode.postMessage({ type: 'agent.session.detach', sessionId: state.activeSessionId }));
-        deleteSessionButton.addEventListener('click', () => {
-            if (!state || !state.session) return;
-            const confirmed = window.confirm('Delete session "' + state.session.title + '"?');
-            if (confirmed) {
-                vscode.postMessage({ type: 'agent.session.delete', sessionId: state.activeSessionId });
-            }
-        });
+        compactContextButton.addEventListener('click', () => state && vscode.postMessage({ type: 'agent.context.compact', sessionId: state.activeSessionId }));
         sessionFilter.addEventListener('change', () => {
             activeFilter = sessionFilter.value || 'current';
             renderSessions();

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -2,6 +2,7 @@ export interface AgentWorkbenchHtmlInput {
     workflowId: string;
     workflowName: string;
     workflowUrl?: string;
+    workflowReloadUrl?: string;
 }
 
 function escapeHtml(value: string): string {
@@ -28,6 +29,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
     const safeWorkflowUrl = escapeHtml(input.workflowUrl || '');
     const workflowIdJs = JSON.stringify(input.workflowId);
     const workflowUrlJs = JSON.stringify(input.workflowUrl || '');
+    const workflowReloadUrlJs = JSON.stringify(input.workflowReloadUrl || input.workflowUrl || '');
     const hasWorkflow = Boolean(input.workflowUrl);
 
     let iframePermissionOrigin = 'src';
@@ -268,6 +270,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const vscode = acquireVsCodeApi();
         let workflowId = ${workflowIdJs};
         let workflowUrl = ${workflowUrlJs};
+        let workflowReloadUrl = ${workflowReloadUrlJs};
         let iframeOrigin = ${JSON.stringify(iframePermissionOrigin)};
         const PASTE_RATE_LIMIT_MS = 1000;
         const GRANT_TTL_MS = 5000;
@@ -316,7 +319,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         function reloadWorkflowFrame() {
             if (!frame || !refreshPill) return;
             refreshPill.style.display = 'block';
-            const currentSrc = workflowUrl || frame.src;
+            const currentSrc = workflowReloadUrl || frame.src || workflowUrl;
             frame.onload = () => {
                 refreshPill.style.display = 'none';
                 frame.onload = null;
@@ -380,6 +383,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             if (message.type === 'workflow.update' && typeof message.url === 'string') {
                 workflowId = String(message.workflowId || workflowId);
                 workflowUrl = message.url;
+                workflowReloadUrl = typeof message.reloadUrl === 'string' && message.reloadUrl ? message.reloadUrl : workflowUrl;
                 try { iframeOrigin = new URL(workflowUrl).origin; } catch (e) { iframeOrigin = 'src'; }
                 if (frame) frame.src = workflowUrl;
                 return;

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -1,0 +1,375 @@
+export interface AgentWorkbenchHtmlInput {
+    workflowId: string;
+    workflowName: string;
+    workflowUrl: string;
+}
+
+function escapeHtml(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+function getNonce(): string {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let nonce = '';
+    for (let i = 0; i < 32; i++) {
+        nonce += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return nonce;
+}
+
+export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string {
+    const nonce = getNonce();
+    const safeWorkflowName = escapeHtml(input.workflowName);
+    const safeWorkflowId = escapeHtml(input.workflowId);
+    const safeWorkflowUrl = escapeHtml(input.workflowUrl);
+    const workflowIdJs = JSON.stringify(input.workflowId);
+    const workflowUrlJs = JSON.stringify(input.workflowUrl);
+
+    let iframePermissionOrigin = 'src';
+    try {
+        iframePermissionOrigin = new URL(input.workflowUrl).origin;
+    } catch {
+        // Fallback to iframe's own source origin behavior if URL parsing fails.
+    }
+    const iframeAllowPolicy = `clipboard-read ${iframePermissionOrigin}; clipboard-write ${iframePermissionOrigin}; geolocation ${iframePermissionOrigin}; microphone ${iframePermissionOrigin}; camera ${iframePermissionOrigin}`;
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; frame-src *; connect-src *; img-src * data:; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>n8n Agent Workbench: ${safeWorkflowName}</title>
+    <style>
+        :root {
+            color-scheme: light dark;
+            --border: var(--vscode-panel-border, #2f3337);
+            --muted: var(--vscode-descriptionForeground, #8b949e);
+            --bg: var(--vscode-editor-background, #1e1e1e);
+            --panel: var(--vscode-sideBar-background, #181818);
+            --text: var(--vscode-editor-foreground, #d4d4d4);
+            --accent: var(--vscode-button-background, #0e639c);
+            --accent-text: var(--vscode-button-foreground, #ffffff);
+            --input: var(--vscode-input-background, #2a2a2a);
+        }
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+            overflow: hidden;
+            background: var(--bg);
+            color: var(--text);
+            font-family: var(--vscode-font-family, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+        }
+        .workbench {
+            display: grid;
+            grid-template-columns: minmax(320px, 36%) minmax(420px, 1fr);
+            height: 100vh;
+            width: 100vw;
+        }
+        .chat {
+            display: grid;
+            grid-template-rows: auto 1fr auto;
+            min-width: 0;
+            border-right: 1px solid var(--border);
+            background: var(--panel);
+        }
+        .header {
+            padding: 14px 16px 12px;
+            border-bottom: 1px solid var(--border);
+        }
+        .kicker {
+            color: var(--muted);
+            font-size: 11px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            margin-bottom: 6px;
+        }
+        .title {
+            font-size: 15px;
+            font-weight: 650;
+            line-height: 1.35;
+        }
+        .subtitle {
+            margin-top: 6px;
+            color: var(--muted);
+            font-size: 12px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .feed {
+            overflow: auto;
+            padding: 14px;
+        }
+        .message, .operation {
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 10px 11px;
+            margin-bottom: 10px;
+            background: color-mix(in srgb, var(--bg) 78%, transparent);
+            white-space: pre-wrap;
+            line-height: 1.45;
+            font-size: 13px;
+        }
+        .message.user {
+            border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+        }
+        .role {
+            color: var(--muted);
+            font-size: 11px;
+            font-weight: 700;
+            letter-spacing: 0.06em;
+            margin-bottom: 5px;
+            text-transform: uppercase;
+        }
+        .operation {
+            color: var(--muted);
+            font-size: 12px;
+        }
+        .operation.running { border-color: var(--accent); }
+        .operation.error { border-color: var(--vscode-errorForeground, #f85149); color: var(--vscode-errorForeground, #f85149); }
+        .composer {
+            display: grid;
+            grid-template-columns: 1fr auto;
+            gap: 8px;
+            padding: 12px;
+            border-top: 1px solid var(--border);
+            background: var(--panel);
+        }
+        textarea {
+            resize: none;
+            min-height: 42px;
+            max-height: 140px;
+            border: 1px solid var(--vscode-input-border, transparent);
+            border-radius: 8px;
+            background: var(--input);
+            color: var(--text);
+            padding: 9px 10px;
+            font: inherit;
+            line-height: 1.35;
+            outline: none;
+        }
+        .actions {
+            display: grid;
+            gap: 8px;
+            align-content: end;
+        }
+        button {
+            border: none;
+            border-radius: 8px;
+            padding: 8px 11px;
+            color: var(--accent-text);
+            background: var(--accent);
+            cursor: pointer;
+            font: inherit;
+            font-size: 12px;
+        }
+        button.secondary {
+            color: var(--vscode-button-secondaryForeground, var(--text));
+            background: var(--vscode-button-secondaryBackground, #3a3d41);
+        }
+        button:disabled {
+            cursor: not-allowed;
+            opacity: 0.55;
+        }
+        .workflow {
+            position: relative;
+            min-width: 0;
+            background: var(--bg);
+        }
+        iframe {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            border: 0;
+        }
+        .refresh-pill {
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            z-index: 2;
+            display: none;
+            padding: 5px 9px;
+            border-radius: 999px;
+            background: var(--accent);
+            color: var(--accent-text);
+            font-size: 12px;
+            box-shadow: 0 2px 12px rgba(0, 0, 0, 0.35);
+        }
+        @media (max-width: 860px) {
+            .workbench {
+                grid-template-columns: 1fr;
+                grid-template-rows: minmax(280px, 45%) 1fr;
+            }
+            .chat {
+                border-right: 0;
+                border-bottom: 1px solid var(--border);
+            }
+        }
+    </style>
+</head>
+<body>
+    <main class="workbench">
+        <section class="chat" aria-label="Agent chat">
+            <header class="header">
+                <div class="kicker">n8n Agent Workbench</div>
+                <div class="title">Workflow Architect</div>
+                <div class="subtitle" title="${safeWorkflowName}">${safeWorkflowName} · ${safeWorkflowId}</div>
+            </header>
+            <div id="feed" class="feed">
+                <div class="message system">
+                    <div class="role">System</div>
+                    Agent workbench is ready. Ask for a workflow inspection, generation plan, validation pass, or deployment step.
+                </div>
+            </div>
+            <form id="composer" class="composer">
+                <textarea id="prompt" placeholder="Ask the n8n agent what to do with this workflow..." rows="2"></textarea>
+                <div class="actions">
+                    <button id="send" type="submit">Send</button>
+                    <button id="stop" class="secondary" type="button" disabled>Stop</button>
+                </div>
+            </form>
+        </section>
+        <section class="workflow" aria-label="n8n workflow">
+            <div id="refresh-pill" class="refresh-pill">Refreshing n8n...</div>
+            <iframe
+                id="workflow-frame"
+                src="${safeWorkflowUrl}"
+                sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals allow-downloads allow-top-navigation allow-top-navigation-by-user-activation"
+                allow="${iframeAllowPolicy}">
+            </iframe>
+        </section>
+    </main>
+    <script nonce="${nonce}">
+        const vscode = acquireVsCodeApi();
+        let workflowId = ${workflowIdJs};
+        let workflowUrl = ${workflowUrlJs};
+        let isRunning = false;
+        let activeAssistantMessage = null;
+
+        const feed = document.getElementById('feed');
+        const form = document.getElementById('composer');
+        const promptInput = document.getElementById('prompt');
+        const sendButton = document.getElementById('send');
+        const stopButton = document.getElementById('stop');
+        const frame = document.getElementById('workflow-frame');
+        const refreshPill = document.getElementById('refresh-pill');
+
+        function appendMessage(role, content) {
+            const el = document.createElement('div');
+            el.className = 'message ' + role;
+            const label = document.createElement('div');
+            label.className = 'role';
+            label.textContent = role;
+            const body = document.createElement('div');
+            body.textContent = content || '';
+            el.append(label, body);
+            feed.appendChild(el);
+            feed.scrollTop = feed.scrollHeight;
+            return body;
+        }
+
+        function appendOperation(label, status, detail) {
+            const el = document.createElement('div');
+            el.className = 'operation ' + status;
+            el.textContent = detail ? label + ': ' + detail : label;
+            feed.appendChild(el);
+            feed.scrollTop = feed.scrollHeight;
+        }
+
+        function setRunning(running) {
+            isRunning = running;
+            sendButton.disabled = running;
+            stopButton.disabled = !running;
+        }
+
+        function reloadWorkflowFrame() {
+            refreshPill.style.display = 'block';
+            const currentSrc = frame.src;
+            frame.onload = () => {
+                refreshPill.style.display = 'none';
+                frame.onload = null;
+            };
+            frame.src = currentSrc;
+        }
+
+        form.addEventListener('submit', (event) => {
+            event.preventDefault();
+            const text = promptInput.value.trim();
+            if (!text || isRunning) return;
+            promptInput.value = '';
+            activeAssistantMessage = null;
+            appendMessage('user', text);
+            vscode.postMessage({ type: 'agent.send', text, workflowId });
+        });
+
+        promptInput.addEventListener('keydown', (event) => {
+            if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+                form.requestSubmit();
+            }
+        });
+
+        stopButton.addEventListener('click', () => {
+            vscode.postMessage({ type: 'agent.stop' });
+        });
+
+        window.addEventListener('message', (event) => {
+            const message = event.data;
+            if (!message || typeof message !== 'object') return;
+
+            if (message.type === 'workflow.reload') {
+                reloadWorkflowFrame();
+                return;
+            }
+
+            if (message.type === 'workflow.update' && typeof message.url === 'string') {
+                workflowId = String(message.workflowId || workflowId);
+                workflowUrl = message.url;
+                frame.src = workflowUrl;
+                return;
+            }
+
+            if (message.type === 'agent.status') {
+                setRunning(message.status === 'running' || message.status === 'stopping');
+                return;
+            }
+
+            if (message.type === 'agent.message') {
+                activeAssistantMessage = appendMessage(message.role || 'assistant', message.content || '');
+                return;
+            }
+
+            if (message.type === 'agent.delta') {
+                if (!activeAssistantMessage) {
+                    activeAssistantMessage = appendMessage('assistant', '');
+                }
+                activeAssistantMessage.textContent += message.content || '';
+                feed.scrollTop = feed.scrollHeight;
+                return;
+            }
+
+            if (message.type === 'agent.operation') {
+                appendOperation(message.label || 'Operation', message.status || 'running', message.detail || '');
+                return;
+            }
+
+            if (message.type === 'agent.error') {
+                appendOperation('Error', 'error', message.message || 'Unknown error');
+                return;
+            }
+
+            if (message.type === 'agent.done') {
+                setRunning(false);
+                return;
+            }
+        });
+    </script>
+</body>
+</html>`;
+}

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -102,6 +102,9 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             text-overflow: ellipsis;
             white-space: nowrap;
         }
+        .header-actions {
+            margin-top: 10px;
+        }
         .feed {
             overflow: auto;
             padding: 14px;
@@ -221,6 +224,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 <div class="kicker">n8n Agent Workbench</div>
                 <div class="title">Workflow Architect</div>
                 <div class="subtitle" title="${safeWorkflowName}">${safeWorkflowName} · ${safeWorkflowId}</div>
+                <div class="header-actions"><button id="select-model" class="secondary" type="button">Provider / Model</button></div>
             </header>
             <div id="feed" class="feed">
                 <div class="message system">
@@ -263,6 +267,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const promptInput = document.getElementById('prompt');
         const sendButton = document.getElementById('send');
         const stopButton = document.getElementById('stop');
+        const selectModelButton = document.getElementById('select-model');
         const frame = document.getElementById('workflow-frame');
         const refreshPill = document.getElementById('refresh-pill');
 
@@ -336,6 +341,10 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
 
         stopButton.addEventListener('click', () => {
             vscode.postMessage({ type: 'agent.stop' });
+        });
+
+        selectModelButton.addEventListener('click', () => {
+            vscode.postMessage({ type: 'agent.selectModel' });
         });
 
         window.addEventListener('message', (event) => {

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -734,6 +734,10 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const runIndicator = document.getElementById('run-indicator');
         const compactContextButton = document.getElementById('compact-context');
 
+        function on(element, eventName, handler) {
+            if (element) element.addEventListener(eventName, handler);
+        }
+
         function setRunning(running) {
             isRunning = running;
             sendButton.disabled = running;
@@ -1007,29 +1011,134 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             }
         }
 
+        function normalizeOperationKind(category, title) {
+            const value = String(category || title || '').toLowerCase().replace(/_/g, '-');
+            if (value === 'read-file' || value === 'file-read' || value === 'read') return 'file-read';
+            if (value === 'write-file' || value === 'file-write' || value === 'write') return 'file-write';
+            if (value.includes('shell')) return 'shell';
+            if (value.includes('web')) return 'web';
+            return value;
+        }
+
+        function findMatchingPendingOperationIndex(entries, operationId, title, category) {
+            const exactIndex = entries.findIndex((entry) => entry.kind === 'operation' && entry.id === operationId);
+            if (exactIndex >= 0) return exactIndex;
+            const targetKind = normalizeOperationKind(category, title);
+            for (let idx = entries.length - 1; idx >= 0; idx -= 1) {
+                const entry = entries[idx];
+                if (!entry || entry.kind !== 'operation') continue;
+                if (entry.status !== 'running') continue;
+                const entryKind = normalizeOperationKind(entry.category, entry.title);
+                if (entryKind && targetKind && entryKind === targetKind) return idx;
+                if ((entry.title || '') !== (title || '')) continue;
+                const entryCategory = String(entry.category || '').toLowerCase();
+                const targetCategory = String(category || '').toLowerCase();
+                if (entryCategory && targetCategory && entryCategory !== targetCategory && entryCategory !== 'phase') continue;
+                return idx;
+            }
+            return -1;
+        }
+
+        function finalizePendingOperations(entries, status) {
+            return entries.map((entry) => {
+                if (!entry || entry.kind !== 'operation' || entry.status !== 'running') return entry;
+                return {
+                    ...entry,
+                    tone: status === 'error' ? 'error' : 'success',
+                    status: status === 'error' ? 'error' : 'done',
+                    endedAt: entry.endedAt || Date.now(),
+                };
+            });
+        }
+
+        function stripEnvironmentDetails(text) {
+            let value = String(text || '');
+            const openTag = '<environment_details>';
+            const closeTag = '</environment_details>';
+            for (;;) {
+                const start = value.toLowerCase().indexOf(openTag);
+                if (start < 0) break;
+                const end = value.toLowerCase().indexOf(closeTag, start + openTag.length);
+                if (end < 0) {
+                    value = value.slice(0, start);
+                    break;
+                }
+                value = value.slice(0, start) + value.slice(end + closeTag.length);
+            }
+            return value.trim();
+        }
+
+        function lastUserMessageIndex(entries) {
+            for (let idx = entries.length - 1; idx >= 0; idx -= 1) {
+                if (entries[idx] && entries[idx].kind === 'user-message') return idx;
+            }
+            return -1;
+        }
+
+        function consolidateFinalAssistant(entries, response, finalState) {
+            const userIdx = lastUserMessageIndex(entries);
+            const finalText = stripEnvironmentDetails(response);
+            let chosenText = finalText;
+            const assistantTexts = [];
+            let firstAssistantIdx = -1;
+            for (let idx = userIdx + 1; idx < entries.length; idx += 1) {
+                const entry = entries[idx];
+                if (entry && entry.kind === 'assistant-body' && stripEnvironmentDetails(entry.text)) {
+                    if (firstAssistantIdx < 0) firstAssistantIdx = idx;
+                    assistantTexts.push(stripEnvironmentDetails(entry.text));
+                }
+            }
+            for (const text of assistantTexts) {
+                if (finalText.includes(text) && text.length >= Math.max(80, finalText.length * 0.6)) {
+                    chosenText = text;
+                }
+            }
+            const result = [];
+            let inserted = false;
+            for (let idx = 0; idx < entries.length; idx += 1) {
+                const entry = entries[idx];
+                if (idx > userIdx && entry.kind === 'assistant-body') {
+                    if (!inserted && chosenText && idx === firstAssistantIdx) {
+                        result.push({ kind: 'assistant-body', id: entry.id || crypto.randomUUID(), text: chosenText, streaming: false, finalState: finalState });
+                        inserted = true;
+                    }
+                    continue;
+                }
+                result.push(entry);
+            }
+            if (!inserted && chosenText) {
+                result.push({ kind: 'assistant-body', id: crypto.randomUUID(), text: chosenText, streaming: false, finalState: finalState });
+            }
+            return result;
+        }
+
         function applyStreamEvent(event) {
             if (!state || !state.session) return;
-            const entries = Array.isArray(state.session.entries) ? [...state.session.entries] : [];
+            let entries = Array.isArray(state.session.entries) ? [...state.session.entries] : [];
             if (event.type === 'start') {
                 state.activeSessionId = event.sessionId;
-            } else if (event.type === 'text-delta') {
                 const last = entries[entries.length - 1];
-                if (last && last.kind === 'assistant-body' && last.streaming) {
-                    last.text += event.delta || '';
+                if (!last || last.kind !== 'user-message' || last.text !== event.message) {
+                    entries.push({ kind: 'user-message', id: crypto.randomUUID(), text: event.message || '', timestamp: Date.now() });
+                }
+            } else if (event.type === 'text-delta') {
+                let streamingIdx = -1;
+                for (let idx = entries.length - 1; idx >= 0; idx -= 1) {
+                    if (entries[idx] && entries[idx].kind === 'assistant-body' && entries[idx].streaming) {
+                        streamingIdx = idx;
+                        break;
+                    }
+                }
+                if (streamingIdx >= 0) {
+                    entries[streamingIdx].text += event.delta || '';
                 } else {
                     entries.push({ kind: 'assistant-body', id: crypto.randomUUID(), text: event.delta || '', streaming: true });
                 }
             } else if (event.type === 'final') {
-                const last = entries[entries.length - 1];
-                if (last && last.kind === 'assistant-body') {
-                    last.streaming = false;
-                    last.finalState = event.finalState;
-                    if (!last.text) last.text = event.response || '';
-                } else {
-                    entries.push({ kind: 'assistant-body', id: crypto.randomUUID(), text: event.response || '', streaming: false, finalState: event.finalState });
-                }
+                entries = finalizePendingOperations(entries, 'done');
+                entries = consolidateFinalAssistant(entries, event.response || '', event.finalState);
             } else if (event.type === 'operation') {
-                const idx = entries.findIndex((entry) => entry.kind === 'operation' && entry.id === event.operationId);
+                const idx = findMatchingPendingOperationIndex(entries, event.operationId, event.label, event.category);
                 const opEntry = {
                     kind: 'operation',
                     id: event.operationId,
@@ -1046,7 +1155,18 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 if (idx >= 0) entries[idx] = opEntry;
                 else entries.push(opEntry);
             } else if (event.type === 'progress') {
-                entries.push({ kind: 'operation', id: crypto.randomUUID(), tone: event.tone, title: event.title, detail: event.detail, category: event.phase || 'phase', status: event.tone === 'error' ? 'error' : 'running' });
+                const idx = findMatchingPendingOperationIndex(entries, '', event.title, event.phase || 'phase');
+                const progressEntry = {
+                    kind: 'operation',
+                    id: idx >= 0 && entries[idx] && entries[idx].kind === 'operation' ? entries[idx].id : crypto.randomUUID(),
+                    tone: event.tone,
+                    title: event.title,
+                    detail: event.detail,
+                    category: event.phase || 'phase',
+                    status: event.tone === 'error' ? 'error' : 'running',
+                };
+                if (idx >= 0) entries[idx] = progressEntry;
+                else entries.push(progressEntry);
             } else if (event.type === 'compaction') {
                 const compactionEntry = { kind: 'compaction', id: crypto.randomUUID(), timestamp: Date.now(), event: event };
                 entries.push(compactionEntry);
@@ -1063,42 +1183,47 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 renderAll();
                 return;
             } else if (event.type === 'error') {
+                entries = finalizePendingOperations(entries, 'error');
                 entries.push({ kind: 'system-notice', id: crypto.randomUUID(), text: 'Error: ' + event.error, timestamp: Date.now() });
             }
             state.session.entries = entries;
             renderAll();
         }
 
-        form.addEventListener('submit', (event) => {
-            event.preventDefault();
+        function sendPrompt() {
             const text = promptInput.value.trim();
             if (!text || isRunning || !state) return;
             promptInput.value = '';
             vscode.postMessage({ type: 'agent.send', text, workflowId, nodeContext: currentNodeContext, sessionId: state.activeSessionId });
+        }
+
+        on(form, 'submit', (event) => {
+            event.preventDefault();
+            sendPrompt();
         });
 
-        promptInput.addEventListener('keydown', (event) => {
+        on(promptInput, 'keydown', (event) => {
             if (event.key === 'Enter' && !event.shiftKey) {
                 event.preventDefault();
-                form.requestSubmit();
+                sendPrompt();
             }
         });
 
-        stopButton.addEventListener('click', () => vscode.postMessage({ type: 'agent.stop' }));
-        workflowSelector.addEventListener('click', () => vscode.postMessage({ type: 'agent.workflow.select' }));
-        historyOpenButton.addEventListener('click', openHistory);
-        historyCloseButton.addEventListener('click', closeHistory);
-        historyOverlay.addEventListener('click', (event) => {
+        on(stopButton, 'click', () => vscode.postMessage({ type: 'agent.stop' }));
+        on(workflowSelector, 'click', () => vscode.postMessage({ type: 'agent.workflow.select' }));
+        on(historyOpenButton, 'click', openHistory);
+        on(historyCloseButton, 'click', closeHistory);
+        on(historyOverlay, 'click', (event) => {
             if (event.target === historyOverlay) closeHistory();
         });
-        selectModelButton.addEventListener('click', () => vscode.postMessage({ type: 'agent.selectModel' }));
-        selectReasoningButton.addEventListener('click', () => vscode.postMessage({ type: 'agent.selectReasoningEffort' }));
-        newSessionButton.addEventListener('click', () => {
+        on(selectModelButton, 'click', () => vscode.postMessage({ type: 'agent.selectModel' }));
+        on(selectReasoningButton, 'click', () => vscode.postMessage({ type: 'agent.selectReasoningEffort' }));
+        on(newSessionButton, 'click', () => {
             closeHistory();
             vscode.postMessage({ type: 'agent.session.new' });
         });
-        compactContextButton.addEventListener('click', () => state && vscode.postMessage({ type: 'agent.context.compact', sessionId: state.activeSessionId }));
-        sessionFilter.addEventListener('change', () => {
+        on(compactContextButton, 'click', () => state && vscode.postMessage({ type: 'agent.context.compact', sessionId: state.activeSessionId }));
+        on(sessionFilter, 'change', () => {
             activeFilter = sessionFilter.value || 'current';
             renderSessions();
         });
@@ -1108,6 +1233,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             if (!message || typeof message !== 'object') return;
 
             if (message.type === 'workflow.reload') {
+                vscode.postMessage({ type: 'workflow.reloadAck', workflowId, hasFrame: Boolean(frame), url: workflowReloadUrl || workflowUrl || '' });
                 reloadWorkflowFrame();
                 return;
             }

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -56,10 +56,14 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             --muted: var(--vscode-descriptionForeground, #8b949e);
             --bg: var(--vscode-editor-background, #1e1e1e);
             --panel: var(--vscode-sideBar-background, #181818);
+            --elevated: color-mix(in srgb, var(--panel) 88%, white 4%);
             --text: var(--vscode-editor-foreground, #d4d4d4);
             --accent: var(--vscode-button-background, #0e639c);
             --accent-text: var(--vscode-button-foreground, #ffffff);
             --input: var(--vscode-input-background, #2a2a2a);
+            --success: var(--vscode-testing-iconPassed, #3fb950);
+            --error: var(--vscode-errorForeground, #f85149);
+            --warning: var(--vscode-editorWarning-foreground, #d29922);
         }
         html, body {
             height: 100%;
@@ -70,91 +74,239 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             color: var(--text);
             font-family: var(--vscode-font-family, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
         }
+        * { box-sizing: border-box; }
+        button, input, select, textarea { font: inherit; }
         .workbench {
             display: grid;
-            grid-template-columns: ${hasWorkflow ? 'minmax(320px, 36%) minmax(420px, 1fr)' : 'minmax(320px, 760px)'};
-            justify-content: ${hasWorkflow ? 'stretch' : 'center'};
+            grid-template-columns: 290px ${hasWorkflow ? 'minmax(360px, .95fr) minmax(420px, 1.05fr)' : 'minmax(420px, 1fr)'};
             height: 100vh;
             width: 100vw;
+            min-width: 0;
+            min-height: 0;
+        }
+        .sidebar, .chat {
+            min-width: 0;
+            min-height: 0;
+            background: var(--panel);
+        }
+        .sidebar {
+            display: grid;
+            grid-template-rows: auto auto 1fr auto;
+            border-right: 1px solid var(--border);
         }
         .chat {
             display: grid;
-            grid-template-rows: auto 1fr auto;
+            grid-template-rows: auto auto 1fr auto;
+            border-right: ${hasWorkflow ? '1px solid var(--border)' : '0'};
+        }
+        .workflow {
+            position: relative;
             min-width: 0;
             min-height: 0;
-            border-right: 1px solid var(--border);
-            background: var(--panel);
+            background: var(--bg);
         }
-        .header {
-            padding: 14px 16px 12px;
+        .section-head, .chat-head, .composer {
+            padding: 12px 14px;
+        }
+        .section-head, .chat-head {
             border-bottom: 1px solid var(--border);
         }
-        .kicker {
-            color: var(--muted);
-            font-size: 11px;
-            letter-spacing: 0.08em;
-            text-transform: uppercase;
-            margin-bottom: 6px;
+        .sidebar-title, .chat-title {
+            font-size: 14px;
+            font-weight: 700;
         }
-        .title {
-            font-size: 15px;
-            font-weight: 650;
-            line-height: 1.35;
-        }
-        .subtitle {
-            margin-top: 6px;
+        .sidebar-subtitle, .chat-subtitle, .meta-text {
             color: var(--muted);
             font-size: 12px;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
+            line-height: 1.4;
         }
-        .header-actions {
+        .toolbar {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
             margin-top: 10px;
+        }
+        .toolbar.compact {
+            margin-top: 0;
+        }
+        .session-filters, .session-actions, .session-meta, .checkpoint-panel {
+            padding: 12px 14px;
+            border-bottom: 1px solid var(--border);
+        }
+        .session-meta, .checkpoint-panel {
+            display: grid;
+            gap: 8px;
+        }
+        .meta-grid {
+            display: grid;
+            gap: 6px;
+        }
+        .meta-row {
+            display: flex;
+            justify-content: space-between;
+            gap: 8px;
+            align-items: baseline;
+        }
+        .meta-row code {
+            color: var(--text);
+            overflow-wrap: anywhere;
+        }
+        .sessions {
+            overflow: auto;
+            min-height: 0;
+            padding: 10px;
+            display: grid;
+            gap: 8px;
+        }
+        .session-item {
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            background: color-mix(in srgb, var(--bg) 82%, transparent);
+            padding: 10px;
+            display: grid;
+            gap: 6px;
+            cursor: pointer;
+        }
+        .session-item.active {
+            border-color: color-mix(in srgb, var(--accent) 58%, var(--border));
+            box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 42%, transparent);
+        }
+        .session-item-head {
+            display: flex;
+            justify-content: space-between;
+            gap: 8px;
+            align-items: flex-start;
+        }
+        .session-item-title {
+            font-size: 13px;
+            font-weight: 650;
+            line-height: 1.35;
+            overflow-wrap: anywhere;
+        }
+        .session-item-badges {
+            display: flex;
+            gap: 6px;
+            flex-wrap: wrap;
+            justify-content: flex-end;
+        }
+        .badge {
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            padding: 2px 7px;
+            font-size: 11px;
+            color: var(--muted);
+        }
+        .badge.active {
+            color: var(--accent-text);
+            background: var(--accent);
+            border-color: var(--accent);
+        }
+        .badge.error {
+            color: var(--error);
+            border-color: color-mix(in srgb, var(--error) 55%, var(--border));
+        }
+        .badge.success {
+            color: var(--success);
+            border-color: color-mix(in srgb, var(--success) 55%, var(--border));
+        }
+        .session-item-foot {
+            display: flex;
+            justify-content: space-between;
+            gap: 8px;
+            color: var(--muted);
+            font-size: 11px;
+        }
+        .chat-head {
+            display: grid;
+            gap: 10px;
+        }
+        .chat-head-row {
+            display: flex;
+            justify-content: space-between;
+            gap: 12px;
+            align-items: flex-start;
+        }
+        .chat-meta {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+            align-items: center;
         }
         .feed {
             overflow: auto;
             min-height: 0;
             padding: 14px;
+            display: grid;
+            gap: 10px;
+            align-content: start;
         }
-        .message, .operation {
+        .entry {
             border: 1px solid var(--border);
-            border-radius: 10px;
+            border-radius: 12px;
+            background: color-mix(in srgb, var(--bg) 84%, transparent);
             padding: 10px 11px;
-            margin-bottom: 10px;
-            background: color-mix(in srgb, var(--bg) 78%, transparent);
             white-space: pre-wrap;
             line-height: 1.45;
             font-size: 13px;
+            overflow-wrap: anywhere;
         }
-        .message.user {
-            border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+        .entry.user { border-color: color-mix(in srgb, var(--accent) 55%, var(--border)); }
+        .entry.system { color: var(--muted); }
+        .entry.assistant.streaming { box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent); }
+        .entry.operation, .entry.compaction, .entry.context { background: color-mix(in srgb, var(--elevated) 90%, transparent); }
+        .entry-head {
+            display: flex;
+            justify-content: space-between;
+            gap: 10px;
+            align-items: center;
+            margin-bottom: 6px;
         }
-        .role {
+        .entry-title {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+            font-weight: 650;
+        }
+        .entry-subtle {
             color: var(--muted);
             font-size: 11px;
-            font-weight: 700;
-            letter-spacing: 0.06em;
-            margin-bottom: 5px;
-            text-transform: uppercase;
         }
-        .operation {
+        .entry-status {
+            color: var(--muted);
+            font-size: 11px;
+        }
+        .entry-status.running { color: var(--warning); }
+        .entry-status.done { color: var(--success); }
+        .entry-status.error { color: var(--error); }
+        .details {
+            margin-top: 8px;
+            border-top: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
+            padding-top: 8px;
+        }
+        .details summary {
+            cursor: pointer;
             color: var(--muted);
             font-size: 12px;
         }
-        .operation.running { border-color: var(--accent); }
-        .operation.error { border-color: var(--vscode-errorForeground, #f85149); color: var(--vscode-errorForeground, #f85149); }
+        .details-body {
+            margin-top: 8px;
+            padding: 8px;
+            border-radius: 8px;
+            background: color-mix(in srgb, var(--bg) 76%, transparent);
+            white-space: pre-wrap;
+            font-family: var(--vscode-editor-font-family, var(--vscode-font-family, monospace));
+            font-size: 12px;
+        }
         .composer {
             display: grid;
             grid-template-columns: 1fr auto;
             gap: 8px;
-            padding: 12px;
             border-top: 1px solid var(--border);
             background: var(--panel);
         }
         .composer-input {
             display: grid;
-            gap: 6px;
+            gap: 8px;
             min-width: 0;
         }
         .composer-meta {
@@ -162,7 +314,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             gap: 8px;
             align-items: center;
             flex-wrap: wrap;
-            min-width: 0;
         }
         .node-context-badge {
             display: none;
@@ -179,37 +330,26 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             text-overflow: ellipsis;
             white-space: nowrap;
         }
-        .provider-model-button {
-            border: 1px solid var(--vscode-button-secondaryBackground, #3a3d41);
-            border-radius: 999px;
-            padding: 4px 9px;
-            color: var(--vscode-button-secondaryForeground, var(--text));
-            background: var(--vscode-button-secondaryBackground, #3a3d41);
-            font: inherit;
-            font-size: 12px;
-            cursor: pointer;
-            max-width: 100%;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
+        .composer-actions {
+            display: grid;
+            gap: 8px;
+            align-content: end;
         }
-        textarea {
-            resize: none;
-            min-height: 42px;
-            max-height: 140px;
+        textarea, input[type="text"], select {
+            width: 100%;
+            min-height: 36px;
             border: 1px solid var(--vscode-input-border, transparent);
             border-radius: 8px;
             background: var(--input);
             color: var(--text);
             padding: 9px 10px;
-            font: inherit;
-            line-height: 1.35;
             outline: none;
         }
-        .actions {
-            display: grid;
-            gap: 8px;
-            align-content: end;
+        textarea {
+            resize: none;
+            min-height: 46px;
+            max-height: 160px;
+            line-height: 1.4;
         }
         button {
             border: none;
@@ -218,22 +358,30 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             color: var(--accent-text);
             background: var(--accent);
             cursor: pointer;
-            font: inherit;
-            font-size: 12px;
         }
         button.secondary {
             color: var(--vscode-button-secondaryForeground, var(--text));
             background: var(--vscode-button-secondaryBackground, #3a3d41);
         }
+        button.ghost {
+            color: var(--muted);
+            background: transparent;
+            border: 1px solid var(--border);
+        }
+        button.small {
+            padding: 5px 8px;
+            font-size: 12px;
+            min-height: 30px;
+        }
         button:disabled {
             cursor: not-allowed;
-            opacity: 0.55;
+            opacity: .55;
         }
-        .workflow {
-            position: relative;
-            min-width: 0;
-            min-height: 0;
-            background: var(--bg);
+        .session-item {
+            color: var(--text);
+            text-align: left;
+            background: color-mix(in srgb, var(--bg) 82%, transparent);
+            border: 1px solid var(--border);
         }
         iframe {
             position: absolute;
@@ -264,35 +412,97 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             font-size: 12px;
             box-shadow: 0 2px 12px rgba(0, 0, 0, 0.35);
         }
-        @media (max-width: 860px) {
+        .empty-note {
+            color: var(--muted);
+            font-size: 12px;
+            line-height: 1.5;
+            padding: 12px 14px;
+        }
+        @media (max-width: 1200px) {
             .workbench {
-                grid-template-columns: 1fr;
-                grid-template-rows: minmax(280px, 45%) 1fr;
+                grid-template-columns: 280px 1fr;
+                grid-template-rows: ${hasWorkflow ? 'minmax(360px, 48%) 1fr' : '1fr'};
             }
             .chat {
                 border-right: 0;
+            }
+            .workflow {
+                grid-column: 1 / -1;
+                border-top: 1px solid var(--border);
+            }
+        }
+        @media (max-width: 900px) {
+            .workbench {
+                grid-template-columns: 1fr;
+                grid-template-rows: auto auto ${hasWorkflow ? 'minmax(280px, 42%)' : ''};
+            }
+            .sidebar, .chat {
+                border-right: 0;
                 border-bottom: 1px solid var(--border);
+            }
+            .composer {
+                grid-template-columns: 1fr;
             }
         }
     </style>
 </head>
 <body>
     <main class="workbench">
+        <aside class="sidebar" aria-label="Agent sessions">
+            <div class="section-head">
+                <div class="sidebar-title">Sessions</div>
+                <div class="sidebar-subtitle">Persisted Yagr-backed conversations, checkpoints, and workflow attachment.</div>
+                <div class="toolbar compact">
+                    <button id="new-session" class="small">New session</button>
+                </div>
+            </div>
+            <div class="session-filters">
+                <div class="meta-text">Filter</div>
+                <select id="session-filter">
+                    <option value="current">Current workflow</option>
+                    <option value="all">All sessions</option>
+                    <option value="unattached">Unattached</option>
+                </select>
+            </div>
+            <div id="session-list" class="sessions"></div>
+            <div class="checkpoint-panel">
+                <div class="meta-grid" id="session-meta"></div>
+                <div class="toolbar compact">
+                    <button id="rename-session" class="secondary small" type="button">Rename</button>
+                    <button id="attach-session" class="secondary small" type="button">Attach</button>
+                    <button id="detach-session" class="secondary small" type="button">Detach</button>
+                    <button id="delete-session" class="ghost small" type="button">Delete</button>
+                </div>
+                <div class="meta-text">Checkpoints</div>
+                <div class="toolbar compact">
+                    <button id="save-checkpoint" class="secondary small" type="button">Save checkpoint</button>
+                </div>
+                <div id="checkpoint-list" class="meta-grid"></div>
+            </div>
+        </aside>
         <section class="chat" aria-label="Agent chat">
-            <header class="header">
-                <div class="title">Workflow Architect</div>
-                <div class="subtitle" title="${safeWorkflowName}">${safeWorkflowName}${safeWorkflowId ? ` · ${safeWorkflowId}` : ' · new workflow chat'}</div>
+            <header class="chat-head">
+                <div class="chat-head-row">
+                    <div>
+                        <div class="chat-title">Workflow Architect</div>
+                        <div id="chat-subtitle" class="chat-subtitle" title="${safeWorkflowName}">${safeWorkflowName}${safeWorkflowId ? ` · ${safeWorkflowId}` : ' · new workflow chat'}</div>
+                    </div>
+                    <div class="toolbar compact">
+                        <button id="select-model" class="secondary small" type="button" title="${safeProviderModelLabel}">${safeProviderModelLabel}</button>
+                        <button id="select-reasoning" class="secondary small" type="button">Reasoning</button>
+                    </div>
+                </div>
+                <div id="chat-meta" class="chat-meta"></div>
             </header>
             <div id="feed" class="feed"></div>
             <form id="composer" class="composer">
                 <div class="composer-input">
                     <div class="composer-meta">
                         <div id="node-context-badge" class="node-context-badge" title=""></div>
-                        <button id="select-model" class="provider-model-button" type="button" title="${safeProviderModelLabel}">${safeProviderModelLabel}</button>
                     </div>
                     <textarea id="prompt" placeholder="Ask the n8n agent what to do with this workflow..." rows="2"></textarea>
                 </div>
-                <div class="actions">
+                <div class="composer-actions">
                     <button id="send" type="submit">Send</button>
                     <button id="stop" class="secondary" type="button" disabled>Stop</button>
                 </div>
@@ -319,8 +529,20 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         let lastPasteMs = 0;
         const pendingGrants = new Map();
         let isRunning = false;
-        let activeAssistantMessage = null;
         let currentNodeContext = null;
+        let activeFilter = 'current';
+        let state = null;
+
+        const OP_ICONS = {
+            'file-read': 'Read',
+            'file-write': 'Write',
+            shell: 'Shell',
+            web: 'Web',
+            tool: 'Tool',
+            agent: 'Agent',
+            phase: 'Phase',
+            thinking: 'Thinking'
+        };
 
         const feed = document.getElementById('feed');
         const form = document.getElementById('composer');
@@ -328,36 +550,49 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const sendButton = document.getElementById('send');
         const stopButton = document.getElementById('stop');
         const selectModelButton = document.getElementById('select-model');
+        const selectReasoningButton = document.getElementById('select-reasoning');
         const frame = document.getElementById('workflow-frame');
         const refreshPill = document.getElementById('refresh-pill');
         const nodeContextBadge = document.getElementById('node-context-badge');
-
-        function appendMessage(role, content) {
-            const el = document.createElement('div');
-            el.className = 'message ' + role;
-            const label = document.createElement('div');
-            label.className = 'role';
-            label.textContent = role;
-            const body = document.createElement('div');
-            body.textContent = content || '';
-            el.append(label, body);
-            feed.appendChild(el);
-            feed.scrollTop = feed.scrollHeight;
-            return body;
-        }
-
-        function appendOperation(label, status, detail) {
-            const el = document.createElement('div');
-            el.className = 'operation ' + status;
-            el.textContent = detail ? label + ': ' + detail : label;
-            feed.appendChild(el);
-            feed.scrollTop = feed.scrollHeight;
-        }
+        const sessionList = document.getElementById('session-list');
+        const sessionFilter = document.getElementById('session-filter');
+        const sessionMeta = document.getElementById('session-meta');
+        const checkpointList = document.getElementById('checkpoint-list');
+        const chatSubtitle = document.getElementById('chat-subtitle');
+        const chatMeta = document.getElementById('chat-meta');
+        const newSessionButton = document.getElementById('new-session');
+        const renameSessionButton = document.getElementById('rename-session');
+        const attachSessionButton = document.getElementById('attach-session');
+        const detachSessionButton = document.getElementById('detach-session');
+        const deleteSessionButton = document.getElementById('delete-session');
+        const saveCheckpointButton = document.getElementById('save-checkpoint');
 
         function setRunning(running) {
             isRunning = running;
             sendButton.disabled = running;
             stopButton.disabled = !running;
+            newSessionButton.disabled = running;
+            renameSessionButton.disabled = running;
+            attachSessionButton.disabled = running;
+            detachSessionButton.disabled = running;
+            deleteSessionButton.disabled = running;
+            saveCheckpointButton.disabled = running;
+        }
+
+        function escapeText(value) {
+            return value == null ? '' : String(value);
+        }
+
+        function escapeHtml(value) {
+            return escapeText(value)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;');
+        }
+
+        function formatDate(value) {
+            try { return new Date(value).toLocaleString(); } catch (e) { return String(value || ''); }
         }
 
         function sanitizeNodeContext(value) {
@@ -423,14 +658,323 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             return true;
         }
 
+        function filteredSessions() {
+            const sessions = (state && state.sessions) || [];
+            if (activeFilter === 'all') return sessions;
+            if (activeFilter === 'unattached') return sessions.filter((session) => !session.workflowId);
+            return sessions.filter((session) => {
+                if (!workflowId) return !session.workflowId;
+                return session.workflowId === workflowId;
+            });
+        }
+
+        function getActiveSession() {
+            return state && state.session ? state.session : null;
+        }
+
+        function renderSessions() {
+            sessionList.innerHTML = '';
+            const sessions = filteredSessions();
+            if (!sessions.length) {
+                const empty = document.createElement('div');
+                empty.className = 'empty-note';
+                empty.textContent = activeFilter === 'all'
+                    ? 'No sessions yet.'
+                    : activeFilter === 'unattached'
+                        ? 'No unattached sessions.'
+                        : 'No sessions for this workflow yet.';
+                sessionList.appendChild(empty);
+                return;
+            }
+
+            for (const session of sessions) {
+                const item = document.createElement('button');
+                item.type = 'button';
+                item.className = 'session-item' + (session.isActive ? ' active' : '');
+                item.addEventListener('click', () => vscode.postMessage({ type: 'agent.session.select', sessionId: session.id }));
+
+                const head = document.createElement('div');
+                head.className = 'session-item-head';
+                const title = document.createElement('div');
+                title.className = 'session-item-title';
+                title.textContent = session.title;
+
+                const badges = document.createElement('div');
+                badges.className = 'session-item-badges';
+                if (session.isActive) badges.appendChild(badge('Active', 'active'));
+                if (session.checkpointCount) badges.appendChild(badge(session.checkpointCount + ' cp', 'success'));
+                if (session.totalCompactions) badges.appendChild(badge(session.totalCompactions + ' compact', ''));
+                head.append(title, badges);
+
+                const foot = document.createElement('div');
+                foot.className = 'session-item-foot';
+                const attachment = document.createElement('span');
+                attachment.textContent = session.workflowLabel;
+                const updated = document.createElement('span');
+                updated.textContent = formatDate(session.updatedAt);
+                foot.append(attachment, updated);
+
+                item.append(head, foot);
+                sessionList.appendChild(item);
+            }
+        }
+
+        function badge(text, klass) {
+            const el = document.createElement('span');
+            el.className = 'badge' + (klass ? ' ' + klass : '');
+            el.textContent = text;
+            return el;
+        }
+
+        function renderMeta() {
+            sessionMeta.innerHTML = '';
+            checkpointList.innerHTML = '';
+            if (!state || !state.session) {
+                sessionMeta.textContent = '';
+                return;
+            }
+
+            const session = state.session;
+            const rows = [
+                ['Session', session.title],
+                ['Attached', session.workflowLabel],
+                ['Checkpoints', String(session.checkpoints.length)],
+                ['Compactions', String(session.totalCompactions)],
+                ['Context', session.contextUsage ? session.contextUsage.fillPercent + '% of ' + session.contextUsage.contextWindowTokens + ' tokens' : 'No estimate yet'],
+            ];
+            for (const [label, value] of rows) {
+                const row = document.createElement('div');
+                row.className = 'meta-row';
+                const left = document.createElement('span');
+                left.className = 'meta-text';
+                left.textContent = label;
+                const right = document.createElement('code');
+                right.textContent = value;
+                row.append(left, right);
+                sessionMeta.appendChild(row);
+            }
+
+            if (!session.checkpoints.length) {
+                const empty = document.createElement('div');
+                empty.className = 'meta-text';
+                empty.textContent = 'No checkpoints saved for this session.';
+                checkpointList.appendChild(empty);
+            } else {
+                for (const checkpoint of session.checkpoints) {
+                    const row = document.createElement('div');
+                    row.className = 'session-item';
+                    const head = document.createElement('div');
+                    head.className = 'session-item-head';
+                    const title = document.createElement('div');
+                    title.className = 'session-item-title';
+                    title.textContent = checkpoint.id;
+                    const summary = document.createElement('div');
+                    summary.className = 'session-item-foot';
+                    const left = document.createElement('span');
+                    left.textContent = checkpoint.messageCount + ' msgs';
+                    const right = document.createElement('span');
+                    right.textContent = formatDate(checkpoint.createdAt);
+                    summary.append(left, right);
+                    head.append(title);
+                    row.append(head, summary);
+
+                    const actions = document.createElement('div');
+                    actions.className = 'toolbar compact';
+                    const restore = document.createElement('button');
+                    restore.className = 'secondary small';
+                    restore.type = 'button';
+                    restore.textContent = 'Restore';
+                    restore.disabled = isRunning;
+                    restore.addEventListener('click', () => vscode.postMessage({ type: 'agent.checkpoint.restore', sessionId: session.sessionId, checkpointId: checkpoint.id }));
+                    const del = document.createElement('button');
+                    del.className = 'ghost small';
+                    del.type = 'button';
+                    del.textContent = 'Delete';
+                    del.disabled = isRunning;
+                    del.addEventListener('click', () => vscode.postMessage({ type: 'agent.checkpoint.delete', sessionId: session.sessionId, checkpointId: checkpoint.id }));
+                    actions.append(restore, del);
+                    row.append(actions);
+                    checkpointList.appendChild(row);
+                }
+            }
+
+            attachSessionButton.disabled = isRunning || !workflowId || session.workflowId === workflowId;
+            detachSessionButton.disabled = isRunning || !session.workflowId;
+        }
+
+        function renderChatMeta() {
+            chatMeta.innerHTML = '';
+            if (!state) return;
+            const bits = [];
+            bits.push(badge((state.provider || 'provider') + (state.model ? ' / ' + state.model : ''), ''));
+            if (state.reasoningEffort) bits.push(badge('Reasoning ' + state.reasoningEffort, ''));
+            if (state.session && state.session.workflowLabel) bits.push(badge(state.session.workflowLabel, ''));
+            if (state.session && state.session.lastCompaction) bits.push(badge('Compacted', 'success'));
+            bits.forEach((el) => chatMeta.appendChild(el));
+            selectReasoningButton.style.display = state.supportsReasoningEffort ? 'inline-block' : 'none';
+        }
+
+        function renderFeed() {
+            feed.innerHTML = '';
+            if (!state || !state.session || !state.session.entries.length) {
+                const empty = document.createElement('div');
+                empty.className = 'entry system';
+                empty.textContent = 'Ask for a workflow inspection, create a new session, or attach a saved conversation to this workflow.';
+                feed.appendChild(empty);
+                return;
+            }
+            for (const entry of state.session.entries) {
+                feed.appendChild(renderEntry(entry));
+            }
+            feed.scrollTop = feed.scrollHeight;
+        }
+
+        function renderEntry(entry) {
+            if (entry.kind === 'user-message') {
+                return textEntry('user', entry.text);
+            }
+            if (entry.kind === 'system-notice') {
+                return textEntry('system', entry.text);
+            }
+            if (entry.kind === 'assistant-body') {
+                return textEntry('assistant' + (entry.streaming ? ' streaming' : ''), entry.text || '');
+            }
+            if (entry.kind === 'context-usage') {
+                const el = document.createElement('div');
+                el.className = 'entry context';
+                el.innerHTML = '<div class="entry-head"><div class="entry-title">Context usage</div><div class="entry-subtle">' + escapeHtml(entry.usage.source) + '</div></div>' +
+                    '<div>' + escapeHtml(entry.usage.fillPercent + '% of ' + entry.usage.contextWindowTokens + ' tokens · prompt ' + entry.usage.promptTokens + ' · completion ' + entry.usage.completionTokens) + '</div>';
+                return el;
+            }
+            if (entry.kind === 'compaction') {
+                const el = document.createElement('div');
+                el.className = 'entry compaction';
+                const details = document.createElement('details');
+                details.className = 'details';
+                details.innerHTML = '<summary>Show compaction details</summary>' +
+                    '<div class="details-body">' +
+                    'Source: ' + escapeHtml(entry.event.source) + '\n' +
+                    'Messages compacted: ' + escapeHtml(entry.event.messagesCompacted) + '\n' +
+                    'Preserved recent messages: ' + escapeHtml(entry.event.preservedRecentMessages) +
+                    (entry.event.estimatedTokens ? '\nEstimated tokens: ' + escapeHtml(entry.event.estimatedTokens) : '') +
+                    (entry.event.thresholdTokens ? '\nThreshold tokens: ' + escapeHtml(entry.event.thresholdTokens) : '') +
+                    (entry.event.fallbackReason ? '\nFallback reason: ' + escapeHtml(entry.event.fallbackReason) : '') +
+                    '</div>';
+                el.innerHTML = '<div class="entry-head"><div class="entry-title">Context compacted</div><div class="entry-subtle">' + escapeHtml(new Date(entry.timestamp).toLocaleTimeString()) + '</div></div><div>' + escapeHtml(entry.event.summary) + '</div>';
+                el.appendChild(details);
+                return el;
+            }
+            if (entry.kind === 'operation') {
+                const el = document.createElement('div');
+                el.className = 'entry operation';
+                const icon = OP_ICONS[entry.category || 'tool'] || 'Tool';
+                const statusClass = entry.status ? ' ' + entry.status : '';
+                el.innerHTML = '<div class="entry-head">' +
+                    '<div class="entry-title"><span>' + escapeHtml(icon) + '</span><span>' + escapeHtml(entry.title || 'Operation') + '</span></div>' +
+                    '<div class="entry-status' + escapeHtml(statusClass) + '">' + escapeHtml(entry.status || entry.tone || '') + '</div>' +
+                    '</div>' +
+                    (entry.detail ? '<div>' + escapeHtml(entry.detail) + '</div>' : '');
+                if (entry.body || entry.summary) {
+                    const details = document.createElement('details');
+                    details.className = 'details';
+                    details.innerHTML = '<summary>Show details</summary><div class="details-body">' + escapeHtml(entry.body || entry.summary || '') + '</div>';
+                    el.appendChild(details);
+                }
+                return el;
+            }
+            return textEntry('system', 'Unsupported entry');
+        }
+
+        function textEntry(kind, text) {
+            const el = document.createElement('div');
+            el.className = 'entry ' + kind;
+            el.textContent = text || '';
+            return el;
+        }
+
+        function renderAll() {
+            renderSessions();
+            renderMeta();
+            renderChatMeta();
+            renderFeed();
+            if (state && state.workflow) {
+                chatSubtitle.textContent = state.workflow.name
+                    ? state.workflow.name + (state.workflow.id ? ' · ' + state.workflow.id : '')
+                    : 'New workflow chat';
+            }
+        }
+
+        function applyStreamEvent(event) {
+            if (!state || !state.session) return;
+            const entries = Array.isArray(state.session.entries) ? [...state.session.entries] : [];
+            if (event.type === 'start') {
+                state.activeSessionId = event.sessionId;
+            } else if (event.type === 'text-delta') {
+                const last = entries[entries.length - 1];
+                if (last && last.kind === 'assistant-body' && last.streaming) {
+                    last.text += event.delta || '';
+                } else {
+                    entries.push({ kind: 'assistant-body', id: crypto.randomUUID(), text: event.delta || '', streaming: true });
+                }
+            } else if (event.type === 'final') {
+                const last = entries[entries.length - 1];
+                if (last && last.kind === 'assistant-body') {
+                    last.streaming = false;
+                    last.finalState = event.finalState;
+                    if (!last.text) last.text = event.response || '';
+                } else {
+                    entries.push({ kind: 'assistant-body', id: crypto.randomUUID(), text: event.response || '', streaming: false, finalState: event.finalState });
+                }
+            } else if (event.type === 'operation') {
+                const idx = entries.findIndex((entry) => entry.kind === 'operation' && entry.id === event.operationId);
+                const opEntry = {
+                    kind: 'operation',
+                    id: event.operationId,
+                    tone: event.status === 'error' ? 'error' : event.status === 'done' ? 'success' : 'info',
+                    title: event.label,
+                    detail: event.summary,
+                    category: event.category,
+                    status: event.status,
+                    body: event.body,
+                    summary: event.summary,
+                    startedAt: event.startedAt,
+                    endedAt: event.endedAt,
+                };
+                if (idx >= 0) entries[idx] = opEntry;
+                else entries.push(opEntry);
+            } else if (event.type === 'progress') {
+                entries.push({ kind: 'operation', id: crypto.randomUUID(), tone: event.tone, title: event.title, detail: event.detail, category: event.phase || 'phase', status: event.tone === 'error' ? 'error' : 'running' });
+            } else if (event.type === 'compaction') {
+                const compactionEntry = { kind: 'compaction', id: crypto.randomUUID(), timestamp: Date.now(), event: event };
+                entries.push(compactionEntry);
+                state.session.lastCompaction = event;
+                state.session.totalCompactions = (state.session.totalCompactions || 0) + 1;
+            } else if (event.type === 'context-usage') {
+                state.session.contextUsage = {
+                    promptTokens: event.promptTokens,
+                    completionTokens: event.completionTokens,
+                    contextWindowTokens: event.contextWindowTokens,
+                    fillPercent: event.fillPercent,
+                    source: event.source,
+                };
+                const filtered = entries.filter((entry) => entry.kind !== 'context-usage');
+                filtered.push({ kind: 'context-usage', id: crypto.randomUUID(), timestamp: Date.now(), usage: state.session.contextUsage });
+                state.session.entries = filtered;
+                renderAll();
+                return;
+            } else if (event.type === 'error') {
+                entries.push({ kind: 'system-notice', id: crypto.randomUUID(), text: 'Error: ' + event.error, timestamp: Date.now() });
+            }
+            state.session.entries = entries;
+            renderAll();
+        }
+
         form.addEventListener('submit', (event) => {
             event.preventDefault();
             const text = promptInput.value.trim();
-            if (!text || isRunning) return;
+            if (!text || isRunning || !state) return;
             promptInput.value = '';
-            activeAssistantMessage = null;
-            appendMessage('user', text);
-            vscode.postMessage({ type: 'agent.send', text, workflowId, nodeContext: currentNodeContext });
+            vscode.postMessage({ type: 'agent.send', text, workflowId, nodeContext: currentNodeContext, sessionId: state.activeSessionId });
         });
 
         promptInput.addEventListener('keydown', (event) => {
@@ -440,12 +984,30 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             }
         });
 
-        stopButton.addEventListener('click', () => {
-            vscode.postMessage({ type: 'agent.stop' });
+        stopButton.addEventListener('click', () => vscode.postMessage({ type: 'agent.stop' }));
+        selectModelButton.addEventListener('click', () => vscode.postMessage({ type: 'agent.selectModel' }));
+        selectReasoningButton.addEventListener('click', () => vscode.postMessage({ type: 'agent.selectReasoningEffort' }));
+        newSessionButton.addEventListener('click', () => vscode.postMessage({ type: 'agent.session.new' }));
+        saveCheckpointButton.addEventListener('click', () => state && vscode.postMessage({ type: 'agent.checkpoint.save', sessionId: state.activeSessionId }));
+        renameSessionButton.addEventListener('click', () => {
+            if (!state || !state.session) return;
+            const title = window.prompt('Rename session', state.session.title);
+            if (typeof title === 'string' && title.trim()) {
+                vscode.postMessage({ type: 'agent.session.rename', sessionId: state.activeSessionId, title: title.trim() });
+            }
         });
-
-        selectModelButton.addEventListener('click', () => {
-            vscode.postMessage({ type: 'agent.selectModel' });
+        attachSessionButton.addEventListener('click', () => state && vscode.postMessage({ type: 'agent.session.attach', sessionId: state.activeSessionId }));
+        detachSessionButton.addEventListener('click', () => state && vscode.postMessage({ type: 'agent.session.detach', sessionId: state.activeSessionId }));
+        deleteSessionButton.addEventListener('click', () => {
+            if (!state || !state.session) return;
+            const confirmed = window.confirm('Delete session "' + state.session.title + '"?');
+            if (confirmed) {
+                vscode.postMessage({ type: 'agent.session.delete', sessionId: state.activeSessionId });
+            }
+        });
+        sessionFilter.addEventListener('change', () => {
+            activeFilter = sessionFilter.value || 'current';
+            renderSessions();
         });
 
         window.addEventListener('message', (event) => {
@@ -518,35 +1080,22 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 return;
             }
 
-            if (message.type === 'agent.message') {
-                activeAssistantMessage = appendMessage(message.role || 'assistant', message.content || '');
-                return;
-            }
-
-            if (message.type === 'agent.delta') {
-                if (!activeAssistantMessage) {
-                    activeAssistantMessage = appendMessage('assistant', '');
+            if (message.type === 'agent.state') {
+                state = message.state || null;
+                if (state && state.currentNodeContext) {
+                    updateNodeContextBadge(state.currentNodeContext);
                 }
-                activeAssistantMessage.textContent += message.content || '';
-                feed.scrollTop = feed.scrollHeight;
+                renderAll();
                 return;
             }
 
-            if (message.type === 'agent.operation') {
-                appendOperation(message.label || 'Operation', message.status || 'running', message.detail || '');
-                return;
-            }
-
-            if (message.type === 'agent.error') {
-                appendOperation('Error', 'error', message.message || 'Unknown error');
-                return;
-            }
-
-            if (message.type === 'agent.done') {
-                setRunning(false);
+            if (message.type === 'agent.streamEvent') {
+                applyStreamEvent(message.event || {});
                 return;
             }
         });
+
+        vscode.postMessage({ type: 'agent.ready' });
     </script>
 </body>
 </html>`;

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -1,6 +1,7 @@
 export interface AgentWorkbenchHtmlInput {
     workflowId: string;
     workflowName: string;
+    workflowAttached?: boolean;
     workflowUrl?: string;
     workflowReloadUrl?: string;
     providerModelLabel: string;
@@ -25,10 +26,11 @@ function getNonce(): string {
 
 export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string {
     const nonce = getNonce();
-    const hasWorkflow = Boolean(input.workflowUrl);
+    const hasWorkflow = Boolean(input.workflowAttached || input.workflowUrl);
+    const hasWorkflowUi = Boolean(input.workflowUrl);
     const safeWorkflowName = escapeHtml(input.workflowName);
     const safeWorkflowId = escapeHtml(input.workflowId);
-    const initialWorkflowLabel = hasWorkflow ? safeWorkflowName : 'New workflow chat';
+    const initialWorkflowLabel = hasWorkflow ? safeWorkflowName : 'No workflow context';
     const safeWorkflowUrl = escapeHtml(input.workflowUrl || '');
     const safeProviderModelLabel = escapeHtml(input.providerModelLabel);
     const workflowIdJs = JSON.stringify(input.workflowId);
@@ -459,8 +461,17 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             flex-wrap: wrap;
             min-width: 0;
         }
-        .node-context-badge {
-            display: none;
+        .context-badges {
+            display: flex;
+            gap: 6px;
+            align-items: center;
+            flex-wrap: wrap;
+            min-width: 0;
+        }
+        .context-badge {
+            display: inline-flex;
+            gap: 6px;
+            align-items: center;
             width: fit-content;
             max-width: 100%;
             padding: 3px 8px;
@@ -474,6 +485,42 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             text-overflow: ellipsis;
             white-space: nowrap;
         }
+        .context-badge.workflow {
+            border-color: color-mix(in srgb, var(--warning) 60%, var(--border));
+            color: var(--text);
+            background: color-mix(in srgb, var(--warning) 30%, transparent);
+        }
+        .context-badge button {
+            border: 0;
+            background: transparent;
+            color: inherit;
+            cursor: pointer;
+            padding: 0 1px;
+            line-height: 1;
+        }
+        .mention-menu {
+            display: none;
+            max-height: 220px;
+            overflow: auto;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: color-mix(in srgb, var(--panel) 96%, black 4%);
+            box-shadow: 0 10px 28px rgba(0, 0, 0, .32);
+        }
+        .mention-menu.open { display: grid; }
+        .mention-option {
+            display: grid;
+            gap: 2px;
+            padding: 8px 10px;
+            border: 0;
+            border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+            background: transparent;
+            color: var(--text);
+            text-align: left;
+            cursor: pointer;
+        }
+        .mention-option:hover { background: color-mix(in srgb, var(--accent) 18%, transparent); }
+        .mention-option small { color: var(--muted); }
         .composer-actions {
             display: flex;
             gap: 8px;
@@ -521,6 +568,23 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             padding: 5px 8px;
             font-size: 12px;
             min-height: 30px;
+        }
+        button.icon-button {
+            display: inline-grid;
+            place-items: center;
+            width: 30px;
+            min-width: 30px;
+            height: 30px;
+            padding: 0;
+        }
+        button.icon-button svg {
+            width: 15px;
+            height: 15px;
+            stroke: currentColor;
+            fill: none;
+            stroke-width: 1.8;
+            stroke-linecap: round;
+            stroke-linejoin: round;
         }
         .composer button.small,
         .composer .send-button,
@@ -618,10 +682,11 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 <div class="chat-head-row">
                     <div class="chat-head-main">
                         <div class="chat-title">Workflow Architect</div>
-                        <button id="workflow-selector" class="workflow-selector" type="button" title="${initialWorkflowLabel}">${initialWorkflowLabel}${safeWorkflowId ? ` · ${safeWorkflowId}` : ''}</button>
+                        <div id="workflow-subtitle" class="workflow-selector" title="${initialWorkflowLabel}">${initialWorkflowLabel}${safeWorkflowId ? ` · ${safeWorkflowId}` : ''}</div>
                     </div>
                     <div class="header-actions">
-                        <button id="history-open" class="ghost small" type="button" title="Conversation history">History</button>
+                        <button id="new-session-header" class="ghost small icon-button" type="button" title="New conversation" aria-label="New conversation"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 3v10M3 8h10"/><path d="M2.5 2.5h3M10.5 2.5h3v3M13.5 10.5v3h-3M5.5 13.5h-3v-3"/></svg></button>
+                        <button id="history-open" class="ghost small icon-button" type="button" title="Conversation history" aria-label="Conversation history"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M3 4.5h10M3 8h10M3 11.5h7"/><path d="M2 2.5h12v11H2z"/></svg></button>
                         <div id="context-pill" class="context-pill" title="Context usage">
                             <span id="context-label">Context</span>
                             <span class="context-meter" aria-hidden="true"><span id="context-meter-fill" class="context-meter-fill"></span></span>
@@ -636,9 +701,8 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             <div id="feed" class="feed"></div>
             <form id="composer" class="composer">
                 <div class="composer-input">
-                    <div class="composer-meta">
-                        <div id="node-context-badge" class="node-context-badge" title=""></div>
-                    </div>
+                    <div id="context-badges" class="context-badges"></div>
+                    <div id="mention-menu" class="mention-menu"></div>
                     <textarea id="prompt" placeholder="Ask the n8n agent what to do with this workflow..." rows="2"></textarea>
                     <div class="composer-toolbar">
                         <div class="composer-provider">
@@ -655,12 +719,12 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         </section>
         ${hasWorkflow ? `<section class="workflow" aria-label="n8n workflow">
             <div id="refresh-pill" class="refresh-pill">Refreshing n8n...</div>
-            <iframe
+            ${hasWorkflowUi ? `<iframe
                 id="workflow-frame"
                 src="${safeWorkflowUrl}"
                 sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals allow-downloads allow-top-navigation allow-top-navigation-by-user-activation"
                 allow="${iframeAllowPolicy}">
-            </iframe>
+            </iframe>` : `<div class="empty-workflow"><div><strong>Workflow UI unavailable</strong><br>Push this workflow to n8n to preview and interact with its UI here.</div></div>`}
         </section>` : ''}
         <div id="history-overlay" class="history-overlay" role="dialog" aria-modal="true" aria-label="Conversation history">
             <div class="history-modal">
@@ -696,7 +760,8 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         let lastPasteMs = 0;
         const pendingGrants = new Map();
         let isRunning = false;
-        let currentNodeContext = null;
+        let currentWorkflowContext = null;
+        let currentNodeContexts = [];
         let activeFilter = 'current';
         let state = null;
 
@@ -720,14 +785,16 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const selectReasoningButton = document.getElementById('select-reasoning');
         const frame = document.getElementById('workflow-frame');
         const refreshPill = document.getElementById('refresh-pill');
-        const nodeContextBadge = document.getElementById('node-context-badge');
+        const contextBadges = document.getElementById('context-badges');
+        const mentionMenu = document.getElementById('mention-menu');
         const sessionList = document.getElementById('session-list');
         const sessionFilter = document.getElementById('session-filter');
-        const workflowSelector = document.getElementById('workflow-selector');
+        const workflowSubtitle = document.getElementById('workflow-subtitle');
         const contextPill = document.getElementById('context-pill');
         const contextLabel = document.getElementById('context-label');
         const contextMeterFill = document.getElementById('context-meter-fill');
         const newSessionButton = document.getElementById('new-session');
+        const newSessionHeaderButton = document.getElementById('new-session-header');
         const historyOpenButton = document.getElementById('history-open');
         const historyCloseButton = document.getElementById('history-close');
         const historyOverlay = document.getElementById('history-overlay');
@@ -744,6 +811,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             stopButton.disabled = !running;
             stopButton.classList.toggle('active', running);
             newSessionButton.disabled = running;
+            newSessionHeaderButton.disabled = running;
             compactContextButton.disabled = running;
             if (runIndicator) runIndicator.classList.toggle('active', running);
         }
@@ -775,20 +843,62 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             };
         }
 
-        function updateNodeContextBadge(node) {
-            currentNodeContext = sanitizeNodeContext(node);
-            if (!nodeContextBadge) return;
-            if (!currentNodeContext) {
-                nodeContextBadge.style.display = 'none';
-                nodeContextBadge.textContent = '';
-                nodeContextBadge.title = '';
-                return;
+        function sameNode(a, b) {
+            return a && b && a.name === b.name && (a.type || '') === (b.type || '') && (a.id || '') === (b.id || '');
+        }
+
+        function setNodeContexts(nodes, notify) {
+            const next = [];
+            for (const value of Array.isArray(nodes) ? nodes : (nodes ? [nodes] : [])) {
+                const node = sanitizeNodeContext(value);
+                if (!node || next.some((existing) => sameNode(existing, node))) continue;
+                next.push(node);
             }
-            nodeContextBadge.textContent = '@' + currentNodeContext.name;
-            nodeContextBadge.title = currentNodeContext.type
-                ? currentNodeContext.name + ' · ' + currentNodeContext.type
-                : currentNodeContext.name;
-            nodeContextBadge.style.display = 'block';
+            currentNodeContexts = currentWorkflowContext ? next : [];
+            renderContextBadges();
+            if (notify && state) {
+                vscode.postMessage({ type: 'agent.nodeDetailChanged', workflowId, nodeContexts: currentNodeContexts, sessionId: state.activeSessionId });
+            }
+        }
+
+        function addNodeContext(node, notify) {
+            if (!currentWorkflowContext) return;
+            const normalized = sanitizeNodeContext(node);
+            if (!normalized || currentNodeContexts.some((existing) => sameNode(existing, normalized))) return;
+            setNodeContexts([...currentNodeContexts, normalized], notify);
+        }
+
+        function renderContextBadges() {
+            if (!contextBadges) return;
+            contextBadges.innerHTML = '';
+            if (currentWorkflowContext) {
+                contextBadges.appendChild(contextBadge('@workflow ' + currentWorkflowContext.name, 'workflow', 'Detach workflow context', () => {
+                    currentWorkflowContext = null;
+                    currentNodeContexts = [];
+                    renderContextBadges();
+                    if (state) vscode.postMessage({ type: 'agent.context.workflow.clear', sessionId: state.activeSessionId });
+                }));
+            }
+            for (const node of currentNodeContexts) {
+                contextBadges.appendChild(contextBadge('@node ' + node.name, 'node', 'Remove node context', () => {
+                    setNodeContexts(currentNodeContexts.filter((candidate) => !sameNode(candidate, node)), true);
+                }));
+            }
+        }
+
+        function contextBadge(text, type, label, onClose) {
+            const badge = document.createElement('span');
+            badge.className = 'context-badge ' + type;
+            const title = document.createElement('span');
+            title.textContent = text;
+            const close = document.createElement('button');
+            close.type = 'button';
+            close.setAttribute('aria-label', label);
+            close.title = label;
+            close.textContent = '×';
+            close.addEventListener('click', onClose);
+            badge.append(title, close);
+            return badge;
         }
 
         function isWorkflowFrameEvent(event) {
@@ -832,8 +942,10 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             if (activeFilter === 'all') return sessions;
             if (activeFilter === 'unattached') return sessions.filter((session) => !session.workflowId);
             return sessions.filter((session) => {
-                if (!workflowId) return !session.workflowId;
-                return session.workflowId === workflowId;
+                const activeWorkflowKey = currentWorkflowContext && (currentWorkflowContext.id || currentWorkflowContext.filename || currentWorkflowContext.name);
+                if (!activeWorkflowKey) return !session.workflowContext;
+                const sessionWorkflow = session.workflowContext || {};
+                return sessionWorkflow.id === activeWorkflowKey || sessionWorkflow.filename === activeWorkflowKey || sessionWorkflow.name === activeWorkflowKey;
             });
         }
 
@@ -931,7 +1043,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         function renderFeed() {
             feed.innerHTML = '';
             const visibleEntries = state && state.session && Array.isArray(state.session.entries)
-                ? state.session.entries.filter((entry) => entry.kind !== 'context-usage')
+                ? state.session.entries.filter((entry) => entry.kind !== 'context-usage' && entry.kind !== 'workflow-context' && entry.kind !== 'node-context')
                 : [];
             if (!visibleEntries.length) {
                 return;
@@ -953,6 +1065,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 return textEntry('assistant' + (entry.streaming ? ' streaming' : ''), entry.text || '');
             }
             if (entry.kind === 'context-usage') return document.createComment('context usage');
+            if (entry.kind === 'workflow-context' || entry.kind === 'node-context') return document.createComment('context marker');
             if (entry.kind === 'compaction') {
                 const el = document.createElement('div');
                 el.className = 'entry compaction';
@@ -1000,15 +1113,97 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         }
 
         function renderAll() {
+            currentWorkflowContext = state && state.session ? state.session.workflowContext || null : null;
+            setNodeContexts(state && state.session ? state.session.nodeContexts || [] : [], false);
             renderSessions();
             renderChatMeta();
             renderFeed();
-            if (state && state.workflow) {
-                workflowSelector.textContent = state.workflow.name
+            if (state && state.workflow && workflowSubtitle) {
+                workflowSubtitle.textContent = state.workflow.name
                     ? state.workflow.name + (state.workflow.id ? ' · ' + state.workflow.id : '')
                     : 'New workflow chat';
-                workflowSelector.title = workflowSelector.textContent;
+                workflowSubtitle.title = workflowSubtitle.textContent;
             }
+            renderMentionMenu();
+        }
+
+        function getMentionQuery() {
+            if (!promptInput) return null;
+            const cursor = promptInput.selectionStart || 0;
+            const before = promptInput.value.slice(0, cursor);
+            const lower = before.toLowerCase();
+            const workflowIndex = lower.lastIndexOf('@workflow');
+            const nodeIndex = lower.lastIndexOf('@node');
+            const start = Math.max(workflowIndex, nodeIndex);
+            if (start < 0) return null;
+            if (start > 0 && !' \t'.includes(before[start - 1])) return null;
+            const kind = start === workflowIndex ? 'workflow' : 'node';
+            const tokenLength = kind === 'workflow' ? '@workflow'.length : '@node'.length;
+            const queryText = before.slice(start + tokenLength);
+            if (queryText.includes(String.fromCharCode(10))) return null;
+            return {
+                kind,
+                query: queryText.trim().toLowerCase(),
+                start,
+                end: cursor,
+            };
+        }
+
+        function renderMentionMenu() {
+            if (!mentionMenu) return;
+            const mention = getMentionQuery();
+            if (!mention || !state) {
+                mentionMenu.classList.remove('open');
+                mentionMenu.innerHTML = '';
+                return;
+            }
+            if (mention.kind === 'node' && !currentWorkflowContext) {
+                mentionMenu.classList.remove('open');
+                mentionMenu.innerHTML = '';
+                return;
+            }
+            const source = mention.kind === 'workflow' ? state.availableWorkflows || [] : state.availableNodes || [];
+            const options = source.filter((item) => {
+                const label = String(item.name || item.id || item.filename || '').toLowerCase();
+                return !mention.query || label.includes(mention.query);
+            }).slice(0, 12);
+            mentionMenu.innerHTML = '';
+            if (!options.length) {
+                mentionMenu.classList.remove('open');
+                return;
+            }
+            for (const option of options) {
+                const button = document.createElement('button');
+                button.type = 'button';
+                button.className = 'mention-option';
+                const label = document.createElement('span');
+                label.textContent = option.name || option.id || option.filename || 'Workflow';
+                const detail = document.createElement('small');
+                detail.textContent = mention.kind === 'workflow'
+                    ? [option.filename, option.id].filter(Boolean).join(' · ') || 'Workflow'
+                    : [option.type, option.id].filter(Boolean).join(' · ') || 'Node';
+                button.append(label, detail);
+                button.addEventListener('click', () => applyMentionSelection(mention, option));
+                mentionMenu.appendChild(button);
+            }
+            mentionMenu.classList.add('open');
+        }
+
+        function applyMentionSelection(mention, option) {
+            const before = promptInput.value.slice(0, mention.start);
+            const after = promptInput.value.slice(mention.end);
+            promptInput.value = (before + after).replace(/ {2,}/g, ' ');
+            promptInput.focus();
+            promptInput.selectionStart = promptInput.selectionEnd = before.length;
+            mentionMenu.classList.remove('open');
+            if (mention.kind === 'workflow') {
+                currentWorkflowContext = option;
+                currentNodeContexts = [];
+                renderContextBadges();
+                if (state) vscode.postMessage({ type: 'agent.context.workflow.set', sessionId: state.activeSessionId, workflow: option });
+                return;
+            }
+            addNodeContext(option, true);
         }
 
         function normalizeOperationKind(category, title) {
@@ -1194,7 +1389,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             const text = promptInput.value.trim();
             if (!text || isRunning || !state) return;
             promptInput.value = '';
-            vscode.postMessage({ type: 'agent.send', text, workflowId, nodeContext: currentNodeContext, sessionId: state.activeSessionId });
+            vscode.postMessage({ type: 'agent.send', text, workflowId, nodeContexts: currentNodeContexts, sessionId: state.activeSessionId });
         }
 
         on(form, 'submit', (event) => {
@@ -1208,9 +1403,10 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 sendPrompt();
             }
         });
+        on(promptInput, 'input', renderMentionMenu);
+        on(promptInput, 'keyup', renderMentionMenu);
 
         on(stopButton, 'click', () => vscode.postMessage({ type: 'agent.stop' }));
-        on(workflowSelector, 'click', () => vscode.postMessage({ type: 'agent.workflow.select' }));
         on(historyOpenButton, 'click', openHistory);
         on(historyCloseButton, 'click', closeHistory);
         on(historyOverlay, 'click', (event) => {
@@ -1218,10 +1414,13 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         });
         on(selectModelButton, 'click', () => vscode.postMessage({ type: 'agent.selectModel' }));
         on(selectReasoningButton, 'click', () => vscode.postMessage({ type: 'agent.selectReasoningEffort' }));
-        on(newSessionButton, 'click', () => {
+        function startNewSession() {
             closeHistory();
             vscode.postMessage({ type: 'agent.session.new' });
-        });
+        }
+
+        on(newSessionButton, 'click', startNewSession);
+        on(newSessionHeaderButton, 'click', startNewSession);
         on(compactContextButton, 'click', () => state && vscode.postMessage({ type: 'agent.context.compact', sessionId: state.activeSessionId }));
         on(sessionFilter, 'change', () => {
             activeFilter = sessionFilter.value || 'current';
@@ -1258,17 +1457,13 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
 
             if (message.type === 'n8n-node-detail-opened') {
                 if (!isWorkflowFrameEvent(event)) return;
-                updateNodeContextBadge(message.node);
-                if (currentNodeContext) {
-                    vscode.postMessage({ type: 'agent.nodeDetailChanged', workflowId, nodeContext: currentNodeContext });
-                }
+                addNodeContext(message.node, true);
                 return;
             }
 
             if (message.type === 'n8n-node-context-cleared') {
                 if (!isWorkflowFrameEvent(event)) return;
-                updateNodeContextBadge(null);
-                vscode.postMessage({ type: 'agent.nodeDetailChanged', workflowId, nodeContext: null });
+                setNodeContexts([], true);
                 return;
             }
 
@@ -1301,9 +1496,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
 
             if (message.type === 'agent.state') {
                 state = message.state || null;
-                if (state && state.currentNodeContext) {
-                    updateNodeContextBadge(state.currentNodeContext);
-                }
                 renderAll();
                 return;
             }

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -250,6 +250,11 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const vscode = acquireVsCodeApi();
         let workflowId = ${workflowIdJs};
         let workflowUrl = ${workflowUrlJs};
+        let iframeOrigin = ${JSON.stringify(iframePermissionOrigin)};
+        const PASTE_RATE_LIMIT_MS = 1000;
+        const GRANT_TTL_MS = 5000;
+        let lastPasteMs = 0;
+        const pendingGrants = new Map();
         let isRunning = false;
         let activeAssistantMessage = null;
 
@@ -299,6 +304,20 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             frame.src = currentSrc;
         }
 
+        function issuePasteGrant() {
+            const token = crypto.randomUUID();
+            pendingGrants.set(token, Date.now() + GRANT_TTL_MS);
+            setTimeout(() => pendingGrants.delete(token), GRANT_TTL_MS);
+            return token;
+        }
+
+        function consumeGrant(token) {
+            const expiry = pendingGrants.get(token);
+            if (!expiry || Date.now() > expiry) return false;
+            pendingGrants.delete(token);
+            return true;
+        }
+
         form.addEventListener('submit', (event) => {
             event.preventDefault();
             const text = promptInput.value.trim();
@@ -331,7 +350,39 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             if (message.type === 'workflow.update' && typeof message.url === 'string') {
                 workflowId = String(message.workflowId || workflowId);
                 workflowUrl = message.url;
+                try { iframeOrigin = new URL(workflowUrl).origin; } catch (e) { iframeOrigin = 'src'; }
                 frame.src = workflowUrl;
+                return;
+            }
+
+            if (message.type === 'n8n-paste-request') {
+                if (event.origin !== iframeOrigin) return;
+                const now = Date.now();
+                if (now - lastPasteMs < PASTE_RATE_LIMIT_MS) return;
+                lastPasteMs = now;
+                vscode.postMessage({ type: 'clipboard-paste-request', grantToken: issuePasteGrant() });
+                return;
+            }
+
+            if (message.type === 'n8n-clipboard-write' && typeof message.text === 'string') {
+                if (event.origin !== iframeOrigin) return;
+                vscode.postMessage({ type: 'clipboard-write', text: message.text });
+                return;
+            }
+
+            if (message.type === 'clipboard-error' && typeof message.grantToken === 'string') {
+                consumeGrant(message.grantToken);
+                return;
+            }
+
+            if (message.type === 'clipboard-paste' && typeof message.text === 'string' && typeof message.grantToken === 'string') {
+                if (event.origin !== window.origin) return;
+                if (!consumeGrant(message.grantToken)) return;
+                try {
+                    if (frame.contentWindow) {
+                        frame.contentWindow.postMessage({ type: 'n8n-clipboard-paste', text: message.text }, iframeOrigin);
+                    }
+                } catch (e) {}
                 return;
             }
 

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -330,36 +330,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             text-overflow: ellipsis;
             white-space: nowrap;
         }
-        .agent-run-indicator {
-            display: none;
-            align-items: center;
-            gap: 8px;
-            color: var(--muted);
-            font-size: 12px;
-        }
-        .agent-run-indicator.active {
-            display: inline-flex;
-        }
-        .pixel-spinner {
-            display: grid;
-            grid-template-columns: repeat(2, 5px);
-            grid-template-rows: repeat(2, 5px);
-            gap: 2px;
-        }
-        .pixel-spinner span {
-            width: 5px;
-            height: 5px;
-            border-radius: 1px;
-            background: color-mix(in srgb, var(--accent) 75%, transparent);
-            animation: pixel-spinner-blink 0.85s steps(1) infinite;
-        }
-        .pixel-spinner span:nth-child(2) { animation-delay: 0.18s; }
-        .pixel-spinner span:nth-child(3) { animation-delay: 0.36s; }
-        .pixel-spinner span:nth-child(4) { animation-delay: 0.54s; }
-        @keyframes pixel-spinner-blink {
-            0%, 100% { opacity: 0.28; transform: scale(0.92); }
-            50% { opacity: 1; transform: scale(1); }
-        }
         .composer-actions {
             display: grid;
             gap: 8px;
@@ -529,15 +499,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 <div class="composer-input">
                     <div class="composer-meta">
                         <div id="node-context-badge" class="node-context-badge" title=""></div>
-                        <div id="agent-run-indicator" class="agent-run-indicator" aria-live="polite">
-                            <div class="pixel-spinner" aria-hidden="true">
-                                <span></span>
-                                <span></span>
-                                <span></span>
-                                <span></span>
-                            </div>
-                            <span>Agent running</span>
-                        </div>
                     </div>
                     <textarea id="prompt" placeholder="Ask the n8n agent what to do with this workflow..." rows="2"></textarea>
                 </div>
@@ -593,7 +554,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const frame = document.getElementById('workflow-frame');
         const refreshPill = document.getElementById('refresh-pill');
         const nodeContextBadge = document.getElementById('node-context-badge');
-        const agentRunIndicator = document.getElementById('agent-run-indicator');
         const sessionList = document.getElementById('session-list');
         const sessionFilter = document.getElementById('session-filter');
         const sessionMeta = document.getElementById('session-meta');
@@ -611,9 +571,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             isRunning = running;
             sendButton.disabled = running;
             stopButton.disabled = !running;
-            if (agentRunIndicator) {
-                agentRunIndicator.classList.toggle('active', running);
-            }
             newSessionButton.disabled = running;
             renameSessionButton.disabled = running;
             attachSessionButton.disabled = running;

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -304,6 +304,11 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             justify-content: flex-end;
             gap: 8px;
         }
+        #checkpoint-open,
+        #checkpoint-overlay,
+        .checkpoint-item .checkpoint-actions {
+            display: none !important;
+        }
         .chat-head {
             display: grid;
             gap: 10px;

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -1,7 +1,7 @@
 export interface AgentWorkbenchHtmlInput {
     workflowId: string;
     workflowName: string;
-    workflowUrl: string;
+    workflowUrl?: string;
 }
 
 function escapeHtml(value: string): string {
@@ -25,13 +25,14 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
     const nonce = getNonce();
     const safeWorkflowName = escapeHtml(input.workflowName);
     const safeWorkflowId = escapeHtml(input.workflowId);
-    const safeWorkflowUrl = escapeHtml(input.workflowUrl);
+    const safeWorkflowUrl = escapeHtml(input.workflowUrl || '');
     const workflowIdJs = JSON.stringify(input.workflowId);
-    const workflowUrlJs = JSON.stringify(input.workflowUrl);
+    const workflowUrlJs = JSON.stringify(input.workflowUrl || '');
+    const hasWorkflow = Boolean(input.workflowUrl);
 
     let iframePermissionOrigin = 'src';
     try {
-        iframePermissionOrigin = new URL(input.workflowUrl).origin;
+        iframePermissionOrigin = input.workflowUrl ? new URL(input.workflowUrl).origin : 'src';
     } catch {
         // Fallback to iframe's own source origin behavior if URL parsing fails.
     }
@@ -67,7 +68,8 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         }
         .workbench {
             display: grid;
-            grid-template-columns: minmax(320px, 36%) minmax(420px, 1fr);
+            grid-template-columns: ${hasWorkflow ? 'minmax(320px, 36%) minmax(420px, 1fr)' : 'minmax(320px, 760px)'};
+            justify-content: ${hasWorkflow ? 'stretch' : 'center'};
             height: 100vh;
             width: 100vw;
         }
@@ -75,6 +77,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             display: grid;
             grid-template-rows: auto 1fr auto;
             min-width: 0;
+            min-height: 0;
             border-right: 1px solid var(--border);
             background: var(--panel);
         }
@@ -107,6 +110,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         }
         .feed {
             overflow: auto;
+            min-height: 0;
             padding: 14px;
         }
         .message, .operation {
@@ -183,6 +187,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         .workflow {
             position: relative;
             min-width: 0;
+            min-height: 0;
             background: var(--bg);
         }
         iframe {
@@ -191,6 +196,15 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             width: 100%;
             height: 100%;
             border: 0;
+        }
+        .empty-workflow {
+            position: absolute;
+            inset: 0;
+            display: grid;
+            place-items: center;
+            padding: 24px;
+            text-align: center;
+            color: var(--muted);
         }
         .refresh-pill {
             position: absolute;
@@ -223,7 +237,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             <header class="header">
                 <div class="kicker">n8n Agent Workbench</div>
                 <div class="title">Workflow Architect</div>
-                <div class="subtitle" title="${safeWorkflowName}">${safeWorkflowName} · ${safeWorkflowId}</div>
+                <div class="subtitle" title="${safeWorkflowName}">${safeWorkflowName}${safeWorkflowId ? ` · ${safeWorkflowId}` : ' · new workflow chat'}</div>
                 <div class="header-actions"><button id="select-model" class="secondary" type="button">Provider / Model</button></div>
             </header>
             <div id="feed" class="feed">
@@ -240,7 +254,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 </div>
             </form>
         </section>
-        <section class="workflow" aria-label="n8n workflow">
+        ${hasWorkflow ? `<section class="workflow" aria-label="n8n workflow">
             <div id="refresh-pill" class="refresh-pill">Refreshing n8n...</div>
             <iframe
                 id="workflow-frame"
@@ -248,7 +262,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals allow-downloads allow-top-navigation allow-top-navigation-by-user-activation"
                 allow="${iframeAllowPolicy}">
             </iframe>
-        </section>
+        </section>` : ''}
     </main>
     <script nonce="${nonce}">
         const vscode = acquireVsCodeApi();
@@ -300,13 +314,20 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         }
 
         function reloadWorkflowFrame() {
+            if (!frame || !refreshPill) return;
             refreshPill.style.display = 'block';
-            const currentSrc = frame.src;
+            const currentSrc = workflowUrl || frame.src;
             frame.onload = () => {
                 refreshPill.style.display = 'none';
                 frame.onload = null;
             };
-            frame.src = currentSrc;
+            try {
+                const reloadUrl = new URL(currentSrc);
+                reloadUrl.searchParams.set('_n8nacRefresh', String(Date.now()));
+                frame.src = reloadUrl.toString();
+            } catch (e) {
+                frame.src = currentSrc;
+            }
         }
 
         function issuePasteGrant() {
@@ -360,7 +381,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 workflowId = String(message.workflowId || workflowId);
                 workflowUrl = message.url;
                 try { iframeOrigin = new URL(workflowUrl).origin; } catch (e) { iframeOrigin = 'src'; }
-                frame.src = workflowUrl;
+                if (frame) frame.src = workflowUrl;
                 return;
             }
 

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -330,6 +330,36 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             text-overflow: ellipsis;
             white-space: nowrap;
         }
+        .agent-run-indicator {
+            display: none;
+            align-items: center;
+            gap: 8px;
+            color: var(--muted);
+            font-size: 12px;
+        }
+        .agent-run-indicator.active {
+            display: inline-flex;
+        }
+        .pixel-spinner {
+            display: grid;
+            grid-template-columns: repeat(2, 5px);
+            grid-template-rows: repeat(2, 5px);
+            gap: 2px;
+        }
+        .pixel-spinner span {
+            width: 5px;
+            height: 5px;
+            border-radius: 1px;
+            background: color-mix(in srgb, var(--accent) 75%, transparent);
+            animation: pixel-spinner-blink 0.85s steps(1) infinite;
+        }
+        .pixel-spinner span:nth-child(2) { animation-delay: 0.18s; }
+        .pixel-spinner span:nth-child(3) { animation-delay: 0.36s; }
+        .pixel-spinner span:nth-child(4) { animation-delay: 0.54s; }
+        @keyframes pixel-spinner-blink {
+            0%, 100% { opacity: 0.28; transform: scale(0.92); }
+            50% { opacity: 1; transform: scale(1); }
+        }
         .composer-actions {
             display: grid;
             gap: 8px;
@@ -499,6 +529,15 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 <div class="composer-input">
                     <div class="composer-meta">
                         <div id="node-context-badge" class="node-context-badge" title=""></div>
+                        <div id="agent-run-indicator" class="agent-run-indicator" aria-live="polite">
+                            <div class="pixel-spinner" aria-hidden="true">
+                                <span></span>
+                                <span></span>
+                                <span></span>
+                                <span></span>
+                            </div>
+                            <span>Agent running</span>
+                        </div>
                     </div>
                     <textarea id="prompt" placeholder="Ask the n8n agent what to do with this workflow..." rows="2"></textarea>
                 </div>
@@ -554,6 +593,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const frame = document.getElementById('workflow-frame');
         const refreshPill = document.getElementById('refresh-pill');
         const nodeContextBadge = document.getElementById('node-context-badge');
+        const agentRunIndicator = document.getElementById('agent-run-indicator');
         const sessionList = document.getElementById('session-list');
         const sessionFilter = document.getElementById('session-filter');
         const sessionMeta = document.getElementById('session-meta');
@@ -571,6 +611,9 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             isRunning = running;
             sendButton.disabled = running;
             stopButton.disabled = !running;
+            if (agentRunIndicator) {
+                agentRunIndicator.classList.toggle('active', running);
+            }
             newSessionButton.disabled = running;
             renameSessionButton.disabled = running;
             attachSessionButton.disabled = running;

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -434,7 +434,8 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         });
 
         promptInput.addEventListener('keydown', (event) => {
-            if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+            if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault();
                 form.requestSubmit();
             }
         });

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -3,9 +3,8 @@ export interface AgentWorkbenchHtmlInput {
     workflowName: string;
     workflowUrl?: string;
     workflowReloadUrl?: string;
+    providerModelLabel: string;
 }
-
-const AGENT_WORKBENCH_CHAT_BUILD = '2026.05.04.8';
 
 function escapeHtml(value: string): string {
     return value
@@ -29,6 +28,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
     const safeWorkflowName = escapeHtml(input.workflowName);
     const safeWorkflowId = escapeHtml(input.workflowId);
     const safeWorkflowUrl = escapeHtml(input.workflowUrl || '');
+    const safeProviderModelLabel = escapeHtml(input.providerModelLabel);
     const workflowIdJs = JSON.stringify(input.workflowId);
     const workflowUrlJs = JSON.stringify(input.workflowUrl || '');
     const workflowReloadUrlJs = JSON.stringify(input.workflowReloadUrl || input.workflowUrl || '');
@@ -101,21 +101,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             font-weight: 650;
             line-height: 1.35;
         }
-        .build-marker {
-            margin-top: 4px;
-            color: var(--muted);
-            font-size: 11px;
-            font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-        }
-        .bridge-status {
-            margin-top: 3px;
-            color: var(--muted);
-            font-size: 11px;
-            font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-        }
-        .bridge-status.connected {
-            color: var(--vscode-testing-iconPassed, #73c991);
-        }
         .subtitle {
             margin-top: 6px;
             color: var(--muted);
@@ -172,6 +157,13 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             gap: 6px;
             min-width: 0;
         }
+        .composer-meta {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+            flex-wrap: wrap;
+            min-width: 0;
+        }
         .node-context-badge {
             display: none;
             width: fit-content;
@@ -183,6 +175,20 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             background: color-mix(in srgb, var(--accent) 60%, transparent);
             font-size: 12px;
             line-height: 1.25;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .provider-model-button {
+            border: 1px solid var(--vscode-button-secondaryBackground, #3a3d41);
+            border-radius: 999px;
+            padding: 4px 9px;
+            color: var(--vscode-button-secondaryForeground, var(--text));
+            background: var(--vscode-button-secondaryBackground, #3a3d41);
+            font: inherit;
+            font-size: 12px;
+            cursor: pointer;
+            max-width: 100%;
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
@@ -274,22 +280,16 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
     <main class="workbench">
         <section class="chat" aria-label="Agent chat">
             <header class="header">
-                <div class="kicker">n8n Agent Workbench</div>
                 <div class="title">Workflow Architect</div>
-                <div class="build-marker">Chat build ${AGENT_WORKBENCH_CHAT_BUILD}</div>
-                <div id="bridge-status" class="bridge-status">n8n bridge pending</div>
                 <div class="subtitle" title="${safeWorkflowName}">${safeWorkflowName}${safeWorkflowId ? ` · ${safeWorkflowId}` : ' · new workflow chat'}</div>
-                <div class="header-actions"><button id="select-model" class="secondary" type="button">Provider / Model</button></div>
             </header>
-            <div id="feed" class="feed">
-                <div class="message system">
-                    <div class="role">System</div>
-                    Agent workbench is ready. Ask for a workflow inspection, generation plan, validation pass, or deployment step.
-                </div>
-            </div>
+            <div id="feed" class="feed"></div>
             <form id="composer" class="composer">
                 <div class="composer-input">
-                    <div id="node-context-badge" class="node-context-badge" title=""></div>
+                    <div class="composer-meta">
+                        <div id="node-context-badge" class="node-context-badge" title=""></div>
+                        <button id="select-model" class="provider-model-button" type="button" title="${safeProviderModelLabel}">${safeProviderModelLabel}</button>
+                    </div>
                     <textarea id="prompt" placeholder="Ask the n8n agent what to do with this workflow..." rows="2"></textarea>
                 </div>
                 <div class="actions">
@@ -331,7 +331,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const frame = document.getElementById('workflow-frame');
         const refreshPill = document.getElementById('refresh-pill');
         const nodeContextBadge = document.getElementById('node-context-badge');
-        const bridgeStatus = document.getElementById('bridge-status');
 
         function appendMessage(role, content) {
             const el = document.createElement('div');
@@ -386,12 +385,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 ? currentNodeContext.name + ' · ' + currentNodeContext.type
                 : currentNodeContext.name;
             nodeContextBadge.style.display = 'block';
-        }
-
-        function updateBridgeStatus(text, connected) {
-            if (!bridgeStatus) return;
-            bridgeStatus.textContent = text;
-            bridgeStatus.classList.toggle('connected', Boolean(connected));
         }
 
         function isWorkflowFrameEvent(event) {
@@ -468,26 +461,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 workflowUrl = message.url;
                 workflowReloadUrl = typeof message.reloadUrl === 'string' && message.reloadUrl ? message.reloadUrl : workflowUrl;
                 try { iframeOrigin = new URL(workflowUrl).origin; } catch (e) { iframeOrigin = 'src'; }
-                updateBridgeStatus('n8n bridge pending', false);
                 if (frame) frame.src = workflowUrl;
-                return;
-            }
-
-            if (message.type === 'n8n-bridge-ready') {
-                if (!isWorkflowFrameEvent(event)) return;
-                updateBridgeStatus('n8n bridge ' + (message.build || 'connected') + (message.pageKind ? ' · ' + message.pageKind : '') + (message.nodeName ? ' · saw ' + message.nodeName : ''), true);
-                return;
-            }
-
-            if (message.type === 'n8n-ui-click') {
-                if (!isWorkflowFrameEvent(event)) return;
-                updateBridgeStatus('n8n bridge ' + (message.build || 'connected') + ' · click ' + (message.nodeName || message.target || 'ui'), true);
-                return;
-            }
-
-            if (message.type === 'n8n-ui-change') {
-                if (!isWorkflowFrameEvent(event)) return;
-                updateBridgeStatus('n8n bridge ' + (message.build || 'connected') + ' · ui changed ' + (message.nodeName || message.count || ''), true);
                 return;
             }
 

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -158,7 +158,7 @@ export class AgentWorkbenchWebview {
 
         if (payload.type === 'agent.send') {
             const nodeContext = this.sanitizeNodeContext(payload.nodeContext) ?? this._nodeContext;
-            await this._agentRuntime.sendPrompt({
+            const result = await this._agentRuntime.sendPrompt({
                 prompt: String(payload.text || ''),
                 workflowId: this._workflow?.id,
                 workflowName: this._workflow?.name,
@@ -168,7 +168,7 @@ export class AgentWorkbenchWebview {
                 nodeContext,
                 sessionId: typeof payload.sessionId === 'string' ? payload.sessionId : undefined,
             }, (event) => this._panel.webview.postMessage(event));
-            if (this._workflow?.id) {
+            if (result.workflowChanged && this._workflow?.id) {
                 await this._panel.webview.postMessage({ type: 'workflow.reload' });
             }
             return;
@@ -178,6 +178,11 @@ export class AgentWorkbenchWebview {
             await vscode.commands.executeCommand('n8n.agent.selectModel');
             this._providerModelLabel = this.getProviderModelLabel();
             await this.postWorkbenchState();
+            return;
+        }
+
+        if (payload.type === 'agent.workflow.select') {
+            await vscode.commands.executeCommand('n8n.openAgentWorkbench');
             return;
         }
 
@@ -241,6 +246,11 @@ export class AgentWorkbenchWebview {
             await this.postWorkbenchState(await this._agentRuntime.deleteCheckpoint(payload.sessionId, payload.checkpointId, this.buildWorkbenchInput()));
             return;
         }
+
+        if (payload.type === 'agent.context.compact' && typeof payload.sessionId === 'string') {
+            await this.postWorkbenchState(await this._agentRuntime.compactSession(payload.sessionId, this.buildWorkbenchInput()));
+            return;
+        }
     }
 
     private sanitizeNodeContext(value: unknown): AgentWorkbenchNodeContext | undefined {
@@ -263,9 +273,7 @@ export class AgentWorkbenchWebview {
         const config = vscode.workspace.getConfiguration('n8n.agent');
         const provider = String(config.get<string>('provider') || 'openai').trim() || 'openai';
         const model = String(config.get<string>('model') || '').trim();
-        const reasoningEffort = String(config.get<string>('reasoningEffort') || '').trim();
-        const label = model ? `${provider} / ${model}` : provider;
-        return reasoningEffort ? `${label} / ${reasoningEffort}` : label;
+        return model ? `${provider} / ${model}` : provider;
     }
 
     private buildWorkbenchInput(): {

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -1,0 +1,125 @@
+import * as vscode from 'vscode';
+import { IWorkflowStatus } from 'n8nac';
+import { AgentRuntimeController } from '../services/agent-runtime-controller.js';
+import { workflowWebviewRegistry } from '../services/workflow-webview-registry.js';
+import { buildAgentWorkbenchHtml } from './agent-workbench-html.js';
+
+export class AgentWorkbenchWebview {
+    public static currentPanel: AgentWorkbenchWebview | undefined;
+
+    private readonly _panel: vscode.WebviewPanel;
+    private readonly _context: vscode.ExtensionContext;
+    private readonly _agentRuntime: AgentRuntimeController;
+    private readonly _disposables: vscode.Disposable[] = [];
+    private _registryDisposable: { dispose(): void } | undefined;
+    private _workflow: IWorkflowStatus;
+    private _workflowUrl: string;
+
+    private constructor(
+        panel: vscode.WebviewPanel,
+        context: vscode.ExtensionContext,
+        workflow: IWorkflowStatus,
+        workflowUrl: string,
+        agentRuntime: AgentRuntimeController,
+    ) {
+        this._panel = panel;
+        this._context = context;
+        this._workflow = workflow;
+        this._workflowUrl = workflowUrl;
+        this._agentRuntime = agentRuntime;
+        this._registryDisposable = workflowWebviewRegistry.register({
+            getWorkflowId: () => this._workflow.id,
+            reloadWorkflow: () => this._panel.webview.postMessage({ type: 'workflow.reload' }),
+        });
+
+        this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+        this._panel.webview.onDidReceiveMessage((message) => {
+            void this.handleMessage(message);
+        }, null, this._disposables);
+        this._panel.webview.html = this.getHtmlForWebview();
+    }
+
+    public static createOrShow(
+        context: vscode.ExtensionContext,
+        workflow: IWorkflowStatus,
+        workflowUrl: string,
+        agentRuntime: AgentRuntimeController,
+        viewColumn?: vscode.ViewColumn,
+    ): void {
+        const column = viewColumn || vscode.ViewColumn.One;
+
+        if (AgentWorkbenchWebview.currentPanel) {
+            AgentWorkbenchWebview.currentPanel._panel.reveal(column);
+            AgentWorkbenchWebview.currentPanel.update(workflow, workflowUrl);
+            return;
+        }
+
+        const panel = vscode.window.createWebviewPanel(
+            'n8nAgentWorkbench',
+            `n8n Agent: ${workflow.name}`,
+            column,
+            {
+                enableScripts: true,
+                retainContextWhenHidden: true,
+                localResourceRoots: [],
+            },
+        );
+
+        AgentWorkbenchWebview.currentPanel = new AgentWorkbenchWebview(panel, context, workflow, workflowUrl, agentRuntime);
+    }
+
+    public update(workflow: IWorkflowStatus, workflowUrl: string): void {
+        this._workflow = workflow;
+        this._workflowUrl = workflowUrl;
+        this._panel.title = `n8n Agent: ${workflow.name}`;
+        this._panel.webview.postMessage({
+            type: 'workflow.update',
+            workflowId: workflow.id,
+            workflowName: workflow.name,
+            url: workflowUrl,
+        });
+    }
+
+    public dispose(): void {
+        if (AgentWorkbenchWebview.currentPanel === this) {
+            AgentWorkbenchWebview.currentPanel = undefined;
+        }
+        this._registryDisposable?.dispose();
+        this._registryDisposable = undefined;
+        this._panel.dispose();
+        while (this._disposables.length) {
+            const disposable = this._disposables.pop();
+            disposable?.dispose();
+        }
+    }
+
+    private async handleMessage(message: unknown): Promise<void> {
+        if (!message || typeof message !== 'object') {
+            return;
+        }
+        const payload = message as Record<string, unknown>;
+
+        if (payload.type === 'agent.send') {
+            await this._agentRuntime.sendPrompt({
+                prompt: String(payload.text || ''),
+                workflowId: this._workflow.id,
+                workflowName: this._workflow.name,
+                workspaceRoot: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+            }, (event) => this._panel.webview.postMessage(event));
+            return;
+        }
+
+        if (payload.type === 'agent.stop') {
+            await this._agentRuntime.stop((event) => this._panel.webview.postMessage(event));
+            return;
+        }
+    }
+
+    private getHtmlForWebview(): string {
+        return buildAgentWorkbenchHtml({
+            workflowId: this._workflow.id,
+            workflowName: this._workflow.name,
+            workflowUrl: this._workflowUrl,
+        });
+    }
+}

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -22,6 +22,10 @@ interface AgentWorkbenchWorkflowProviders {
     listWorkflows(): Promise<IWorkflowStatus[]>;
     resolveWorkflow(workflow: AgentWorkflowContext): Promise<AgentWorkflowTarget>;
     listWorkflowNodes(workflow: AgentWorkflowContext): Promise<AgentWorkbenchNodeContext[]>;
+    listProviderOptions(): Promise<Array<Record<string, unknown>>>;
+    listModelOptions(provider: string): Promise<Array<Record<string, unknown>>>;
+    selectProviderModel(provider: string, model: string): Promise<void>;
+    selectReasoningEffort(effort: string): Promise<void>;
 }
 
 export class AgentWorkbenchWebview {
@@ -70,6 +74,11 @@ export class AgentWorkbenchWebview {
         this.updateRegistryRegistration();
 
         this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+        this._panel.onDidChangeViewState((event) => {
+            if (event.webviewPanel.visible) {
+                void this.postWorkbenchState();
+            }
+        }, null, this._disposables);
         this._panel.webview.onDidReceiveMessage((message) => {
             void this.handleMessage(message).catch((error: any) => {
                 const detail = error?.message || String(error);
@@ -219,8 +228,21 @@ export class AgentWorkbenchWebview {
         }
 
         if (payload.type === 'agent.selectModel') {
-            await vscode.commands.executeCommand('n8n.agent.selectModel');
-            this._providerModelLabel = this.getProviderModelLabel();
+            const provider = typeof payload.provider === 'string' ? payload.provider : this.readSelectedProvider();
+            await this._panel.webview.postMessage({
+                type: 'agent.providerModels',
+                provider,
+                models: await this._workflowProviders.listModelOptions(provider),
+            });
+            return;
+        }
+
+        if (payload.type === 'agent.providers.configure') {
+            await vscode.commands.executeCommand('n8n.openAgentManager');
+            return;
+        }
+
+        if (payload.type === 'agent.providers.refresh') {
             await this.postWorkbenchState();
             return;
         }
@@ -231,7 +253,16 @@ export class AgentWorkbenchWebview {
         }
 
         if (payload.type === 'agent.selectReasoningEffort') {
-            await vscode.commands.executeCommand('n8n.agent.selectReasoningEffort');
+            if (typeof payload.effort === 'string') {
+                await this._workflowProviders.selectReasoningEffort(payload.effort);
+                await this.postWorkbenchState();
+            }
+            return;
+        }
+
+        if (payload.type === 'agent.providerModel.select' && typeof payload.provider === 'string' && typeof payload.model === 'string') {
+            await this._workflowProviders.selectProviderModel(payload.provider, payload.model);
+            this._providerModelLabel = this.getProviderModelLabel();
             await this.postWorkbenchState();
             return;
         }
@@ -310,7 +341,35 @@ export class AgentWorkbenchWebview {
         }
 
         if (payload.type === 'agent.context.compact' && typeof payload.sessionId === 'string') {
-            await this.postWorkbenchState(await this._agentRuntime.compactSession(payload.sessionId, this.buildWorkbenchInput()));
+            await this._panel.webview.postMessage({ type: 'agent.status', status: 'running', detail: 'Compacting context...' });
+            await this._panel.webview.postMessage({
+                type: 'agent.streamEvent',
+                event: {
+                    type: 'progress',
+                    tone: 'info',
+                    title: 'Compacting context',
+                    detail: 'Requesting runtime context compaction from Yagr.',
+                    phase: 'compaction',
+                },
+            });
+            try {
+                await this.postWorkbenchState(await this._agentRuntime.compactSession(payload.sessionId, this.buildWorkbenchInput()));
+            } catch (error: any) {
+                const message = error?.message || String(error);
+                await this._panel.webview.postMessage({
+                    type: 'agent.streamEvent',
+                    event: {
+                        type: 'progress',
+                        tone: 'error',
+                        title: 'Context compaction failed',
+                        detail: message,
+                        phase: 'compaction',
+                    },
+                });
+                throw error;
+            } finally {
+                await this._panel.webview.postMessage({ type: 'agent.status', status: 'idle' });
+            }
             return;
         }
     }
@@ -364,9 +423,14 @@ export class AgentWorkbenchWebview {
 
     private getProviderModelLabel(): string {
         const config = vscode.workspace.getConfiguration('n8n.agent');
-        const provider = String(config.get<string>('provider') || 'openai').trim() || 'openai';
+        const provider = this.readSelectedProvider();
         const model = String(config.get<string>('model') || '').trim();
         return model ? `${provider} / ${model}` : provider;
+    }
+
+    private readSelectedProvider(): string {
+        const config = vscode.workspace.getConfiguration('n8n.agent');
+        return String(config.get<string>('provider') || 'openai').trim() || 'openai';
     }
 
     private buildWorkbenchInput(): {
@@ -398,6 +462,13 @@ export class AgentWorkbenchWebview {
             ...nextState,
             availableWorkflows: await this.getWorkflowOptions(),
             availableNodes: await this.getWorkflowNodeOptions(),
+            providerOptions: await this._workflowProviders.listProviderOptions().catch(() => []),
+            modelOptions: await this._workflowProviders.listModelOptions(String(nextState.provider || '')).catch(() => []),
+            reasoningOptions: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'].map((effort) => ({
+                id: effort,
+                label: effort,
+                selected: effort === nextState.reasoningEffort,
+            })),
         };
         await this._panel.webview.postMessage({ type: 'agent.state', state: enrichedState });
     }

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -14,6 +14,7 @@ export class AgentWorkbenchWebview {
     private _registryDisposable: { dispose(): void } | undefined;
     private _workflow: IWorkflowStatus | undefined;
     private _workflowUrl: string | undefined;
+    private _workflowReloadUrl: string | undefined;
     private _onClipboardPasteRequest: ((panel: vscode.WebviewPanel, grantToken: string) => Promise<void>) | undefined;
 
     private constructor(
@@ -21,12 +22,14 @@ export class AgentWorkbenchWebview {
         context: vscode.ExtensionContext,
         workflow: IWorkflowStatus | undefined,
         workflowUrl: string | undefined,
+        workflowReloadUrl: string | undefined,
         agentRuntime: AgentRuntimeController,
     ) {
         this._panel = panel;
         this._context = context;
         this._workflow = workflow;
         this._workflowUrl = workflowUrl;
+        this._workflowReloadUrl = workflowReloadUrl;
         this._agentRuntime = agentRuntime;
         this.updateRegistryRegistration();
 
@@ -41,6 +44,7 @@ export class AgentWorkbenchWebview {
         context: vscode.ExtensionContext,
         workflow: IWorkflowStatus | undefined,
         workflowUrl: string | undefined,
+        workflowReloadUrl: string | undefined,
         agentRuntime: AgentRuntimeController,
         viewColumn?: vscode.ViewColumn,
     ): void {
@@ -48,7 +52,7 @@ export class AgentWorkbenchWebview {
 
         if (AgentWorkbenchWebview.currentPanel) {
             AgentWorkbenchWebview.currentPanel._panel.reveal(column);
-            AgentWorkbenchWebview.currentPanel.update(workflow, workflowUrl);
+            AgentWorkbenchWebview.currentPanel.update(workflow, workflowUrl, workflowReloadUrl);
             return;
         }
 
@@ -63,7 +67,7 @@ export class AgentWorkbenchWebview {
             },
         );
 
-        AgentWorkbenchWebview.currentPanel = new AgentWorkbenchWebview(panel, context, workflow, workflowUrl, agentRuntime);
+        AgentWorkbenchWebview.currentPanel = new AgentWorkbenchWebview(panel, context, workflow, workflowUrl, workflowReloadUrl, agentRuntime);
     }
 
     public static onClipboardPasteRequest(handler: (panel: vscode.WebviewPanel, grantToken: string) => Promise<void>): void {
@@ -72,11 +76,12 @@ export class AgentWorkbenchWebview {
         }
     }
 
-    public update(workflow: IWorkflowStatus | undefined, workflowUrl: string | undefined): void {
+    public update(workflow: IWorkflowStatus | undefined, workflowUrl: string | undefined, workflowReloadUrl: string | undefined): void {
         const hadWorkflowFrame = Boolean(this._workflowUrl);
         const hasWorkflowFrame = Boolean(workflowUrl);
         this._workflow = workflow;
         this._workflowUrl = workflowUrl;
+        this._workflowReloadUrl = workflowReloadUrl;
         this.updateRegistryRegistration();
         this._panel.title = `n8n Agent: ${workflow?.name || 'New workflow'}`;
 
@@ -90,6 +95,7 @@ export class AgentWorkbenchWebview {
             workflowId: workflow?.id || '',
             workflowName: workflow?.name || 'New workflow',
             url: workflowUrl,
+            reloadUrl: workflowReloadUrl,
         });
     }
 
@@ -135,6 +141,9 @@ export class AgentWorkbenchWebview {
                 workflowFilename: this._workflow?.filename,
                 workspaceRoot: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
             }, (event) => this._panel.webview.postMessage(event));
+            if (this._workflow?.id) {
+                await this._panel.webview.postMessage({ type: 'workflow.reload' });
+            }
             return;
         }
 
@@ -172,6 +181,7 @@ export class AgentWorkbenchWebview {
             workflowId: this._workflow?.id || '',
             workflowName: this._workflow?.name || 'New workflow',
             workflowUrl: this._workflowUrl,
+            workflowReloadUrl: this._workflowReloadUrl,
         });
     }
 }

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -4,6 +4,12 @@ import { AgentRuntimeController } from '../services/agent-runtime-controller.js'
 import { workflowWebviewRegistry } from '../services/workflow-webview-registry.js';
 import { buildAgentWorkbenchHtml } from './agent-workbench-html.js';
 
+interface AgentWorkbenchNodeContext {
+    name: string;
+    type?: string;
+    id?: string;
+}
+
 export class AgentWorkbenchWebview {
     public static currentPanel: AgentWorkbenchWebview | undefined;
 
@@ -15,6 +21,7 @@ export class AgentWorkbenchWebview {
     private _workflow: IWorkflowStatus | undefined;
     private _workflowUrl: string | undefined;
     private _workflowReloadUrl: string | undefined;
+    private _nodeContext: AgentWorkbenchNodeContext | undefined;
     private _onClipboardPasteRequest: ((panel: vscode.WebviewPanel, grantToken: string) => Promise<void>) | undefined;
 
     private constructor(
@@ -134,12 +141,14 @@ export class AgentWorkbenchWebview {
         }
 
         if (payload.type === 'agent.send') {
+            const nodeContext = this.sanitizeNodeContext(payload.nodeContext) ?? this._nodeContext;
             await this._agentRuntime.sendPrompt({
                 prompt: String(payload.text || ''),
                 workflowId: this._workflow?.id,
                 workflowName: this._workflow?.name,
                 workflowFilename: this._workflow?.filename,
                 workspaceRoot: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+                nodeContext,
             }, (event) => this._panel.webview.postMessage(event));
             if (this._workflow?.id) {
                 await this._panel.webview.postMessage({ type: 'workflow.reload' });
@@ -152,10 +161,31 @@ export class AgentWorkbenchWebview {
             return;
         }
 
+        if (payload.type === 'agent.nodeDetailChanged') {
+            this._nodeContext = this.sanitizeNodeContext(payload.nodeContext);
+            return;
+        }
+
         if (payload.type === 'agent.stop') {
             await this._agentRuntime.stop((event) => this._panel.webview.postMessage(event));
             return;
         }
+    }
+
+    private sanitizeNodeContext(value: unknown): AgentWorkbenchNodeContext | undefined {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+            return undefined;
+        }
+        const record = value as Record<string, unknown>;
+        const name = typeof record.name === 'string' ? record.name.trim() : '';
+        if (!name) {
+            return undefined;
+        }
+        return {
+            name,
+            type: typeof record.type === 'string' ? record.type.trim() || undefined : undefined,
+            id: typeof record.id === 'string' ? record.id.trim() || undefined : undefined,
+        };
     }
 
     private updateRegistryRegistration(): void {

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -14,6 +14,7 @@ export class AgentWorkbenchWebview {
     private _registryDisposable: { dispose(): void } | undefined;
     private _workflow: IWorkflowStatus;
     private _workflowUrl: string;
+    private _onClipboardPasteRequest: ((panel: vscode.WebviewPanel, grantToken: string) => Promise<void>) | undefined;
 
     private constructor(
         panel: vscode.WebviewPanel,
@@ -68,6 +69,12 @@ export class AgentWorkbenchWebview {
         AgentWorkbenchWebview.currentPanel = new AgentWorkbenchWebview(panel, context, workflow, workflowUrl, agentRuntime);
     }
 
+    public static onClipboardPasteRequest(handler: (panel: vscode.WebviewPanel, grantToken: string) => Promise<void>): void {
+        if (AgentWorkbenchWebview.currentPanel) {
+            AgentWorkbenchWebview.currentPanel._onClipboardPasteRequest = handler;
+        }
+    }
+
     public update(workflow: IWorkflowStatus, workflowUrl: string): void {
         this._workflow = workflow;
         this._workflowUrl = workflowUrl;
@@ -98,6 +105,21 @@ export class AgentWorkbenchWebview {
             return;
         }
         const payload = message as Record<string, unknown>;
+
+        if (payload.type === 'clipboard-write' && typeof payload.text === 'string') {
+            try {
+                await vscode.env.clipboard.writeText(payload.text);
+            } catch (error) {
+                console.error('[AgentWorkbench] Clipboard write error', error);
+            }
+            return;
+        }
+
+        if (payload.type === 'clipboard-paste-request' && typeof payload.grantToken === 'string') {
+            void this._onClipboardPasteRequest?.(this._panel, payload.grantToken)
+                ?.catch(error => console.error('[AgentWorkbench] Clipboard paste handler error', error));
+            return;
+        }
 
         if (payload.type === 'agent.send') {
             await this._agentRuntime.sendPrompt({

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -19,6 +19,7 @@ export class AgentWorkbenchWebview {
     private readonly _disposables: vscode.Disposable[] = [];
     private _registryDisposable: { dispose(): void } | undefined;
     private _workflow: IWorkflowStatus | undefined;
+    private _workflowFilePath: string | undefined;
     private _workflowUrl: string | undefined;
     private _workflowReloadUrl: string | undefined;
     private _providerModelLabel: string;
@@ -29,6 +30,7 @@ export class AgentWorkbenchWebview {
         panel: vscode.WebviewPanel,
         context: vscode.ExtensionContext,
         workflow: IWorkflowStatus | undefined,
+        workflowFilePath: string | undefined,
         workflowUrl: string | undefined,
         workflowReloadUrl: string | undefined,
         providerModelLabel: string,
@@ -37,6 +39,7 @@ export class AgentWorkbenchWebview {
         this._panel = panel;
         this._context = context;
         this._workflow = workflow;
+        this._workflowFilePath = workflowFilePath;
         this._workflowUrl = workflowUrl;
         this._workflowReloadUrl = workflowReloadUrl;
         this._providerModelLabel = providerModelLabel;
@@ -53,6 +56,7 @@ export class AgentWorkbenchWebview {
     public static createOrShow(
         context: vscode.ExtensionContext,
         workflow: IWorkflowStatus | undefined,
+        workflowFilePath: string | undefined,
         workflowUrl: string | undefined,
         workflowReloadUrl: string | undefined,
         providerModelLabel: string,
@@ -63,7 +67,7 @@ export class AgentWorkbenchWebview {
 
         if (AgentWorkbenchWebview.currentPanel) {
             AgentWorkbenchWebview.currentPanel._panel.reveal(column);
-            AgentWorkbenchWebview.currentPanel.update(workflow, workflowUrl, workflowReloadUrl, providerModelLabel);
+            AgentWorkbenchWebview.currentPanel.update(workflow, workflowFilePath, workflowUrl, workflowReloadUrl, providerModelLabel);
             return;
         }
 
@@ -78,7 +82,7 @@ export class AgentWorkbenchWebview {
             },
         );
 
-        AgentWorkbenchWebview.currentPanel = new AgentWorkbenchWebview(panel, context, workflow, workflowUrl, workflowReloadUrl, providerModelLabel, agentRuntime);
+        AgentWorkbenchWebview.currentPanel = new AgentWorkbenchWebview(panel, context, workflow, workflowFilePath, workflowUrl, workflowReloadUrl, providerModelLabel, agentRuntime);
     }
 
     public static onClipboardPasteRequest(handler: (panel: vscode.WebviewPanel, grantToken: string) => Promise<void>): void {
@@ -87,10 +91,11 @@ export class AgentWorkbenchWebview {
         }
     }
 
-    public update(workflow: IWorkflowStatus | undefined, workflowUrl: string | undefined, workflowReloadUrl: string | undefined, providerModelLabel: string): void {
+    public update(workflow: IWorkflowStatus | undefined, workflowFilePath: string | undefined, workflowUrl: string | undefined, workflowReloadUrl: string | undefined, providerModelLabel: string): void {
         const hadWorkflowFrame = Boolean(this._workflowUrl);
         const hasWorkflowFrame = Boolean(workflowUrl);
         this._workflow = workflow;
+        this._workflowFilePath = workflowFilePath;
         this._workflowUrl = workflowUrl;
         this._workflowReloadUrl = workflowReloadUrl;
         this._providerModelLabel = providerModelLabel;
@@ -109,6 +114,7 @@ export class AgentWorkbenchWebview {
             url: workflowUrl,
             reloadUrl: workflowReloadUrl,
         });
+        void this.postWorkbenchState();
     }
 
     public dispose(): void {
@@ -129,6 +135,11 @@ export class AgentWorkbenchWebview {
             return;
         }
         const payload = message as Record<string, unknown>;
+
+        if (payload.type === 'agent.ready') {
+            await this.postWorkbenchState();
+            return;
+        }
 
         if (payload.type === 'clipboard-write' && typeof payload.text === 'string') {
             try {
@@ -152,8 +163,10 @@ export class AgentWorkbenchWebview {
                 workflowId: this._workflow?.id,
                 workflowName: this._workflow?.name,
                 workflowFilename: this._workflow?.filename,
+                workflowFilePath: this._workflowFilePath,
                 workspaceRoot: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
                 nodeContext,
+                sessionId: typeof payload.sessionId === 'string' ? payload.sessionId : undefined,
             }, (event) => this._panel.webview.postMessage(event));
             if (this._workflow?.id) {
                 await this._panel.webview.postMessage({ type: 'workflow.reload' });
@@ -164,7 +177,13 @@ export class AgentWorkbenchWebview {
         if (payload.type === 'agent.selectModel') {
             await vscode.commands.executeCommand('n8n.agent.selectModel');
             this._providerModelLabel = this.getProviderModelLabel();
-            this._panel.webview.html = this.getHtmlForWebview();
+            await this.postWorkbenchState();
+            return;
+        }
+
+        if (payload.type === 'agent.selectReasoningEffort') {
+            await vscode.commands.executeCommand('n8n.agent.selectReasoningEffort');
+            await this.postWorkbenchState();
             return;
         }
 
@@ -175,6 +194,51 @@ export class AgentWorkbenchWebview {
 
         if (payload.type === 'agent.stop') {
             await this._agentRuntime.stop((event) => this._panel.webview.postMessage(event));
+            return;
+        }
+
+        if (payload.type === 'agent.session.new') {
+            await this.postWorkbenchState(await this._agentRuntime.createSession(this.buildWorkbenchInput()));
+            return;
+        }
+
+        if (payload.type === 'agent.session.select' && typeof payload.sessionId === 'string') {
+            await this.postWorkbenchState(await this._agentRuntime.selectSession(payload.sessionId, this.buildWorkbenchInput()));
+            return;
+        }
+
+        if (payload.type === 'agent.session.rename' && typeof payload.sessionId === 'string' && typeof payload.title === 'string') {
+            await this.postWorkbenchState(await this._agentRuntime.renameSession(payload.sessionId, payload.title, this.buildWorkbenchInput()));
+            return;
+        }
+
+        if (payload.type === 'agent.session.delete' && typeof payload.sessionId === 'string') {
+            await this.postWorkbenchState(await this._agentRuntime.deleteSession(payload.sessionId, this.buildWorkbenchInput()));
+            return;
+        }
+
+        if (payload.type === 'agent.session.attach' && typeof payload.sessionId === 'string') {
+            await this.postWorkbenchState(await this._agentRuntime.attachSessionToCurrentWorkflow(payload.sessionId, this.buildWorkbenchInput()));
+            return;
+        }
+
+        if (payload.type === 'agent.session.detach' && typeof payload.sessionId === 'string') {
+            await this.postWorkbenchState(await this._agentRuntime.detachSession(payload.sessionId, this.buildWorkbenchInput()));
+            return;
+        }
+
+        if (payload.type === 'agent.checkpoint.save' && typeof payload.sessionId === 'string') {
+            await this.postWorkbenchState(await this._agentRuntime.saveCheckpoint(payload.sessionId, this.buildWorkbenchInput()));
+            return;
+        }
+
+        if (payload.type === 'agent.checkpoint.restore' && typeof payload.sessionId === 'string' && typeof payload.checkpointId === 'string') {
+            await this.postWorkbenchState(await this._agentRuntime.restoreCheckpoint(payload.sessionId, payload.checkpointId, this.buildWorkbenchInput()));
+            return;
+        }
+
+        if (payload.type === 'agent.checkpoint.delete' && typeof payload.sessionId === 'string' && typeof payload.checkpointId === 'string') {
+            await this.postWorkbenchState(await this._agentRuntime.deleteCheckpoint(payload.sessionId, payload.checkpointId, this.buildWorkbenchInput()));
             return;
         }
     }
@@ -199,7 +263,30 @@ export class AgentWorkbenchWebview {
         const config = vscode.workspace.getConfiguration('n8n.agent');
         const provider = String(config.get<string>('provider') || 'openai').trim() || 'openai';
         const model = String(config.get<string>('model') || '').trim();
-        return model ? `${provider} / ${model}` : provider;
+        const reasoningEffort = String(config.get<string>('reasoningEffort') || '').trim();
+        const label = model ? `${provider} / ${model}` : provider;
+        return reasoningEffort ? `${label} / ${reasoningEffort}` : label;
+    }
+
+    private buildWorkbenchInput(): {
+        workflowId?: string;
+        workflowName?: string;
+        workflowFilename?: string;
+        workspaceRoot?: string;
+        nodeContext?: AgentWorkbenchNodeContext;
+    } {
+        return {
+            workflowId: this._workflow?.id,
+            workflowName: this._workflow?.name,
+            workflowFilename: this._workflow?.filename,
+            workspaceRoot: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+            nodeContext: this._nodeContext,
+        };
+    }
+
+    private async postWorkbenchState(state?: Awaited<ReturnType<AgentRuntimeController['getWorkbenchState']>>): Promise<void> {
+        const nextState = state ?? await this._agentRuntime.getWorkbenchState(this.buildWorkbenchInput());
+        await this._panel.webview.postMessage({ type: 'agent.state', state: nextState });
     }
 
     private updateRegistryRegistration(): void {

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -16,6 +16,7 @@ export class AgentWorkbenchWebview {
     private readonly _panel: vscode.WebviewPanel;
     private readonly _context: vscode.ExtensionContext;
     private readonly _agentRuntime: AgentRuntimeController;
+    private readonly _outputChannel: vscode.OutputChannel;
     private readonly _disposables: vscode.Disposable[] = [];
     private _registryDisposable: { dispose(): void } | undefined;
     private _workflow: IWorkflowStatus | undefined;
@@ -35,6 +36,7 @@ export class AgentWorkbenchWebview {
         workflowReloadUrl: string | undefined,
         providerModelLabel: string,
         agentRuntime: AgentRuntimeController,
+        outputChannel: vscode.OutputChannel,
     ) {
         this._panel = panel;
         this._context = context;
@@ -44,11 +46,16 @@ export class AgentWorkbenchWebview {
         this._workflowReloadUrl = workflowReloadUrl;
         this._providerModelLabel = providerModelLabel;
         this._agentRuntime = agentRuntime;
+        this._outputChannel = outputChannel;
         this.updateRegistryRegistration();
 
         this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
         this._panel.webview.onDidReceiveMessage((message) => {
-            void this.handleMessage(message);
+            void this.handleMessage(message).catch((error: any) => {
+                const detail = error?.message || String(error);
+                console.error('[AgentWorkbench] Message handler error', error);
+                void this._panel.webview.postMessage({ type: 'agent.streamEvent', event: { type: 'error', error: detail } });
+            });
         }, null, this._disposables);
         this._panel.webview.html = this.getHtmlForWebview();
     }
@@ -61,6 +68,7 @@ export class AgentWorkbenchWebview {
         workflowReloadUrl: string | undefined,
         providerModelLabel: string,
         agentRuntime: AgentRuntimeController,
+        outputChannel: vscode.OutputChannel,
         viewColumn?: vscode.ViewColumn,
     ): void {
         const column = viewColumn || vscode.ViewColumn.One;
@@ -82,7 +90,7 @@ export class AgentWorkbenchWebview {
             },
         );
 
-        AgentWorkbenchWebview.currentPanel = new AgentWorkbenchWebview(panel, context, workflow, workflowFilePath, workflowUrl, workflowReloadUrl, providerModelLabel, agentRuntime);
+        AgentWorkbenchWebview.currentPanel = new AgentWorkbenchWebview(panel, context, workflow, workflowFilePath, workflowUrl, workflowReloadUrl, providerModelLabel, agentRuntime, outputChannel);
     }
 
     public static onClipboardPasteRequest(handler: (panel: vscode.WebviewPanel, grantToken: string) => Promise<void>): void {
@@ -137,7 +145,13 @@ export class AgentWorkbenchWebview {
         const payload = message as Record<string, unknown>;
 
         if (payload.type === 'agent.ready') {
+            this._outputChannel.appendLine(`[n8n-agent-debug] webview ready workflowId=${this._workflow?.id || 'none'} workflowFilePath=${this._workflowFilePath || 'none'}`);
             await this.postWorkbenchState();
+            return;
+        }
+
+        if (payload.type === 'workflow.reloadAck') {
+            this._outputChannel.appendLine(`[n8n-agent-debug] webview received workflow.reload workflowId=${String(payload.workflowId || this._workflow?.id || 'none')} hasFrame=${String(Boolean(payload.hasFrame))} url=${String(payload.url || this._workflowReloadUrl || this._workflowUrl || '')}`);
             return;
         }
 
@@ -158,6 +172,7 @@ export class AgentWorkbenchWebview {
 
         if (payload.type === 'agent.send') {
             const nodeContext = this.sanitizeNodeContext(payload.nodeContext) ?? this._nodeContext;
+            this._outputChannel.appendLine(`[n8n-agent-debug] agent.send workflowId=${this._workflow?.id || 'none'} workflowFilePath=${this._workflowFilePath || 'none'} sessionId=${typeof payload.sessionId === 'string' ? payload.sessionId : 'none'}`);
             const result = await this._agentRuntime.sendPrompt({
                 prompt: String(payload.text || ''),
                 workflowId: this._workflow?.id,
@@ -168,7 +183,9 @@ export class AgentWorkbenchWebview {
                 nodeContext,
                 sessionId: typeof payload.sessionId === 'string' ? payload.sessionId : undefined,
             }, (event) => this._panel.webview.postMessage(event));
+            this._outputChannel.appendLine(`[n8n-agent-debug] agent.send completed workflowId=${this._workflow?.id || 'none'} workflowChanged=${String(result.workflowChanged)}`);
             if (result.workflowChanged && this._workflow?.id) {
+                this._outputChannel.appendLine(`[n8n-agent-debug] posting workflow.reload after local workflowChanged workflowId=${this._workflow.id}`);
                 await this._panel.webview.postMessage({ type: 'workflow.reload' });
             }
             return;
@@ -311,8 +328,13 @@ export class AgentWorkbenchWebview {
 
         this._registryDisposable = workflowWebviewRegistry.register({
             getWorkflowId: () => this._workflow?.id,
-            reloadWorkflow: () => this._panel.webview.postMessage({ type: 'workflow.reload' }),
+            describeTarget: () => `agent-workbench:${this._panel.title}`,
+            reloadWorkflow: () => {
+                this._outputChannel.appendLine(`[n8n-agent-debug] registry requested workflow.reload workflowId=${this._workflow?.id || 'none'} panel=${this._panel.title}`);
+                return this._panel.webview.postMessage({ type: 'workflow.reload' });
+            },
         });
+        this._outputChannel.appendLine(`[n8n-agent-debug] registry registration ensured workflowId=${workflowId}`);
     }
 
     private getHtmlForWebview(): string {

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -12,15 +12,15 @@ export class AgentWorkbenchWebview {
     private readonly _agentRuntime: AgentRuntimeController;
     private readonly _disposables: vscode.Disposable[] = [];
     private _registryDisposable: { dispose(): void } | undefined;
-    private _workflow: IWorkflowStatus;
-    private _workflowUrl: string;
+    private _workflow: IWorkflowStatus | undefined;
+    private _workflowUrl: string | undefined;
     private _onClipboardPasteRequest: ((panel: vscode.WebviewPanel, grantToken: string) => Promise<void>) | undefined;
 
     private constructor(
         panel: vscode.WebviewPanel,
         context: vscode.ExtensionContext,
-        workflow: IWorkflowStatus,
-        workflowUrl: string,
+        workflow: IWorkflowStatus | undefined,
+        workflowUrl: string | undefined,
         agentRuntime: AgentRuntimeController,
     ) {
         this._panel = panel;
@@ -28,10 +28,7 @@ export class AgentWorkbenchWebview {
         this._workflow = workflow;
         this._workflowUrl = workflowUrl;
         this._agentRuntime = agentRuntime;
-        this._registryDisposable = workflowWebviewRegistry.register({
-            getWorkflowId: () => this._workflow.id,
-            reloadWorkflow: () => this._panel.webview.postMessage({ type: 'workflow.reload' }),
-        });
+        this.updateRegistryRegistration();
 
         this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
         this._panel.webview.onDidReceiveMessage((message) => {
@@ -42,8 +39,8 @@ export class AgentWorkbenchWebview {
 
     public static createOrShow(
         context: vscode.ExtensionContext,
-        workflow: IWorkflowStatus,
-        workflowUrl: string,
+        workflow: IWorkflowStatus | undefined,
+        workflowUrl: string | undefined,
         agentRuntime: AgentRuntimeController,
         viewColumn?: vscode.ViewColumn,
     ): void {
@@ -57,7 +54,7 @@ export class AgentWorkbenchWebview {
 
         const panel = vscode.window.createWebviewPanel(
             'n8nAgentWorkbench',
-            `n8n Agent: ${workflow.name}`,
+            `n8n Agent: ${workflow?.name || 'New workflow'}`,
             column,
             {
                 enableScripts: true,
@@ -75,14 +72,23 @@ export class AgentWorkbenchWebview {
         }
     }
 
-    public update(workflow: IWorkflowStatus, workflowUrl: string): void {
+    public update(workflow: IWorkflowStatus | undefined, workflowUrl: string | undefined): void {
+        const hadWorkflowFrame = Boolean(this._workflowUrl);
+        const hasWorkflowFrame = Boolean(workflowUrl);
         this._workflow = workflow;
         this._workflowUrl = workflowUrl;
-        this._panel.title = `n8n Agent: ${workflow.name}`;
+        this.updateRegistryRegistration();
+        this._panel.title = `n8n Agent: ${workflow?.name || 'New workflow'}`;
+
+        if (hadWorkflowFrame !== hasWorkflowFrame) {
+            this._panel.webview.html = this.getHtmlForWebview();
+            return;
+        }
+
         this._panel.webview.postMessage({
             type: 'workflow.update',
-            workflowId: workflow.id,
-            workflowName: workflow.name,
+            workflowId: workflow?.id || '',
+            workflowName: workflow?.name || 'New workflow',
             url: workflowUrl,
         });
     }
@@ -124,8 +130,9 @@ export class AgentWorkbenchWebview {
         if (payload.type === 'agent.send') {
             await this._agentRuntime.sendPrompt({
                 prompt: String(payload.text || ''),
-                workflowId: this._workflow.id,
-                workflowName: this._workflow.name,
+                workflowId: this._workflow?.id,
+                workflowName: this._workflow?.name,
+                workflowFilename: this._workflow?.filename,
                 workspaceRoot: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
             }, (event) => this._panel.webview.postMessage(event));
             return;
@@ -142,10 +149,28 @@ export class AgentWorkbenchWebview {
         }
     }
 
+    private updateRegistryRegistration(): void {
+        const workflowId = this._workflow?.id;
+        if (!workflowId) {
+            this._registryDisposable?.dispose();
+            this._registryDisposable = undefined;
+            return;
+        }
+
+        if (this._registryDisposable) {
+            return;
+        }
+
+        this._registryDisposable = workflowWebviewRegistry.register({
+            getWorkflowId: () => this._workflow?.id,
+            reloadWorkflow: () => this._panel.webview.postMessage({ type: 'workflow.reload' }),
+        });
+    }
+
     private getHtmlForWebview(): string {
         return buildAgentWorkbenchHtml({
-            workflowId: this._workflow.id,
-            workflowName: this._workflow.name,
+            workflowId: this._workflow?.id || '',
+            workflowName: this._workflow?.name || 'New workflow',
             workflowUrl: this._workflowUrl,
         });
     }

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -80,10 +80,11 @@ export class AgentWorkbenchWebview {
             }
         }, null, this._disposables);
         this._panel.webview.onDidReceiveMessage((message) => {
-            void this.handleMessage(message).catch((error: any) => {
+            void this.handleMessage(message).catch(async (error: any) => {
                 const detail = error?.message || String(error);
                 console.error('[AgentWorkbench] Message handler error', error);
                 void this._panel.webview.postMessage({ type: 'agent.streamEvent', event: { type: 'error', error: detail } });
+                await this.postWorkbenchState();
             });
         }, null, this._disposables);
         this._panel.webview.html = this.getHtmlForWebview();

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -131,6 +131,11 @@ export class AgentWorkbenchWebview {
             return;
         }
 
+        if (payload.type === 'agent.selectModel') {
+            await vscode.commands.executeCommand('n8n.agent.selectModel');
+            return;
+        }
+
         if (payload.type === 'agent.stop') {
             await this._agentRuntime.stop((event) => this._panel.webview.postMessage(event));
             return;

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
 import { IWorkflowStatus } from 'n8nac';
-import { AgentRuntimeController } from '../services/agent-runtime-controller.js';
+import { AgentRuntimeController, type AgentWorkflowContext } from '../services/agent-runtime-controller.js';
 import { workflowWebviewRegistry } from '../services/workflow-webview-registry.js';
 import { buildAgentWorkbenchHtml } from './agent-workbench-html.js';
 
@@ -8,6 +9,19 @@ interface AgentWorkbenchNodeContext {
     name: string;
     type?: string;
     id?: string;
+}
+
+interface AgentWorkflowTarget {
+    workflow?: IWorkflowStatus;
+    workflowFilePath?: string;
+    workflowUrl?: string;
+    workflowReloadUrl?: string;
+}
+
+interface AgentWorkbenchWorkflowProviders {
+    listWorkflows(): Promise<IWorkflowStatus[]>;
+    resolveWorkflow(workflow: AgentWorkflowContext): Promise<AgentWorkflowTarget>;
+    listWorkflowNodes(workflow: AgentWorkflowContext): Promise<AgentWorkbenchNodeContext[]>;
 }
 
 export class AgentWorkbenchWebview {
@@ -24,7 +38,9 @@ export class AgentWorkbenchWebview {
     private _workflowUrl: string | undefined;
     private _workflowReloadUrl: string | undefined;
     private _providerModelLabel: string;
-    private _nodeContext: AgentWorkbenchNodeContext | undefined;
+    private _nodeContexts: AgentWorkbenchNodeContext[] = [];
+    private _workflowProviders: AgentWorkbenchWorkflowProviders;
+    private _activeSessionId: string | undefined;
     private _onClipboardPasteRequest: ((panel: vscode.WebviewPanel, grantToken: string) => Promise<void>) | undefined;
 
     private constructor(
@@ -37,6 +53,8 @@ export class AgentWorkbenchWebview {
         providerModelLabel: string,
         agentRuntime: AgentRuntimeController,
         outputChannel: vscode.OutputChannel,
+        workflowProviders: AgentWorkbenchWorkflowProviders,
+        initialSessionId: string | undefined,
     ) {
         this._panel = panel;
         this._context = context;
@@ -47,6 +65,8 @@ export class AgentWorkbenchWebview {
         this._providerModelLabel = providerModelLabel;
         this._agentRuntime = agentRuntime;
         this._outputChannel = outputChannel;
+        this._workflowProviders = workflowProviders;
+        this._activeSessionId = initialSessionId;
         this.updateRegistryRegistration();
 
         this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
@@ -69,12 +89,16 @@ export class AgentWorkbenchWebview {
         providerModelLabel: string,
         agentRuntime: AgentRuntimeController,
         outputChannel: vscode.OutputChannel,
+        workflowProviders: AgentWorkbenchWorkflowProviders,
+        initialSessionId?: string,
         viewColumn?: vscode.ViewColumn,
     ): void {
         const column = viewColumn || vscode.ViewColumn.One;
 
         if (AgentWorkbenchWebview.currentPanel) {
             AgentWorkbenchWebview.currentPanel._panel.reveal(column);
+            AgentWorkbenchWebview.currentPanel._workflowProviders = workflowProviders;
+            AgentWorkbenchWebview.currentPanel._activeSessionId = initialSessionId || AgentWorkbenchWebview.currentPanel._activeSessionId;
             AgentWorkbenchWebview.currentPanel.update(workflow, workflowFilePath, workflowUrl, workflowReloadUrl, providerModelLabel);
             return;
         }
@@ -90,7 +114,7 @@ export class AgentWorkbenchWebview {
             },
         );
 
-        AgentWorkbenchWebview.currentPanel = new AgentWorkbenchWebview(panel, context, workflow, workflowFilePath, workflowUrl, workflowReloadUrl, providerModelLabel, agentRuntime, outputChannel);
+        AgentWorkbenchWebview.currentPanel = new AgentWorkbenchWebview(panel, context, workflow, workflowFilePath, workflowUrl, workflowReloadUrl, providerModelLabel, agentRuntime, outputChannel, workflowProviders, initialSessionId);
     }
 
     public static onClipboardPasteRequest(handler: (panel: vscode.WebviewPanel, grantToken: string) => Promise<void>): void {
@@ -99,9 +123,11 @@ export class AgentWorkbenchWebview {
         }
     }
 
-    public update(workflow: IWorkflowStatus | undefined, workflowFilePath: string | undefined, workflowUrl: string | undefined, workflowReloadUrl: string | undefined, providerModelLabel: string): void {
-        const hadWorkflowFrame = Boolean(this._workflowUrl);
-        const hasWorkflowFrame = Boolean(workflowUrl);
+    public update(workflow: IWorkflowStatus | undefined, workflowFilePath: string | undefined, workflowUrl: string | undefined, workflowReloadUrl: string | undefined, providerModelLabel: string, postState = true): void {
+        const hadWorkflowFrame = Boolean(this._workflow);
+        const hasWorkflowFrame = Boolean(workflow);
+        const hadWorkflowUi = Boolean(this._workflowUrl);
+        const hasWorkflowUi = Boolean(workflowUrl);
         this._workflow = workflow;
         this._workflowFilePath = workflowFilePath;
         this._workflowUrl = workflowUrl;
@@ -110,7 +136,7 @@ export class AgentWorkbenchWebview {
         this.updateRegistryRegistration();
         this._panel.title = `n8n Agent: ${workflow?.name || 'New workflow'}`;
 
-        if (hadWorkflowFrame !== hasWorkflowFrame) {
+        if (hadWorkflowFrame !== hasWorkflowFrame || hadWorkflowUi !== hasWorkflowUi) {
             this._panel.webview.html = this.getHtmlForWebview();
             return;
         }
@@ -122,7 +148,7 @@ export class AgentWorkbenchWebview {
             url: workflowUrl,
             reloadUrl: workflowReloadUrl,
         });
-        void this.postWorkbenchState();
+        if (postState) void this.postWorkbenchState();
     }
 
     public dispose(): void {
@@ -171,7 +197,7 @@ export class AgentWorkbenchWebview {
         }
 
         if (payload.type === 'agent.send') {
-            const nodeContext = this.sanitizeNodeContext(payload.nodeContext) ?? this._nodeContext;
+            const nodeContexts = this.sanitizeNodeContexts(payload.nodeContexts) || this.sanitizeNodeContexts(payload.nodeContext) || this._nodeContexts;
             this._outputChannel.appendLine(`[n8n-agent-debug] agent.send workflowId=${this._workflow?.id || 'none'} workflowFilePath=${this._workflowFilePath || 'none'} sessionId=${typeof payload.sessionId === 'string' ? payload.sessionId : 'none'}`);
             const result = await this._agentRuntime.sendPrompt({
                 prompt: String(payload.text || ''),
@@ -180,7 +206,8 @@ export class AgentWorkbenchWebview {
                 workflowFilename: this._workflow?.filename,
                 workflowFilePath: this._workflowFilePath,
                 workspaceRoot: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
-                nodeContext,
+                nodeContext: nodeContexts[0],
+                nodeContexts,
                 sessionId: typeof payload.sessionId === 'string' ? payload.sessionId : undefined,
             }, (event) => this._panel.webview.postMessage(event));
             this._outputChannel.appendLine(`[n8n-agent-debug] agent.send completed workflowId=${this._workflow?.id || 'none'} workflowChanged=${String(result.workflowChanged)}`);
@@ -210,7 +237,24 @@ export class AgentWorkbenchWebview {
         }
 
         if (payload.type === 'agent.nodeDetailChanged') {
-            this._nodeContext = this.sanitizeNodeContext(payload.nodeContext);
+            this._nodeContexts = this.sanitizeNodeContexts(payload.nodeContexts) || this.sanitizeNodeContexts(payload.nodeContext) || [];
+            if (typeof payload.sessionId === 'string') {
+                await this.postWorkbenchState(await this._agentRuntime.setNodeContexts(payload.sessionId, this._nodeContexts, this.buildWorkbenchInput()));
+            }
+            return;
+        }
+
+        if (payload.type === 'agent.context.workflow.set' && typeof payload.sessionId === 'string') {
+            const workflow = this.sanitizeWorkflowContext(payload.workflow);
+            if (!workflow) return;
+            await this.postWorkbenchState(await this._agentRuntime.setWorkflowContext(payload.sessionId, workflow, this.buildWorkbenchInput()));
+            return;
+        }
+
+        if (payload.type === 'agent.context.workflow.clear' && typeof payload.sessionId === 'string') {
+            this._activeSessionId = payload.sessionId;
+            this._nodeContexts = [];
+            await this.postWorkbenchState(await this._agentRuntime.clearWorkflowContext(payload.sessionId, this.buildWorkbenchInput()));
             return;
         }
 
@@ -225,6 +269,7 @@ export class AgentWorkbenchWebview {
         }
 
         if (payload.type === 'agent.session.select' && typeof payload.sessionId === 'string') {
+            this._activeSessionId = payload.sessionId;
             await this.postWorkbenchState(await this._agentRuntime.selectSession(payload.sessionId, this.buildWorkbenchInput()));
             return;
         }
@@ -286,6 +331,37 @@ export class AgentWorkbenchWebview {
         };
     }
 
+    private sanitizeNodeContexts(value: unknown): AgentWorkbenchNodeContext[] | undefined {
+        const values = Array.isArray(value) ? value : value ? [value] : [];
+        const contexts = values
+            .map((item) => this.sanitizeNodeContext(item))
+            .filter((item): item is AgentWorkbenchNodeContext => Boolean(item));
+        if (!contexts.length) return undefined;
+        const seen = new Set<string>();
+        return contexts.filter((node) => {
+            const key = [node.name, node.type || '', node.id || ''].join('|');
+            if (seen.has(key)) return false;
+            seen.add(key);
+            return true;
+        });
+    }
+
+    private sanitizeWorkflowContext(value: unknown): AgentWorkflowContext | undefined {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+        const record = value as Record<string, unknown>;
+        const id = typeof record.id === 'string' ? record.id.trim() : '';
+        const name = typeof record.name === 'string' ? record.name.trim() : '';
+        const filename = typeof record.filename === 'string' ? record.filename.trim() : '';
+        const filePath = typeof record.filePath === 'string' ? record.filePath.trim() : '';
+        if (!id && !name && !filename) return undefined;
+        return {
+            id: id || undefined,
+            name: name || id || filename,
+            filename: filename || undefined,
+            filePath: filePath || undefined,
+        };
+    }
+
     private getProviderModelLabel(): string {
         const config = vscode.workspace.getConfiguration('n8n.agent');
         const provider = String(config.get<string>('provider') || 'openai').trim() || 'openai';
@@ -299,19 +375,102 @@ export class AgentWorkbenchWebview {
         workflowFilename?: string;
         workspaceRoot?: string;
         nodeContext?: AgentWorkbenchNodeContext;
+        nodeContexts?: AgentWorkbenchNodeContext[];
+        sessionId?: string;
     } {
         return {
             workflowId: this._workflow?.id,
             workflowName: this._workflow?.name,
             workflowFilename: this._workflow?.filename,
             workspaceRoot: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
-            nodeContext: this._nodeContext,
+            nodeContext: this._nodeContexts[0],
+            nodeContexts: this._nodeContexts,
+            sessionId: this._activeSessionId,
         };
     }
 
     private async postWorkbenchState(state?: Awaited<ReturnType<AgentRuntimeController['getWorkbenchState']>>): Promise<void> {
         const nextState = state ?? await this._agentRuntime.getWorkbenchState(this.buildWorkbenchInput());
-        await this._panel.webview.postMessage({ type: 'agent.state', state: nextState });
+        this._activeSessionId = nextState.activeSessionId;
+        await this.reconcileWorkflowContext(nextState.workflowContext);
+        this._nodeContexts = Array.isArray(nextState.currentNodeContexts) ? nextState.currentNodeContexts : [];
+        const enrichedState = {
+            ...nextState,
+            availableWorkflows: await this.getWorkflowOptions(),
+            availableNodes: await this.getWorkflowNodeOptions(),
+        };
+        await this._panel.webview.postMessage({ type: 'agent.state', state: enrichedState });
+    }
+
+    private async reconcileWorkflowContext(workflowContext: AgentWorkflowContext | undefined): Promise<void> {
+        if (!workflowContext) {
+            if (this._workflow || this._workflowUrl || this._workflowFilePath) {
+                this.update(undefined, undefined, undefined, undefined, this._providerModelLabel, false);
+            }
+            return;
+        }
+        const currentKey = this._workflow?.id || this._workflow?.filename || this._workflow?.name || '';
+        const nextKey = workflowContext.id || workflowContext.filename || workflowContext.name || '';
+        if (currentKey === nextKey && this._workflowFilePath === workflowContext.filePath) {
+            return;
+        }
+        const target = await this._workflowProviders.resolveWorkflow(workflowContext);
+        const workflow = target.workflow || ({
+            id: workflowContext.id || '',
+            name: workflowContext.name,
+            filename: workflowContext.filename || '',
+        } as IWorkflowStatus);
+        this.update(workflow, target.workflowFilePath || workflowContext.filePath, target.workflowUrl, target.workflowReloadUrl, this._providerModelLabel, false);
+    }
+
+    private async getWorkflowOptions(): Promise<AgentWorkflowContext[]> {
+        const workflows = await this._workflowProviders.listWorkflows().catch(() => []);
+        return workflows.map((workflow) => ({
+            id: workflow.id || undefined,
+            name: workflow.name || workflow.id || workflow.filename || 'Workflow',
+            filename: workflow.filename || undefined,
+        }));
+    }
+
+    private async getWorkflowNodeOptions(): Promise<AgentWorkbenchNodeContext[]> {
+        if (this._workflowFilePath) {
+            try {
+                const raw = await fs.promises.readFile(this._workflowFilePath, 'utf8');
+                return this.extractNodeContextsFromTypeScript(raw)
+                    .filter((node): node is AgentWorkbenchNodeContext => Boolean(node));
+            } catch {
+                // Fall through to remote lookup when the local path is stale or unavailable.
+            }
+        }
+        if (!this._workflow?.id) return [];
+        return this._workflowProviders.listWorkflowNodes({
+            id: this._workflow.id,
+            name: this._workflow.name || this._workflow.id,
+            filename: this._workflow.filename || undefined,
+            filePath: this._workflowFilePath,
+        }).catch(() => []);
+    }
+
+    private extractNodeContextsFromTypeScript(source: string): AgentWorkbenchNodeContext[] {
+        const nodes: AgentWorkbenchNodeContext[] = [];
+        const nodeDecoratorPattern = /@node\s*\(\s*\{([\s\S]*?)\}\s*\)/g;
+        let match: RegExpExecArray | null;
+        while ((match = nodeDecoratorPattern.exec(source))) {
+            const decoratorContent = match[1] || '';
+            const name = this.extractStringProperty(decoratorContent, 'name');
+            if (!name) continue;
+            nodes.push({
+                name,
+                type: this.extractStringProperty(decoratorContent, 'type'),
+                id: this.extractStringProperty(decoratorContent, 'id'),
+            });
+        }
+        return nodes;
+    }
+
+    private extractStringProperty(source: string, property: string): string | undefined {
+        const match = source.match(new RegExp(`${property}\\s*:\\s*(["'])((?:\\\\.|(?!\\1)[\\s\\S])*?)\\1`));
+        return match?.[2]?.trim() || undefined;
     }
 
     private updateRegistryRegistration(): void {
@@ -341,6 +500,7 @@ export class AgentWorkbenchWebview {
         return buildAgentWorkbenchHtml({
             workflowId: this._workflow?.id || '',
             workflowName: this._workflow?.name || 'New workflow',
+            workflowAttached: Boolean(this._workflow),
             workflowUrl: this._workflowUrl,
             workflowReloadUrl: this._workflowReloadUrl,
             providerModelLabel: this._providerModelLabel,

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -80,11 +80,10 @@ export class AgentWorkbenchWebview {
             }
         }, null, this._disposables);
         this._panel.webview.onDidReceiveMessage((message) => {
-            void this.handleMessage(message).catch(async (error: any) => {
+            void this.handleMessage(message).catch((error: any) => {
                 const detail = error?.message || String(error);
                 console.error('[AgentWorkbench] Message handler error', error);
                 void this._panel.webview.postMessage({ type: 'agent.streamEvent', event: { type: 'error', error: detail } });
-                await this.postWorkbenchState();
             });
         }, null, this._disposables);
         this._panel.webview.html = this.getHtmlForWebview();

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -158,7 +158,7 @@ export class AgentWorkbenchWebview {
 
         if (payload.type === 'agent.send') {
             const nodeContext = this.sanitizeNodeContext(payload.nodeContext) ?? this._nodeContext;
-            await this._agentRuntime.sendPrompt({
+            const workflowChanged = await this._agentRuntime.sendPrompt({
                 prompt: String(payload.text || ''),
                 workflowId: this._workflow?.id,
                 workflowName: this._workflow?.name,
@@ -168,7 +168,7 @@ export class AgentWorkbenchWebview {
                 nodeContext,
                 sessionId: typeof payload.sessionId === 'string' ? payload.sessionId : undefined,
             }, (event) => this._panel.webview.postMessage(event));
-            if (this._workflow?.id) {
+            if (workflowChanged && this._workflow?.id) {
                 await this._panel.webview.postMessage({ type: 'workflow.reload' });
             }
             return;

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -21,6 +21,7 @@ export class AgentWorkbenchWebview {
     private _workflow: IWorkflowStatus | undefined;
     private _workflowUrl: string | undefined;
     private _workflowReloadUrl: string | undefined;
+    private _providerModelLabel: string;
     private _nodeContext: AgentWorkbenchNodeContext | undefined;
     private _onClipboardPasteRequest: ((panel: vscode.WebviewPanel, grantToken: string) => Promise<void>) | undefined;
 
@@ -30,6 +31,7 @@ export class AgentWorkbenchWebview {
         workflow: IWorkflowStatus | undefined,
         workflowUrl: string | undefined,
         workflowReloadUrl: string | undefined,
+        providerModelLabel: string,
         agentRuntime: AgentRuntimeController,
     ) {
         this._panel = panel;
@@ -37,6 +39,7 @@ export class AgentWorkbenchWebview {
         this._workflow = workflow;
         this._workflowUrl = workflowUrl;
         this._workflowReloadUrl = workflowReloadUrl;
+        this._providerModelLabel = providerModelLabel;
         this._agentRuntime = agentRuntime;
         this.updateRegistryRegistration();
 
@@ -52,6 +55,7 @@ export class AgentWorkbenchWebview {
         workflow: IWorkflowStatus | undefined,
         workflowUrl: string | undefined,
         workflowReloadUrl: string | undefined,
+        providerModelLabel: string,
         agentRuntime: AgentRuntimeController,
         viewColumn?: vscode.ViewColumn,
     ): void {
@@ -59,7 +63,7 @@ export class AgentWorkbenchWebview {
 
         if (AgentWorkbenchWebview.currentPanel) {
             AgentWorkbenchWebview.currentPanel._panel.reveal(column);
-            AgentWorkbenchWebview.currentPanel.update(workflow, workflowUrl, workflowReloadUrl);
+            AgentWorkbenchWebview.currentPanel.update(workflow, workflowUrl, workflowReloadUrl, providerModelLabel);
             return;
         }
 
@@ -74,7 +78,7 @@ export class AgentWorkbenchWebview {
             },
         );
 
-        AgentWorkbenchWebview.currentPanel = new AgentWorkbenchWebview(panel, context, workflow, workflowUrl, workflowReloadUrl, agentRuntime);
+        AgentWorkbenchWebview.currentPanel = new AgentWorkbenchWebview(panel, context, workflow, workflowUrl, workflowReloadUrl, providerModelLabel, agentRuntime);
     }
 
     public static onClipboardPasteRequest(handler: (panel: vscode.WebviewPanel, grantToken: string) => Promise<void>): void {
@@ -83,12 +87,13 @@ export class AgentWorkbenchWebview {
         }
     }
 
-    public update(workflow: IWorkflowStatus | undefined, workflowUrl: string | undefined, workflowReloadUrl: string | undefined): void {
+    public update(workflow: IWorkflowStatus | undefined, workflowUrl: string | undefined, workflowReloadUrl: string | undefined, providerModelLabel: string): void {
         const hadWorkflowFrame = Boolean(this._workflowUrl);
         const hasWorkflowFrame = Boolean(workflowUrl);
         this._workflow = workflow;
         this._workflowUrl = workflowUrl;
         this._workflowReloadUrl = workflowReloadUrl;
+        this._providerModelLabel = providerModelLabel;
         this.updateRegistryRegistration();
         this._panel.title = `n8n Agent: ${workflow?.name || 'New workflow'}`;
 
@@ -158,6 +163,8 @@ export class AgentWorkbenchWebview {
 
         if (payload.type === 'agent.selectModel') {
             await vscode.commands.executeCommand('n8n.agent.selectModel');
+            this._providerModelLabel = this.getProviderModelLabel();
+            this._panel.webview.html = this.getHtmlForWebview();
             return;
         }
 
@@ -188,6 +195,13 @@ export class AgentWorkbenchWebview {
         };
     }
 
+    private getProviderModelLabel(): string {
+        const config = vscode.workspace.getConfiguration('n8n.agent');
+        const provider = String(config.get<string>('provider') || 'openai').trim() || 'openai';
+        const model = String(config.get<string>('model') || '').trim();
+        return model ? `${provider} / ${model}` : provider;
+    }
+
     private updateRegistryRegistration(): void {
         const workflowId = this._workflow?.id;
         if (!workflowId) {
@@ -212,6 +226,7 @@ export class AgentWorkbenchWebview {
             workflowName: this._workflow?.name || 'New workflow',
             workflowUrl: this._workflowUrl,
             workflowReloadUrl: this._workflowReloadUrl,
+            providerModelLabel: this._providerModelLabel,
         });
     }
 }

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -158,7 +158,7 @@ export class AgentWorkbenchWebview {
 
         if (payload.type === 'agent.send') {
             const nodeContext = this.sanitizeNodeContext(payload.nodeContext) ?? this._nodeContext;
-            const workflowChanged = await this._agentRuntime.sendPrompt({
+            await this._agentRuntime.sendPrompt({
                 prompt: String(payload.text || ''),
                 workflowId: this._workflow?.id,
                 workflowName: this._workflow?.name,
@@ -168,7 +168,7 @@ export class AgentWorkbenchWebview {
                 nodeContext,
                 sessionId: typeof payload.sessionId === 'string' ? payload.sessionId : undefined,
             }, (event) => this._panel.webview.postMessage(event));
-            if (workflowChanged && this._workflow?.id) {
+            if (this._workflow?.id) {
                 await this._panel.webview.postMessage({ type: 'workflow.reload' });
             }
             return;

--- a/packages/vscode-extension/src/ui/configuration-webview-html.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview-html.ts
@@ -21,13 +21,48 @@ export function getConfigurationHtml(nonce: string): string {
       color: var(--vscode-foreground);
       font-family: var(--vscode-font-family);
     }
+    .settings-shell {
+      min-height: 100vh;
+      display: grid;
+      grid-template-columns: 180px minmax(0, 1fr);
+    }
+    .sidebar {
+      border-right: 1px solid var(--border);
+      background: color-mix(in srgb, var(--vscode-sideBar-background, var(--surface)) 88%, var(--surface));
+      padding: 14px 8px;
+      display: grid;
+      align-content: start;
+      gap: 6px;
+    }
+    .sidebar-title {
+      padding: 0 8px 10px;
+      font-weight: 700;
+    }
+    .tab-button {
+      width: 100%;
+      justify-content: flex-start;
+      text-align: left;
+      color: var(--vscode-foreground);
+      background: transparent;
+      border-color: transparent;
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      font-weight: 600;
+    }
+    .tab-button.active {
+      background: var(--vscode-list-activeSelectionBackground, var(--vscode-list-hoverBackground));
+      color: var(--vscode-list-activeSelectionForeground, var(--vscode-foreground));
+    }
     .page {
-      max-width: 1040px;
-      margin: 0 auto;
+      max-width: 1240px;
+      width: 100%;
       padding: 18px;
       display: grid;
       gap: 14px;
     }
+    .tab-panel { display: none; }
+    .tab-panel.active { display: grid; gap: 14px; }
     header {
       display: flex;
       justify-content: space-between;
@@ -63,6 +98,20 @@ export function getConfigurationHtml(nonce: string): string {
     }
     .toolbar { display: flex; flex-wrap: wrap; gap: 8px; }
     .instances { display: grid; gap: 10px; }
+    .providers { display: grid; gap: 10px; }
+    .provider-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 14px;
+      align-items: center;
+      border-top: 1px solid var(--border);
+      padding: 13px 0;
+    }
+    .provider-row:first-child { border-top: 0; }
+    .provider-main { display: grid; gap: 4px; min-width: 0; }
+    .provider-title { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; font-weight: 700; }
+    .provider-detail { color: var(--muted); font-size: 12px; }
+    .provider-actions { display: flex; flex-wrap: wrap; gap: 8px; justify-content: flex-end; }
     .instance-row {
       display: grid;
       grid-template-columns: 1fr;
@@ -225,60 +274,107 @@ export function getConfigurationHtml(nonce: string): string {
     }
     .message.error { color: var(--vscode-errorForeground); }
     .message.ok { color: var(--vscode-testing-iconPassed, var(--vscode-foreground)); }
+    .about-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
+    .about-card { border: 1px solid var(--border); border-radius: 10px; padding: 14px; background: var(--soft); display: grid; gap: 8px; }
     @media (max-width: 860px) {
-      header, .grid, .form-grid, .field-row, .credential-row { grid-template-columns: 1fr; }
+      .settings-shell, header, .grid, .form-grid, .field-row, .credential-row { grid-template-columns: 1fr; }
+      .sidebar { border-right: 0; border-bottom: 1px solid var(--border); grid-template-columns: repeat(3, 1fr); }
+      .sidebar-title { grid-column: 1 / -1; }
       .instance-top, .instance-foot { display: grid; grid-template-columns: 1fr; }
       .instance-status { justify-content: flex-start; }
+      .provider-row { grid-template-columns: 1fr; }
+      .provider-actions { justify-content: flex-start; }
     }
   </style>
 </head>
 <body>
-  <div class="page">
-    <header>
-      <div>
-        <h1>n8n configuration</h1>
-        <p class="muted">Manage n8n instances and click a card to choose what this workspace uses.</p>
-      </div>
-      <button id="refresh" class="secondary">Refresh</button>
-    </header>
+  <div class="settings-shell">
+    <nav class="sidebar" aria-label="n8n settings sections">
+      <div class="sidebar-title">Settings</div>
+      <button class="tab-button active" data-tab="n8n-instances" type="button">n8n Instances</button>
+      <button class="tab-button" data-tab="agent-providers" type="button">Agent Providers</button>
+      <button class="tab-button" data-tab="about" type="button">About</button>
+    </nav>
 
-    <div class="grid">
-      <section class="panel">
-        <div class="panel-head">
-          <div>
-            <h2>n8n instances</h2>
-            <p class="muted">Click a card to connect this workspace to that instance. The active workspace instance is highlighted.</p>
-          </div>
-          <button id="addInstance">Add instance</button>
-        </div>
-        <div id="instanceList" class="instances"></div>
-      </section>
-
-      <section class="panel">
+    <div class="page">
+      <header>
         <div>
-          <h2>Workspace settings</h2>
-          <p class="muted">Folder and project stay scoped to this workspace.</p>
+          <h1>n8n-as-code settings</h1>
+          <p class="muted">Manage n8n instances, agent providers, and extension information from one place.</p>
         </div>
-        <label>
-          Sync folder
-          <input id="workspaceSync" type="text" placeholder="Use workspace default: workflows" />
-        </label>
-        <div class="field-row">
-          <label>
-            Project
-            <select id="workspaceProject" disabled><option value="">Load projects from effective instance</option></select>
-          </label>
-          <button id="loadProjects" class="secondary">Load projects</button>
-        </div>
-        <div class="toolbar">
-          <button id="saveWorkspace">Save settings</button>
-          <button id="clearWorkspaceSettings" class="secondary">Clear folder/project</button>
+        <button id="refresh" class="secondary">Refresh</button>
+      </header>
+
+      <section id="tab-n8n-instances" class="tab-panel active">
+        <div class="grid">
+          <section class="panel">
+            <div class="panel-head">
+              <div>
+                <h2>n8n instances</h2>
+                <p class="muted">Click a card to connect this workspace to that instance. The active workspace instance is highlighted.</p>
+              </div>
+              <button id="addInstance">Add instance</button>
+            </div>
+            <div id="instanceList" class="instances"></div>
+          </section>
+
+          <section class="panel">
+            <div>
+              <h2>Workspace settings</h2>
+              <p class="muted">Folder and project stay scoped to this workspace.</p>
+            </div>
+            <label>
+              Sync folder
+              <input id="workspaceSync" type="text" placeholder="Use workspace default: workflows" />
+            </label>
+            <div class="field-row">
+              <label>
+                Project
+                <select id="workspaceProject" disabled><option value="">Load projects from effective instance</option></select>
+              </label>
+              <button id="loadProjects" class="secondary">Load projects</button>
+            </div>
+            <div class="toolbar">
+              <button id="saveWorkspace">Save settings</button>
+              <button id="clearWorkspaceSettings" class="secondary">Clear folder/project</button>
+            </div>
+          </section>
         </div>
       </section>
-    </div>
 
-    <div id="error" class="message error"></div>
-    <div id="saved" class="message ok">Saved.</div>
+      <section id="tab-agent-providers" class="tab-panel">
+        <section class="panel">
+          <div class="panel-head">
+            <div>
+              <h2>Agent providers</h2>
+              <p class="muted">Connect API and OAuth providers, then select provider/model for chat sessions.</p>
+            </div>
+            <button id="providerSelectModel" class="secondary">Select Provider / Model</button>
+          </div>
+          <div>
+            <h3>Connected providers</h3>
+            <div id="connectedProviders" class="providers"></div>
+          </div>
+          <div>
+            <h3>Available providers</h3>
+            <div id="availableProviders" class="providers"></div>
+          </div>
+        </section>
+      </section>
+
+      <section id="tab-about" class="tab-panel">
+        <section class="panel">
+          <div>
+            <h2>About n8n-as-code</h2>
+            <p class="muted">Edit and sync n8n workflows from VS Code with embedded agent assistance.</p>
+          </div>
+          <div id="aboutGrid" class="about-grid"></div>
+        </section>
+      </section>
+
+      <div id="error" class="message error"></div>
+      <div id="saved" class="message ok">Saved.</div>
+    </div>
   </div>
 
   <div id="instanceModal" class="modal-backdrop hidden">
@@ -414,9 +510,15 @@ export function getConfigurationHtml(nonce: string): string {
       copyCredentialUsername: document.getElementById('copyCredentialUsername'),
       copyCredentialPassword: document.getElementById('copyCredentialPassword'),
       closeCredentialsModal: document.getElementById('closeCredentialsModal'),
+      tabButtons: Array.from(document.querySelectorAll('.tab-button')),
+      tabPanels: Array.from(document.querySelectorAll('.tab-panel')),
+      connectedProviders: document.getElementById('connectedProviders'),
+      availableProviders: document.getElementById('availableProviders'),
+      providerSelectModel: document.getElementById('providerSelectModel'),
+      aboutGrid: document.getElementById('aboutGrid'),
     };
 
-    let state = { global: { instances: [] }, workspace: {}, effective: undefined };
+    let state = { global: { instances: [] }, workspace: {}, effective: undefined, providers: [], about: {} };
     const PERSONAL_PROJECT = { id: 'personal', name: 'Personal', type: 'personal' };
     let projects = [PERSONAL_PROJECT];
     let editingInstanceId = '';
@@ -438,6 +540,9 @@ export function getConfigurationHtml(nonce: string): string {
     }
     function instances() {
       return state.global?.instances || [];
+    }
+    function providers() {
+      return state.providers || [];
     }
     function instanceById(id) {
       return instances().find((instance) => instance.id === id);
@@ -465,6 +570,16 @@ export function getConfigurationHtml(nonce: string): string {
       els.workspaceSync.value = workspace.syncFolder || '';
       renderInstanceList();
       renderProjects(workspace.projectId || effective?.projectId || 'personal');
+      renderProviders();
+      renderAbout();
+    }
+    function setActiveTab(tab) {
+      for (const button of els.tabButtons) {
+        button.classList.toggle('active', button.dataset.tab === tab);
+      }
+      for (const panel of els.tabPanels) {
+        panel.classList.toggle('active', panel.id === 'tab-' + tab);
+      }
     }
     function renderInstanceList() {
       els.instanceList.innerHTML = '';
@@ -567,6 +682,74 @@ export function getConfigurationHtml(nonce: string): string {
       el.className = 'badge ' + cls;
       el.textContent = text;
       return el;
+    }
+    function providerBadge(provider) {
+      if (provider.selected) return badge('Selected', 'active');
+      if (provider.credentialSource === 'environment') return badge('Environment', 'ready');
+      if (provider.credentialSource === 'secret') return badge(provider.authKind === 'oauth-device' ? 'OAuth' : 'Stored', 'ready');
+      return badge(provider.authKind, 'stopped');
+    }
+    function renderProviders() {
+      const connected = providers().filter((provider) => provider.connected);
+      const available = providers().filter((provider) => !provider.connected);
+      renderProviderList(els.connectedProviders, connected, true);
+      renderProviderList(els.availableProviders, available, false);
+    }
+    function renderProviderList(container, list, connected) {
+      container.innerHTML = '';
+      if (!list.length) {
+        const empty = document.createElement('p');
+        empty.className = 'muted';
+        empty.textContent = connected ? 'No connected providers yet.' : 'All available providers are connected.';
+        container.appendChild(empty);
+        return;
+      }
+      for (const provider of list) {
+        const row = document.createElement('div');
+        row.className = 'provider-row';
+        const main = document.createElement('div');
+        main.className = 'provider-main';
+        const title = document.createElement('div');
+        title.className = 'provider-title';
+        const name = document.createElement('span');
+        name.textContent = provider.label;
+        title.append(name, providerBadge(provider));
+        const detail = document.createElement('div');
+        detail.className = 'provider-detail';
+        const model = provider.selected && provider.model ? ' · Model: ' + provider.model : provider.defaultModel ? ' · Default: ' + provider.defaultModel : '';
+        const baseUrl = provider.id === 'openai-compatible' && provider.baseUrl ? ' · ' + provider.baseUrl : '';
+        detail.textContent = provider.description + model + baseUrl;
+        main.append(title, detail);
+        const actions = document.createElement('div');
+        actions.className = 'provider-actions';
+        if (connected) {
+          actions.append(button('Use / Model', 'secondary compact', () => post('selectProviderModel', { provider: provider.id })));
+          actions.append(button('Disconnect', 'danger compact', () => post('disconnectProvider', { provider: provider.id })));
+        } else {
+          actions.append(button('Connect', 'compact', () => post('connectProvider', { provider: provider.id })));
+        }
+        row.append(main, actions);
+        container.appendChild(row);
+      }
+    }
+    function renderAbout() {
+      els.aboutGrid.innerHTML = '';
+      const cards = [
+        ['Extension', state.about?.extensionVersion || 'unknown'],
+        ['n8nac dependency', state.about?.cliVersion || 'unknown'],
+        ['Workspace', state.effective?.activeInstanceName || state.effective?.activeInstanceId || 'No active n8n instance'],
+      ];
+      for (const [title, value] of cards) {
+        const card = document.createElement('div');
+        card.className = 'about-card';
+        const h = document.createElement('h2');
+        h.textContent = title;
+        const p = document.createElement('p');
+        p.className = 'muted';
+        p.textContent = value;
+        card.append(h, p);
+        els.aboutGrid.appendChild(card);
+      }
     }
     function button(text, cls, onClick) {
       const el = document.createElement('button');
@@ -701,6 +884,8 @@ export function getConfigurationHtml(nonce: string): string {
       vscode.postMessage({ type, ...payload });
     }
     els.refresh.addEventListener('click', () => post('refreshState'));
+    els.tabButtons.forEach((tabButton) => tabButton.addEventListener('click', () => setActiveTab(tabButton.dataset.tab)));
+    els.providerSelectModel.addEventListener('click', () => post('selectProviderModel', { provider: providers().find((provider) => provider.selected)?.id || 'openai' }));
     els.addInstance.addEventListener('click', () => openModal(undefined));
     els.closeModal.addEventListener('click', closeModal);
     els.cancelModal.addEventListener('click', closeModal);
@@ -749,6 +934,8 @@ export function getConfigurationHtml(nonce: string): string {
           global: message.global || { instances: [] },
           workspace: message.workspace || {},
           effective: message.effective,
+          providers: message.providers || [],
+          about: message.about || {},
         };
         projects = state.effective?.projectId
           ? [{ id: state.effective.projectId, name: state.effective.projectName || state.effective.projectId, type: state.effective.projectId === 'personal' ? 'personal' : 'unknown' }]
@@ -767,6 +954,8 @@ export function getConfigurationHtml(nonce: string): string {
         showError(message.message || 'Unexpected error');
       } else if (message.type === 'instanceDeleted') {
         showSaved();
+      } else if (message.type === 'activeTab') {
+        setActiveTab(message.tab || 'n8n-instances');
       }
     });
   </script>

--- a/packages/vscode-extension/src/ui/configuration-webview-html.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview-html.ts
@@ -717,8 +717,9 @@ export function getConfigurationHtml(nonce: string): string {
         const detail = document.createElement('div');
         detail.className = 'provider-detail';
         const model = provider.selected && provider.model ? ' · Model: ' + provider.model : provider.defaultModel ? ' · Default: ' + provider.defaultModel : '';
+        const reasoning = provider.selected && provider.reasoningEffort ? ' · Reasoning: ' + provider.reasoningEffort : '';
         const baseUrl = provider.id === 'openai-compatible' && provider.baseUrl ? ' · ' + provider.baseUrl : '';
-        detail.textContent = provider.description + model + baseUrl;
+        detail.textContent = provider.description + model + reasoning + baseUrl;
         main.append(title, detail);
         const actions = document.createElement('div');
         actions.className = 'provider-actions';

--- a/packages/vscode-extension/src/ui/configuration-webview.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview.ts
@@ -355,6 +355,7 @@ export class ConfigurationWebview {
     const instanceId = String(payload.instanceId || '').trim() || undefined;
     const instanceName = String(payload.instanceName || '').trim() || undefined;
     const setActive = Boolean(payload.setActive);
+    const workspaceRoot = getWorkspaceRoot();
 
     if (mode === 'managed-local-docker') {
       const previousActive = await facade.getGlobalActiveInstance();

--- a/packages/vscode-extension/src/ui/configuration-webview.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview.ts
@@ -417,9 +417,7 @@ export class ConfigurationWebview {
         const access = await facade.resolveInstanceAccess({
           instanceId: instance.id,
           workspaceRoot,
-          syncFolderDefault: 'workspace',
-          consumer: 'vscode',
-          mode: instance.publicUrlEnabled ? 'reconcile' : 'observe',
+          mode: 'observe',
         });
         const displayUrl = access.authUrl || access.publicN8nUrl || (access.publicUrlEnabled ? '' : access.apiBaseUrl || '');
         return {

--- a/packages/vscode-extension/src/ui/configuration-webview.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { createN8nManagerFacade } from '@n8n-as-code/manager-adapter';
 import { getWorkspaceRoot } from '../utils/state-detection.js';
 import type { N8nConfigurationController, N8nConfigurationSnapshot } from '../services/n8n-configuration-controller.js';
+import { YagrProviderService, normalizeYagrProviderId, type YagrModelProvider } from '../services/yagr-provider-service.js';
 import { getConfigurationHtml } from './configuration-webview-html.js';
 import { getCanonicalProjectName, getProjectDetail, getProjectDisplayLabel } from '../utils/project-display.js';
 
@@ -62,17 +63,22 @@ export class ConfigurationWebview {
   private readonly _panel: vscode.WebviewPanel;
   private readonly _context: vscode.ExtensionContext;
   private readonly _configurationController: N8nConfigurationController;
+  private readonly _providerService: YagrProviderService;
   private readonly _disposables: vscode.Disposable[] = [];
   private _stateVersion = 0;
+  private _initialTab: string | undefined;
 
   private constructor(
     panel: vscode.WebviewPanel,
     context: vscode.ExtensionContext,
     configurationController: N8nConfigurationController,
+    initialTab?: string,
   ) {
     this._panel = panel;
     this._context = context;
     this._configurationController = configurationController;
+    this._providerService = new YagrProviderService(context);
+    this._initialTab = initialTab;
 
     this._panel.onDidDispose(() => {
       for (const disposable of this._disposables) {
@@ -103,11 +109,15 @@ export class ConfigurationWebview {
   public static createOrShow(
     context: vscode.ExtensionContext,
     configurationController: N8nConfigurationController,
+    initialTab?: string,
   ): void {
     const column = vscode.ViewColumn.One;
 
     if (ConfigurationWebview.currentPanel) {
       ConfigurationWebview.currentPanel._panel.reveal(column);
+      if (initialTab) {
+        ConfigurationWebview.currentPanel._panel.webview.postMessage({ type: 'activeTab', tab: initialTab });
+      }
       return;
     }
 
@@ -118,7 +128,7 @@ export class ConfigurationWebview {
       { enableScripts: true },
     );
 
-    ConfigurationWebview.currentPanel = new ConfigurationWebview(panel, context, configurationController);
+    ConfigurationWebview.currentPanel = new ConfigurationWebview(panel, context, configurationController, initialTab);
   }
 
   private async handleMessage(message: unknown): Promise<void> {
@@ -289,6 +299,41 @@ export class ConfigurationWebview {
         case 'openSettings':
           await vscode.commands.executeCommand('n8n.openSettings');
           return;
+
+        case 'connectProvider': {
+          const provider = normalizeYagrProviderId(String(payload.provider || ''));
+          if (!provider) throw new Error('Unsupported provider.');
+          const configured = await this._providerService.setupProvider(provider);
+          if (configured) {
+            await this._providerService.selectModel(provider);
+          }
+          await this.postInitialState();
+          this._panel.webview.postMessage({ type: 'activeTab', tab: 'agent-providers' });
+          this._panel.webview.postMessage({ type: 'saved' });
+          return;
+        }
+
+        case 'disconnectProvider': {
+          const provider = normalizeYagrProviderId(String(payload.provider || ''));
+          if (!provider) throw new Error('Unsupported provider.');
+          await this._providerService.disconnectProvider(provider);
+          await this.postInitialState();
+          this._panel.webview.postMessage({ type: 'activeTab', tab: 'agent-providers' });
+          this._panel.webview.postMessage({ type: 'saved' });
+          return;
+        }
+
+        case 'selectProviderModel': {
+          const provider = normalizeYagrProviderId(String(payload.provider || ''));
+          if (!provider) throw new Error('Unsupported provider.');
+          const config = vscode.workspace.getConfiguration('n8n.agent');
+          await config.update('provider', provider, vscode.ConfigurationTarget.Global);
+          await this._providerService.selectModel(provider as YagrModelProvider);
+          await this.postInitialState();
+          this._panel.webview.postMessage({ type: 'activeTab', tab: 'agent-providers' });
+          this._panel.webview.postMessage({ type: 'saved' });
+          return;
+        }
       }
     } catch (error: any) {
       await this._configurationController.refresh('webview-error-refresh', { force: true }).catch(() => undefined);
@@ -418,7 +463,16 @@ export class ConfigurationWebview {
         projectName: effectiveContext.projectName || '',
         sources: effectiveContext.sources,
       } : undefined,
+      providers: await this._providerService.listProviderConnectionStates(),
+      about: {
+        extensionVersion: String(this._context.extension.packageJSON?.version || ''),
+        cliVersion: String(this._context.extension.packageJSON?.dependencies?.n8nac || ''),
+      },
     });
+    if (this._initialTab) {
+      this._panel.webview.postMessage({ type: 'activeTab', tab: this._initialTab });
+      this._initialTab = undefined;
+    }
   }
 
   private getHtmlForWebview(): string {

--- a/packages/vscode-extension/src/ui/configuration-webview.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { createN8nManagerFacade } from '@n8n-as-code/manager-adapter';
+import { ConfigService, resolveInstanceIdentifier } from 'n8nac';
 import { getWorkspaceRoot } from '../utils/state-detection.js';
 import type { N8nConfigurationController, N8nConfigurationSnapshot } from '../services/n8n-configuration-controller.js';
 import { YagrProviderService, normalizeYagrProviderId, type YagrModelProvider } from '../services/yagr-provider-service.js';
@@ -368,6 +369,10 @@ export class ConfigurationWebview {
         tunnel: Boolean(payload.tunnel),
       }));
 
+      if (workspaceRoot && instance.baseUrl) {
+        await new ConfigService(workspaceRoot).getOrCreateInstanceIdentifier(instance.baseUrl, instance.id).catch(() => undefined);
+      }
+
       if (instanceName) {
         await facade.upsertInstance({ id: instance.id, name: instanceName, publicUrlEnabled: Boolean(payload.tunnel) }, { setActive });
       }
@@ -381,12 +386,17 @@ export class ConfigurationWebview {
       throw new Error('Host and API key are required for a new existing n8n instance.');
     }
 
+    const identifierResolution = host && apiKey
+      ? await resolveInstanceIdentifier({ host, apiKey })
+      : undefined;
+
     await facade.upsertInstance({
       id: instanceId,
       name: instanceName,
       mode: mode === 'generation-only' ? 'generation-only' : 'existing',
       baseUrl: host || undefined,
       apiKey: apiKey || undefined,
+      instanceIdentifier: identifierResolution?.identifier,
     }, { setActive });
     return [];
   }

--- a/packages/vscode-extension/src/ui/configuration-webview.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview.ts
@@ -414,8 +414,14 @@ export class ConfigurationWebview {
     const instances = await Promise.all(globalConfig.instances.map(async (instance) => {
       try {
         const runtime = await facade.status({ instanceId: instance.id });
-        const access = await facade.resolveInstanceAccess({ instanceId: instance.id, workspaceRoot, mode: 'observe' });
-        const displayUrl = access.authUrl || (access.publicUrlEnabled ? '' : access.apiBaseUrl || '');
+        const access = await facade.resolveInstanceAccess({
+          instanceId: instance.id,
+          workspaceRoot,
+          syncFolderDefault: 'workspace',
+          consumer: 'vscode',
+          mode: instance.publicUrlEnabled ? 'reconcile' : 'observe',
+        });
+        const displayUrl = access.authUrl || access.publicN8nUrl || (access.publicUrlEnabled ? '' : access.apiBaseUrl || '');
         return {
           ...instance,
           host: displayUrl,

--- a/packages/vscode-extension/src/ui/enhanced-workflow-tree-provider.ts
+++ b/packages/vscode-extension/src/ui/enhanced-workflow-tree-provider.ts
@@ -244,12 +244,41 @@ export class EnhancedWorkflowTreeProvider implements vscode.TreeDataProvider<Bas
     if (this.syncManager) {
       const aiAction = new AIActionItem(this.aiLastVersion, this.aiNeedsUpdate);
       items.push(aiAction);
+      items.push(...this.getAgentShortcutItems());
     }
 
     this.cachedTreeItems = items;
     this.cacheInvalidationTime = Date.now();
 
     return items;
+  }
+
+  private getAgentShortcutItems(): BaseTreeItem[] {
+    const workbenchItem = new InfoItem('Open Agent Workbench', 'Chat + n8n split view', new vscode.ThemeIcon('hubot'));
+    workbenchItem.command = {
+      command: 'n8n.openAgentWorkbench',
+      title: 'Open Agent Workbench'
+    };
+
+    const managerItem = new InfoItem('Open Agent Manager', 'Providers and agent profiles', new vscode.ThemeIcon('account'));
+    managerItem.command = {
+      command: 'n8n.openAgentManager',
+      title: 'Open Agent Manager'
+    };
+
+    const providerItem = new InfoItem('Set Up Agent Provider', 'API key or OAuth', new vscode.ThemeIcon('key'));
+    providerItem.command = {
+      command: 'n8n.agent.setupProvider',
+      title: 'Set Up Agent Provider'
+    };
+
+    const modelItem = new InfoItem('Select Agent Model', 'Provider + dynamic model list', new vscode.ThemeIcon('symbol-enum'));
+    modelItem.command = {
+      command: 'n8n.agent.selectModel',
+      title: 'Select Agent Model'
+    };
+
+    return [workbenchItem, managerItem, providerItem, modelItem];
   }
 
   private getErrorItems(): BaseTreeItem[] {

--- a/packages/vscode-extension/src/ui/enhanced-workflow-tree-provider.ts
+++ b/packages/vscode-extension/src/ui/enhanced-workflow-tree-provider.ts
@@ -244,41 +244,12 @@ export class EnhancedWorkflowTreeProvider implements vscode.TreeDataProvider<Bas
     if (this.syncManager) {
       const aiAction = new AIActionItem(this.aiLastVersion, this.aiNeedsUpdate);
       items.push(aiAction);
-      items.push(...this.getAgentShortcutItems());
     }
 
     this.cachedTreeItems = items;
     this.cacheInvalidationTime = Date.now();
 
     return items;
-  }
-
-  private getAgentShortcutItems(): BaseTreeItem[] {
-    const workbenchItem = new InfoItem('Open Agent Workbench', 'Chat + n8n split view', new vscode.ThemeIcon('hubot'));
-    workbenchItem.command = {
-      command: 'n8n.openAgentWorkbench',
-      title: 'Open Agent Workbench'
-    };
-
-    const managerItem = new InfoItem('Open Agent Manager', 'Providers and agent profiles', new vscode.ThemeIcon('account'));
-    managerItem.command = {
-      command: 'n8n.openAgentManager',
-      title: 'Open Agent Manager'
-    };
-
-    const providerItem = new InfoItem('Set Up Agent Provider', 'API key or OAuth', new vscode.ThemeIcon('key'));
-    providerItem.command = {
-      command: 'n8n.agent.setupProvider',
-      title: 'Set Up Agent Provider'
-    };
-
-    const modelItem = new InfoItem('Select Agent Model', 'Provider + dynamic model list', new vscode.ThemeIcon('symbol-enum'));
-    modelItem.command = {
-      command: 'n8n.agent.selectModel',
-      title: 'Select Agent Model'
-    };
-
-    return [workbenchItem, managerItem, providerItem, modelItem];
   }
 
   private getErrorItems(): BaseTreeItem[] {

--- a/packages/vscode-extension/src/ui/webview-html.ts
+++ b/packages/vscode-extension/src/ui/webview-html.ts
@@ -173,7 +173,13 @@ export function buildWebviewHtml(workflowId: string, url: string): string {
                     };
 
                     // Trigger load in pending frame
-                    pendingFrame.src = activeFrame.src;
+                    try {
+                        const reloadUrl = new URL(activeFrame.src);
+                        reloadUrl.searchParams.set('_n8nacRefresh', String(Date.now()));
+                        pendingFrame.src = reloadUrl.toString();
+                    } catch (e) {
+                        pendingFrame.src = activeFrame.src;
+                    }
                 }
 
                 // Handle messages from the extension and iframe

--- a/packages/vscode-extension/src/ui/workflow-webview.ts
+++ b/packages/vscode-extension/src/ui/workflow-webview.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { IWorkflowStatus } from 'n8nac';
 import { buildWebviewHtml } from './webview-html.js';
+import { workflowWebviewRegistry } from '../services/workflow-webview-registry.js';
 export { buildWebviewHtml } from './webview-html.js';
 
 export class WorkflowWebview {
@@ -8,12 +9,17 @@ export class WorkflowWebview {
     private readonly _panel: vscode.WebviewPanel;
     private _workflowId: string;
     private _disposables: vscode.Disposable[] = [];
+    private _registryDisposable: { dispose(): void } | undefined;
 
     private _onClipboardPasteRequest: ((panel: vscode.WebviewPanel, grantToken: string) => Promise<void>) | undefined;
 
     private constructor(panel: vscode.WebviewPanel, workflowId: string, url: string) {
         this._panel = panel;
         this._workflowId = workflowId;
+        this._registryDisposable = workflowWebviewRegistry.register({
+            getWorkflowId: () => this._workflowId,
+            reloadWorkflow: () => this._panel.webview.postMessage({ type: 'reload' }),
+        });
         this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
         this._panel.webview.html = this.getHtmlForWebview(workflowId, url);
 
@@ -77,15 +83,7 @@ export class WorkflowWebview {
      * Trigger a reload of the webview if the workflowId matches the one currently displayed.
      */
     public static reloadIfMatching(workflowId: string, _outputChannel?: vscode.OutputChannel) {
-        if (WorkflowWebview.currentPanel) {
-            const panelId = WorkflowWebview.currentPanel._workflowId;
-            if (panelId === workflowId) {
-                // outputChannel?.appendLine(`[Webview] Reloading matching workflow: ${workflowId}`);
-                WorkflowWebview.currentPanel._panel.webview.postMessage({ type: 'reload' });
-                return true;
-            }
-        }
-        return false;
+        return workflowWebviewRegistry.reloadIfMatching(workflowId);
     }
 
     public update(workflowId: string, url: string) {
@@ -95,7 +93,11 @@ export class WorkflowWebview {
     }
 
     public dispose() {
-        WorkflowWebview.currentPanel = undefined;
+        if (WorkflowWebview.currentPanel === this) {
+            WorkflowWebview.currentPanel = undefined;
+        }
+        this._registryDisposable?.dispose();
+        this._registryDisposable = undefined;
         this._panel.dispose();
         while (this._disposables.length) {
             const x = this._disposables.pop();

--- a/packages/vscode-extension/src/utils/state-detection.ts
+++ b/packages/vscode-extension/src/utils/state-detection.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { ConfigService, isReusableInstanceIdentifier } from 'n8nac';
+import { ConfigService, isCanonicalUserInstanceIdentifier } from 'n8nac';
 import { ConfigValidationResult } from '../types.js';
 import { readUnifiedWorkspaceConfig } from './unified-config.js';
 
@@ -96,15 +96,14 @@ export function validateN8nConfig(): ConfigValidationResult {
 }
 
 /**
- * Check if a workspace folder was previously initialized with n8n-as-code
- * Checks for both n8nac-instance.json (new) and n8n-as-code-instance.json (legacy)
+ * Check if a workspace folder was initialized with a canonical n8n sync identity.
  */
 export function isFolderPreviouslyInitialized(workspaceRoot: string): boolean {
   if (!workspaceRoot) {
     return false;
   }
 
-  return isReusableInstanceIdentifier(readUnifiedWorkspaceConfig(workspaceRoot).instanceIdentifier);
+  return isCanonicalUserInstanceIdentifier(readUnifiedWorkspaceConfig(workspaceRoot).instanceIdentifier);
 }
 
 /**
@@ -194,10 +193,9 @@ export function doesSyncDirectoryExist(): boolean {
 }
 
 /**
- * Get instance identifier from existing configuration
- * Checks for both n8nac-instance.json (new) and n8n-as-code-instance.json (legacy)
+ * Get the canonical instance identifier from existing configuration.
  */
 export function getExistingInstanceIdentifier(workspaceRoot: string): string | undefined {
   const identifier = readUnifiedWorkspaceConfig(workspaceRoot).instanceIdentifier;
-  return isReusableInstanceIdentifier(identifier) ? identifier : undefined;
+  return isCanonicalUserInstanceIdentifier(identifier) ? identifier : undefined;
 }

--- a/packages/vscode-extension/src/utils/state-detection.ts
+++ b/packages/vscode-extension/src/utils/state-detection.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { ConfigService } from 'n8nac';
+import { ConfigService, isReusableInstanceIdentifier } from 'n8nac';
 import { ConfigValidationResult } from '../types.js';
 import { readUnifiedWorkspaceConfig } from './unified-config.js';
 
@@ -104,7 +104,7 @@ export function isFolderPreviouslyInitialized(workspaceRoot: string): boolean {
     return false;
   }
 
-  return !!readUnifiedWorkspaceConfig(workspaceRoot).instanceIdentifier;
+  return isReusableInstanceIdentifier(readUnifiedWorkspaceConfig(workspaceRoot).instanceIdentifier);
 }
 
 /**
@@ -198,5 +198,6 @@ export function doesSyncDirectoryExist(): boolean {
  * Checks for both n8nac-instance.json (new) and n8n-as-code-instance.json (legacy)
  */
 export function getExistingInstanceIdentifier(workspaceRoot: string): string | undefined {
-  return readUnifiedWorkspaceConfig(workspaceRoot).instanceIdentifier;
+  const identifier = readUnifiedWorkspaceConfig(workspaceRoot).instanceIdentifier;
+  return isReusableInstanceIdentifier(identifier) ? identifier : undefined;
 }

--- a/packages/vscode-extension/src/utils/unified-config.ts
+++ b/packages/vscode-extension/src/utils/unified-config.ts
@@ -95,6 +95,7 @@ export async function buildUnifiedWorkspaceConfig(
     const current = input.createNew ? undefined : getCurrentInstance(existing, input.instanceId);
     const storedSyncFolder = toStoredSyncFolder(input.workspaceRoot, input.syncFolder || 'workflows');
 
+    const instanceId = current?.id || input.instanceId || createDraftInstanceId();
     let resolvedInstanceIdentifier: string | undefined = input.instanceIdentifier;
     if (input.host && input.apiKey) {
         const credentials: IN8nCredentials = {
@@ -102,14 +103,13 @@ export async function buildUnifiedWorkspaceConfig(
             apiKey: input.apiKey
         };
         const { identifier } = await resolveInstanceIdentifier(credentials, {
-            client: input.client
+            client: input.client,
         });
         resolvedInstanceIdentifier = identifier;
     } else if (input.apiKey !== '' || input.host !== '') {
         resolvedInstanceIdentifier = undefined;
     }
 
-    const instanceId = current?.id || input.instanceId || createDraftInstanceId();
     const instanceName = input.instanceName?.trim() || current?.name || input.host || 'Default instance';
     const profile: IInstanceProfile = {
         id: instanceId,

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -26,12 +26,12 @@ test('Agent Workbench HTML: forwards node detail context to the agent', () => {
         providerModelLabel: 'openai / gpt-5.4',
     });
 
-    assert.ok(html.includes('node-context-badge'), 'Must render the node context badge container');
+    assert.ok(html.includes('id="context-badges"'), 'Must render the context badge container');
     assert.ok(html.includes("message.type === 'n8n-node-context-cleared'"), 'Must clear node context from iframe events');
     assert.ok(html.includes('isWorkflowFrameEvent'), 'Must validate iframe-originated node context messages');
     assert.ok(html.includes("message.type === 'n8n-node-detail-opened'"), 'Must handle node detail messages from iframe');
     assert.ok(html.includes("type: 'agent.nodeDetailChanged'"), 'Must forward node context to extension host');
-    assert.ok(html.includes("nodeContext: currentNodeContext"), 'Must include node context when sending prompts');
+    assert.ok(html.includes('nodeContexts: currentNodeContexts'), 'Must include node contexts when sending prompts');
 });
 
 test('Agent Workbench HTML: renders provider/session controls', () => {
@@ -65,5 +65,26 @@ test('Agent Workbench HTML: Enter submits and Shift+Enter keeps multiline input'
 
     assert.ok(html.includes("event.key === 'Enter' && !event.shiftKey"), 'Must submit on Enter unless Shift is held');
     assert.ok(html.includes('event.preventDefault()'), 'Must prevent textarea newline insertion on submit');
-    assert.ok(html.includes('form.requestSubmit()'), 'Must submit the composer form from the Enter key handler');
+    assert.ok(html.includes('sendPrompt();'), 'Must submit the composer from the Enter key handler');
+});
+
+test('Agent Workbench HTML: context usage and compaction follow Yagr runtime contracts', () => {
+    const { buildAgentWorkbenchHtml } = require('../../src/ui/agent-workbench-html.js');
+    const html: string = buildAgentWorkbenchHtml({
+        workflowId: 'wf-1',
+        workflowName: 'Workflow 1',
+        workflowUrl: 'http://localhost:5678/workflow/wf-1',
+        providerModelLabel: 'openai / gpt-5.4',
+    });
+
+    assert.ok(html.includes('id="context-pill"'), 'Must render the context usage pill');
+    assert.ok(html.includes('id="compact-context"'), 'Must render the manual compaction button');
+    assert.ok(!html.includes('.context-actions {\n            display: none;'), 'Must not hide context actions globally');
+    assert.ok(html.includes("if (!usage || usage.source !== 'api')"), 'Must hide context usage unless the source is api');
+    assert.ok(html.includes("if (event.source !== 'api')"), 'Must ignore estimated stream usage events');
+    assert.ok(html.includes('state.session.contextUsage = undefined'), 'Must reset context usage when a run starts');
+    assert.ok(html.includes("entry.kind !== 'context-usage' && entry.kind !== 'workflow-context' && entry.kind !== 'node-context'"), 'Must hide only metadata entries from the feed');
+    assert.ok(!html.includes("entry.kind !== 'compaction'"), 'Must keep compaction entries visible in the feed');
+    assert.ok(html.includes('Context compacted with fallback'), 'Must label fallback compactions explicitly');
+    assert.ok(html.includes("type: 'agent.context.compact'"), 'Must request runtime compaction from the extension host');
 });

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -15,3 +15,34 @@ test('Agent Workbench HTML: workflow reload forces iframe navigation', () => {
     assert.ok(html.includes('_n8nacRefresh'), 'Reload must add a cache-busting query param');
     assert.ok(html.includes('frame.src = reloadUrl.toString()'), 'Reload must assign a fresh iframe URL');
 });
+
+test('Agent Workbench HTML: forwards node detail context to the agent', () => {
+    const { buildAgentWorkbenchHtml } = require('../../src/ui/agent-workbench-html.js');
+    const html: string = buildAgentWorkbenchHtml({
+        workflowId: 'wf-1',
+        workflowName: 'Workflow 1',
+        workflowUrl: 'http://localhost:5678/workflow/wf-1',
+    });
+
+    assert.ok(html.includes('node-context-badge'), 'Must render the node context badge container');
+    assert.ok(html.includes('bridge-status'), 'Must render the n8n bridge status marker');
+    assert.ok(html.includes("message.type === 'n8n-bridge-ready'"), 'Must handle iframe bridge ready events');
+    assert.ok(html.includes("message.type === 'n8n-ui-click'"), 'Must handle iframe click diagnostics');
+    assert.ok(html.includes("message.type === 'n8n-ui-change'"), 'Must handle iframe UI mutation diagnostics');
+    assert.ok(html.includes("message.type === 'n8n-node-context-cleared'"), 'Must clear node context from iframe events');
+    assert.ok(html.includes('isWorkflowFrameEvent'), 'Must validate iframe-originated node context messages');
+    assert.ok(html.includes("message.type === 'n8n-node-detail-opened'"), 'Must handle node detail messages from iframe');
+    assert.ok(html.includes("type: 'agent.nodeDetailChanged'"), 'Must forward node context to extension host');
+    assert.ok(html.includes("nodeContext: currentNodeContext"), 'Must include node context when sending prompts');
+});
+
+test('Agent Workbench HTML: renders chat build marker', () => {
+    const { buildAgentWorkbenchHtml } = require('../../src/ui/agent-workbench-html.js');
+    const html: string = buildAgentWorkbenchHtml({
+        workflowId: 'wf-1',
+        workflowName: 'Workflow 1',
+        workflowUrl: 'http://localhost:5678/workflow/wf-1',
+    });
+
+    assert.ok(html.includes('Chat build 2026.05.04.8'), 'Must render visible chat build marker');
+});

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -6,10 +6,12 @@ test('Agent Workbench HTML: workflow reload forces iframe navigation', () => {
     const html: string = buildAgentWorkbenchHtml({
         workflowId: 'wf-1',
         workflowName: 'Workflow 1',
-        workflowUrl: 'http://localhost:5678/workflow/wf-1',
+        workflowUrl: 'http://localhost:5678/__n8n-manager/open-workflow/wf-1',
+        workflowReloadUrl: 'http://localhost:5678/workflow/wf-1',
     });
 
     assert.ok(html.includes("message.type === 'workflow.reload'"), 'Must listen for workflow reload messages');
+    assert.ok(html.includes('http://localhost:5678/workflow/wf-1'), 'Reload must use the final n8n workflow URL');
     assert.ok(html.includes('_n8nacRefresh'), 'Reload must add a cache-busting query param');
     assert.ok(html.includes('frame.src = reloadUrl.toString()'), 'Reload must assign a fresh iframe URL');
 });

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -45,9 +45,10 @@ test('Agent Workbench HTML: renders provider/session controls', () => {
 
     assert.ok(html.includes('id="select-model"'), 'Must render provider/model button in the chat header');
     assert.ok(html.includes('id="select-reasoning"'), 'Must render reasoning effort button');
-    assert.ok(html.includes('id="session-list"'), 'Must render the persisted session sidebar');
+    assert.ok(html.includes('id="history-open"'), 'Must render the conversation history button');
+    assert.ok(html.includes('id="session-list"'), 'Must render the persisted session list in history modal');
     assert.ok(html.includes("type: 'agent.session.new'"), 'Must allow creating new persisted sessions');
-    assert.ok(html.includes("type: 'agent.checkpoint.save'"), 'Must expose checkpoint save actions');
+    assert.ok(html.includes('history-overlay'), 'Must render conversation history as a modal overlay');
     assert.ok(html.includes("type: 'agent.ready'"), 'Must request initial state from the extension host');
     assert.ok(html.includes('openai / gpt-5.4'), 'Must render selected provider/model label');
     assert.ok(!html.includes('Agent workbench is ready. Ask for a workflow inspection'), 'Must remove initial system message');

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+test('Agent Workbench HTML: workflow reload forces iframe navigation', () => {
+    const { buildAgentWorkbenchHtml } = require('../../src/ui/agent-workbench-html.js');
+    const html: string = buildAgentWorkbenchHtml({
+        workflowId: 'wf-1',
+        workflowName: 'Workflow 1',
+        workflowUrl: 'http://localhost:5678/workflow/wf-1',
+    });
+
+    assert.ok(html.includes("message.type === 'workflow.reload'"), 'Must listen for workflow reload messages');
+    assert.ok(html.includes('_n8nacRefresh'), 'Reload must add a cache-busting query param');
+    assert.ok(html.includes('frame.src = reloadUrl.toString()'), 'Reload must assign a fresh iframe URL');
+});

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -48,3 +48,17 @@ test('Agent Workbench HTML: renders provider model button in composer', () => {
     assert.ok(!html.includes('class="kicker"'), 'Must remove workbench kicker from header');
     assert.ok(!html.includes('Agent workbench is ready. Ask for a workflow inspection'), 'Must remove initial system message');
 });
+
+test('Agent Workbench HTML: Enter submits and Shift+Enter keeps multiline input', () => {
+    const { buildAgentWorkbenchHtml } = require('../../src/ui/agent-workbench-html.js');
+    const html: string = buildAgentWorkbenchHtml({
+        workflowId: 'wf-1',
+        workflowName: 'Workflow 1',
+        workflowUrl: 'http://localhost:5678/workflow/wf-1',
+        providerModelLabel: 'openai / gpt-5.4',
+    });
+
+    assert.ok(html.includes("event.key === 'Enter' && !event.shiftKey"), 'Must submit on Enter unless Shift is held');
+    assert.ok(html.includes('event.preventDefault()'), 'Must prevent textarea newline insertion on submit');
+    assert.ok(html.includes('form.requestSubmit()'), 'Must submit the composer form from the Enter key handler');
+});

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -8,6 +8,7 @@ test('Agent Workbench HTML: workflow reload forces iframe navigation', () => {
         workflowName: 'Workflow 1',
         workflowUrl: 'http://localhost:5678/__n8n-manager/open-workflow/wf-1',
         workflowReloadUrl: 'http://localhost:5678/workflow/wf-1',
+        providerModelLabel: 'openai / gpt-5.4',
     });
 
     assert.ok(html.includes("message.type === 'workflow.reload'"), 'Must listen for workflow reload messages');
@@ -22,13 +23,10 @@ test('Agent Workbench HTML: forwards node detail context to the agent', () => {
         workflowId: 'wf-1',
         workflowName: 'Workflow 1',
         workflowUrl: 'http://localhost:5678/workflow/wf-1',
+        providerModelLabel: 'openai / gpt-5.4',
     });
 
     assert.ok(html.includes('node-context-badge'), 'Must render the node context badge container');
-    assert.ok(html.includes('bridge-status'), 'Must render the n8n bridge status marker');
-    assert.ok(html.includes("message.type === 'n8n-bridge-ready'"), 'Must handle iframe bridge ready events');
-    assert.ok(html.includes("message.type === 'n8n-ui-click'"), 'Must handle iframe click diagnostics');
-    assert.ok(html.includes("message.type === 'n8n-ui-change'"), 'Must handle iframe UI mutation diagnostics');
     assert.ok(html.includes("message.type === 'n8n-node-context-cleared'"), 'Must clear node context from iframe events');
     assert.ok(html.includes('isWorkflowFrameEvent'), 'Must validate iframe-originated node context messages');
     assert.ok(html.includes("message.type === 'n8n-node-detail-opened'"), 'Must handle node detail messages from iframe');
@@ -36,13 +34,17 @@ test('Agent Workbench HTML: forwards node detail context to the agent', () => {
     assert.ok(html.includes("nodeContext: currentNodeContext"), 'Must include node context when sending prompts');
 });
 
-test('Agent Workbench HTML: renders chat build marker', () => {
+test('Agent Workbench HTML: renders provider model button in composer', () => {
     const { buildAgentWorkbenchHtml } = require('../../src/ui/agent-workbench-html.js');
     const html: string = buildAgentWorkbenchHtml({
         workflowId: 'wf-1',
         workflowName: 'Workflow 1',
         workflowUrl: 'http://localhost:5678/workflow/wf-1',
+        providerModelLabel: 'openai / gpt-5.4',
     });
 
-    assert.ok(html.includes('Chat build 2026.05.04.8'), 'Must render visible chat build marker');
+    assert.ok(html.includes('provider-model-button'), 'Must render provider/model button in composer');
+    assert.ok(html.includes('openai / gpt-5.4'), 'Must render selected provider/model label');
+    assert.ok(!html.includes('class="kicker"'), 'Must remove workbench kicker from header');
+    assert.ok(!html.includes('Agent workbench is ready. Ask for a workflow inspection'), 'Must remove initial system message');
 });

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -34,7 +34,7 @@ test('Agent Workbench HTML: forwards node detail context to the agent', () => {
     assert.ok(html.includes("nodeContext: currentNodeContext"), 'Must include node context when sending prompts');
 });
 
-test('Agent Workbench HTML: renders provider model button in composer', () => {
+test('Agent Workbench HTML: renders provider/session controls', () => {
     const { buildAgentWorkbenchHtml } = require('../../src/ui/agent-workbench-html.js');
     const html: string = buildAgentWorkbenchHtml({
         workflowId: 'wf-1',
@@ -43,9 +43,13 @@ test('Agent Workbench HTML: renders provider model button in composer', () => {
         providerModelLabel: 'openai / gpt-5.4',
     });
 
-    assert.ok(html.includes('provider-model-button'), 'Must render provider/model button in composer');
+    assert.ok(html.includes('id="select-model"'), 'Must render provider/model button in the chat header');
+    assert.ok(html.includes('id="select-reasoning"'), 'Must render reasoning effort button');
+    assert.ok(html.includes('id="session-list"'), 'Must render the persisted session sidebar');
+    assert.ok(html.includes("type: 'agent.session.new'"), 'Must allow creating new persisted sessions');
+    assert.ok(html.includes("type: 'agent.checkpoint.save'"), 'Must expose checkpoint save actions');
+    assert.ok(html.includes("type: 'agent.ready'"), 'Must request initial state from the extension host');
     assert.ok(html.includes('openai / gpt-5.4'), 'Must render selected provider/model label');
-    assert.ok(!html.includes('class="kicker"'), 'Must remove workbench kicker from header');
     assert.ok(!html.includes('Agent workbench is ready. Ask for a workflow inspection'), 'Must remove initial system message');
 });
 

--- a/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
+++ b/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
@@ -168,6 +168,14 @@ test('Parent webview HTML: iframeOrigin reflects the supplied URL (panel reuse)'
     assert.ok(!html2.includes('http://localhost:5000'), 'Second HTML must not contain stale origin from first URL');
 });
 
+test('Parent webview HTML: seamless reload forces iframe navigation', () => {
+    const { buildWebviewHtml } = require('../../src/ui/webview-html.js');
+    const html: string = buildWebviewHtml('wf-1', 'http://localhost:5678/workflow/wf-1');
+
+    assert.ok(html.includes('_n8nacRefresh'), 'Reload must add a cache-busting query param');
+    assert.ok(html.includes('pendingFrame.src = reloadUrl.toString()'), 'Reload must assign a fresh iframe URL');
+});
+
 // ── 4 : macOS-only activation ───────────────────────────────────────────────
 
 test('registerClipboardHandler: guard skips registration on non-darwin platforms', () => {

--- a/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
+++ b/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
@@ -54,6 +54,27 @@ test('Bridge script: sends n8n-clipboard-write message type for copy', () => {
     assert.ok(script.includes('"n8n-clipboard-write"'), 'Must use correct clipboard-write message type');
 });
 
+test('Bridge script: sends node detail opened messages', () => {
+    const { ProxyService } = require('../../src/services/proxy-service.js');
+    const script: string = ProxyService.buildBridgeScript(false);
+
+    assert.ok(script.includes('CLIPBOARD_BRIDGE_ENABLED = false'), 'Clipboard bridge can be disabled for non-macOS injection');
+    assert.ok(script.includes('"n8n-bridge-ready"'), 'Must publish bridge ready events');
+    assert.ok(script.includes('2026.05.04.8'), 'Must expose the bridge build marker');
+    assert.ok(script.includes('NODE_BRIDGE_ENABLED'), 'Must support disabling node detection on auth routes');
+    assert.ok(script.includes('pageKind'), 'Must publish bridge page kind diagnostics');
+    assert.ok(script.includes('"n8n-ui-click"'), 'Must publish iframe click diagnostics');
+    assert.ok(script.includes('"n8n-ui-change"'), 'Must publish iframe mutation diagnostics');
+    assert.ok(script.includes('"n8n-node-context-cleared"'), 'Must publish node context clear events');
+    assert.ok(script.includes('isCanvasSurfaceElement'), 'Must detect canvas background clicks');
+    assert.ok(script.includes('findNodeDetailTitleByPanelText'), 'Must scan visible panel titles for node context');
+    assert.ok(script.includes('readNodeTitleFromPanelTopBand'), 'Must scan the top band of visible n8n panels');
+    assert.ok(script.includes('"n8n-node-detail-opened"'), 'Must publish node detail open events');
+    assert.ok(script.includes('MutationObserver'), 'Must observe n8n UI changes');
+    assert.ok(script.includes('"dblclick"'), 'Must detect node detail opening from canvas double-clicks');
+    assert.ok(script.includes('readNodeFromElement'), 'Must extract node context from canvas elements');
+});
+
 test('Bridge script: does not validate nonce on incoming paste message', () => {
     // The n8n-clipboard-paste handler in the iframe should accept the message
     // without a nonce check — security is enforced in the parent webview layer.
@@ -79,6 +100,18 @@ test('injectClipboardBridge: injects before </head>', () => {
     const scriptIdx = result.indexOf('<script>');
     const headIdx = result.indexOf('</head>');
     assert.ok(scriptIdx < headIdx, 'Script must be injected before </head>');
+});
+
+test('injectClipboardBridge: can inject UI bridge with clipboard disabled', () => {
+    const { ProxyService } = require('../../src/services/proxy-service.js');
+    const service = new ProxyService();
+    const html = '<html><head><title>n8n login route</title></head><body></body></html>';
+    const result: string = (service as any).injectClipboardBridge(html, false, false, 'auth-route');
+
+    assert.ok(result.includes('"n8n-bridge-ready"'), 'Injected route HTML must publish bridge readiness');
+    assert.ok(result.includes('CLIPBOARD_BRIDGE_ENABLED = false'), 'Clipboard bridge must be disabled when requested');
+    assert.ok(result.includes('NODE_BRIDGE_ENABLED = false'), 'Node bridge must be disabled on auth routes');
+    assert.ok(result.includes('auth-route'), 'Auth routes must identify their bridge page kind');
 });
 
 test('injectClipboardBridge: falls back to </body> when no </head>', () => {

--- a/packages/vscode-extension/tests/unit/unified-config.test.ts
+++ b/packages/vscode-extension/tests/unit/unified-config.test.ts
@@ -31,7 +31,7 @@ async function withManagerHome<T>(managerHome: string, callback: () => Promise<T
     }
 }
 
-test('buildUnifiedWorkspaceConfig regenerates stale instanceIdentifier from current instance settings', async () => {
+test('buildUnifiedWorkspaceConfig resolves instanceIdentifier from API key user identity', async () => {
     const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-unified-config-'));
     const unifiedPath = path.join(workspaceRoot, 'n8nac-config.json');
     const managerHome = writeManagerConfig([{
@@ -39,7 +39,7 @@ test('buildUnifiedWorkspaceConfig regenerates stale instanceIdentifier from curr
         name: 'Local',
         mode: 'existing',
         baseUrl: 'http://localhost:5678',
-        instanceIdentifier: 'local_5678_old_user',
+        instanceIdentifier: 'invalid_identifier',
         defaultProject: {
             id: 'project-1',
             name: 'Personal',

--- a/packages/vscode-extension/tests/unit/unified-config.test.ts
+++ b/packages/vscode-extension/tests/unit/unified-config.test.ts
@@ -164,6 +164,7 @@ test('buildUnifiedWorkspaceConfig preserves global instances while updating the 
         client: {
             async getCurrentUser() {
                 return {
+                    id: 'user-prod',
                     email: 'etienne@example.com'
                 };
             }

--- a/packages/vscode-extension/tests/unit/unified-config.test.ts
+++ b/packages/vscode-extension/tests/unit/unified-config.test.ts
@@ -74,10 +74,10 @@ test('buildUnifiedWorkspaceConfig regenerates stale instanceIdentifier from curr
         }
     }));
 
-    assert.strictEqual(unified.instanceIdentifier, 'n8n_c6c289e49e_etienne_l');
+    assert.strictEqual(unified.instanceIdentifier, 'n8n_c6c289e49e');
     assert.strictEqual(unified.activeInstanceId, unified.instances[0].id);
     assert.strictEqual(unified.instances[0].name, 'Cloud');
-    assert.strictEqual(unified.instances[0].instanceIdentifier, 'n8n_c6c289e49e_etienne_l');
+    assert.strictEqual(unified.instances[0].instanceIdentifier, 'n8n_c6c289e49e');
 });
 
 test('buildUnifiedWorkspaceConfig clears instanceIdentifier when credentials are incomplete', async () => {

--- a/scripts/observe-n8n-tunnels.mjs
+++ b/scripts/observe-n8n-tunnels.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const args = parseArgs(process.argv.slice(2));
+const managerHome = path.resolve(args.home || process.env.N8N_MANAGER_HOME || path.join(os.homedir(), '.n8n-manager'));
+const intervalMs = Number(args.interval || 500);
+const logPath = path.resolve(args.log || path.join(managerHome, `tunnel-observer-${new Date().toISOString().replace(/[:.]/g, '-')}.log`));
+const runtimeDir = path.join(managerHome, 'runtime');
+const instancesPath = path.join(managerHome, 'instances.json');
+const logOffsets = new Map();
+let previous = undefined;
+let stopped = false;
+
+fs.mkdirSync(path.dirname(logPath), { recursive: true });
+
+process.on('SIGINT', () => stop('SIGINT'));
+process.on('SIGTERM', () => stop('SIGTERM'));
+
+log('observer.start', {
+  managerHome,
+  runtimeDir,
+  instancesPath,
+  intervalMs,
+  logPath,
+  pid: process.pid,
+});
+
+while (!stopped) {
+  try {
+    const snapshot = await collectSnapshot();
+    emitDiff(previous, snapshot);
+    previous = snapshot;
+    tailCloudflaredLogs();
+  } catch (error) {
+    log('observer.error', { message: error instanceof Error ? error.message : String(error) });
+  }
+  await sleep(intervalMs);
+}
+
+function parseArgs(argv) {
+  const result = {};
+  for (let index = 0; index < argv.length; index++) {
+    const item = argv[index];
+    if (!item.startsWith('--')) continue;
+    const key = item.slice(2);
+    const value = argv[index + 1] && !argv[index + 1].startsWith('--') ? argv[++index] : 'true';
+    result[key] = value;
+  }
+  return result;
+}
+
+function stop(signal) {
+  log('observer.stop', { signal, pid: process.pid });
+  stopped = true;
+}
+
+async function collectSnapshot() {
+  const instances = readJson(instancesPath)?.instances || [];
+  const runtimeStates = listRuntimeStates();
+  const cloudflared = await listCloudflaredProcesses();
+  return {
+    instances: Object.fromEntries(instances.map((instance) => [instance.id, pickTunnelFields(instance)])),
+    runtime: Object.fromEntries(runtimeStates.map((state) => [state.id || path.basename(state.__path), pickTunnelFields(state)])),
+    processes: Object.fromEntries(cloudflared.map((proc) => [String(proc.pid), proc])),
+  };
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+function listRuntimeStates() {
+  try {
+    return fs.readdirSync(runtimeDir)
+      .filter((name) => name.endsWith('.json'))
+      .map((name) => {
+        const filePath = path.join(runtimeDir, name);
+        const value = readJson(filePath);
+        return value ? { ...value, __path: filePath } : undefined;
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function pickTunnelFields(source) {
+  return {
+    id: source.id,
+    name: source.name,
+    mode: source.mode,
+    baseUrl: source.baseUrl,
+    desiredState: source.desiredState,
+    publicUrlEnabled: source.publicUrlEnabled,
+    tunnelPublicUrl: source.tunnelPublicUrl,
+    tunnelTargetUrl: source.tunnelTargetUrl,
+    tunnelPid: source.tunnelPid,
+    tunnelPidAlive: typeof source.tunnelPid === 'number' ? pidAlive(source.tunnelPid) : false,
+    tunnelLastAttemptAt: source.tunnelLastAttemptAt,
+    tunnelLastError: source.tunnelLastError,
+    tunnelNextRetryAt: source.tunnelNextRetryAt,
+    updatedAt: source.updatedAt,
+    runtimeStatePath: source.runtimeStatePath,
+  };
+}
+
+async function listCloudflaredProcesses() {
+  try {
+    const { stdout } = await execFileAsync('ps', ['-eo', 'pid=,ppid=,pgid=,sid=,stat=,etimes=,command='], { encoding: 'utf8' });
+    return stdout.split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map(parsePsLine)
+      .filter((proc) => proc.command.includes('cloudflared') || proc.command.includes('trycloudflare'));
+  } catch (error) {
+    log('process.scan.error', { message: error instanceof Error ? error.message : String(error) });
+    return [];
+  }
+}
+
+function parsePsLine(line) {
+  const match = line.match(/^(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\S+)\s+(\d+)\s+(.+)$/);
+  if (!match) {
+    return { pid: 0, ppid: 0, pgid: 0, sid: 0, stat: '?', etimes: 0, command: line };
+  }
+  return {
+    pid: Number(match[1]),
+    ppid: Number(match[2]),
+    pgid: Number(match[3]),
+    sid: Number(match[4]),
+    stat: match[5],
+    etimes: Number(match[6]),
+    command: match[7],
+  };
+}
+
+function pidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function emitDiff(before, after) {
+  if (!before) {
+    log('snapshot.initial', after);
+    return;
+  }
+  diffGroup('instance', before.instances, after.instances);
+  diffGroup('runtime', before.runtime, after.runtime);
+  diffGroup('process', before.processes, after.processes);
+}
+
+function diffGroup(kind, before, after) {
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+  for (const key of keys) {
+    if (!(key in before)) {
+      log(`${kind}.added`, { key, value: after[key] });
+      continue;
+    }
+    if (!(key in after)) {
+      log(`${kind}.removed`, { key, value: before[key] });
+      continue;
+    }
+    const changes = shallowChanges(before[key], after[key]);
+    if (Object.keys(changes).length > 0) {
+      log(`${kind}.changed`, { key, changes });
+    }
+  }
+}
+
+function shallowChanges(before, after) {
+  const changes = {};
+  const keys = new Set([...Object.keys(before || {}), ...Object.keys(after || {})]);
+  for (const key of keys) {
+    if (JSON.stringify(before?.[key]) !== JSON.stringify(after?.[key])) {
+      changes[key] = { from: before?.[key], to: after?.[key] };
+    }
+  }
+  return changes;
+}
+
+function tailCloudflaredLogs() {
+  const files = findCloudflaredLogFiles();
+  for (const filePath of files) {
+    let stat;
+    try {
+      stat = fs.statSync(filePath);
+    } catch {
+      continue;
+    }
+    if (!logOffsets.has(filePath)) {
+      logOffsets.set(filePath, stat.size);
+      log('cloudflared.log.discovered', { filePath, size: stat.size });
+      continue;
+    }
+    const offset = logOffsets.get(filePath);
+    if (stat.size < offset) {
+      logOffsets.set(filePath, 0);
+    }
+    if (stat.size <= offset) continue;
+    const fd = fs.openSync(filePath, 'r');
+    try {
+      const buffer = Buffer.alloc(stat.size - offset);
+      fs.readSync(fd, buffer, 0, buffer.length, offset);
+      logOffsets.set(filePath, stat.size);
+      for (const line of buffer.toString('utf8').split('\n').filter(Boolean)) {
+        log('cloudflared.log.line', { filePath, line });
+      }
+    } finally {
+      fs.closeSync(fd);
+    }
+  }
+}
+
+function findCloudflaredLogFiles() {
+  const directories = [runtimeDir, path.join(managerHome, 'logs')];
+  const files = [];
+  for (const directory of directories) {
+    try {
+      for (const name of fs.readdirSync(directory)) {
+        if (name.includes('cloudflared') && name.endsWith('.log')) {
+          files.push(path.join(directory, name));
+        }
+      }
+    } catch {
+      // Directory may not exist yet.
+    }
+  }
+  return files.sort();
+}
+
+function log(event, data) {
+  const line = JSON.stringify({ ts: new Date().toISOString(), event, ...data });
+  fs.appendFileSync(logPath, `${line}\n`);
+  console.log(line);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/scripts/update-yagr-versions.mjs
+++ b/scripts/update-yagr-versions.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { syncDependencyManifests } from './sync-dependencies.mjs';
+
+const workspaceRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DEPENDENCY_SECTIONS = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'];
+const YAGR_PACKAGE_PATTERN = /^@yagr\//;
+const SEMVER_SPEC_PATTERN = /^(?<prefix>[~^]?)(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-(?<prerelease>[0-9A-Za-z.-]+))?(?:\+(?<build>[0-9A-Za-z.-]+))?$/;
+const DEFAULT_RANGE_PREFIX = '^';
+
+function normalizePath(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+function readJsonFile(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  return {
+    content,
+    value: JSON.parse(content),
+  };
+}
+
+function getJsonIndent(content) {
+  const match = content.match(/^([ \t]+)"/m);
+  return match ? match[1] : '  ';
+}
+
+function writeJsonFile(filePath, value, indent) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, indent)}\n`);
+}
+
+function getWorkspacePatterns(rootPackageJson) {
+  if (Array.isArray(rootPackageJson.workspaces)) {
+    return rootPackageJson.workspaces;
+  }
+  if (Array.isArray(rootPackageJson.workspaces?.packages)) {
+    return rootPackageJson.workspaces.packages;
+  }
+  return [];
+}
+
+function expandWorkspacePattern(rootDir, pattern) {
+  if (!pattern.endsWith('/*')) {
+    const packageJsonPath = path.join(rootDir, pattern, 'package.json');
+    return fs.existsSync(packageJsonPath) ? [path.dirname(packageJsonPath)] : [];
+  }
+
+  const parent = path.join(rootDir, pattern.slice(0, -2));
+  if (!fs.existsSync(parent)) {
+    return [];
+  }
+
+  return fs.readdirSync(parent, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => path.join(parent, entry.name))
+    .filter(dir => fs.existsSync(path.join(dir, 'package.json')));
+}
+
+function collectManifests(rootDir = workspaceRoot) {
+  const rootPackageJsonPath = path.join(rootDir, 'package.json');
+  const rootPackageJson = readJsonFile(rootPackageJsonPath).value;
+  const workspaceDirs = getWorkspacePatterns(rootPackageJson)
+    .flatMap(pattern => expandWorkspacePattern(rootDir, pattern));
+
+  return [rootPackageJsonPath, ...workspaceDirs.map(dir => path.join(dir, 'package.json'))]
+    .map(filePath => {
+      const { content, value } = readJsonFile(filePath);
+      return {
+        filePath,
+        relativePath: normalizePath(path.relative(rootDir, filePath)),
+        content,
+        indent: getJsonIndent(content),
+        json: value,
+      };
+    })
+    .sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+}
+
+function isYagrDependency(dependencyName) {
+  return YAGR_PACKAGE_PATTERN.test(dependencyName);
+}
+
+function getLatestPublishedVersion(packageName) {
+  return execFileSync('npm', ['view', `${packageName}@latest`, 'version'], {
+    cwd: workspaceRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function getSpecPrefix(spec) {
+  const match = SEMVER_SPEC_PATTERN.exec(spec);
+  return match?.groups?.prefix || DEFAULT_RANGE_PREFIX;
+}
+
+function updateYagrDependencySpecs(manifests) {
+  const packageNames = new Set();
+  for (const manifest of manifests) {
+    for (const section of DEPENDENCY_SECTIONS) {
+      for (const dependencyName of Object.keys(manifest.json[section] || {})) {
+        if (isYagrDependency(dependencyName)) {
+          packageNames.add(dependencyName);
+        }
+      }
+    }
+  }
+
+  const sortedPackageNames = [...packageNames].sort();
+  const latestVersions = new Map(sortedPackageNames.map(name => [name, getLatestPublishedVersion(name)]));
+  const changes = [];
+
+  for (const manifest of manifests) {
+    for (const section of DEPENDENCY_SECTIONS) {
+      const dependencies = manifest.json[section];
+      if (!dependencies) {
+        continue;
+      }
+
+      for (const [dependencyName, currentSpec] of Object.entries(dependencies)) {
+        if (!latestVersions.has(dependencyName)) {
+          continue;
+        }
+
+        const nextSpec = `${getSpecPrefix(currentSpec)}${latestVersions.get(dependencyName)}`;
+        if (currentSpec === nextSpec) {
+          continue;
+        }
+
+        dependencies[dependencyName] = nextSpec;
+        changes.push({
+          file: manifest.relativePath,
+          section,
+          dependency: dependencyName,
+          from: currentSpec,
+          to: nextSpec,
+        });
+      }
+    }
+  }
+
+  const changedFiles = [];
+  for (const manifest of manifests) {
+    const nextContent = `${JSON.stringify(manifest.json, null, manifest.indent)}\n`;
+    if (nextContent === manifest.content) {
+      continue;
+    }
+    writeJsonFile(manifest.filePath, manifest.json, manifest.indent);
+    changedFiles.push(manifest.relativePath);
+  }
+
+  return { changes, changedFiles, packageNames: sortedPackageNames };
+}
+
+function installWorkspaceDependencies() {
+  execFileSync('npm', ['install'], {
+    cwd: workspaceRoot,
+    stdio: 'inherit',
+  });
+}
+
+function runCli() {
+  const manifests = collectManifests();
+  const result = updateYagrDependencySpecs(manifests);
+
+  if (result.packageNames.length === 0) {
+    console.log('No Yagr dependencies found in workspace manifests.');
+    return;
+  }
+
+  if (result.changes.length === 0) {
+    console.log('Yagr dependency specs are already at the latest published versions.');
+    return;
+  }
+
+  console.log('Updated Yagr dependency specs:');
+  for (const change of result.changes) {
+    console.log(`  - ${change.file}: ${change.section}.${change.dependency} ${change.from} -> ${change.to}`);
+  }
+
+  const syncResult = syncDependencyManifests({ mode: 'write' });
+  if (!syncResult.ok) {
+    throw new Error(syncResult.errors.join('\n'));
+  }
+
+  console.log('Refreshing workspace installation...');
+  installWorkspaceDependencies();
+}
+
+try {
+  runCli();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- Add a VS Code Agent Workbench with chat on the left and the active n8n workflow iframe on the right.
- Add an Agent Manager surface plus provider settings and Secret Storage API-key setup for embedded Yagr chat.
- Introduce a shared workflow webview reload registry so standalone workflow panels and workbench panels refresh together.

## Validation
- npm run compile
- npm run package-bundle
- npm run test