### PR TITLE
feat(telemetry): embed PostHog release config

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,2 +1,7 @@
 N8N_API_Key=xxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 N8N_HOST = 'http://localhost:5678'
+
+# PostHog telemetry ingestion. Use the PostHog Project token, not the Project ID.
+N8NAC_POSTHOG_KEY=phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+N8NAC_POSTHOG_HOST=https://us.i.posthog.com
+N8NAC_TELEMETRY_ENV=dev

--- a/.env.test.example
+++ b/.env.test.example
@@ -1,2 +1,5 @@
 N8N_HOST=https://your-instance.app.n8n.cloud
 N8N_API_KEY=replace-me
+N8NAC_POSTHOG_KEY=phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+N8NAC_POSTHOG_HOST=https://us.i.posthog.com
+N8NAC_TELEMETRY_ENV=test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
     environment: prod
     env:
       GITHUB_TOKEN: ${{ github.token }}
+      N8NAC_POSTHOG_KEY: ${{ secrets.N8NAC_POSTHOG_KEY }}
+      N8NAC_POSTHOG_HOST: ${{ vars.N8NAC_POSTHOG_HOST }}
+      N8NAC_TELEMETRY_ENV: prod
     outputs:
       pending: ${{ steps.pending.outputs.pending }}
     steps:
@@ -77,6 +80,22 @@ jobs:
           key: ${{ runner.os }}-n8n-cache-${{ steps.n8n-tag.outputs.tag }}-${{ hashFiles('scripts/ensure-n8n-cache.cjs') }}
           restore-keys: |
             ${{ runner.os }}-n8n-cache-
+
+      - name: Verify telemetry release configuration
+        if: steps.pending.outputs.pending == 'true'
+        run: |
+          if [[ -z "${N8NAC_POSTHOG_KEY:-}" ]]; then
+            echo "❌ N8NAC_POSTHOG_KEY is missing in prod environment secrets."
+            exit 1
+          fi
+          if [[ -z "${N8NAC_POSTHOG_HOST:-}" ]]; then
+            echo "❌ N8NAC_POSTHOG_HOST is missing in prod environment variables."
+            exit 1
+          fi
+          if [[ "${N8NAC_TELEMETRY_ENV:-}" != "prod" ]]; then
+            echo "❌ N8NAC_TELEMETRY_ENV must be prod for stable releases."
+            exit 1
+          fi
 
       - name: Build all packages
         if: steps.pending.outputs.pending == 'true'
@@ -471,6 +490,9 @@ jobs:
     environment: next
     env:
       GITHUB_TOKEN: ${{ github.token }}
+      N8NAC_POSTHOG_KEY: ${{ secrets.N8NAC_POSTHOG_KEY }}
+      N8NAC_POSTHOG_HOST: ${{ vars.N8NAC_POSTHOG_HOST }}
+      N8NAC_TELEMETRY_ENV: next
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -525,6 +547,22 @@ jobs:
       - name: Refresh lockfile
         if: steps.prerelease-plan.outputs.changed == 'true'
         run: npm install --package-lock-only
+
+      - name: Verify telemetry release configuration
+        if: steps.prerelease-plan.outputs.changed == 'true'
+        run: |
+          if [[ -z "${N8NAC_POSTHOG_KEY:-}" ]]; then
+            echo "❌ N8NAC_POSTHOG_KEY is missing in next environment secrets."
+            exit 1
+          fi
+          if [[ -z "${N8NAC_POSTHOG_HOST:-}" ]]; then
+            echo "❌ N8NAC_POSTHOG_HOST is missing in next environment variables."
+            exit 1
+          fi
+          if [[ "${N8NAC_TELEMETRY_ENV:-}" != "next" ]]; then
+            echo "❌ N8NAC_TELEMETRY_ENV must be next for prereleases."
+            exit 1
+          fi
 
       - name: Build all packages
         if: steps.prerelease-plan.outputs.changed == 'true'

--- a/docs/docs/usage/telemetry.md
+++ b/docs/docs/usage/telemetry.md
@@ -47,11 +47,50 @@ The VS Code extension also respects VS Code's telemetry setting.
 
 On the documentation site, use the telemetry control in the bottom-right corner to disable or re-enable anonymous docs telemetry in your browser.
 
+## Connect PostHog Cloud
+
+n8n-as-code sends telemetry to a PostHog project using the PostHog **Project token**. The PostHog **Project ID** is for the PostHog API and is not used for event ingestion.
+
+For a US Cloud PostHog project:
+
+```bash
+export N8NAC_POSTHOG_KEY="phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+export N8NAC_POSTHOG_HOST="https://us.i.posthog.com"
+export N8NAC_TELEMETRY_ENV="dev"
+```
+
+For an EU Cloud PostHog project:
+
+```bash
+export N8NAC_POSTHOG_KEY="phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+export N8NAC_POSTHOG_HOST="https://eu.i.posthog.com"
+export N8NAC_TELEMETRY_ENV="dev"
+```
+
+Every event includes a `telemetry_environment` property so one PostHog project can safely separate local development, tests, prereleases, and production. Use `N8NAC_TELEMETRY_ENV=dev` in `./.env`, `N8NAC_TELEMETRY_ENV=test` in `./.env.test`, `N8NAC_TELEMETRY_ENV=next` for prerelease builds, and `N8NAC_TELEMETRY_ENV=prod` for stable production builds.
+
+During release builds, `@n8n-as-code/telemetry` embeds the PostHog project token, host, and telemetry environment from the build environment into the published package. Runtime environment variables still take precedence, so local development and tests can override the release defaults without changing the published artifacts.
+
+Check the local telemetry status:
+
+```bash
+n8nac telemetry status
+```
+
+To inspect events locally while testing:
+
+```bash
+N8NAC_TELEMETRY_DEBUG=1 n8nac workspace status
+```
+
+In PostHog, open the target project and use the `Events` or `Activity` view to verify events such as `first_seen`, `product_active`, `cli_command_completed`, or `vscode_extension_activated`. Dashboards are built from PostHog insights over those events; the product code only needs the project token and region host.
+
 ## What Is Collected
 
 Telemetry events contain only coarse product usage metadata:
 
 - anonymous installation ID
+- telemetry environment, such as `dev`, `test`, `next`, or `prod`
 - facade, such as `cli`, `vscode`, `mcp`, `skills`, or `openclaw`
 - package or extension version
 - command or tool name from a controlled list

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -4,6 +4,18 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
+function getTelemetryEnvironment(): string {
+  const explicit = process.env.N8NAC_TELEMETRY_ENV?.trim();
+  if (explicit) return explicit;
+
+  const refName = process.env.GITHUB_REF_NAME || process.env.GITHUB_REF?.replace(/^refs\/heads\//, '');
+  if (refName === 'main') return 'prod';
+  if (refName === 'next') return 'next';
+  if (process.env.NODE_ENV === 'test') return 'test';
+  if (process.env.CI === 'true') return 'ci';
+  return 'dev';
+}
+
 const config: Config = {
   title: 'n8n-as-code',
   tagline: 'Manage n8n workflows as code with version control and AI assistance',
@@ -11,6 +23,7 @@ const config: Config = {
   customFields: {
     posthogKey: process.env.N8NAC_POSTHOG_KEY || process.env.POSTHOG_KEY || '',
     posthogHost: process.env.N8NAC_POSTHOG_HOST || process.env.POSTHOG_HOST || 'https://eu.i.posthog.com',
+    telemetryEnvironment: getTelemetryEnvironment(),
   },
 
 

--- a/docs/src/telemetry/posthog.ts
+++ b/docs/src/telemetry/posthog.ts
@@ -1,8 +1,9 @@
 import siteConfig from '@generated/docusaurus.config';
 
-const customFields = siteConfig.customFields as { posthogKey?: string; posthogHost?: string };
+const customFields = siteConfig.customFields as { posthogKey?: string; posthogHost?: string; telemetryEnvironment?: string };
 const POSTHOG_KEY = customFields.posthogKey;
 const POSTHOG_HOST = (customFields.posthogHost || 'https://eu.i.posthog.com').replace(/\/$/, '');
+const TELEMETRY_ENVIRONMENT = customFields.telemetryEnvironment || 'dev';
 const STORAGE_KEY = 'n8n-as-code:docs-telemetry-id';
 const DISABLED_KEY = 'n8n-as-code:telemetry-disabled';
 
@@ -51,6 +52,7 @@ function trackDocsPageView(): void {
         app: 'n8n-as-code',
         facade: 'docs',
         telemetry_schema_version: 1,
+        telemetry_environment: TELEMETRY_ENVIRONMENT,
         path_group: getPathGroup(pathname),
       },
     }),

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "sync:deps": "node scripts/sync-dependencies.mjs --write",
     "check:deps": "node scripts/sync-dependencies.mjs --check",
     "update:n8n-manager": "node scripts/update-n8n-manager-versions.mjs",
-    "build": "npm run sync:brand-assets && npm run generate:nodes && tsc -b --force && npm run build --workspace=packages/skills --workspace=packages/cli --workspace=packages/mcp --workspace=packages/vscode-extension --workspace=plugins/openclaw/n8n-as-code",
+    "build": "npm run sync:brand-assets && npm run generate:nodes && tsc -b --force && npm run build --workspace=packages/telemetry && npm run build --workspace=packages/skills --workspace=packages/cli --workspace=packages/mcp --workspace=packages/vscode-extension --workspace=plugins/openclaw/n8n-as-code",
     "build:cli": "cd packages/cli && npm run build",
     "build:mcp": "cd packages/mcp && npm run build",
     "build:claude-plugin": "npm run build --workspace=packages/skills && npm run build:adapters --workspace=packages/skills",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -340,6 +340,7 @@ telemetryProgram.command('status')
                 `Telemetry: ${status.enabled ? chalk.green('enabled') : chalk.yellow('disabled')}`,
                 `Configured: ${status.configured ? chalk.green('yes') : chalk.yellow('no PostHog key configured')}`,
                 status.disabledReason ? `Disabled reason: ${status.disabledReason}` : undefined,
+                `Environment: ${status.telemetryEnvironment}`,
                 `Config: ${status.configPath}`,
                 `Host: ${status.posthogHost}`,
             ].filter(Boolean).join('\n'),

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -21,7 +21,7 @@
     "directory": "packages/telemetry"
   },
   "scripts": {
-    "build": "tsc -b",
+    "build": "tsc -b && node scripts/embed-build-config.mjs",
     "clean": "rm -rf dist tsconfig.tsbuildinfo"
   },
   "devDependencies": {

--- a/packages/telemetry/scripts/embed-build-config.mjs
+++ b/packages/telemetry/scripts/embed-build-config.mjs
@@ -1,0 +1,43 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const distIndexPath = resolve(here, '..', 'dist', 'index.js');
+
+function readBuildEnvironment() {
+  const explicit = process.env.N8NAC_TELEMETRY_ENV || process.env.N8NAC_ENV;
+  if (explicit?.trim()) return explicit.trim();
+
+  const refName = process.env.GITHUB_REF_NAME || process.env.GITHUB_REF?.replace(/^refs\/heads\//, '').replace(/^refs\/tags\//, '');
+  if (refName === 'main') return 'prod';
+  if (refName === 'next') return 'next';
+
+  return '';
+}
+
+function replaceConst(source, name, value) {
+  const pattern = new RegExp(`const ${name} = ['\"][^'\"]*['\"];`);
+  const replacement = `const ${name} = ${JSON.stringify(value)};`;
+  if (!pattern.test(source)) {
+    throw new Error(`Unable to find build config constant ${name} in ${distIndexPath}`);
+  }
+  return source.replace(pattern, replacement);
+}
+
+const values = {
+  BUILD_POSTHOG_KEY: (process.env.N8NAC_POSTHOG_KEY || process.env.POSTHOG_KEY || '').trim(),
+  BUILD_POSTHOG_HOST: (process.env.N8NAC_POSTHOG_HOST || process.env.POSTHOG_HOST || '').trim(),
+  BUILD_TELEMETRY_ENVIRONMENT: readBuildEnvironment(),
+};
+
+let source = readFileSync(distIndexPath, 'utf8');
+for (const [name, value] of Object.entries(values)) {
+  source = replaceConst(source, name, value);
+}
+writeFileSync(distIndexPath, source, 'utf8');
+
+const configured = Boolean(values.BUILD_POSTHOG_KEY);
+const host = values.BUILD_POSTHOG_HOST || '(runtime default)';
+const environment = values.BUILD_TELEMETRY_ENVIRONMENT || '(runtime default)';
+console.log(`[telemetry] build config embedded: configured=${configured} host=${host} environment=${environment}`);

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -4,6 +4,7 @@ import { homedir, platform } from 'node:os';
 import { dirname, join } from 'node:path';
 
 export type TelemetryFacade = 'cli' | 'vscode' | 'mcp' | 'skills' | 'openclaw' | 'claude' | 'docs' | 'yagr';
+export type TelemetryEnvironment = 'dev' | 'test' | 'next' | 'prod' | 'ci';
 export type TelemetryOutcome = 'success' | 'failure' | 'cancelled' | 'skipped';
 export type ErrorCategory =
     | 'configuration_error'
@@ -70,6 +71,7 @@ export interface TelemetryStatus {
     configPath: string;
     anonymousId?: string;
     posthogHost: string;
+    telemetryEnvironment: TelemetryEnvironment;
     noticeShownAt?: string;
 }
 
@@ -98,6 +100,9 @@ interface QueuedEvent {
 
 const TELEMETRY_SCHEMA_VERSION = 1;
 const DEFAULT_POSTHOG_HOST = 'https://eu.i.posthog.com';
+const BUILD_POSTHOG_KEY = 'N8NAC_BUILD_POSTHOG_KEY_PLACEHOLDER';
+const BUILD_POSTHOG_HOST = 'N8NAC_BUILD_POSTHOG_HOST_PLACEHOLDER';
+const BUILD_TELEMETRY_ENVIRONMENT = 'N8NAC_BUILD_TELEMETRY_ENVIRONMENT_PLACEHOLDER';
 
 const ALLOWED_PROPERTY_KEYS = new Set([
     'activation_source_event',
@@ -146,6 +151,7 @@ const ALLOWED_PROPERTY_KEYS = new Set([
     'subcommand',
     'target',
     'telemetry_schema_version',
+    'telemetry_environment',
     'tool_name',
     'tracked_count',
     'transport',
@@ -225,11 +231,56 @@ function getNodeMajor(): number | undefined {
 }
 
 function getPostHogKey(): string | undefined {
-    return process.env.N8NAC_POSTHOG_KEY?.trim() || process.env.POSTHOG_KEY?.trim() || undefined;
+    return process.env.N8NAC_POSTHOG_KEY?.trim() || process.env.POSTHOG_KEY?.trim() || getBuildValue(BUILD_POSTHOG_KEY);
 }
 
 function getPostHogHost(): string {
-    return (process.env.N8NAC_POSTHOG_HOST?.trim() || process.env.POSTHOG_HOST?.trim() || DEFAULT_POSTHOG_HOST).replace(/\/$/, '');
+    return (process.env.N8NAC_POSTHOG_HOST?.trim() || process.env.POSTHOG_HOST?.trim() || getBuildValue(BUILD_POSTHOG_HOST) || DEFAULT_POSTHOG_HOST).replace(/\/$/, '');
+}
+
+function getBuildValue(value: string): string | undefined {
+    const trimmed = value.trim();
+    if (!trimmed || trimmed.startsWith('N8NAC_BUILD_')) return undefined;
+    return trimmed;
+}
+
+function normalizeTelemetryEnvironment(value?: string): TelemetryEnvironment | undefined {
+    const normalized = value?.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    if (!normalized) return undefined;
+    if (normalized === 'production' || normalized === 'prod' || normalized === 'main' || normalized === 'stable') return 'prod';
+    if (normalized === 'next' || normalized === 'preview' || normalized === 'prerelease' || normalized === 'pre_release') return 'next';
+    if (normalized === 'development' || normalized === 'dev' || normalized === 'local') return 'dev';
+    if (normalized === 'test' || normalized === 'testing') return 'test';
+    if (normalized === 'ci') return 'ci';
+    return undefined;
+}
+
+function getGitHubRefName(): string | undefined {
+    const refName = process.env.GITHUB_REF_NAME?.trim();
+    if (refName) return refName;
+
+    const ref = process.env.GITHUB_REF?.trim();
+    return ref?.replace(/^refs\/heads\//, '').replace(/^refs\/tags\//, '') || undefined;
+}
+
+function getTelemetryEnvironment(): TelemetryEnvironment {
+    const explicit = normalizeTelemetryEnvironment(process.env.N8NAC_TELEMETRY_ENV || process.env.N8NAC_ENV);
+    if (explicit) return explicit;
+
+    const branchEnvironment = normalizeTelemetryEnvironment(getGitHubRefName());
+    if (branchEnvironment === 'prod' || branchEnvironment === 'next') return branchEnvironment;
+
+    const nodeEnvironment = normalizeTelemetryEnvironment(process.env.NODE_ENV);
+    if (nodeEnvironment === 'test') return 'test';
+
+    const lifecycleEvent = process.env.npm_lifecycle_event?.toLowerCase() || '';
+    if (lifecycleEvent.includes('test')) return 'test';
+
+    const buildEnvironment = normalizeTelemetryEnvironment(getBuildValue(BUILD_TELEMETRY_ENVIRONMENT));
+    if (buildEnvironment) return buildEnvironment;
+
+    if (process.env.CI === 'true') return 'ci';
+    return 'dev';
 }
 
 function sanitizeProperties(properties: TelemetryProperties): TelemetryProperties {
@@ -317,6 +368,7 @@ export function getTelemetryStatus(context?: Pick<TelemetryContext, 'forceDisabl
         configPath: path,
         anonymousId: config.anonymousId,
         posthogHost: getPostHogHost(),
+        telemetryEnvironment: getTelemetryEnvironment(),
         noticeShownAt: config.noticeShownAt,
     };
 }
@@ -355,6 +407,7 @@ export function createTelemetryClient(context: TelemetryContext): TelemetryClien
         app: 'n8n-as-code',
         facade: context.facade,
         telemetry_schema_version: TELEMETRY_SCHEMA_VERSION,
+        telemetry_environment: getTelemetryEnvironment(),
         package_version: context.version,
         session_id: sessionId,
         workspace_id: context.workspaceId,


### PR DESCRIPTION
## Summary
- Embed PostHog project token, host, and telemetry environment into the telemetry package during release builds while keeping runtime env overrides.
- Add `telemetry_environment` across CLI/package/docs telemetry and document dev/test/next/prod setup.
- Wire prod/next GitHub release jobs to fail fast when PostHog release configuration is missing.

## Validation
- `N8NAC_POSTHOG_KEY=phc_build_smoke N8NAC_POSTHOG_HOST=https://us.i.posthog.com N8NAC_TELEMETRY_ENV=prod npm run build --workspace=packages/telemetry`
- build-time smoke check confirmed `configured=true`, US host, and `telemetryEnvironment=prod` without runtime env vars
- `env -u N8NAC_POSTHOG_KEY -u POSTHOG_KEY -u N8NAC_POSTHOG_HOST -u POSTHOG_HOST -u N8NAC_TELEMETRY_ENV -u N8NAC_ENV npm run build --workspace=packages/telemetry`
- `npm run build --workspace=packages/cli`
- `npm run build --workspace=packages/vscode-extension`
- `npx tsc --noEmit` in `docs`