### PR TITLE
Add Yagr checkpoint controls to Agent Workbench

### DIFF
--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -48,6 +48,9 @@ export interface AgentCheckpointSummary {
     createdAt: string;
     messageCount: number;
     summary?: string;
+    reason?: CheckpointReason;
+    label?: string;
+    restoredAt?: string;
 }
 
 export interface AgentCompactionSummary {
@@ -201,6 +204,42 @@ type SessionCheckpointMetadata = {
     createdAt: string;
     messageCount: number;
     summary?: string;
+    reason?: CheckpointReason;
+    label?: string;
+    restoredAt?: string;
+};
+
+type CheckpointReason = 'manual' | 'auto' | 'before-tool' | 'after-tool' | 'before-compaction' | 'after-compaction';
+
+type SaveCheckpointOptions = {
+    reason?: CheckpointReason;
+    label?: string;
+    summary?: string;
+    payloads?: Record<string, unknown>;
+    payloadState?: unknown | null;
+};
+
+type RestoreCheckpointResult = {
+    sessionId: string;
+    checkpointId: string;
+    restoredAt: string;
+    langGraphRestored?: boolean;
+    pendingWritesRestored?: boolean;
+    payloads?: Record<string, unknown>;
+    payloadsRestored?: string[];
+    displayThreadRestored?: boolean;
+    warnings?: string[];
+    payloadState?: unknown | null;
+};
+
+type AgentWorkbenchCheckpointSurfacePayload = {
+    version: 1;
+    displayThread: AgentTimelineEntry[];
+    contextMarkers: AgentTimelineEntry[];
+    selectedWorkflow?: AgentWorkflowContext;
+    selectedNodes: AgentNodeContext[];
+    title: string;
+    scope?: DeepAgentSessionScope;
 };
 
 type WebUiSession = {
@@ -224,8 +263,9 @@ type SessionServiceHandle = {
     setCheckpointer(checkpointer: unknown): void;
     buildSessionConfig(sessionId: string): Record<string, unknown>;
     listCheckpoints(sessionId: string): Promise<SessionCheckpointMetadata[]>;
-    saveCheckpoint(sessionId: string, options?: { payloadState?: unknown | null }): Promise<SessionCheckpointMetadata>;
-    restoreCheckpoint(sessionId: string, checkpointId: string): Promise<{ payloadState: unknown | null }>;
+    saveCheckpoint(sessionId: string, options?: SaveCheckpointOptions): Promise<SessionCheckpointMetadata>;
+    maybeSaveCheckpoint?(sessionId: string, reason: CheckpointReason, options?: Omit<SaveCheckpointOptions, 'reason'>): Promise<SessionCheckpointMetadata | undefined>;
+    restoreCheckpoint(sessionId: string, checkpointId: string): Promise<RestoreCheckpointResult>;
     deleteCheckpoint(sessionId: string, checkpointId: string): Promise<void>;
     syncDisplayThread(sessionId: string, displayThread: unknown[]): void;
     clearDisplayThread(sessionId: string): void;
@@ -423,37 +463,72 @@ export class AgentRuntimeController implements vscode.Disposable {
     async saveCheckpoint(sessionId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
         const sessions = await this.getSessionRuntime();
         const handle = await this.ensureAgentHandleWithCheckpoint(input);
-        await sessions.service.saveCheckpoint(sessionId, {
-            payloadState: handle.compactionService.getState(sessionId),
+        const surface = this.buildCheckpointSurfacePayload(sessions.service, sessionId);
+        const compaction = handle.compactionService?.getState?.(sessionId);
+        const label = surface.selectedWorkflow ? 'Before workflow edit' : 'Manual checkpoint';
+        await this.saveYagrCheckpoint(sessions.service, sessionId, {
+            reason: 'manual',
+            label,
+            summary: this.buildCheckpointSummary(surface),
+            payloads: {
+                surface,
+                ...(compaction ? { compaction } : {}),
+            },
         });
         const entries = this.readSessionEntries(sessions.service, sessionId);
         this.writeSessionEntries(sessions.service, sessionId, [
             ...entries,
-            this.createSystemNotice('Checkpoint saved.'),
+            this.createSystemNotice(`Checkpoint saved: ${label}.`),
         ]);
-        return this.getWorkbenchState(input);
+        return this.getWorkbenchState({ ...input, sessionId });
     }
 
     async restoreCheckpoint(sessionId: string, checkpointId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
         const sessions = await this.getSessionRuntime();
         const handle = await this.ensureAgentHandleWithCheckpoint(input);
         const result = await sessions.service.restoreCheckpoint(sessionId, checkpointId);
-        sessions.service.clearDisplayThread(sessionId);
-        if (this.isCompactionState(result.payloadState)) {
-            handle.compactionService.setState(sessionId, result.payloadState);
+        const payloads = this.extractCheckpointPayloads(result);
+        const notices: AgentTimelineEntry[] = [];
+        const surface = payloads.surface;
+        if (this.isWorkbenchSurfacePayload(surface)) {
+            const entries = this.normalizeEntries(surface.displayThread);
+            const title = surface.title.trim() || sessions.service.get(sessionId)?.title || this.getDefaultSessionTitle(input.workflowName);
+            sessions.service.touch(sessionId, { title });
+            sessions.service.setTitle(sessionId, title);
+            this.writeSessionEntries(sessions.service, sessionId, [
+                ...entries,
+                this.createSystemNotice(`Restored checkpoint ${checkpointId}.`),
+            ]);
         } else {
-            handle.compactionService.reset(sessionId);
+            notices.push(this.createSystemNotice(`Restored checkpoint ${checkpointId}. Runtime state was restored, but this checkpoint does not include Workbench surface state, so the visible conversation was kept.`));
         }
-        this.writeSessionEntries(sessions.service, sessionId, [
-            this.createSystemNotice(`Restored checkpoint ${checkpointId}.`),
-        ]);
-        return this.getWorkbenchState(input);
+        if (this.isCompactionState(payloads.compaction) && typeof handle.compactionService?.setState === 'function') {
+            handle.compactionService.setState(sessionId, payloads.compaction);
+        }
+        for (const warning of result.warnings || []) {
+            const message = typeof warning === 'string' ? warning : String(warning);
+            this.outputChannel.appendLine(`[n8n-agent] Checkpoint restore warning: ${message}`);
+            notices.push(this.createSystemNotice(`Checkpoint warning: ${message}`));
+        }
+        if (notices.length) {
+            this.writeSessionEntries(sessions.service, sessionId, [
+                ...this.readSessionEntries(sessions.service, sessionId),
+                ...notices,
+            ]);
+        }
+        return this.getWorkbenchState({ ...input, sessionId });
     }
 
     async deleteCheckpoint(sessionId: string, checkpointId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
         const sessions = await this.getSessionRuntime();
         await sessions.service.deleteCheckpoint(sessionId, checkpointId);
-        return this.getWorkbenchState(input);
+        if ((input.sessionId || sessionId) === sessionId) {
+            this.writeSessionEntries(sessions.service, sessionId, [
+                ...this.readSessionEntries(sessions.service, sessionId),
+                this.createSystemNotice('Checkpoint deleted.'),
+            ]);
+        }
+        return this.getWorkbenchState({ ...input, sessionId });
     }
 
     async compactSession(sessionId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
@@ -495,8 +570,15 @@ export class AgentRuntimeController implements vscode.Disposable {
                     ];
                 }
                 this.writeSessionEntries(sessions.service, sessionId, entries);
-                await sessions.service.saveCheckpoint(sessionId, {
-                    payloadState: handle.compactionService.getState(sessionId),
+                const surface = this.buildCheckpointSurfacePayload(sessions.service, sessionId, entries);
+                await this.saveYagrCheckpoint(sessions.service, sessionId, {
+                    reason: 'after-compaction',
+                    label: 'After context compaction',
+                    summary: 'Workbench checkpoint after context compaction',
+                    payloads: {
+                        surface,
+                        compaction: handle.compactionService.getState(sessionId),
+                    },
                 }).catch((error: any) => {
                     this.outputChannel.appendLine(`[n8n-agent] Manual compaction checkpoint failed: ${error?.message || String(error)}`);
                 });
@@ -739,17 +821,6 @@ export class AgentRuntimeController implements vscode.Disposable {
                 });
             }
 
-            if (accumulator.fileModificationDetected) {
-                this.outputChannel.appendLine(`[n8n-agent-debug] agent runtime detected local workflow modification sessionId=${input.sessionId || 'none'} workflowId=${input.workflowId || 'none'} workflowFilePath=${input.workflowFilePath || 'none'}`);
-                try {
-                    await sessions.service.saveCheckpoint(input.sessionId || '', {
-                        payloadState: handle.compactionService.getState(input.sessionId || ''),
-                    });
-                } catch (error: any) {
-                    this.outputChannel.appendLine(`[n8n-agent] Auto-checkpoint failed: ${error?.message || String(error)}`);
-                }
-            }
-
             const finalEvent: AgentStreamEvent = {
                 type: 'final',
                 sessionId: input.sessionId || '',
@@ -758,6 +829,21 @@ export class AgentRuntimeController implements vscode.Disposable {
             };
             entries = this.applyStreamEvent(entries, finalEvent);
             await postMessage({ type: 'agent.streamEvent', event: finalEvent });
+            if (accumulator.fileModificationDetected) {
+                this.outputChannel.appendLine(`[n8n-agent-debug] agent runtime detected local workflow modification sessionId=${input.sessionId || 'none'} workflowId=${input.workflowId || 'none'} workflowFilePath=${input.workflowFilePath || 'none'}`);
+                try {
+                    await this.maybeSaveYagrCheckpoint(sessions.service, input.sessionId || '', 'after-tool', {
+                        label: 'After file modifications',
+                        summary: 'Saved after file modifications',
+                        payloads: {
+                            surface: this.buildCheckpointSurfacePayload(sessions.service, input.sessionId || '', entries),
+                            compaction: handle.compactionService?.getState?.(input.sessionId || ''),
+                        },
+                    });
+                } catch (error: any) {
+                    this.outputChannel.appendLine(`[n8n-agent] Auto-checkpoint failed: ${error?.message || String(error)}`);
+                }
+            }
             this.outputChannel.appendLine(`[n8n-agent-debug] agent runtime completed sessionId=${input.sessionId || 'none'} workflowId=${input.workflowId || 'none'} workflowChanged=${String(Boolean(accumulator.fileModificationDetected))}`);
             return { entries, workflowChanged: Boolean(accumulator.fileModificationDetected) };
         }
@@ -1138,7 +1224,15 @@ export class AgentRuntimeController implements vscode.Disposable {
                 const service = new module.SessionService({
                     sessionsDir: path.join(sessionsRoot, 'records'),
                     webUiSessionsDir,
-                }) as SessionServiceHandle;
+                    checkpointPolicy: {
+                        enabled: true,
+                        afterFileModifications: true,
+                        beforeToolCalls: false,
+                        beforeCompaction: false,
+                        afterCompaction: false,
+                        maxCheckpointsPerSession: 20,
+                    },
+                } as any) as SessionServiceHandle;
                 return {
                     service,
                     deriveSessionTitle: module.deriveSessionTitle as SessionRuntime['deriveSessionTitle'],
@@ -1225,6 +1319,9 @@ export class AgentRuntimeController implements vscode.Disposable {
                 createdAt: checkpoint.createdAt,
                 messageCount: checkpoint.messageCount,
                 summary: checkpoint.summary,
+                reason: checkpoint.reason,
+                label: checkpoint.label,
+                restoredAt: checkpoint.restoredAt,
             })),
             contextUsage: latestUsageEntry?.usage,
             lastCompaction: compactionState.lastCompaction || undefined,
@@ -1634,6 +1731,98 @@ export class AgentRuntimeController implements vscode.Disposable {
 
     private withoutContextUsage(entries: AgentTimelineEntry[]): AgentTimelineEntry[] {
         return entries.filter((entry) => entry.kind !== 'context-usage');
+    }
+
+    private buildCheckpointSurfacePayload(
+        service: SessionServiceHandle,
+        sessionId: string,
+        entriesOverride?: AgentTimelineEntry[],
+    ): AgentWorkbenchCheckpointSurfacePayload {
+        const displaySession = service.readDisplaySession(sessionId);
+        const record = service.get(sessionId);
+        const displayThread = this.normalizeEntries(entriesOverride || displaySession?.displayThread);
+        const selectedWorkflow = this.getLatestWorkflowContext(displayThread, record);
+        const selectedNodes = selectedWorkflow ? this.getLatestNodeContexts(displayThread) : [];
+        return {
+            version: 1,
+            displayThread,
+            contextMarkers: displayThread.filter((entry) => entry.kind === 'workflow-context' || entry.kind === 'node-context'),
+            selectedWorkflow,
+            selectedNodes,
+            title: displaySession?.title || record?.title || this.getDefaultSessionTitle(),
+            scope: record?.scope,
+        };
+    }
+
+    private buildCheckpointSummary(surface: AgentWorkbenchCheckpointSurfacePayload): string {
+        if (surface.selectedWorkflow && surface.selectedNodes.length) {
+            return `Workbench checkpoint for ${surface.selectedWorkflow.name} with ${surface.selectedNodes.length} selected node${surface.selectedNodes.length === 1 ? '' : 's'}`;
+        }
+        if (surface.selectedWorkflow) {
+            return `Workbench checkpoint for ${surface.selectedWorkflow.name}`;
+        }
+        return 'Workbench checkpoint';
+    }
+
+    private async saveYagrCheckpoint(
+        service: SessionServiceHandle,
+        sessionId: string,
+        options: SaveCheckpointOptions,
+    ): Promise<SessionCheckpointMetadata> {
+        return service.saveCheckpoint(sessionId, this.withLegacyCheckpointPayload(options));
+    }
+
+    private async maybeSaveYagrCheckpoint(
+        service: SessionServiceHandle,
+        sessionId: string,
+        reason: CheckpointReason,
+        options: Omit<SaveCheckpointOptions, 'reason'>,
+    ): Promise<SessionCheckpointMetadata | undefined> {
+        if (typeof service.maybeSaveCheckpoint !== 'function') {
+            return undefined;
+        }
+        return service.maybeSaveCheckpoint(sessionId, reason, this.withLegacyCheckpointPayload(options));
+    }
+
+    private withLegacyCheckpointPayload<T extends SaveCheckpointOptions>(options: T): T {
+        if (!options.payloads || options.payloadState !== undefined) {
+            return options;
+        }
+        return {
+            ...options,
+            payloadState: { payloads: options.payloads },
+        };
+    }
+
+    private extractCheckpointPayloads(result: RestoreCheckpointResult): Record<string, unknown> {
+        if (this.isRecord(result.payloads)) {
+            return result.payloads;
+        }
+        const payloadState = result.payloadState;
+        if (this.isRecord(payloadState)) {
+            if (this.isRecord(payloadState.payloads)) {
+                return payloadState.payloads;
+            }
+            if (this.isRecord(payloadState.surface) || this.isRecord(payloadState.compaction)) {
+                return payloadState;
+            }
+        }
+        if (this.isCompactionState(payloadState)) {
+            return { compaction: payloadState };
+        }
+        return {};
+    }
+
+    private isWorkbenchSurfacePayload(value: unknown): value is AgentWorkbenchCheckpointSurfacePayload {
+        if (!this.isRecord(value)) return false;
+        if (value.version !== 1) return false;
+        if (!Array.isArray(value.displayThread)) return false;
+        if (typeof value.title !== 'string') return false;
+        return true;
+    }
+
+    private isRecord(value: unknown): value is Record<string, unknown> {
+        return Boolean(value && typeof value === 'object' && !Array.isArray(value));
     }
 
     private toCompactionSummary(value: unknown): AgentCompactionSummary | undefined {

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -504,6 +504,8 @@ export class AgentRuntimeController implements vscode.Disposable {
         }
         if (this.isCompactionState(payloads.compaction) && typeof handle.compactionService?.setState === 'function') {
             handle.compactionService.setState(sessionId, payloads.compaction);
+        } else if (typeof handle.compactionService?.reset === 'function') {
+            handle.compactionService.reset(sessionId);
         }
         for (const warning of result.warnings || []) {
             const message = typeof warning === 'string' ? warning : String(warning);
@@ -1779,7 +1781,7 @@ export class AgentRuntimeController implements vscode.Disposable {
         options: Omit<SaveCheckpointOptions, 'reason'>,
     ): Promise<SessionCheckpointMetadata | undefined> {
         if (typeof service.maybeSaveCheckpoint !== 'function') {
-            return undefined;
+            return this.saveYagrCheckpoint(service, sessionId, { ...options, reason });
         }
         return service.maybeSaveCheckpoint(sessionId, reason, this.withLegacyCheckpointPayload(options));
     }

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -48,6 +48,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
     const newConversationIcon = lucideIcon('<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/><path d="M12 7v6"/><path d="M9 10h6"/>');
     const historyIcon = lucideIcon('<path d="M3 12a9 9 0 1 0 9-9 9.8 9.8 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M12 7v5l4 2"/>');
     const compactIcon = lucideIcon('<path d="M6 12h12"/><path d="m8 4 4 4 4-4"/><path d="m8 20 4-4 4 4"/>');
+    const checkpointIcon = lucideIcon('<path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2Z"/><path d="M17 21v-8H7v8"/><path d="M7 3v5h8"/>');
     const sendIcon = lucideIcon('<path d="m22 2-7 20-4-9-9-4Z"/><path d="M22 2 11 13"/>');
 
     return `<!DOCTYPE html>
@@ -211,7 +212,40 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             color: var(--muted);
             font-size: 11px;
         }
-        .history-overlay {
+        .checkpoint-item {
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            background: color-mix(in srgb, var(--bg) 82%, transparent);
+            padding: 10px;
+            display: grid;
+            gap: 8px;
+        }
+        .checkpoint-item-head,
+        .checkpoint-item-foot {
+            display: flex;
+            justify-content: space-between;
+            gap: 8px;
+            align-items: flex-start;
+        }
+        .checkpoint-item-title {
+            font-size: 13px;
+            font-weight: 650;
+            line-height: 1.35;
+            overflow-wrap: anywhere;
+        }
+        .checkpoint-item-meta {
+            color: var(--muted);
+            font-size: 11px;
+            line-height: 1.4;
+        }
+        .checkpoint-actions {
+            display: flex;
+            gap: 7px;
+            justify-content: flex-end;
+            flex-wrap: wrap;
+        }
+        .history-overlay,
+        .checkpoint-overlay {
             position: fixed;
             inset: 0;
             z-index: 10;
@@ -221,8 +255,10 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             padding-top: 42px;
             background: rgba(0, 0, 0, .28);
         }
-        .history-overlay.open { display: flex; }
-        .history-modal {
+        .history-overlay.open,
+        .checkpoint-overlay.open { display: flex; }
+        .history-modal,
+        .checkpoint-modal {
             width: min(560px, calc(100vw - 28px));
             max-height: min(640px, calc(100vh - 84px));
             display: grid;
@@ -233,28 +269,35 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             box-shadow: 0 18px 48px rgba(0, 0, 0, .45);
             overflow: hidden;
         }
+        .checkpoint-modal { grid-template-rows: auto 1fr auto; }
         .history-head,
         .history-controls,
-        .history-foot {
+        .history-foot,
+        .checkpoint-head,
+        .checkpoint-foot {
             padding: 12px;
             border-bottom: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
         }
-        .history-head {
+        .history-head,
+        .checkpoint-head {
             display: flex;
             align-items: center;
             justify-content: space-between;
             gap: 12px;
         }
-        .history-title {
+        .history-title,
+        .checkpoint-title {
             font-size: 14px;
             font-weight: 650;
         }
-        .history-list {
+        .history-list,
+        .checkpoint-list {
             overflow: auto;
             min-height: 0;
             padding: 10px 12px;
         }
-        .history-foot {
+        .history-foot,
+        .checkpoint-foot {
             border-bottom: 0;
             border-top: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
             display: flex;
@@ -853,6 +896,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                         </div>
                     </div>
                     <div class="header-actions">
+                        <button id="checkpoint-open" class="ghost small icon-button" type="button" title="Checkpoints" aria-label="Checkpoints">${checkpointIcon}</button>
                         <button id="history-open" class="ghost small icon-button" type="button" title="Conversation history" aria-label="Conversation history">${historyIcon}</button>
                         <button id="new-session-header" class="ghost small icon-button" type="button" title="New conversation" aria-label="New conversation">${newConversationIcon}</button>
                         <div id="run-indicator" class="run-indicator" aria-label="Agent running" title="Agent running">
@@ -912,6 +956,21 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 </div>
             </div>
         </div>
+        <div id="checkpoint-overlay" class="checkpoint-overlay" role="dialog" aria-modal="true" aria-label="Checkpoints">
+            <div class="checkpoint-modal">
+                <div class="checkpoint-head">
+                    <div>
+                        <div class="checkpoint-title">Checkpoints</div>
+                        <div class="meta-text">Save, restore, or delete checkpoints for this conversation.</div>
+                    </div>
+                    <button id="checkpoint-close" class="ghost small" type="button" aria-label="Close checkpoints">Close</button>
+                </div>
+                <div id="checkpoint-list" class="checkpoint-list sessions"></div>
+                <div class="checkpoint-foot">
+                    <button id="checkpoint-save" class="secondary small" type="button">Save checkpoint</button>
+                </div>
+            </div>
+        </div>
     </main>
     <script nonce="${nonce}">
         const vscode = acquireVsCodeApi();
@@ -968,6 +1027,11 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const contextMeterFill = document.getElementById('context-meter-fill');
         const newSessionButton = document.getElementById('new-session');
         const newSessionHeaderButton = document.getElementById('new-session-header');
+        const checkpointOpenButton = document.getElementById('checkpoint-open');
+        const checkpointCloseButton = document.getElementById('checkpoint-close');
+        const checkpointOverlay = document.getElementById('checkpoint-overlay');
+        const checkpointList = document.getElementById('checkpoint-list');
+        const checkpointSaveButton = document.getElementById('checkpoint-save');
         const historyOpenButton = document.getElementById('history-open');
         const historyCloseButton = document.getElementById('history-close');
         const historyOverlay = document.getElementById('history-overlay');
@@ -990,8 +1054,11 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             stopButton.classList.toggle('active', running);
             newSessionButton.disabled = running;
             newSessionHeaderButton.disabled = running;
+            checkpointOpenButton.disabled = running;
+            checkpointSaveButton.disabled = running;
             compactContextButton.disabled = running;
             if (runIndicator) runIndicator.classList.toggle('active', running);
+            renderCheckpoints();
         }
 
         function escapeText(value) {
@@ -1194,6 +1261,82 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
 
         function closeHistory() {
             historyOverlay.classList.remove('open');
+        }
+
+        function renderCheckpoints() {
+            if (!checkpointList) return;
+            checkpointList.innerHTML = '';
+            const session = getActiveSession();
+            const checkpoints = session && Array.isArray(session.checkpoints) ? session.checkpoints : [];
+            if (!checkpoints.length) {
+                const empty = document.createElement('div');
+                empty.className = 'empty-note';
+                empty.textContent = 'No checkpoints for this conversation yet.';
+                checkpointList.appendChild(empty);
+                return;
+            }
+            for (const checkpoint of checkpoints) {
+                const item = document.createElement('div');
+                item.className = 'checkpoint-item';
+
+                const head = document.createElement('div');
+                head.className = 'checkpoint-item-head';
+                const titleWrap = document.createElement('div');
+                const title = document.createElement('div');
+                title.className = 'checkpoint-item-title';
+                title.textContent = checkpoint.label || checkpoint.summary || 'Checkpoint';
+                const meta = document.createElement('div');
+                meta.className = 'checkpoint-item-meta';
+                const metaParts = [formatDate(checkpoint.createdAt), (checkpoint.messageCount || 0) + ' messages'];
+                if (checkpoint.restoredAt) metaParts.push('Restored ' + formatDate(checkpoint.restoredAt));
+                meta.textContent = metaParts.join(' · ');
+                titleWrap.append(title, meta);
+                head.appendChild(titleWrap);
+                if (checkpoint.reason) head.appendChild(badge(checkpoint.reason, 'success'));
+
+                const foot = document.createElement('div');
+                foot.className = 'checkpoint-item-foot';
+                const summary = document.createElement('div');
+                summary.className = 'checkpoint-item-meta';
+                summary.textContent = checkpoint.summary || '';
+                const actions = document.createElement('div');
+                actions.className = 'checkpoint-actions';
+                const restore = document.createElement('button');
+                restore.type = 'button';
+                restore.className = 'secondary small';
+                restore.textContent = 'Restore';
+                restore.disabled = isRunning;
+                restore.addEventListener('click', () => {
+                    if (!state || !state.activeSessionId) return;
+                    if (!window.confirm('Restore this checkpoint? The agent runtime and saved Workbench surface state will be restored.')) return;
+                    closeCheckpointPanel();
+                    vscode.postMessage({ type: 'agent.checkpoint.restore', sessionId: state.activeSessionId, checkpointId: checkpoint.id });
+                });
+                const del = document.createElement('button');
+                del.type = 'button';
+                del.className = 'ghost small';
+                del.textContent = 'Delete';
+                del.disabled = isRunning;
+                del.addEventListener('click', () => {
+                    if (!state || !state.activeSessionId) return;
+                    if (!window.confirm('Delete this checkpoint? This cannot be undone.')) return;
+                    vscode.postMessage({ type: 'agent.checkpoint.delete', sessionId: state.activeSessionId, checkpointId: checkpoint.id });
+                });
+                actions.append(restore, del);
+                foot.append(summary, actions);
+                item.append(head, foot);
+                checkpointList.appendChild(item);
+            }
+        }
+
+        function openCheckpointPanel() {
+            closeHistory();
+            renderCheckpoints();
+            checkpointOverlay.classList.add('open');
+        }
+
+        function closeCheckpointPanel() {
+            checkpointOverlay.classList.remove('open');
         }
 
         function closeInlineMenus() {
@@ -1502,6 +1645,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             renderChatMeta();
             renderFeed();
             renderMentionMenu();
+            if (checkpointOverlay && checkpointOverlay.classList.contains('open')) renderCheckpoints();
         }
 
         function getMentionQuery() {
@@ -1792,6 +1936,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 closeInlineMenus();
                 if (mentionMenu) mentionMenu.classList.remove('open');
                 if (historyOverlay && historyOverlay.classList.contains('open')) closeHistory();
+                if (checkpointOverlay && checkpointOverlay.classList.contains('open')) closeCheckpointPanel();
             }
         });
         window.addEventListener('pointerdown', (event) => {
@@ -1813,6 +1958,11 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         on(historyOverlay, 'click', (event) => {
             if (event.target === historyOverlay) closeHistory();
         });
+        on(checkpointOpenButton, 'click', openCheckpointPanel);
+        on(checkpointCloseButton, 'click', closeCheckpointPanel);
+        on(checkpointOverlay, 'click', (event) => {
+            if (event.target === checkpointOverlay) closeCheckpointPanel();
+        });
         on(selectModelButton, 'click', () => {
             providerMenuOpen = !providerMenuOpen;
             reasoningMenuOpen = false;
@@ -1831,11 +1981,16 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         });
         function startNewSession() {
             closeHistory();
+            closeCheckpointPanel();
             vscode.postMessage({ type: 'agent.session.new' });
         }
 
         on(newSessionButton, 'click', startNewSession);
         on(newSessionHeaderButton, 'click', startNewSession);
+        on(checkpointSaveButton, 'click', () => {
+            if (!state || !state.activeSessionId || isRunning) return;
+            vscode.postMessage({ type: 'agent.checkpoint.save', sessionId: state.activeSessionId });
+        });
         on(compactContextButton, 'click', () => state && vscode.postMessage({ type: 'agent.context.compact', sessionId: state.activeSessionId }));
         on(sessionFilter, 'change', () => {
             activeFilter = sessionFilter.value || 'current';


### PR DESCRIPTION
## Summary
- Add versioned Workbench surface payloads to Yagr checkpoint save/restore flows so visible chat, workflow context, node selections, and title can be restored.
- Add a Checkpoints panel in the Agent Workbench for saving, restoring, and deleting checkpoints.
- Use Yagr checkpoint metadata and policy-aware auto checkpoint hooks while preserving compatibility with legacy payloadState runtimes.

## Validation
- npm run compile --workspace=packages/vscode-extension
- webview script syntax validation with generated Agent Workbench HTML