### PR TITLE
fix(vscode): preserve workflow context for new agent chats

### DIFF
--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -1341,13 +1341,17 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     private getInputWorkflowContext(input: Omit<AgentPromptInput, 'prompt'>): AgentWorkflowContext | undefined {
-        if (!input.workflowId && !input.workflowName && !input.workflowFilename) return undefined;
-        const name = input.workflowName?.trim() || input.workflowId || input.workflowFilename || 'Workflow';
+        const id = input.workflowId?.trim();
+        const workflowName = input.workflowName?.trim();
+        const filename = input.workflowFilename?.trim();
+        const filePath = input.workflowFilePath?.trim();
+        if (!id && !workflowName && !filename && !filePath) return undefined;
+        const name = workflowName || id || filename || (filePath ? path.basename(filePath) : undefined) || 'Workflow';
         return {
-            id: input.workflowId?.trim() || undefined,
+            id: id || undefined,
             name,
-            filename: input.workflowFilename?.trim() || undefined,
-            filePath: input.workflowFilePath?.trim() || undefined,
+            filename: filename || undefined,
+            filePath: filePath || undefined,
         };
     }
 

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -395,12 +395,17 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     async createSession(input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
-        const scope = this.getUnattachedSessionScope();
+        const workflow = this.getInputWorkflowContext(input);
+        const scope = workflow ? this.getSessionScope(input) : this.getUnattachedSessionScope();
         const sessions = await this.getSessionRuntime();
-        sessions.service.rotateForScope(scope, {
-            title: this.getDefaultSessionTitle(),
+        const record = sessions.service.rotateForScope(scope, {
+            title: this.getDefaultSessionTitle(workflow?.name),
         });
-        return this.getWorkbenchState({ ...input, workflowId: undefined, workflowName: undefined, workflowFilename: undefined, workflowFilePath: undefined, nodeContext: undefined, nodeContexts: undefined, sessionId: undefined });
+        if (workflow) {
+            this.writeSessionEntries(sessions.service, record.id, this.withWorkflowContext([], workflow));
+            return this.getWorkbenchState({ ...input, sessionId: record.id, nodeContext: undefined, nodeContexts: undefined });
+        }
+        return this.getWorkbenchState({ ...input, workflowId: undefined, workflowName: undefined, workflowFilename: undefined, workflowFilePath: undefined, nodeContext: undefined, nodeContexts: undefined, sessionId: record.id });
     }
 
     async getLatestSessionId(): Promise<string | undefined> {
@@ -1333,6 +1338,17 @@ export class AgentRuntimeController implements vscode.Disposable {
             return { kind: 'vscode-workflow', key: input.workflowId };
         }
         return this.getUnattachedSessionScope();
+    }
+
+    private getInputWorkflowContext(input: Omit<AgentPromptInput, 'prompt'>): AgentWorkflowContext | undefined {
+        if (!input.workflowId && !input.workflowName && !input.workflowFilename) return undefined;
+        const name = input.workflowName?.trim() || input.workflowId || input.workflowFilename || 'Workflow';
+        return {
+            id: input.workflowId?.trim() || undefined,
+            name,
+            filename: input.workflowFilename?.trim() || undefined,
+            filePath: input.workflowFilePath?.trim() || undefined,
+        };
     }
 
     private getUnattachedSessionScope(): DeepAgentSessionScope {

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -433,6 +433,7 @@ export class AgentWorkbenchWebview {
         workflowId?: string;
         workflowName?: string;
         workflowFilename?: string;
+        workflowFilePath?: string;
         workspaceRoot?: string;
         nodeContext?: AgentWorkbenchNodeContext;
         nodeContexts?: AgentWorkbenchNodeContext[];
@@ -442,6 +443,7 @@ export class AgentWorkbenchWebview {
             workflowId: this._workflow?.id,
             workflowName: this._workflow?.name,
             workflowFilename: this._workflow?.filename,
+            workflowFilePath: this._workflowFilePath,
             workspaceRoot: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
             nodeContext: this._nodeContexts[0],
             nodeContexts: this._nodeContexts,


### PR DESCRIPTION
## Summary
- Keep the current workflow context when starting a new agent workbench conversation from a workflow split view.
- Carry the workflow file path through workbench state so the new conversation can resolve the same workflow surface.

## Validation
- npm run build --workspace=packages/vscode-extension
- npm test --workspace=packages/vscode-extension -- agent-workbench-html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions can be created as workflow-attached or standalone, with session rotation scoped accordingly
  * Improved workflow input normalization (trimmed values and sensible defaults) for more reliable context initialization
  * Webview now includes workflow file path in the workbench payload so session/state calls receive full workflow metadata

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/430)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->