### PR TITLE
feat(vscode): choose context for new agent chats

### DIFF
--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -1341,13 +1341,17 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     private getInputWorkflowContext(input: Omit<AgentPromptInput, 'prompt'>): AgentWorkflowContext | undefined {
-        if (!input.workflowId && !input.workflowName && !input.workflowFilename) return undefined;
-        const name = input.workflowName?.trim() || input.workflowId || input.workflowFilename || 'Workflow';
+        const id = input.workflowId?.trim();
+        const workflowName = input.workflowName?.trim();
+        const filename = input.workflowFilename?.trim();
+        const filePath = input.workflowFilePath?.trim();
+        if (!id && !workflowName && !filename && !filePath) return undefined;
+        const name = workflowName || id || filename || (filePath ? path.basename(filePath) : undefined) || 'Workflow';
         return {
-            id: input.workflowId?.trim() || undefined,
+            id: id || undefined,
             name,
-            filename: input.workflowFilename?.trim() || undefined,
-            filePath: input.workflowFilePath?.trim() || undefined,
+            filename: filename || undefined,
+            filePath: filePath || undefined,
         };
     }
 

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -395,12 +395,17 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     async createSession(input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
-        const scope = this.getUnattachedSessionScope();
+        const workflow = this.getInputWorkflowContext(input);
+        const scope = workflow ? this.getSessionScope(input) : this.getUnattachedSessionScope();
         const sessions = await this.getSessionRuntime();
-        sessions.service.rotateForScope(scope, {
-            title: this.getDefaultSessionTitle(),
+        const record = sessions.service.rotateForScope(scope, {
+            title: this.getDefaultSessionTitle(workflow?.name),
         });
-        return this.getWorkbenchState({ ...input, workflowId: undefined, workflowName: undefined, workflowFilename: undefined, workflowFilePath: undefined, nodeContext: undefined, nodeContexts: undefined, sessionId: undefined });
+        if (workflow) {
+            this.writeSessionEntries(sessions.service, record.id, this.withWorkflowContext([], workflow));
+            return this.getWorkbenchState({ ...input, sessionId: record.id, nodeContext: undefined, nodeContexts: undefined });
+        }
+        return this.getWorkbenchState({ ...input, workflowId: undefined, workflowName: undefined, workflowFilename: undefined, workflowFilePath: undefined, nodeContext: undefined, nodeContexts: undefined, sessionId: record.id });
     }
 
     async getLatestSessionId(): Promise<string | undefined> {
@@ -1333,6 +1338,17 @@ export class AgentRuntimeController implements vscode.Disposable {
             return { kind: 'vscode-workflow', key: input.workflowId };
         }
         return this.getUnattachedSessionScope();
+    }
+
+    private getInputWorkflowContext(input: Omit<AgentPromptInput, 'prompt'>): AgentWorkflowContext | undefined {
+        if (!input.workflowId && !input.workflowName && !input.workflowFilename) return undefined;
+        const name = input.workflowName?.trim() || input.workflowId || input.workflowFilename || 'Workflow';
+        return {
+            id: input.workflowId?.trim() || undefined,
+            name,
+            filename: input.workflowFilename?.trim() || undefined,
+            filePath: input.workflowFilePath?.trim() || undefined,
+        };
     }
 
     private getUnattachedSessionScope(): DeepAgentSessionScope {

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -378,6 +378,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             text-decoration: underline;
         }
         .header-actions {
+            position: relative;
             display: flex;
             gap: 8px;
             align-items: center;
@@ -612,6 +613,13 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             right: 0;
             width: 220px;
         }
+        .inline-popover.new-session {
+            left: auto;
+            right: 0;
+            top: calc(100% + 8px);
+            bottom: auto;
+            width: min(340px, calc(100vw - 28px));
+        }
         .inline-popover-head {
             display: flex;
             justify-content: space-between;
@@ -662,6 +670,11 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         .inline-popover-foot {
             padding: 7px 10px;
             border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+        }
+        .inline-divider {
+            height: 1px;
+            margin: 4px 6px;
+            background: color-mix(in srgb, var(--border) 72%, transparent);
         }
         .inline-link {
             width: auto;
@@ -958,6 +971,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                         <button id="checkpoint-open" class="ghost small icon-button" type="button" title="Checkpoints" aria-label="Checkpoints">${checkpointIcon}</button>
                         <button id="history-open" class="ghost small icon-button" type="button" title="Conversation history" aria-label="Conversation history">${historyIcon}</button>
                         <button id="new-session-header" class="ghost small icon-button" type="button" title="New conversation" aria-label="New conversation">${newConversationIcon}</button>
+                        <div id="new-session-menu" class="inline-popover new-session" role="menu" aria-label="Start new conversation"></div>
                     </div>
                 </div>
             </header>
@@ -1052,6 +1066,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         let providerMenuProvider = '';
         let modelSearchQuery = '';
         let reasoningMenuOpen = false;
+        let newSessionMenuOpen = false;
         let autoScrollFeed = true;
 
         const OP_ICONS = {
@@ -1092,6 +1107,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const contextMeterFill = document.getElementById('context-meter-fill');
         const newSessionButton = document.getElementById('new-session');
         const newSessionHeaderButton = document.getElementById('new-session-header');
+        const newSessionMenu = document.getElementById('new-session-menu');
         const checkpointOpenButton = document.getElementById('checkpoint-open');
         const checkpointCloseButton = document.getElementById('checkpoint-close');
         const checkpointOverlay = document.getElementById('checkpoint-overlay');
@@ -1407,8 +1423,67 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         function closeInlineMenus() {
             providerMenuOpen = false;
             reasoningMenuOpen = false;
+            newSessionMenuOpen = false;
             if (providerMenu) providerMenu.classList.remove('open');
             if (reasoningMenu) reasoningMenu.classList.remove('open');
+            if (newSessionMenu) newSessionMenu.classList.remove('open');
+        }
+
+        function workflowKey(workflow) {
+            return workflow && (workflow.id || workflow.filename || workflow.name || '');
+        }
+
+        function renderNewSessionMenu() {
+            if (!newSessionMenu || !state) return;
+            newSessionMenu.innerHTML = '';
+
+            const head = document.createElement('div');
+            head.className = 'inline-popover-head';
+            head.innerHTML = '<strong>New conversation</strong><span>Select context</span>';
+            newSessionMenu.appendChild(head);
+
+            const list = document.createElement('div');
+            list.className = 'inline-popover-list';
+            if (currentWorkflowContext) {
+                const current = inlineOption('This workflow', currentWorkflowContext.name || 'Current workflow', 'Current', 'workflow');
+                current.addEventListener('click', () => startNewSession(currentWorkflowContext));
+                list.appendChild(current);
+            }
+
+            const blank = inlineOption('New workflow', 'Start without workflow context', '', 'workflow');
+            blank.addEventListener('click', () => startNewSession(null));
+            list.appendChild(blank);
+
+            const workflows = Array.isArray(state.availableWorkflows) ? state.availableWorkflows : [];
+            if (workflows.length) {
+                const divider = document.createElement('div');
+                divider.className = 'inline-divider';
+                list.appendChild(divider);
+            }
+            const currentKey = workflowKey(currentWorkflowContext);
+            for (const workflow of workflows) {
+                const key = workflowKey(workflow);
+                if (currentKey && key && key === currentKey) continue;
+                const label = workflow.name || workflow.id || workflow.filename || 'Workflow';
+                const detail = [workflow.filename, workflow.id].filter(Boolean).join(' · ') || 'Existing workflow';
+                const option = inlineOption(label, detail, '', 'workflow');
+                option.addEventListener('click', () => startNewSession(workflow));
+                list.appendChild(option);
+            }
+
+            newSessionMenu.appendChild(list);
+            newSessionMenu.classList.toggle('open', newSessionMenuOpen);
+        }
+
+        function openNewSessionMenu() {
+            closeHistory();
+            closeCheckpointPanel();
+            providerMenuOpen = false;
+            reasoningMenuOpen = false;
+            newSessionMenuOpen = !newSessionMenuOpen;
+            if (providerMenu) providerMenu.classList.remove('open');
+            if (reasoningMenu) reasoningMenu.classList.remove('open');
+            renderNewSessionMenu();
         }
 
         function connectedProviders() {
@@ -1607,6 +1682,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             selectReasoningButton.style.display = state.supportsReasoningEffort ? 'inline-block' : 'none';
             renderProviderMenu();
             renderReasoningMenu();
+            renderNewSessionMenu();
             const usage = state.session && state.session.contextUsage;
             if (!usage || usage.source !== 'api') {
                 contextPill.classList.remove('active');
@@ -2014,6 +2090,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             if (!(target instanceof Node)) return;
             if (providerMenu && (providerMenu.contains(target) || selectModelButton.contains(target))) return;
             if (reasoningMenu && (reasoningMenu.contains(target) || selectReasoningButton.contains(target))) return;
+            if (newSessionMenu && (newSessionMenu.contains(target) || newSessionHeaderButton.contains(target))) return;
             closeInlineMenus();
         }, true);
         on(promptInput, 'input', renderMentionMenu);
@@ -2049,14 +2126,15 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             renderProviderMenu();
             renderReasoningMenu();
         });
-        function startNewSession() {
+        function startNewSession(workflow) {
             closeHistory();
             closeCheckpointPanel();
-            vscode.postMessage({ type: 'agent.session.new' });
+            closeInlineMenus();
+            vscode.postMessage({ type: 'agent.session.new', workflow });
         }
 
-        on(newSessionButton, 'click', startNewSession);
-        on(newSessionHeaderButton, 'click', startNewSession);
+        on(newSessionButton, 'click', openNewSessionMenu);
+        on(newSessionHeaderButton, 'click', openNewSessionMenu);
         on(checkpointSaveButton, 'click', () => {
             if (!state || !state.activeSessionId || isRunning) return;
             vscode.postMessage({ type: 'agent.checkpoint.save', sessionId: state.activeSessionId });

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -291,7 +291,27 @@ export class AgentWorkbenchWebview {
         }
 
         if (payload.type === 'agent.session.new') {
-            await this.postWorkbenchState(await this._agentRuntime.createSession(this.buildWorkbenchInput()));
+            const workflow = this.sanitizeWorkflowContext(payload.workflow);
+            const input = workflow
+                ? {
+                    ...this.buildWorkbenchInput(),
+                    workflowId: workflow.id,
+                    workflowName: workflow.name,
+                    workflowFilename: workflow.filename,
+                    workflowFilePath: workflow.filePath,
+                    nodeContext: undefined,
+                    nodeContexts: undefined,
+                }
+                : {
+                    ...this.buildWorkbenchInput(),
+                    workflowId: undefined,
+                    workflowName: undefined,
+                    workflowFilename: undefined,
+                    workflowFilePath: undefined,
+                    nodeContext: undefined,
+                    nodeContexts: undefined,
+                };
+            await this.postWorkbenchState(await this._agentRuntime.createSession(input));
             return;
         }
 

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -433,6 +433,7 @@ export class AgentWorkbenchWebview {
         workflowId?: string;
         workflowName?: string;
         workflowFilename?: string;
+        workflowFilePath?: string;
         workspaceRoot?: string;
         nodeContext?: AgentWorkbenchNodeContext;
         nodeContexts?: AgentWorkbenchNodeContext[];
@@ -442,6 +443,7 @@ export class AgentWorkbenchWebview {
             workflowId: this._workflow?.id,
             workflowName: this._workflow?.name,
             workflowFilename: this._workflow?.filename,
+            workflowFilePath: this._workflowFilePath,
             workspaceRoot: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
             nodeContext: this._nodeContexts[0],
             nodeContexts: this._nodeContexts,

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -48,6 +48,11 @@ test('Agent Workbench HTML: renders provider/session controls', () => {
     assert.ok(html.includes('id="history-open"'), 'Must render the conversation history button');
     assert.ok(html.includes('id="session-list"'), 'Must render the persisted session list in history modal');
     assert.ok(html.includes("type: 'agent.session.new'"), 'Must allow creating new persisted sessions');
+    assert.ok(html.includes('id="new-session-menu"'), 'Must render new conversation context picker');
+    assert.ok(html.includes('This workflow'), 'Must allow a new chat for the current workflow');
+    assert.ok(html.includes('New workflow'), 'Must allow a new unattached workflow chat');
+    assert.ok(html.includes('state.availableWorkflows'), 'Must list available workflows in the new chat picker');
+    assert.ok(html.includes('startNewSession(null)'), 'Must request an unattached session for new workflow');
     assert.ok(html.includes('history-overlay'), 'Must render conversation history as a modal overlay');
     assert.ok(html.includes("type: 'agent.ready'"), 'Must request initial state from the extension host');
     assert.ok(html.includes('openai / gpt-5.4'), 'Must render selected provider/model label');


### PR DESCRIPTION
## Summary
- Add a New conversation context picker with This workflow, New workflow, and existing workflow choices.
- Preserve or clear workflow context based on the selected option when creating a fresh agent session.
- Keep workflow file path propagation and file-only workflow context handling from the previous fix.

## Validation
- Attempted `npm run build --workspace=packages/vscode-extension`
- Attempted `npm test --workspace=packages/vscode-extension -- agent-workbench-html`

Both validation commands currently fail on the `indigo-polyanthus` base before reaching these changes because the settings webview React migration imports `react`, `react-dom/client`, and `react-redux`, but those dependencies/types are not installed in this worktree.