### PR TITLE
fix(vscode): keep distinct personal projects selectable

### DIFF
--- a/packages/vscode-extension/src/ui/configuration-webview-projects.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview-projects.ts
@@ -59,14 +59,6 @@ function dedupeUiProjects(projects: UiProject[]): UiProject[] {
     }
   }
 
-  const personal = [...byId.values()].filter((project) => project.id === 'personal' || project.type === 'personal');
-  if (personal.length > 1) {
-    const preferred = personal.find((project) => project.id !== 'personal') ?? personal[0];
-    for (const project of personal) {
-      if (project.id !== preferred.id) byId.delete(project.id);
-    }
-  }
-
   return [...byId.values()];
 }
 

--- a/packages/vscode-extension/src/ui/settings-webview/app.tsx
+++ b/packages/vscode-extension/src/ui/settings-webview/app.tsx
@@ -293,7 +293,7 @@ function ProjectFields({ draft, patch, draftId, selected }: { draft: Environment
   const selectableProjects = projects.filter((project) => project.id !== 'personal' || projects.length > 1);
   if (selectableProjects.length <= 1 && selectableProjects[0]?.id === 'personal') return null;
   if (!selectableProjects.length) return null;
-  return <div className="form-grid"><label>Project<select value={draft.projectId} onChange={(event) => { const project = projects.find((item) => item.id === event.target.value); patch({ projectId: event.target.value, projectName: project?.name || '' }); }}>{selectableProjects.map((project) => <option key={project.id} value={project.id}>{project.name}</option>)}</select></label></div>;
+  return <div className="form-grid"><label>Project<select value={draft.projectId} onChange={(event) => { const project = projects.find((item) => item.id === event.target.value); patch({ projectId: event.target.value, projectName: project?.name || '' }); }}>{selectableProjects.map((project) => <option key={project.id} value={project.id}>{project.displayName || project.name}</option>)}</select></label></div>;
 }
 
 function ManagedInstanceFormModal({ returnToEnvironmentForm, returnToEnvironmentDraftId }: { returnToEnvironmentForm?: boolean; returnToEnvironmentDraftId?: string }) {

--- a/packages/vscode-extension/src/ui/settings-webview/store.ts
+++ b/packages/vscode-extension/src/ui/settings-webview/store.ts
@@ -25,7 +25,7 @@ export interface EnvironmentDraft {
   description: string;
   dirty: boolean;
   projectsLoading?: boolean;
-  projects?: Array<{ id: string; name: string }>;
+  projects?: Array<{ id: string; name: string; type?: string; detail?: string; displayName?: string }>;
   projectError?: string;
   projectRequestKey?: string;
 }
@@ -217,7 +217,7 @@ const draftsSlice = createSlice({
       const existing = state.environment[action.payload.id] || blankEnvironmentDraft(action.payload.id);
       state.environment[action.payload.id] = { ...existing, ...action.payload.patch, dirty: true };
     },
-    environmentDraftProjectsReceived: (state, action: PayloadAction<{ id: string; requestKey?: string; projects?: Array<{ id: string; name: string }>; selectedProjectId?: string; selectedProjectName?: string; error?: string }>) => {
+    environmentDraftProjectsReceived: (state, action: PayloadAction<{ id: string; requestKey?: string; projects?: Array<{ id: string; name: string; type?: string; detail?: string; displayName?: string }>; selectedProjectId?: string; selectedProjectName?: string; error?: string }>) => {
       const existing = state.environment[action.payload.id];
       if (!existing) return;
       if (action.payload.requestKey && existing.projectRequestKey && action.payload.requestKey !== existing.projectRequestKey) return;

--- a/packages/vscode-extension/tests/unit/configuration-webview-projects.test.ts
+++ b/packages/vscode-extension/tests/unit/configuration-webview-projects.test.ts
@@ -67,3 +67,32 @@ test('loadProjects resolves managed environment targets before stale host payloa
     assert.strictEqual(message.requestId, 7);
     assert.deepStrictEqual(message.projects.map((project) => project.id), ['personal']);
 });
+
+test('loadProjects keeps distinct personal projects selectable', async () => {
+    const workspaceFacade = {
+        async listProjects() {
+            return [
+                { id: 'project-alice', name: 'Alice', type: 'personal' },
+                { id: 'project-bob', name: 'Bob', type: 'personal' },
+            ];
+        },
+    };
+    const globalFacade = {
+        async listProjects() {
+            return [];
+        },
+    };
+
+    const message = await loadProjectsForConfigurationWebview({
+        type: 'loadProjects',
+        scope: 'workspace',
+        requestId: 8,
+    }, {
+        workspaceFacade,
+        globalFacade,
+    });
+
+    assert.deepStrictEqual(message.projects.map((project) => project.id), ['project-alice', 'project-bob']);
+    assert.deepStrictEqual(message.projects.map((project) => project.name), ['Personal', 'Personal']);
+    assert.deepStrictEqual(message.projects.map((project) => project.displayName), ['Personal - Alice', 'Personal - Bob']);
+});


### PR DESCRIPTION
## Summary
- Preserve distinct n8n personal projects in the settings project selector instead of collapsing all `type: personal` entries.
- Use the owner-aware `displayName` when rendering project options so multiple personal projects remain distinguishable.
- Add a regression test covering multiple personal projects.

## Tests
- `npm test --workspace=packages/vscode-extension`

Fixes #432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects now display with preferred display names for improved clarity and identification.

* **Bug Fixes**
  * Fixed issue where multiple personal projects were being merged; they are now kept distinct and individually selectable within your workspace.

* **Tests**
  * Added test coverage to verify multiple personal projects remain distinct and selectable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/435)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->