### PR TITLE
Fix workflow webview proxy in code-server

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1147,10 +1147,41 @@ async function startWorkflowProxy(n8nBaseUrl: string): Promise<WorkflowProxyUrls
 }
 
 function externalizeProxyUrl(url: string, proxyUrls: WorkflowProxyUrls): string {
-    if (proxyUrls.publicBaseUrl === proxyUrls.localBaseUrl || !url.startsWith(proxyUrls.localBaseUrl)) {
+    if (proxyUrls.publicBaseUrl === proxyUrls.localBaseUrl) {
         return url;
     }
-    return `${proxyUrls.publicBaseUrl}${url.slice(proxyUrls.localBaseUrl.length)}`;
+
+    try {
+        const targetUrl = new URL(url);
+        const localBaseUrl = new URL(proxyUrls.localBaseUrl);
+        if (targetUrl.origin !== localBaseUrl.origin) {
+            return url;
+        }
+
+        const localBasePath = trimTrailingSlash(localBaseUrl.pathname);
+        if (!urlPathMatchesBase(targetUrl.pathname, localBasePath)) {
+            return url;
+        }
+
+        const remainingPath = localBasePath ? targetUrl.pathname.slice(localBasePath.length) : targetUrl.pathname === '/' ? '' : targetUrl.pathname;
+        return buildProxyUrl(proxyUrls.publicBaseUrl, remainingPath, targetUrl.search, targetUrl.hash);
+    } catch {
+        return url;
+    }
+}
+
+function trimTrailingSlash(pathname: string): string {
+    const trimmed = pathname.replace(/\/$/, '');
+    return trimmed === '/' ? '' : trimmed;
+}
+
+function urlPathMatchesBase(pathname: string, basePath: string): boolean {
+    return !basePath || pathname === basePath || pathname.startsWith(`${basePath}/`);
+}
+
+function buildProxyUrl(proxyBaseUrl: string, pathname: string, search = '', hash = ''): string {
+    const path = pathname ? pathname.startsWith('/') ? pathname : `/${pathname}` : '';
+    return `${proxyBaseUrl}${path}${search}${hash}`;
 }
 
 function externalizeProxyHtml(html: string, proxyUrls: WorkflowProxyUrls): string {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1071,27 +1071,30 @@ async function resolveWorkflowWebviewTarget(workflow: IWorkflowStatus): Promise<
         if (workspaceConfig.version === 4) {
             const environment = await configService.prepareEnvironment();
             const n8nBaseUrl = environment.host;
-            const proxyUrl = await proxyService.start(n8nBaseUrl);
+            const proxyUrls = await startWorkflowProxy(n8nBaseUrl);
             const workflowUrl = new URL(`/workflow/${encodeURIComponent(workflow.id)}`, n8nBaseUrl.endsWith('/') ? n8nBaseUrl : `${n8nBaseUrl}/`);
             workflowUrl.searchParams.set('_n8nacBridge', String(Date.now()));
             if (environment.sourceKind === 'managed-instance') {
                 const openTarget = await facade.resolveWorkflowWebviewOpen({
                     workflowId: workflow.id,
-                    proxyBaseUrl: proxyUrl,
+                    proxyBaseUrl: proxyUrls.localBaseUrl,
                     workspaceRoot,
                     workflowUrl: workflowUrl.toString(),
                     instanceId: environment.managedInstanceId,
                 });
                 if (openTarget.routePath && openTarget.autoLoginPageHtml) {
-                    proxyService.registerHtmlRoute(openTarget.routePath, openTarget.autoLoginPageHtml);
+                    proxyService.registerHtmlRoute(openTarget.routePath, externalizeProxyHtml(openTarget.autoLoginPageHtml, proxyUrls));
                     outputChannel.appendLine(`[n8n] Opening workflow ${workflow.id} in environment ${environment.environmentName} through managed auto-login route.`);
                 } else {
                     outputChannel.appendLine(`[n8n] Opening workflow ${workflow.id} in environment ${environment.environmentName} through direct route.`);
                 }
-                return { url: openTarget.url, targetUrl: openTarget.targetUrl };
+                return {
+                    url: externalizeProxyUrl(openTarget.url, proxyUrls),
+                    targetUrl: externalizeProxyUrl(openTarget.targetUrl, proxyUrls),
+                };
             }
             outputChannel.appendLine(`[n8n] Opening workflow ${workflow.id} in external-instance workspace environment ${environment.environmentName}.`);
-            return { url: `${proxyUrl}/workflow/${encodeURIComponent(workflow.id)}?${workflowUrl.searchParams.toString()}`, targetUrl: workflowUrl.toString() };
+            return { url: `${proxyUrls.publicBaseUrl}/workflow/${encodeURIComponent(workflow.id)}?${workflowUrl.searchParams.toString()}`, targetUrl: workflowUrl.toString() };
         }
     }
     const prepared = await facade.prepareEffectiveContext({
@@ -1105,24 +1108,71 @@ async function resolveWorkflowWebviewTarget(workflow: IWorkflowStatus): Promise<
     }
     const effective = prepared.context;
     const n8nBaseUrl = effective.apiBaseUrl ?? effective.host;
-    const proxyUrl = await proxyService.start(n8nBaseUrl);
+    const proxyUrls = await startWorkflowProxy(n8nBaseUrl);
     const workflowUrl = new URL(`/workflow/${encodeURIComponent(workflow.id)}`, n8nBaseUrl.endsWith('/') ? n8nBaseUrl : `${n8nBaseUrl}/`);
     workflowUrl.searchParams.set('_n8nacBridge', String(Date.now()));
     const openTarget = await facade.resolveWorkflowWebviewOpen({
         workflowId: workflow.id,
-        proxyBaseUrl: proxyUrl,
+        proxyBaseUrl: proxyUrls.localBaseUrl,
         workspaceRoot,
         workflowUrl: workflowUrl.toString(),
     });
 
     if (openTarget.routePath && openTarget.autoLoginPageHtml) {
-        proxyService.registerHtmlRoute(openTarget.routePath, openTarget.autoLoginPageHtml);
+        proxyService.registerHtmlRoute(openTarget.routePath, externalizeProxyHtml(openTarget.autoLoginPageHtml, proxyUrls));
         outputChannel.appendLine(`[n8n] Opening workflow ${workflow.id} through managed auto-login webview route.`);
     } else {
         outputChannel.appendLine(`[n8n] Opening workflow ${workflow.id} through direct webview route.`);
     }
 
-    return { url: openTarget.url, targetUrl: openTarget.targetUrl };
+    return {
+        url: externalizeProxyUrl(openTarget.url, proxyUrls),
+        targetUrl: externalizeProxyUrl(openTarget.targetUrl, proxyUrls),
+    };
+}
+
+type WorkflowProxyUrls = {
+    localBaseUrl: string;
+    publicBaseUrl: string;
+};
+
+async function startWorkflowProxy(n8nBaseUrl: string): Promise<WorkflowProxyUrls> {
+    const localProxyUrl = await proxyService.start(n8nBaseUrl);
+    const publicProxyUrl = await resolveWebviewProxyBaseUrl(localProxyUrl);
+    proxyService.setPublicBaseUrl(publicProxyUrl);
+    return {
+        localBaseUrl: localProxyUrl.replace(/\/$/, ''),
+        publicBaseUrl: publicProxyUrl,
+    };
+}
+
+function externalizeProxyUrl(url: string, proxyUrls: WorkflowProxyUrls): string {
+    if (proxyUrls.publicBaseUrl === proxyUrls.localBaseUrl || !url.startsWith(proxyUrls.localBaseUrl)) {
+        return url;
+    }
+    return `${proxyUrls.publicBaseUrl}${url.slice(proxyUrls.localBaseUrl.length)}`;
+}
+
+function externalizeProxyHtml(html: string, proxyUrls: WorkflowProxyUrls): string {
+    if (proxyUrls.publicBaseUrl === proxyUrls.localBaseUrl) {
+        return html;
+    }
+    return html.split(proxyUrls.localBaseUrl).join(proxyUrls.publicBaseUrl);
+}
+
+async function resolveWebviewProxyBaseUrl(localProxyUrl: string): Promise<string> {
+    const normalizedLocalProxyUrl = localProxyUrl.replace(/\/$/, '');
+    try {
+        const externalUri = await vscode.env.asExternalUri(vscode.Uri.parse(normalizedLocalProxyUrl));
+        const externalProxyUrl = externalUri.toString(true).replace(/\/$/, '');
+        if (externalProxyUrl !== normalizedLocalProxyUrl) {
+            outputChannel.appendLine(`[n8n] Exposed workflow proxy for webview: ${externalProxyUrl}`);
+        }
+        return externalProxyUrl;
+    } catch (error: any) {
+        outputChannel.appendLine(`[n8n] Failed to resolve external workflow proxy URL; using local URL. ${error?.message || String(error)}`);
+        return normalizedLocalProxyUrl;
+    }
 }
 
 function updateContextKeys() {

--- a/packages/vscode-extension/src/services/proxy-service.ts
+++ b/packages/vscode-extension/src/services/proxy-service.ts
@@ -43,23 +43,26 @@ export class ProxyService {
 
     private rewriteProxyLocation(location: string): string {
         const proxyBaseUrl = this.getProxyBaseUrl();
-        if (location.startsWith('/') && !location.startsWith('//')) {
-            return `${proxyBaseUrl}${location}`;
-        }
-
         try {
-            const locationUrl = new URL(location);
             const targetUrl = new URL(this.target);
+            const targetBasePath = this.trimTrailingSlash(targetUrl.pathname);
+
+            if (location.startsWith('/') && !location.startsWith('//')) {
+                const locationUrl = new URL(location, targetUrl.origin);
+                const remainingPath = this.stripTargetBasePath(locationUrl.pathname, targetBasePath);
+                return `${proxyBaseUrl}${remainingPath}${locationUrl.search}${locationUrl.hash}`;
+            }
+
+            const locationUrl = new URL(location);
             if (locationUrl.origin !== targetUrl.origin) {
                 return location;
             }
 
-            const targetBasePath = this.trimTrailingSlash(targetUrl.pathname);
             if (!this.urlPathMatchesBase(locationUrl.pathname, targetBasePath)) {
                 return location;
             }
 
-            const remainingPath = targetBasePath ? locationUrl.pathname.slice(targetBasePath.length) : locationUrl.pathname === '/' ? '' : locationUrl.pathname;
+            const remainingPath = this.stripTargetBasePath(locationUrl.pathname, targetBasePath);
             return `${proxyBaseUrl}${remainingPath}${locationUrl.search}${locationUrl.hash}`;
         } catch {
             return location;
@@ -73,6 +76,16 @@ export class ProxyService {
 
     private urlPathMatchesBase(pathname: string, basePath: string): boolean {
         return !basePath || pathname === basePath || pathname.startsWith(`${basePath}/`);
+    }
+
+    private stripTargetBasePath(pathname: string, basePath: string): string {
+        if (!this.urlPathMatchesBase(pathname, basePath)) {
+            return pathname;
+        }
+        if (!basePath) {
+            return pathname === '/' ? '' : pathname;
+        }
+        return pathname.slice(basePath.length);
     }
 
     /**

--- a/packages/vscode-extension/src/services/proxy-service.ts
+++ b/packages/vscode-extension/src/services/proxy-service.ts
@@ -43,13 +43,36 @@ export class ProxyService {
 
     private rewriteProxyLocation(location: string): string {
         const proxyBaseUrl = this.getProxyBaseUrl();
-        if (location.startsWith(this.target)) {
-            return `${proxyBaseUrl}${location.slice(this.target.length)}`;
-        }
-        if (location.startsWith('/')) {
+        if (location.startsWith('/') && !location.startsWith('//')) {
             return `${proxyBaseUrl}${location}`;
         }
-        return location;
+
+        try {
+            const locationUrl = new URL(location);
+            const targetUrl = new URL(this.target);
+            if (locationUrl.origin !== targetUrl.origin) {
+                return location;
+            }
+
+            const targetBasePath = this.trimTrailingSlash(targetUrl.pathname);
+            if (!this.urlPathMatchesBase(locationUrl.pathname, targetBasePath)) {
+                return location;
+            }
+
+            const remainingPath = targetBasePath ? locationUrl.pathname.slice(targetBasePath.length) : locationUrl.pathname === '/' ? '' : locationUrl.pathname;
+            return `${proxyBaseUrl}${remainingPath}${locationUrl.search}${locationUrl.hash}`;
+        } catch {
+            return location;
+        }
+    }
+
+    private trimTrailingSlash(pathname: string): string {
+        const trimmed = pathname.replace(/\/$/, '');
+        return trimmed === '/' ? '' : trimmed;
+    }
+
+    private urlPathMatchesBase(pathname: string, basePath: string): boolean {
+        return !basePath || pathname === basePath || pathname.startsWith(`${basePath}/`);
     }
 
     /**

--- a/packages/vscode-extension/src/services/proxy-service.ts
+++ b/packages/vscode-extension/src/services/proxy-service.ts
@@ -11,6 +11,7 @@ export class ProxyService {
     private wsServer: WebSocketServer | undefined;
     private port: number = 0;
     private target: string = '';
+    private publicBaseUrl: string | undefined;
     private outputChannel: vscode.OutputChannel | undefined;
     private secrets: vscode.SecretStorage | undefined;
 
@@ -29,6 +30,26 @@ export class ProxyService {
 
     public registerHtmlRoute(routePath: string, html: string): void {
         this.htmlRoutes.set(this.normalizeRoutePath(routePath), html);
+    }
+
+    public setPublicBaseUrl(publicBaseUrl: string | undefined): void {
+        const trimmed = publicBaseUrl?.trim();
+        this.publicBaseUrl = trimmed ? trimmed.replace(/\/$/, '') : undefined;
+    }
+
+    private getProxyBaseUrl(): string {
+        return this.publicBaseUrl || `http://localhost:${this.port}`;
+    }
+
+    private rewriteProxyLocation(location: string): string {
+        const proxyBaseUrl = this.getProxyBaseUrl();
+        if (location.startsWith(this.target)) {
+            return `${proxyBaseUrl}${location.slice(this.target.length)}`;
+        }
+        if (location.startsWith('/')) {
+            return `${proxyBaseUrl}${location}`;
+        }
+        return location;
     }
 
     /**
@@ -125,6 +146,7 @@ export class ProxyService {
         // Reset state
         this.cookieJar.clear();
         this.htmlRoutes.clear();
+        this.setPublicBaseUrl(undefined);
         this.target = normalizedTarget;
         this.port = stablePort;
 
@@ -159,14 +181,7 @@ export class ProxyService {
 
             // Rewrite Location header for redirects
             if (proxyRes.headers['location']) {
-                const location = proxyRes.headers['location'];
-                const newLocation = location.startsWith(this.target)
-                    ? location.replace(this.target, `http://localhost:${this.port}`)
-                    : location.startsWith('/')
-                        ? `http://localhost:${this.port}${location}`
-                        : location;
-
-                proxyRes.headers['location'] = newLocation;
+                proxyRes.headers['location'] = this.rewriteProxyLocation(proxyRes.headers['location']);
             }
 
             // CRITICAL: Capture and Fix cookies for iframe/webview context

--- a/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
+++ b/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
@@ -163,6 +163,30 @@ test('ProxyService: redirects use configured public proxy base URL', () => {
         (service as any).rewriteProxyLocation('https://other.example.test/path'),
         'https://other.example.test/path',
     );
+    assert.equal(
+        (service as any).rewriteProxyLocation('http://n8n.internal:56789/workflow/wf-1'),
+        'http://n8n.internal:56789/workflow/wf-1',
+    );
+    assert.equal(
+        (service as any).rewriteProxyLocation('//other.example.test/signin'),
+        '//other.example.test/signin',
+    );
+});
+
+test('ProxyService: redirects match target base paths on URL boundaries', () => {
+    const { ProxyService } = require('../../src/services/proxy-service.js');
+    const service = new ProxyService();
+    (service as any).target = 'https://n8n.example.test/base';
+    service.setPublicBaseUrl('https://code.example.test/proxy/25444');
+
+    assert.equal(
+        (service as any).rewriteProxyLocation('https://n8n.example.test/base/workflow/wf-1?x=1#node'),
+        'https://code.example.test/proxy/25444/workflow/wf-1?x=1#node',
+    );
+    assert.equal(
+        (service as any).rewriteProxyLocation('https://n8n.example.test/baseline/workflow/wf-1'),
+        'https://n8n.example.test/baseline/workflow/wf-1',
+    );
 });
 
 // ── 3 : parent webview HTML — grant token & rate-limit markers ──────────────

--- a/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
+++ b/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
@@ -144,6 +144,27 @@ test('ProxyService: registered HTML routes are normalized by pathname', () => {
     );
 });
 
+test('ProxyService: redirects use configured public proxy base URL', () => {
+    const { ProxyService } = require('../../src/services/proxy-service.js');
+    const service = new ProxyService();
+    (service as any).target = 'http://n8n.internal:5678';
+    (service as any).port = 25444;
+    service.setPublicBaseUrl('https://code.example.test/proxy/25444/');
+
+    assert.equal(
+        (service as any).rewriteProxyLocation('http://n8n.internal:5678/workflow/wf-1'),
+        'https://code.example.test/proxy/25444/workflow/wf-1',
+    );
+    assert.equal(
+        (service as any).rewriteProxyLocation('/signin'),
+        'https://code.example.test/proxy/25444/signin',
+    );
+    assert.equal(
+        (service as any).rewriteProxyLocation('https://other.example.test/path'),
+        'https://other.example.test/path',
+    );
+});
+
 // ── 3 : parent webview HTML — grant token & rate-limit markers ──────────────
 // buildWebviewHtml is a pure function (no vscode dependency) that generates
 // the parent-webview HTML. We assert on the security-relevant parts of the

--- a/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
+++ b/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
@@ -184,8 +184,20 @@ test('ProxyService: redirects match target base paths on URL boundaries', () => 
         'https://code.example.test/proxy/25444/workflow/wf-1?x=1#node',
     );
     assert.equal(
+        (service as any).rewriteProxyLocation('/base/workflow/wf-1?x=1#node'),
+        'https://code.example.test/proxy/25444/workflow/wf-1?x=1#node',
+    );
+    assert.equal(
+        (service as any).rewriteProxyLocation('/base?x=1'),
+        'https://code.example.test/proxy/25444?x=1',
+    );
+    assert.equal(
         (service as any).rewriteProxyLocation('https://n8n.example.test/baseline/workflow/wf-1'),
         'https://n8n.example.test/baseline/workflow/wf-1',
+    );
+    assert.equal(
+        (service as any).rewriteProxyLocation('/baseline/workflow/wf-1'),
+        'https://code.example.test/proxy/25444/baseline/workflow/wf-1',
     );
 });
 


### PR DESCRIPTION
## Summary
- Use VS Code external URI mapping for workflow webview proxy URLs so browser-hosted editors like code-server do not load container-local `localhost` URLs.
- Keep manager auto-login routes registered on the local proxy while externalizing browser-facing URLs and embedded route HTML.
- Rewrite proxied redirects through the external proxy base URL and add regression coverage.

## Tests
- `npm test --workspace=packages/vscode-extension`

Fixes #428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Unified proxy handling for workflow webviews: distinguishes local vs public proxy bases, starts local proxy when needed, and rewrites proxied URLs and embedded auto-login HTML to use externally reachable bases.
  * Proxy service accepts an explicit public base URL to correctly rewrite upstream redirect locations.

* **Tests**
  * Added unit tests validating proxy redirect rewriting and path-boundary behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/436)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->