### PR TITLE
Remove Claude Account provider

### DIFF
--- a/packages/cli/src/core/services/instance-identifier.ts
+++ b/packages/cli/src/core/services/instance-identifier.ts
@@ -41,12 +41,23 @@ export async function resolveN8nIdentity(
     }
 
     const instanceIdentity = await client.getInstanceIdentity?.().catch(() => null);
-    const instanceSeed = instanceIdentity?.id || options.instanceSeed || credentials.host;
+    const normalizedHost = normalizeHostSeed(credentials.host);
+    const instanceSeed = instanceIdentity?.id || options.instanceSeed || normalizedHost;
 
     return {
         instanceIdentifier: createCanonicalInstanceIdentifier(instanceSeed),
         instanceUserIdentifier: createInstanceUserIdentifier(user),
     };
+}
+
+function normalizeHostSeed(host?: string): string | undefined {
+    const trimmed = host?.trim();
+    if (!trimmed) return undefined;
+    try {
+        return new URL(trimmed).origin.toLowerCase();
+    } catch {
+        return trimmed.replace(/\/+$/, '').toLowerCase();
+    }
 }
 
 export async function resolveInstanceIdentifier(

--- a/packages/cli/tests/unit/workflow-dir-name.test.ts
+++ b/packages/cli/tests/unit/workflow-dir-name.test.ts
@@ -42,6 +42,26 @@ describe('workflow directory names', () => {
         ]));
     });
 
+    it('rejects blank required identity fields', () => {
+        const cases = [
+            { field: 'environmentId', value: '' },
+            { field: 'environmentId', value: '   ' },
+            { field: 'instanceIdentifier', value: '' },
+            { field: 'instanceIdentifier', value: '   ' },
+            { field: 'instanceUserIdentifier', value: '' },
+            { field: 'instanceUserIdentifier', value: '   ' },
+            { field: 'projectId', value: '' },
+            { field: 'projectId', value: '   ' },
+        ] as const;
+
+        for (const testCase of cases) {
+            expect(() => serializeWorkflowDirIdentityV1({
+                ...identity,
+                [testCase.field]: testCase.value,
+            })).toThrow();
+        }
+    });
+
     it('keeps the v1 wordlists at the expected minimum size', () => {
         expect(WORKFLOW_DIR_NAME_ADJECTIVES.length).toBeGreaterThanOrEqual(128);
         expect(WORKFLOW_DIR_NAME_NOUNS.length).toBeGreaterThanOrEqual(256);

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -335,7 +335,6 @@
             "mistral",
             "openrouter",
             "openai-oauth",
-            "anthropic-proxy",
             "copilot-proxy",
             "minimax",
             "minimax-token-plan",

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -303,7 +303,6 @@ const YAGR_MODEL_PROVIDERS = Object.freeze([
     'mistral',
     'openrouter',
     'openai-oauth',
-    'anthropic-proxy',
     'copilot-proxy',
     'minimax',
     'minimax-token-plan',
@@ -317,7 +316,6 @@ const YAGR_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
     mistral: 'Mistral API',
     openrouter: 'OpenRouter API',
     'openai-oauth': 'OpenAI ChatGPT OAuth',
-    'anthropic-proxy': 'Claude Account',
     'copilot-proxy': 'GitHub Copilot OAuth',
     minimax: 'MiniMax API',
     'minimax-token-plan': 'MiniMax Token Plan',
@@ -983,7 +981,7 @@ export class AgentRuntimeController implements vscode.Disposable {
                 temperature: 0,
             };
         }
-        if (providerRegistry.providerRequiresApiKey(normalizedProvider) && !apiKey && normalizedProvider !== 'openai-oauth' && normalizedProvider !== 'copilot-proxy' && normalizedProvider !== 'anthropic-proxy') {
+        if (providerRegistry.providerRequiresApiKey(normalizedProvider) && !apiKey && normalizedProvider !== 'openai-oauth' && normalizedProvider !== 'copilot-proxy') {
             return {
                 ready: false,
                 reason: `Missing API key for ${providerRegistry.getProviderDisplayName(normalizedProvider)}. Open Settings > Agent Providers to connect it.`,

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -328,6 +328,7 @@ function normalizeAgentProviderId(provider: string | undefined): string | undefi
     const normalized = provider?.trim().toLowerCase();
     if (!normalized) return undefined;
     if (normalized === 'claude') return 'anthropic';
+    if (normalized === 'anthropic-proxy') return 'anthropic';
     if (normalized === 'gemini') return 'google';
     return YAGR_MODEL_PROVIDERS.includes(normalized) ? normalized : undefined;
 }

--- a/packages/vscode-extension/src/services/yagr-provider-service.ts
+++ b/packages/vscode-extension/src/services/yagr-provider-service.ts
@@ -186,6 +186,7 @@ export function normalizeYagrProviderId(provider?: string): YagrModelProvider | 
     const normalized = provider?.trim().toLowerCase();
     if (!normalized) return undefined;
     if (normalized === 'claude') return 'anthropic';
+    if (normalized === 'anthropic-proxy') return 'anthropic';
     if (normalized === 'gemini') return 'google';
     return normalized in YAGR_PROVIDER_DEFINITIONS ? normalized as YagrModelProvider : undefined;
 }

--- a/packages/vscode-extension/src/services/yagr-provider-service.ts
+++ b/packages/vscode-extension/src/services/yagr-provider-service.ts
@@ -8,7 +8,6 @@ export type YagrModelProvider =
     | 'mistral'
     | 'openrouter'
     | 'openai-oauth'
-    | 'anthropic-proxy'
     | 'copilot-proxy'
     | 'minimax'
     | 'minimax-token-plan'
@@ -134,16 +133,6 @@ export const YAGR_PROVIDER_DEFINITIONS: Record<YagrModelProvider, YagrProviderDe
         requiresApiKey: false,
         authKind: 'oauth-device',
         envKeys: [],
-        canDiscoverModels: true,
-    },
-    'anthropic-proxy': {
-        id: 'anthropic-proxy',
-        label: 'Claude Account',
-        description: 'Claude setup-token',
-        defaultModel: 'claude-haiku-4-5',
-        requiresApiKey: false,
-        authKind: 'setup-token',
-        envKeys: ['YAGR_ANTHROPIC_SETUP_TOKEN'],
         canDiscoverModels: true,
     },
     'copilot-proxy': {
@@ -401,7 +390,7 @@ export class YagrProviderService {
             return [];
         }
 
-        if (provider === 'anthropic' || provider === 'anthropic-proxy') {
+        if (provider === 'anthropic') {
             return this.fetchJsonModels('https://api.anthropic.com/v1/models', { 'x-api-key': apiKey || '', 'anthropic-version': '2023-06-01' });
         }
         if (provider === 'google') {


### PR DESCRIPTION
## Summary
- Remove the Claude Account / anthropic-proxy provider from VS Code extension provider choices and runtime provider display handling.
- Keep Claude API support via the Anthropic API provider.
- Includes existing branch updates for opaque environment workflow directories and related CLI/tests.

## Validation
- npm run compile --workspace not used; ran from packages/vscode-extension: npm run compile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `openrouter` and `openai-oauth` agent providers in VS Code extension
  * Enhanced instance identity resolution with improved seed normalization

* **Removed**
  * Removed `anthropic-proxy` agent provider from VS Code extension (now routes to `anthropic`)

* **Tests**
  * Added validation for required workflow identity fields to prevent blank or whitespace values

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/438)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->