### PR TITLE
docs: align environment terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ n8n-as-code has three user-facing command groups:
 
 | Group | Command | Owns |
 |---|---|---|
-| **Usage Principal** | `n8nac env` | Workspace environments: URL or managed instance, project, sync folder, active environment |
-| **Maintenance Workspace** | `n8nac workspace` | Readiness, unified migration, previous config upgrade |
-| **Instances Managées** | `n8n-manager` | Local managed instances, Docker lifecycle, tunnels, machine-local state |
+| **Primary Usage** | `n8nac env` | Workspace environments: remote n8n URL or local managed instance, project, sync folder, active environment |
+| **Workspace Maintenance** | `n8nac workspace` | Readiness and unified workspace migration |
+| **Managed Local Instances** | `n8n-manager` | Local managed instances, Docker lifecycle, tunnels, machine-local state |
 
 The repository source of truth is `n8nac-config.json`. It stores workspace environments and is safe to commit when it contains no secrets.
 
@@ -61,7 +61,7 @@ API keys and local managed instance state stay machine-local. They are not commi
 4. Create or select an `n8n environment`.
 5. Pull or create workflows, then use the integrated Agent Workbench.
 
-The configuration UI uses the same model as the CLI: environments are workspace context, managed instances are local machine resources.
+The configuration UI uses the same model as the CLI: workspace environments are repository context, local managed instances are machine resources.
 
 [VS Code / Cursor guide](https://n8nascode.dev/docs/usage/vscode-extension/)
 
@@ -76,7 +76,7 @@ npx --yes n8nac env use Dev
 npx --yes n8nac update-ai
 ```
 
-Or use a local managed instance:
+Or attach a local managed instance:
 
 ```bash
 n8n-manager instance list
@@ -119,7 +119,7 @@ If your agent asks for an explicit skill path, use `skills/n8n-architect`.
 
 ## Command Groups
 
-### Usage Principal: `n8nac env`
+### Primary Usage: `n8nac env`
 
 ```bash
 n8nac env list
@@ -132,19 +132,17 @@ n8nac env remove Dev
 
 Use `n8nac env` for everything that describes how this repository connects to n8n.
 
-### Maintenance Workspace: `n8nac workspace`
+### Workspace Maintenance: `n8nac workspace`
 
 ```bash
 n8nac workspace status
 n8nac workspace migrate --json
 n8nac workspace migrate --write
-n8nac workspace upgrade
-n8nac workspace upgrade --write
 ```
 
-Use `workspace migrate --json` as the migration dry-run. It reports one unified `operations` list for legacy workspace and global instance changes; apply all required operations together with `workspace migrate --write`. Use `workspace upgrade` for previous V3/`next` configs that need the environment model.
+Use `workspace migrate --json` as the migration dry-run. It reports one unified `operations` list for legacy workspace and global instance changes; apply all required operations together with `workspace migrate --write`.
 
-### Instances Managées: `n8n-manager`
+### Managed Local Instances: `n8n-manager`
 
 ```bash
 n8n-manager instance list
@@ -158,7 +156,7 @@ n8n-manager tunnel stop <id>
 
 Use `n8n-manager` only for local managed instances and machine-local operations. Do not use it as the workspace source of truth.
 
-### Compatibilité Cachée
+### Hidden Compatibility
 
 Older commands can remain callable for compatibility but are not the primary model:
 
@@ -245,7 +243,7 @@ n8nac convert-batch workflows/ --format typescript
 
 - **VS Code/Cursor extension**: visual workflow workspace and integrated Agent Workbench.
 - **`n8nac env`**: repository-level environment source of truth.
-- **`n8nac workspace`**: readiness, unified migrations, and upgrades.
+- **`n8nac workspace`**: readiness and unified workspace migration.
 - **`n8n-manager`**: local managed instances, Docker lifecycle, tunnels, and machine-local secrets.
 - **Skills and MCP**: grounded n8n knowledge for agents.
 

--- a/docs/docs/contribution/architecture.md
+++ b/docs/docs/contribution/architecture.md
@@ -10,8 +10,8 @@ n8n-as-code is a monorepo built with a modular architecture that separates works
 
 The public brand can stay unified as `n8n-as-code` / `n8nac`, but internally there are three concerns:
 
-1. **Workspace environments**: `n8nac env` owns the repository-level source of truth: environment name, n8n endpoint or managed-instance reference, project, sync folder, and active environment.
-2. **Instances managées**: the independent `n8n-manager` repo owns local managed instances, Docker lifecycle, tunnels, and machine-local state.
+1. **Workspace environments**: `n8nac env` owns the repository-level source of truth: environment name, remote n8n endpoint or local managed instance reference, project, sync folder, and active environment.
+2. **Managed local instances**: the independent `n8n-manager` repo owns local managed instances, Docker lifecycle, tunnels, and machine-local state.
 3. **Workflow engine/commands**: workflow representation, generation, validation, schemas, templates, node knowledge, and commands that read/write workflows through a resolved environment.
 
 The dependency rule is:
@@ -32,7 +32,7 @@ n8nac env
   workspace environments, active environment, local auth binding
 
 n8nac workspace
-  status, migration, upgrade
+  readiness and unified workspace migration
 
 n8nac workflow commands
   list/pull/push/sync/test/workflow/execution using a resolved environment

--- a/docs/docs/contribution/cli.md
+++ b/docs/docs/contribution/cli.md
@@ -343,7 +343,7 @@ beforeEach(() => {
       environmentTargets: [{
         id: 'dev',
         name: 'Dev',
-        kind: 'external-instance',
+        kind: 'external-instance', // persisted kind for a remote n8n URL target
         url: 'http://test.n8n'
       }]
     })

--- a/docs/docs/getting-started/index.md
+++ b/docs/docs/getting-started/index.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 title: Getting Started
-description: Set up n8n-as-code with n8n environments, VS Code/Cursor, the CLI, and AI agents.
+description: Set up n8n-as-code with workspace environments, VS Code/Cursor, the CLI, and AI agents.
 ---
 
 # Getting Started
@@ -19,9 +19,9 @@ This guide gets you from an empty workspace to an agent-assisted n8n workflow lo
 
 | Group | Command | Use it for |
 |---|---|---|
-| Usage Principal | `n8nac env` | Workspace environments |
-| Maintenance Workspace | `n8nac workspace` | Readiness, unified migration, upgrade |
-| Instances Managées | `n8n-manager` | Local managed instances and tunnels |
+| Primary Usage | `n8nac env` | Workspace environments |
+| Workspace Maintenance | `n8nac workspace` | Readiness and unified workspace migration |
+| Managed Local Instances | `n8n-manager` | Local managed instances and tunnels |
 
 An environment stores the workspace-safe context: n8n endpoint, project, sync folder, and active selection. API keys stay local.
 
@@ -31,7 +31,7 @@ An environment stores the workspace-safe context: n8n endpoint, project, sync fo
 2. Open a folder or `.code-workspace`.
 3. Open the `n8n` view.
 4. Run **n8n: Configure**.
-5. In **n8n environments**, choose `Enter URL and API key` or select a managed local instance.
+5. In **n8n environments**, choose `Enter URL and API key` for a remote n8n environment or select a local managed instance.
 6. Choose the project and sync folder.
 7. Save the environment.
 
@@ -39,7 +39,7 @@ After that, use the sidebar to pull workflows or create a local workflow file, t
 
 ## CLI Setup
 
-### Existing n8n URL
+### Remote n8n environment
 
 ```bash
 n8nac env add Dev --base-url https://n8n.example.com --sync-folder workflows/dev
@@ -48,7 +48,7 @@ n8nac env use Dev
 n8nac update-ai
 ```
 
-### Managed local instance
+### Local managed instance
 
 ```bash
 n8n-manager instance list
@@ -74,24 +74,17 @@ n8nac push workflows/dev/my-workflow.workflow.ts --verify
 
 Sync is explicit. The CLI and extension do not silently overwrite local or remote work.
 
-## Migration And Upgrade
+## Workspace Migration
 
 Existing repositories are not rewritten automatically on open.
 
-Legacy V1/V2 config:
+Inspect and apply required workspace migrations explicitly:
 
 ```bash
 n8nac workspace migrate --json
 n8nac workspace migrate --write
 n8nac workspace migrate --json
 n8nac env status --json
-```
-
-Previous V3/`next` config:
-
-```bash
-n8nac workspace upgrade
-n8nac workspace upgrade --write
 ```
 
 Run the JSON dry-run first and review the unified `operations` list. The `--write` form applies the migration atomically and creates a backup before updating `n8nac-config.json`.
@@ -110,7 +103,7 @@ your-project/
 
 - `n8nac-config.json` stores workspace environments and is safe to commit when it contains no secrets.
 - API keys stay local through `n8nac env auth` or the extension.
-- Managed local instances and tunnel state stay in `n8n-manager` storage.
+- Local managed instances and tunnel state stay in `n8n-manager` storage.
 - `AGENTS.md` gives local coding agents grounded n8n instructions.
 
 ## Agent Skills And Plugins

--- a/docs/docs/home/index.md
+++ b/docs/docs/home/index.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 title: Home
-description: n8n-as-code gives VS Code, Cursor, terminals, and AI agents a single n8n environments model for workflow development.
+description: n8n-as-code gives VS Code, Cursor, terminals, and AI agents a single workspace environments model for workflow development.
 slug: /
 ---
 
@@ -13,9 +13,9 @@ The product model is intentionally small:
 
 | Group | Command | Use it for |
 |---|---|---|
-| Usage Principal | `n8nac env` | Workspace environments: URL or managed instance, project, sync folder, active environment |
-| Maintenance Workspace | `n8nac workspace` | Readiness, unified migration, previous config upgrade |
-| Instances Managées | `n8n-manager` | Local managed instances, Docker lifecycle, tunnels, machine-local state |
+| Primary Usage | `n8nac env` | Workspace environments: remote n8n URL or local managed instance, project, sync folder, active environment |
+| Workspace Maintenance | `n8nac workspace` | Readiness and unified workspace migration |
+| Managed Local Instances | `n8n-manager` | Local managed instances, Docker lifecycle, tunnels, machine-local state |
 
 ## How It Works
 

--- a/docs/docs/migration/v1-to-v2.md
+++ b/docs/docs/migration/v1-to-v2.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
 title: Workspace Migration
-description: Migrate legacy n8n-as-code workspace and instance config to n8n environments.
+description: Migrate legacy n8n-as-code workspace and instance config to workspace environments.
 ---
 
 # Workspace Migration
 
-Current n8n-as-code workspaces use **n8n environments** as the source of truth.
+Current n8n-as-code workspaces use **workspace environments** as the source of truth.
 
 Legacy V1/V2 configs can contain old workspace instance data, global instance references, or API keys. Migrate them explicitly; n8n-as-code does not rewrite the workspace automatically on open.
 
@@ -38,8 +38,8 @@ The dry-run and verification output use a single migration report. Review the `o
 | Legacy config | New model |
 |---|---|
 | Direct instance fields in workspace config | Workspace environment in `n8nac-config.json` |
-| Embedded URL | `external-instance` environment target URL |
-| Global managed instance reference | `managed-instance` environment target reference |
+| Embedded URL | Remote n8n URL environment target |
+| Global managed instance reference | Local managed instance environment target reference |
 | Embedded API key | Local API key storage |
 | Sync folder | Environment sync folder |
 | Old active instance | Active environment |
@@ -60,14 +60,7 @@ n8nac env auth set <environment> --api-key-stdin
 
 Do not commit backup files if they contain API keys.
 
-## Previous V3 / next Configs
-
-For previous V3 or `next` configs, use upgrade instead of workspace migration:
-
-```bash
-n8nac workspace upgrade
-n8nac workspace upgrade --write
-```
+The persisted config still uses internal target kind literals such as `external-instance` for remote n8n URL targets and `managed-instance` for local managed instance references. User-facing commands and UI describe those as remote n8n environments and local managed instances.
 
 ## V1 Packages
 

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -83,10 +83,11 @@ n8nac env status --json
 
 Review the dry-run `operations` list before applying. `workspace migrate --write` applies all required migration operations together.
 
-For previous V3/`next` configs:
+If the migration banner remains after applying, inspect the remaining migration plan:
 
 ```bash
-n8nac workspace upgrade --write
+n8nac workspace migrate --json
+n8nac workspace migrate --write
 ```
 
 ## Sync Issues
@@ -115,7 +116,7 @@ The remote changed since your last pull. Pull first or resolve the conflict inte
 
 ## Managed Local Instances
 
-Managed instances are local machine resources. They are not created or deleted by `n8nac env remove`.
+Local managed instances are local machine resources. They are not created or deleted by `n8nac env remove`.
 
 ```bash
 n8n-manager instance list
@@ -125,7 +126,7 @@ n8n-manager tunnel start <id>
 n8n-manager tunnel stop <id>
 ```
 
-If a workspace environment references a missing managed instance, recreate it or point the environment to a remote URL:
+If a workspace environment references a missing local managed instance, recreate it or point the environment to a remote n8n URL:
 
 ```bash
 n8nac env update <environment> --base-url <url>

--- a/docs/docs/usage/claude-plugin.md
+++ b/docs/docs/usage/claude-plugin.md
@@ -37,7 +37,7 @@ Ask Claude to initialize n8n-as-code in the workspace. The installed skills guid
 
 - creating or selecting an n8n environment
 - storing remote API keys locally
-- creating or selecting managed local instances when needed
+- creating or selecting local managed instances when needed
 - generating `AGENTS.md`
 - materializing `.agents/skills/n8n-architect`
 
@@ -85,7 +85,7 @@ Claude pushes when asked
 - Skills run locally.
 - Workspace environment config can be committed when it contains no secrets.
 - Remote API keys stay local.
-- Managed local instance state stays in `n8n-manager` storage.
+- Local managed instance state stays in `n8n-manager` storage.
 
 ## Related
 

--- a/docs/docs/usage/cli.md
+++ b/docs/docs/usage/cli.md
@@ -41,16 +41,16 @@ npm uninstall -g @n8n-as-code/cli
 
 | Group | Command | Purpose |
 |---|---|---|
-| Usage Principal | `n8nac env` | Workspace environments |
-| Maintenance Workspace | `n8nac workspace` | Readiness, unified migration, upgrade |
-| Instances Managées | `n8n-manager` | Local managed instances and tunnels |
-| Compat Cachée | `instance-target`, `target`, `setup`, old `workspace` mutations | Compatibility only |
+| Primary Usage | `n8nac env` | Workspace environments |
+| Workspace Maintenance | `n8nac workspace` | Readiness and unified workspace migration |
+| Managed Local Instances | `n8n-manager` | Local managed instances and tunnels |
+| Hidden Compatibility | `instance-target`, `target`, `setup`, old `workspace` mutations | Compatibility only |
 
 For a compact overview, see the [Command Glossary](/docs/usage/commands).
 
 ## Quick Start
 
-### Existing n8n URL
+### Remote n8n environment
 
 ```bash
 n8nac env add Dev --base-url https://n8n.example.com --sync-folder workflows/dev
@@ -59,7 +59,7 @@ n8nac env use Dev
 n8nac update-ai
 ```
 
-### Managed local instance
+### Local managed instance
 
 ```bash
 n8n-manager instance list
@@ -99,9 +99,9 @@ n8nac env add Staging --base-url https://staging.example.com --sync-folder workf
 n8nac env auth set Staging --api-key-stdin
 ```
 
-### Managed local environments
+### Local managed instance environments
 
-Managed local environments reference a local `n8n-manager` instance.
+These workspace environments reference a local `n8n-manager` instance.
 
 ```bash
 n8n-manager instance list
@@ -112,17 +112,15 @@ The workspace does not copy Docker paths, tunnel state, logs, or local secrets.
 
 ## `workspace`
 
-Use `workspace` for inspection and explicit migrations/upgrades only.
+Use `workspace` for inspection and explicit migrations only.
 
 ```bash
 n8nac workspace status
 n8nac workspace migrate --json
 n8nac workspace migrate --write
-n8nac workspace upgrade
-n8nac workspace upgrade --write
 ```
 
-`migrate --json` is the dry-run for legacy V1/V2 configs and reports one unified `operations` list. `migrate --write` applies all required migration operations together. `upgrade` is for previous V3/`next` configs and should be run without `--write` first.
+`migrate --json` is the dry-run for legacy config models and reports one unified `operations` list. `migrate --write` applies all required migration operations together.
 
 ## Sync Commands
 
@@ -266,6 +264,8 @@ Current config is environment-based and safe to commit when it contains no secre
 ```
 
 API keys are stored locally with `n8nac env auth set <env> --api-key-stdin`.
+
+In config examples, `kind: "external-instance"` is the persisted target kind for a remote n8n URL. Prefer the user-facing term "remote n8n environment" outside raw config discussions.
 
 ## Scripting Example
 

--- a/docs/docs/usage/commands.md
+++ b/docs/docs/usage/commands.md
@@ -17,7 +17,7 @@ Use this page when you need to choose the right command family.
 | Create, start, stop, or tunnel a local managed instance | `n8n-manager` |
 | Maintain old scripts only | compat hidden commands |
 
-## Usage Principal
+## Primary Usage
 
 `n8nac env` manages workspace environments.
 
@@ -39,21 +39,19 @@ Use it for:
 - project and sync-folder context
 - active environment selection
 
-## Maintenance Workspace
+## Workspace Maintenance
 
-`n8nac workspace` is for readiness, unified migration, and upgrade.
+`n8nac workspace` is for readiness and unified workspace migration.
 
 ```bash
 n8nac workspace status
 n8nac workspace migrate --json
 n8nac workspace migrate --write
-n8nac workspace upgrade
-n8nac workspace upgrade --write
 ```
 
-Use `migrate --json` as the dry-run for legacy V1/V2 configs. It reports one `operations` list and `migrate --write` applies all required migration operations together. Use `upgrade` for previous V3 or `next` configs.
+Use `migrate --json` as the dry-run for legacy config models. It reports one `operations` list and `migrate --write` applies all required migration operations together.
 
-## Instances Managées
+## Managed Local Instances
 
 `n8n-manager` manages local machine resources.
 
@@ -90,7 +88,7 @@ n8nac skills node-info googleSheets
 n8nac skills validate workflows/dev/my-workflow.workflow.ts
 ```
 
-## Compat Cachée
+## Hidden Compatibility
 
 These commands may remain callable for old scripts, but they are not first-level user flows:
 

--- a/docs/docs/usage/index.md
+++ b/docs/docs/usage/index.md
@@ -6,16 +6,16 @@ description: Guides for using n8n-as-code with n8n environments, VS Code, CLI, n
 
 # Usage
 
-n8n-as-code uses one workflow model across all surfaces: workspace environments, explicit sync, local AI context, and managed local instances when you need them.
+n8n-as-code uses one workflow model across all surfaces: workspace environments, explicit sync, local AI context, and local managed instances when you need them.
 
 ## Command Groups
 
 | Group | Command | Purpose |
 |---|---|---|
-| Usage Principal | `n8nac env` | Workspace environments and active sync context |
-| Maintenance Workspace | `n8nac workspace` | Readiness, unified migration, upgrade |
-| Instances Managées | `n8n-manager` | Local managed instances, Docker, tunnels |
-| Compat Cachée | old `target`, `setup`, and workspace mutation commands | Compatibility only |
+| Primary Usage | `n8nac env` | Workspace environments and active sync context |
+| Workspace Maintenance | `n8nac workspace` | Readiness and unified workspace migration |
+| Managed Local Instances | `n8n-manager` | Local managed instances, Docker, tunnels |
+| Hidden Compatibility | old `target`, `setup`, and workspace mutation commands | Compatibility only |
 
 [Command Glossary](/docs/usage/commands)
 

--- a/docs/docs/usage/mcp.md
+++ b/docs/docs/usage/mcp.md
@@ -8,7 +8,7 @@ The `@n8n-as-code/mcp` package is a dedicated [Model Context Protocol](https://m
 
 It gives AI assistants offline access to the full n8n node catalogue, community workflow examples, and workflow validation without requiring a live n8n instance.
 
-Live workspace context uses the normal environments model: `n8nac-config.json` stores workspace environments, remote API keys stay local, and `n8n-manager` owns only managed local instances and tunnels. Initialize the workspace with `n8nac env` when you want an MCP-backed assistant to reason from the same local context as the CLI or editor.
+Live workspace context uses the normal environments model: `n8nac-config.json` stores workspace environments, remote API keys stay local, and `n8n-manager` owns only local managed instances and tunnels. Initialize the workspace with `n8nac env` when you want an MCP-backed assistant to reason from the same local context as the CLI or editor.
 
 See the [CLI guide](/docs/usage/cli) and [n8n-manager guide](/docs/usage/n8n-manager) for setup details.
 

--- a/docs/docs/usage/n8n-manager.md
+++ b/docs/docs/usage/n8n-manager.md
@@ -6,7 +6,7 @@ description: Use n8n-manager for local managed instances, Docker lifecycle, tunn
 
 # n8n-manager
 
-`n8n-manager` owns **instances managées**: local managed n8n instances, Docker lifecycle, tunnels, and machine-local state.
+`n8n-manager` owns **local managed instances**: local managed n8n instances, Docker lifecycle, tunnels, and machine-local state.
 
 It is not the workspace source of truth. Workspace environments belong to `n8nac env`.
 
@@ -15,7 +15,7 @@ It is not the workspace source of truth. Workspace environments belong to `n8nac
 | Concern | Owner |
 |---|---|
 | Workspace environments | `n8nac env` |
-| Readiness, unified migration, upgrade | `n8nac workspace` |
+| Readiness and unified workspace migration | `n8nac workspace` |
 | Local managed instances | `n8n-manager` |
 | Docker start/stop/remove | `n8n-manager` |
 | Tunnels for local instances | `n8n-manager` |
@@ -33,7 +33,7 @@ n8n-manager tunnel start <id>
 n8n-manager tunnel stop <id>
 ```
 
-Then attach a managed local instance to the workspace with `n8nac env`:
+Then attach a local managed instance to the workspace with `n8nac env`:
 
 ```bash
 n8nac env add Local --managed-instance <id> --sync-folder workflows/local
@@ -72,7 +72,7 @@ The URL is workspace-safe. The API key is local.
 In VS Code, use:
 
 - **n8n environments** for workspace configuration
-- **Mes instances managées** for local managed instances only
+- **Managed local instances** for local managed instances only
 
 Adding or removing a workspace environment does not delete a managed local instance.
 

--- a/docs/docs/usage/openclaw.md
+++ b/docs/docs/usage/openclaw.md
@@ -29,9 +29,9 @@ OpenClaw uses the same command split as every other surface:
 
 | Group | Command | Purpose |
 |---|---|---|
-| Usage Principal | `n8nac env` | Workspace environments |
-| Maintenance Workspace | `n8nac workspace` | Readiness, unified migration, upgrade |
-| Instances Managées | `n8n-manager` | Local managed instances and tunnels |
+| Primary Usage | `n8nac env` | Workspace environments |
+| Workspace Maintenance | `n8nac workspace` | Readiness and unified workspace migration |
+| Managed Local Instances | `n8n-manager` | Local managed instances and tunnels |
 
 ## Workspace
 
@@ -45,7 +45,7 @@ OpenClaw stores its working files under:
   workflows/
 ```
 
-`n8nac-config.json` stores workspace environments. API keys and managed local instance state stay outside the committed workspace.
+`n8nac-config.json` stores workspace environments. API keys and local managed instance state stay outside the committed workspace.
 
 ## Manual Equivalent
 
@@ -56,7 +56,7 @@ n8nac env use Dev
 n8nac update-ai
 ```
 
-For a managed local instance:
+For a local managed instance:
 
 ```bash
 n8n-manager instance list

--- a/docs/docs/usage/vscode-extension.md
+++ b/docs/docs/usage/vscode-extension.md
@@ -15,9 +15,9 @@ The extension is the recommended n8n-as-code experience. It adds an n8n sidebar,
 3. Click the **n8n** icon in the Activity Bar.
 4. Run **n8n: Configure**.
 5. In **n8n environments**, choose an instance:
-   - `Enter URL and API key` for n8n Cloud or self-hosted n8n.
-   - an existing managed local instance.
-   - `Creer une instance local` to create one locally.
+   - `Enter URL and API key` for a remote n8n environment.
+   - an existing local managed instance.
+   - `Create local instance` to create one locally.
 6. Select the project and sync folder.
 7. Save the environment.
 
@@ -27,10 +27,10 @@ The extension is the recommended n8n-as-code experience. It adds an n8n sidebar,
 |---|---|
 | `n8n environments` | Workspace environments stored in `n8nac-config.json` |
 | `Instance` selector | The n8n endpoint used by the environment |
-| `Mes instances managées` | Local managed instances on this machine |
+| `Managed local instances` | Local managed instances on this machine |
 | API key input | Stored locally, not committed |
 
-An environment is workspace context. A managed instance is a local machine resource.
+An environment is workspace context. A local managed instance is a local machine resource.
 
 ## Daily Workflow
 
@@ -55,7 +55,7 @@ The Agent can use:
 - generated `AGENTS.md`
 - bundled n8n schemas, docs, examples, templates, and validation rules
 
-## Migration And Upgrade
+## Workspace Migration
 
 The extension can detect older config models, but it does not rewrite config on workspace open.
 
@@ -64,13 +64,11 @@ Use the explicit button in the UI or the CLI:
 ```bash
 n8nac workspace migrate --json
 n8nac workspace migrate --write
-n8nac workspace upgrade --write
 ```
 
-- `migrate --json` is the dry-run for legacy V1/V2 configs and reports one unified `operations` list.
+- `migrate --json` is the dry-run for legacy config models and reports one unified `operations` list.
 - `migrate --write` applies the required migration as one operation.
-- `upgrade` is for previous V3/`next` configs.
-- Both create a backup before replacing `n8nac-config.json`.
+- The write step creates a backup before replacing `n8nac-config.json`.
 
 ## CLI Equivalent
 
@@ -83,7 +81,7 @@ n8nac pull <workflow-id>
 n8nac push workflows/dev/my-workflow.workflow.ts --verify
 ```
 
-For a managed local instance:
+For a local managed instance:
 
 ```bash
 n8n-manager instance list

--- a/docs/docs/usage/vscode-extension.md
+++ b/docs/docs/usage/vscode-extension.md
@@ -14,7 +14,7 @@ The extension is the recommended n8n-as-code experience. It adds an n8n sidebar,
 2. Open a folder or `.code-workspace`.
 3. Click the **n8n** icon in the Activity Bar.
 4. Run **n8n: Configure**.
-5. In **n8n environments**, choose an instance:
+5. In **n8n environments**, choose an environment target type:
    - `Enter URL and API key` for a remote n8n environment.
    - an existing local managed instance.
    - `Create local instance` to create one locally.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,14 +35,14 @@ Full documentation: [CLI guide](https://n8nascode.dev/docs/usage/cli/) · [n8n-m
 
 | Group | Command | Purpose |
 |---|---|---|
-| Usage Principal | `n8nac env` | Workspace environments: n8n URL or managed instance, project, sync folder, active environment |
-| Maintenance Workspace | `n8nac workspace` | Readiness, unified migration, upgrade |
-| Instances Managées | `n8n-manager` | Local managed instances, Docker lifecycle, tunnels, local secrets |
-| Compat Cachée | `instance-target`, `target`, `setup`, old `workspace` mutations | Compatibility only |
+| Primary Usage | `n8nac env` | Workspace environments: remote n8n URL or local managed instance, project, sync folder, active environment |
+| Workspace Maintenance | `n8nac workspace` | Readiness and unified workspace migration |
+| Managed Local Instances | `n8n-manager` | Local managed instances, Docker lifecycle, tunnels, local secrets |
+| Hidden Compatibility | `instance-target`, `target`, `setup`, old `workspace` mutations | Compatibility only |
 
 ## Workspace Environments
 
-Create an environment for an existing n8n URL:
+Create a remote n8n environment for an existing n8n URL:
 
 ```bash
 n8nac env add Dev --base-url https://n8n.example.com --sync-folder workflows/dev
@@ -50,7 +50,7 @@ printf '%s' "$N8N_API_KEY" | n8nac env auth set Dev --api-key-stdin
 n8nac env use Dev
 ```
 
-Create an environment from a local managed instance:
+Attach a workspace environment to a local managed instance:
 
 ```bash
 n8n-manager instance list
@@ -72,24 +72,17 @@ Remove an environment mapping:
 n8nac env remove Dev
 ```
 
-Removing an environment does not delete remote workflows, local workflow files, or local managed instances.
+Removing a workspace environment does not delete remote workflows, local workflow files, or local managed instances.
 
-## Migration And Upgrade
+## Workspace Migration
 
-Legacy V1/V2 config:
+Inspect and apply required workspace migrations explicitly:
 
 ```bash
 n8nac workspace migrate --json
 n8nac workspace migrate --write
 n8nac workspace migrate --json
 n8nac env status --json
-```
-
-Previous V3/`next` config model:
-
-```bash
-n8nac workspace upgrade
-n8nac workspace upgrade --write
 ```
 
 Dry-run with `--json` first, then apply with `--write` after reviewing the unified `operations` list. Applied migrations create a backup before replacing `n8nac-config.json`.
@@ -176,7 +169,7 @@ Current workspace config is environment-based:
 }
 ```
 
-Do not store API keys in this file. Use `n8nac env auth set <env> --api-key-stdin` for remote environments.
+In config examples, `kind: "external-instance"` is the persisted target kind for a remote n8n URL. Do not store API keys in this file. Use `n8nac env auth set <env> --api-key-stdin` for remote n8n environments.
 
 ## Compatibility Commands
 

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -6,7 +6,7 @@ This package powers the shared n8n ontology behind `n8n-as-code`: searchable nod
 
 > **⚠️ BREAKING CHANGE (v0.16.0)**: Workflows are now generated and documented in **TypeScript format** (`.workflow.ts`) instead of JSON for better AI compatibility and readability.
 
-> **BREAKING CHANGE (v2.0.0)**: Generated agent context now assumes the environment model: use `n8nac env` for workspace environments, `n8nac workspace` for readiness/migration/upgrade, and `n8n-manager` for local managed instances. Legacy workspace-local instance libraries are no longer treated as the source of truth.
+> **BREAKING CHANGE (v2.0.0)**: Generated agent context now assumes the workspace environment model: use `n8nac env` for workspace environments, `n8nac workspace` for readiness and unified migration, and `n8n-manager` for local managed instances. Legacy workspace-local instance libraries are no longer treated as the source of truth.
 
 Documentation: [CLI guide](https://n8nascode.dev/docs/usage/cli/) · [n8n-manager guide](https://n8nascode.dev/docs/usage/n8n-manager/) · [Skills guide](https://n8nascode.dev/docs/usage/skills/)
 

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -2,7 +2,7 @@
 
 The VS Code and Cursor workspace for building n8n workflows with an AI agent that has live n8n context.
 
-The extension centers on **n8n environments**: a workspace environment points to an n8n instance, a project, and a sync folder. Local Docker instances and tunnels are managed separately as **instances managées** through `n8n-manager`.
+The extension centers on **workspace environments**: a workspace environment points to a remote n8n URL or local managed instance, a project, and a sync folder. Local Docker instances and tunnels are managed separately through `n8n-manager`.
 
 Published for both the Microsoft Marketplace and Open VSX.
 
@@ -15,7 +15,7 @@ Published for both the Microsoft Marketplace and Open VSX.
 1. Install `n8n-as-code` from the Microsoft Marketplace or Open VSX.
 2. Open a folder or `.code-workspace`.
 3. Open the `n8n` view and run `n8n: Configure`.
-4. Create an `n8n environment` from an existing URL or a managed local instance.
+4. Create a workspace environment from a remote n8n URL or a local managed instance.
 5. Save the workspace environment, pull or create workflows, then use the Agent Workbench.
 
 Marketplace links:
@@ -38,7 +38,7 @@ Documentation links:
 | Managed local instances | `n8n-manager` | local machine store |
 | Docker lifecycle and tunnels | `n8n-manager` | local machine store |
 
-Use the **n8n environments** tab for workspace configuration. Use **Mes instances managées** only for local managed instances.
+Use the **n8n environments** tab for workspace configuration. Use **Managed local instances** only for local managed instances.
 
 ## What You Get
 
@@ -62,9 +62,9 @@ The Agent can use:
 
 ### Managed Local Instances
 
-The extension can surface local managed instances through `n8n-manager`. These are machine-local resources. Adding or removing an environment does not create or delete a Docker instance unless you explicitly use the managed instance controls.
+The extension can surface local managed instances through `n8n-manager`. These are machine-local resources. Adding or removing an environment does not create or delete a Docker instance unless you explicitly use the local instance controls.
 
-## Migration And Upgrade
+## Workspace Migration
 
 The extension detects old config models but does not rewrite them automatically when a workspace opens.
 
@@ -73,13 +73,11 @@ Use explicit actions:
 ```bash
 n8nac workspace migrate --json
 n8nac workspace migrate --write
-n8nac workspace upgrade --write
 ```
 
-- `migrate --json` is the dry-run for legacy V1/V2 configs and reports one unified `operations` list.
+- `migrate --json` is the dry-run for legacy config models and reports one unified `operations` list.
 - `migrate --write` applies the required migration as one operation.
-- `upgrade` is for previous V3/`next` configs.
-- Both create backups before writing.
+- The write step creates a backup before writing.
 
 ## CLI Equivalent
 
@@ -92,7 +90,7 @@ n8nac pull <workflow-id>
 n8nac push workflows/dev/my-workflow.workflow.ts --verify
 ```
 
-For a managed local instance:
+For a local managed instance:
 
 ```bash
 n8n-manager instance list

--- a/plugins/claude/n8n-as-code/README.md
+++ b/plugins/claude/n8n-as-code/README.md
@@ -23,8 +23,8 @@ Use the full HTTPS URL because the `owner/repo` shorthand may trigger SSH clonin
 
 | Group | Command | Purpose |
 |---|---|---|
-| Usage Principal | `n8nac env` | Workspace environments |
-| Maintenance Workspace | `n8nac workspace` | Readiness, unified migration, upgrade |
+| Primary Usage | `n8nac env` | Workspace environments |
+| Workspace Maintenance | `n8nac workspace` | Readiness and unified workspace migration |
 | Managed Local Runtime | `n8n-manager` | Local managed instances and tunnels only |
 
 ## After Install
@@ -38,7 +38,7 @@ n8nac env use Dev
 n8nac update-ai
 ```
 
-For a managed local instance:
+For a local managed instance:
 
 ```bash
 n8n-manager instance list

--- a/plugins/claude/n8n-as-code/skills/n8n-architect/README.md
+++ b/plugins/claude/n8n-as-code/skills/n8n-architect/README.md
@@ -8,7 +8,7 @@ Turns Claude into a specialized n8n workflow engineer using the `n8nac` CLI and 
 
 ## Recommended Claude Code setup
 
-After installing the plugin, configure the target workspace with an n8n environment. `n8nac env` owns workspace context, `n8nac workspace` owns status/migration/upgrade, and `n8n-manager` owns only local managed instances. `update-ai` refreshes the generated context later:
+After installing the plugin, configure the target workspace with a workspace environment. `n8nac env` owns workspace context, `n8nac workspace` owns readiness and unified migration, and `n8n-manager` owns only local managed instances. `update-ai` refreshes the generated context later:
 
 ```bash
 npx --yes n8nac env add Dev --base-url <your-n8n-url> --sync-folder workflows/dev

--- a/plugins/openclaw/n8n-as-code/README.md
+++ b/plugins/openclaw/n8n-as-code/README.md
@@ -6,9 +6,9 @@ The plugin uses the same model as VS Code, Claude, and the CLI:
 
 | Group | Command | Purpose |
 |---|---|---|
-| Usage Principal | `n8nac env` | Workspace environments |
-| Maintenance Workspace | `n8nac workspace` | Readiness, unified migration, upgrade |
-| Instances Managées | `n8n-manager` | Local managed instances and tunnels |
+| Primary Usage | `n8nac env` | Workspace environments |
+| Workspace Maintenance | `n8nac workspace` | Readiness and unified workspace migration |
+| Managed Local Instances | `n8n-manager` | Local managed instances and tunnels |
 
 ## Install
 
@@ -58,7 +58,7 @@ OpenClaw files live in `~/.openclaw/n8nac/`:
   workflows/
 ```
 
-`n8nac-config.json` stores workspace environments. API keys and managed local instance state stay local.
+`n8nac-config.json` stores workspace environments. API keys and local managed instance state stay local.
 
 Manual equivalent:
 
@@ -69,7 +69,7 @@ n8nac env use Dev
 n8nac update-ai
 ```
 
-For a managed local instance:
+For a local managed instance:
 
 ```bash
 n8n-manager instance list


### PR DESCRIPTION
## Summary
- Align README and Docusaurus docs with the current workspace environment model.
- Replace outdated user-facing managed/external instance wording with remote n8n environment and local managed instance terminology.
- Remove stale workspace upgrade guidance in favor of the unified `n8nac workspace migrate` flow.

## Validation
- `git diff --check`
- `npm run docs:build` attempted, but the Docusaurus binary is not installed in this worktree (`sh: 1: docusaurus: not found`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified command organization: primary commands vs. hidden compatibility
  * Emphasized workspace migration flow: inspect dry-run (`--json`) then apply (`--write`)
  * Standardized "workspace environments" and "local managed instance" terminology across guides
  * Updated VS Code/CLI/extension docs with revised setup, storage, and migration guidance

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/442)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->