### PR TITLE
fix(transformer): preserve continueOnFail/disabled/notes/notesInFlow on roundtrip

### DIFF
--- a/packages/cli/src/core/assets/n8n-workflows.d.ts
+++ b/packages/cli/src/core/assets/n8n-workflows.d.ts
@@ -116,6 +116,14 @@ declare module '@n8n-as-code/transformer' {
         maxTries?: number;
         /** Milliseconds to wait between retries (used with retryOnFail) */
         waitBetweenTries?: number;
+        /** Continue execution even if this node fails (legacy; prefer onError) */
+        continueOnFail?: boolean;
+        /** Disable this node (skip during execution) */
+        disabled?: boolean;
+        /** Free-form user notes attached to the node */
+        notes?: string;
+        /** Whether the notes are also rendered inline on the canvas */
+        notesInFlow?: boolean;
     }
 
     // =========================================================================

--- a/packages/transformer/src/compiler/typescript-parser.ts
+++ b/packages/transformer/src/compiler/typescript-parser.ts
@@ -180,6 +180,10 @@ export class TypeScriptParser {
                 ...(metadata.retryOnFail !== undefined && { retryOnFail: metadata.retryOnFail }),
                 ...(metadata.maxTries !== undefined && { maxTries: metadata.maxTries }),
                 ...(metadata.waitBetweenTries !== undefined && { waitBetweenTries: metadata.waitBetweenTries }),
+                ...(metadata.continueOnFail !== undefined && { continueOnFail: metadata.continueOnFail }),
+                ...(metadata.disabled !== undefined && { disabled: metadata.disabled }),
+                ...(metadata.notes !== undefined && { notes: metadata.notes }),
+                ...(metadata.notesInFlow !== undefined && { notesInFlow: metadata.notesInFlow }),
                 parameters
                 // aiDependencies will be added by extractAIDependencies()
             });

--- a/packages/transformer/src/compiler/workflow-builder.ts
+++ b/packages/transformer/src/compiler/workflow-builder.ts
@@ -103,7 +103,19 @@ export class WorkflowBuilder {
             if (node.waitBetweenTries !== undefined) {
                 n8nNode.waitBetweenTries = node.waitBetweenTries;
             }
-            
+            if (node.continueOnFail !== undefined) {
+                n8nNode.continueOnFail = node.continueOnFail;
+            }
+            if (node.disabled !== undefined) {
+                n8nNode.disabled = node.disabled;
+            }
+            if (node.notes !== undefined) {
+                n8nNode.notes = node.notes;
+            }
+            if (node.notesInFlow !== undefined) {
+                n8nNode.notesInFlow = node.notesInFlow;
+            }
+
             return n8nNode;
         });
     }

--- a/packages/transformer/src/decorators/types.ts
+++ b/packages/transformer/src/decorators/types.ts
@@ -71,6 +71,18 @@ export interface NodeDecoratorMetadata {
 
     /** Milliseconds to wait between retries (used with retryOnFail) */
     waitBetweenTries?: number;
+
+    /** Continue execution even if this node fails (legacy; prefer onError) */
+    continueOnFail?: boolean;
+
+    /** Disable this node (skip during execution) */
+    disabled?: boolean;
+
+    /** Free-form user notes attached to the node */
+    notes?: string;
+
+    /** Whether the notes are also rendered inline on the canvas */
+    notesInFlow?: boolean;
 }
 
 // =====================================================================

--- a/packages/transformer/src/parser/ast-to-typescript.ts
+++ b/packages/transformer/src/parser/ast-to-typescript.ts
@@ -109,6 +109,9 @@ export class AstToTypeScriptGenerator {
             if (n.alwaysOutputData) flags.push('[alwaysOutput]');
             if (n.executeOnce) flags.push('[executeOnce]');
             if (n.retryOnFail) flags.push('[retry]');
+            if (n.continueOnFail) flags.push('[continueOnFail]');
+            if (n.disabled) flags.push('[disabled]');
+            if (n.notes) flags.push('[notes]');
             for (const role of subNodeRoles.get(n.propertyName) ?? []) flags.push(`[${role}]`);
             lines.push(`// ${prop} ${t} ${flags.join(' ')}`);
         }
@@ -351,7 +354,19 @@ export class AstToTypeScriptGenerator {
         if (node.waitBetweenTries !== undefined) {
             parts.push(`waitBetweenTries: ${node.waitBetweenTries}`);
         }
-        
+        if (node.continueOnFail !== undefined) {
+            parts.push(`continueOnFail: ${node.continueOnFail}`);
+        }
+        if (node.disabled !== undefined) {
+            parts.push(`disabled: ${node.disabled}`);
+        }
+        if (node.notes !== undefined) {
+            parts.push(`notes: ${JSON.stringify(node.notes)}`);
+        }
+        if (node.notesInFlow !== undefined) {
+            parts.push(`notesInFlow: ${node.notesInFlow}`);
+        }
+
         return `{\n        ${parts.join(',\n        ')}\n    }`;
     }
 

--- a/packages/transformer/src/parser/json-to-ast.ts
+++ b/packages/transformer/src/parser/json-to-ast.ts
@@ -96,6 +96,10 @@ export class JsonToAstParser {
             ...(node.retryOnFail !== undefined && { retryOnFail: node.retryOnFail }),
             ...(node.maxTries !== undefined && { maxTries: node.maxTries }),
             ...(node.waitBetweenTries !== undefined && { waitBetweenTries: node.waitBetweenTries }),
+            ...(node.continueOnFail !== undefined && { continueOnFail: node.continueOnFail }),
+            ...(node.disabled !== undefined && { disabled: node.disabled }),
+            ...(node.notes !== undefined && { notes: node.notes }),
+            ...(node.notesInFlow !== undefined && { notesInFlow: node.notesInFlow }),
         };
     }
     

--- a/packages/transformer/src/types.ts
+++ b/packages/transformer/src/types.ts
@@ -82,7 +82,11 @@ export interface NodeAST {
     retryOnFail?: boolean;
     maxTries?: number;
     waitBetweenTries?: number;
-    
+    continueOnFail?: boolean;
+    disabled?: boolean;
+    notes?: string;
+    notesInFlow?: boolean;
+
     // Node parameters (property value in TypeScript)
     parameters: Record<string, any>;
     
@@ -190,6 +194,10 @@ export interface N8nNode {
     retryOnFail?: boolean;
     maxTries?: number;
     waitBetweenTries?: number;
+    continueOnFail?: boolean;
+    disabled?: boolean;
+    notes?: string;
+    notesInFlow?: boolean;
 }
 
 /**

--- a/packages/transformer/tests/json-to-typescript.test.ts
+++ b/packages/transformer/tests/json-to-typescript.test.ts
@@ -399,6 +399,61 @@ export class AiTestWorkflow {
         expect(rebuiltNode.executeOnce).toBeUndefined();
     });
 
+    it('should preserve continueOnFail / disabled / notes / notesInFlow through full pull→push roundtrip', async () => {
+        const workflowJson = {
+            id: 'wf-roundtrip-extras-1',
+            name: 'Roundtrip Extras Workflow',
+            active: false,
+            nodes: [
+                {
+                    id: 'node-rt-extras-1',
+                    name: 'Annotated Node',
+                    type: 'n8n-nodes-base.set',
+                    typeVersion: 3,
+                    position: [200, 400],
+                    parameters: { mode: 'manual' },
+                    continueOnFail: true,
+                    disabled: true,
+                    notes: 'Legacy node — see RUNBOOK-42',
+                    notesInFlow: true,
+                },
+            ],
+            connections: {},
+            settings: {},
+        };
+
+        // JSON → AST → TypeScript
+        const jsonParser = new JsonToAstParser();
+        const ast1 = jsonParser.parse(workflowJson as any);
+        expect(ast1.nodes[0].continueOnFail).toBe(true);
+        expect(ast1.nodes[0].disabled).toBe(true);
+        expect(ast1.nodes[0].notes).toBe('Legacy node — see RUNBOOK-42');
+        expect(ast1.nodes[0].notesInFlow).toBe(true);
+
+        const generator = new AstToTypeScriptGenerator();
+        const tsCode = await generator.generate(ast1, { format: false, commentStyle: 'minimal' });
+        expect(tsCode).toContain('continueOnFail: true');
+        expect(tsCode).toContain('disabled: true');
+        expect(tsCode).toContain('notes: "Legacy node — see RUNBOOK-42"');
+        expect(tsCode).toContain('notesInFlow: true');
+
+        // TypeScript → AST → JSON
+        const tsParser = new TypeScriptParser();
+        const ast2 = await tsParser.parseCode(tsCode);
+        expect(ast2.nodes[0].continueOnFail).toBe(true);
+        expect(ast2.nodes[0].disabled).toBe(true);
+        expect(ast2.nodes[0].notes).toBe('Legacy node — see RUNBOOK-42');
+        expect(ast2.nodes[0].notesInFlow).toBe(true);
+
+        const builder = new WorkflowBuilder();
+        const rebuilt = builder.build(ast2);
+        const rebuiltNode = rebuilt.nodes[0];
+        expect(rebuiltNode.continueOnFail).toBe(true);
+        expect(rebuiltNode.disabled).toBe(true);
+        expect(rebuiltNode.notes).toBe('Legacy node — see RUNBOOK-42');
+        expect(rebuiltNode.notesInFlow).toBe(true);
+    });
+
     it('should emit [alwaysOutput] and [retry] flags in workflow-map for execution-setting nodes', async () => {
         const workflowJson = {
             id: 'wf-flags-1',


### PR DESCRIPTION
## Summary

PR #212 fixed the JSON↔TS roundtrip for `retryOnFail` / `maxTries` / `waitBetweenTries` / `alwaysOutputData` / `executeOnce`. This patch closes the remaining gap — four more native n8n node-level fields that are still being silently dropped on both `n8nac push` and `n8nac pull`:

| Field | Why it matters |
|---|---|
| `continueOnFail` | Legacy error-handling flag. Workflows authored before `onError` migration still use it; today's roundtrip wipes it. |
| `disabled` | Skip-during-execution toggle. Common for staged rollouts / A-B testing. |
| `notes` | Free-form annotations attached to a node — actual operational context that engineers write. |
| `notesInFlow` | Whether the notes render inline on the canvas. Visual-affordance pair to `notes`. |

## Repro (against `@n8n-as-code/cli` ≤0.9.8, before PR #212 / without this patch)

```
1. In n8n UI: set `disabled: true` and `notes: 'Disabled during incident X'` on a node.
2. n8nac pull --workflowsid <id>
3. grep -E 'disabled|notes' <workflow>.workflow.ts   → no hits
4. n8nac push --workflowsid <id>
5. n8n UI shows the node re-enabled, notes gone.
```

## Files touched

Carriers (both directions wired through):
- `packages/transformer/src/parser/json-to-ast.ts` — n8n JSON → AST
- `packages/transformer/src/parser/ast-to-typescript.ts` — AST → `.workflow.ts` (also adds `[continueOnFail] / [disabled] / [notes]` flags to the generated `workflow-map` header)
- `packages/transformer/src/compiler/typescript-parser.ts` — `.workflow.ts` → AST
- `packages/transformer/src/compiler/workflow-builder.ts` — AST → n8n PUT payload

Declarative schemas (kept in sync):
- `packages/transformer/src/decorators/types.ts` — `NodeDecoratorMetadata`
- `packages/transformer/src/types.ts` — `NodeAST` + `N8nNode`
- `packages/cli/src/core/assets/n8n-workflows.d.ts` — CLI stub mirror (autocomplete in user projects)

## Test

New regression test: `should preserve continueOnFail / disabled / notes / notesInFlow through full pull→push roundtrip` in `packages/transformer/tests/json-to-typescript.test.ts` — mirrors the existing retry/alwaysOutputData test from PR #212 and asserts on all 4 stages (`JSON → AST`, `AST → TS source`, `TS source → AST`, `AST → JSON`).

Full transformer suite: 75/75 passing. `npm run build:cli` succeeds.

## Test plan

- [x] `cd packages/transformer && npx vitest run` — 75/75 green
- [x] `npm run build:cli` — succeeds, stubs compile
- [x] New roundtrip test asserts each of the 4 fields lands correctly at every stage
- [ ] Manual smoke against a live n8n instance (out of scope for fork-side PR; existing pattern from PR #212 covers behaviour)

## Real-world breakage

Surfaced during a BNPL weekly-reports incident on 2026-05-12. Three pipeline runs failed due to a transient GitLab 5xx on a single repo with no retry configured. Fixing it via `.workflow.ts` would have been the natural path — but the moment we tried, retry fields disappeared on roundtrip. We had to apply them via the n8n public REST API as an out-of-band script.

PR #212 already closed that specific symptom for the retry fields. This patch extends the same shape to `continueOnFail` / `disabled` / `notes` / `notesInFlow` so we don't repeat the same root cause for the remaining node-level metadata.

## Notes for reviewer

- No public-API behaviour change beyond "fields that were silently dropped are now preserved."
- The `N8nNode` interface in `types.ts` is extended with the same four optional fields so the compiler payload typechecks.
- Workflow-map flag rendering is opt-in (only emitted when the corresponding field is truthy / non-empty), so unchanged workflows produce identical output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded node-level configuration options: disable individual nodes, add freeform notes and annotations, control inline canvas rendering of notes, and configure error continuation behavior.

* **Tests**
  * Added comprehensive test coverage for node metadata transformations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/446)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->