### PR TITLE
fix(config): tolerate duplicate instance target names

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -67,9 +67,7 @@ async function ensureManagedLocalTarget(configService: ConfigService, instanceId
     if (instance.mode !== 'managed-local-docker') {
         throw new Error(`Instance "${instance.name || instance.id}" is not managed locally. Use --base-url for remote n8n environments.`);
     }
-    const externalInstance = configService.listInstanceTargets().find((target) => target.kind === 'managed-instance' && target.managedInstanceId === instance.id);
-    if (externalInstance) return externalInstance;
-    return configService.addInstanceTarget({
+    return configService.ensureManagedInstanceTarget({
         name: instance.name || instance.id,
         managedInstanceId: instance.id,
     });

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -971,6 +971,9 @@ export class ConfigService {
         const saved = this.manager.upsertInstance(input, {
             setActive: options.setActive,
         });
+        if (options.apiKey) {
+            this.manager.saveApiKey(saved.id, options.apiKey);
+        }
 
         if (workspaceConfigIsV4) {
             return this.toInstanceProfile(saved);
@@ -1726,6 +1729,26 @@ export class ConfigService {
     }
 
     private readLegacyStoredApiKey(instanceId: string, host?: string): string | undefined {
+        const readFromStore = (store: { hosts?: Record<string, unknown>; instanceProfiles?: Record<string, unknown> } | undefined): string | undefined => {
+            const instanceApiKey = asString(store?.instanceProfiles?.[instanceId]);
+            if (instanceApiKey) return instanceApiKey;
+            if (!host) return undefined;
+            return asString(store?.hosts?.[this.normalizeHost(host)]);
+        };
+
+        for (const root of [process.env.XDG_CONFIG_HOME, process.env.N8N_MANAGER_HOME]) {
+            if (!root) continue;
+            const filePath = path.join(root, 'n8nac-nodejs', 'credentials.json');
+            if (!fs.existsSync(filePath)) continue;
+            try {
+                const value = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+                const apiKey = readFromStore(value && typeof value === 'object' && !Array.isArray(value) ? value as any : undefined);
+                if (apiKey) return apiKey;
+            } catch {
+                // Try the Conf-backed store below.
+            }
+        }
+
         try {
             const store = new Conf<Record<string, unknown>>({
                 projectName: 'n8nac',
@@ -1733,12 +1756,8 @@ export class ConfigService {
                 configFileMode: 0o600,
             });
             const instanceProfiles = store.get('instanceProfiles') as Record<string, unknown> | undefined;
-            const instanceApiKey = asString(instanceProfiles?.[instanceId]);
-            if (instanceApiKey) return instanceApiKey;
-
-            if (!host) return undefined;
             const hosts = store.get('hosts') as Record<string, unknown> | undefined;
-            return asString(hosts?.[this.normalizeHost(host)]);
+            return readFromStore({ hosts, instanceProfiles });
         } catch {
             return undefined;
         }

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -443,6 +443,31 @@ export class ConfigService {
         });
     }
 
+    ensureManagedInstanceTarget(input: { name: string; managedInstanceId: string; id?: string; description?: string }): IEnvironmentTarget {
+        const managedInstanceId = cleanRequired(input.managedInstanceId, 'Managed instance ID');
+        const config = this.ensureV4WorkspaceConfig();
+        const managedInstance = config.environmentTargets.find((target) => {
+            return target.kind === 'managed-instance' && target.managedInstanceId === managedInstanceId;
+        });
+        if (managedInstance) return managedInstance;
+
+        const existingNames = new Set(config.environmentTargets.map((target) => target.name.toLowerCase()));
+        const baseName = cleanRequired(input.name, 'Instance name');
+        let name = baseName;
+        let counter = 2;
+        while (existingNames.has(name.toLowerCase())) {
+            name = `${baseName} ${counter}`;
+            counter += 1;
+        }
+
+        return this.addInstanceTarget({
+            name,
+            id: input.id,
+            managedInstanceId,
+            description: input.description,
+        });
+    }
+
     updateInstanceTarget(nameOrId: string, patch: { name?: string; managedInstanceId?: string; url?: string; description?: string }): IEnvironmentTarget {
         const config = this.ensureV4WorkspaceConfig();
         const target = this.findInstanceTarget(config, nameOrId);
@@ -1819,7 +1844,7 @@ export class ConfigService {
         const rawEnvironments = raw.environments as unknown[];
         const environmentTargets = rawInstanceTargets.map((target, index) => this.sanitizeInstanceTarget(target, index));
         const environments = rawEnvironments.map((environment, index) => this.sanitizeEnvironment(environment, index));
-        this.assertUniqueIdsAndNames(environmentTargets, 'instance target');
+        this.assertUniqueIds(environmentTargets, 'instance target');
         this.assertUniqueIdsAndNames(environments, 'environment');
         const targetIds = new Set(environmentTargets.map((target) => target.id));
         for (const environment of environments) {
@@ -1878,14 +1903,20 @@ export class ConfigService {
     }
 
     private assertUniqueIdsAndNames<T extends { id: string; name: string }>(items: T[], label: string): void {
-        const ids = new Set<string>();
+        this.assertUniqueIds(items, label);
         const names = new Set<string>();
         for (const item of items) {
-            if (ids.has(item.id)) throw new Error(`Invalid v4 workspace config: duplicate ${label} ID "${item.id}".`);
-            ids.add(item.id);
             const name = item.name.toLowerCase();
             if (names.has(name)) throw new Error(`Invalid v4 workspace config: duplicate ${label} name "${item.name}".`);
             names.add(name);
+        }
+    }
+
+    private assertUniqueIds<T extends { id: string }>(items: T[], label: string): void {
+        const ids = new Set<string>();
+        for (const item of items) {
+            if (ids.has(item.id)) throw new Error(`Invalid v4 workspace config: duplicate ${label} ID "${item.id}".`);
+            ids.add(item.id);
         }
     }
 

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -2130,8 +2130,10 @@ export class ConfigService {
             `N8NAC_ENV_${envVarSlug(environment.id)}_API_KEY`,
             `N8NAC_ENV_${envVarSlug(environment.name)}_API_KEY`,
             `N8NAC_TARGET_${envVarSlug(target.id)}_API_KEY`,
-            `N8NAC_TARGET_${envVarSlug(target.name)}_API_KEY`,
         ];
+        if (this.isUniqueInstanceTargetName(target)) {
+            candidates.push(`N8NAC_TARGET_${envVarSlug(target.name)}_API_KEY`);
+        }
         for (const key of candidates) {
             const value = process.env[key]?.trim().replace(/^['"]|['"]$/g, '');
             if (value) return value;
@@ -2142,13 +2144,21 @@ export class ConfigService {
     private readTargetEnvApiKey(target: IEnvironmentTarget): string | undefined {
         const candidates = [
             `N8NAC_TARGET_${envVarSlug(target.id)}_API_KEY`,
-            `N8NAC_TARGET_${envVarSlug(target.name)}_API_KEY`,
         ];
+        if (this.isUniqueInstanceTargetName(target)) {
+            candidates.push(`N8NAC_TARGET_${envVarSlug(target.name)}_API_KEY`);
+        }
         for (const key of candidates) {
             const value = process.env[key]?.trim().replace(/^["']|["']$/g, '');
             if (value) return value;
         }
         return undefined;
+    }
+
+    private isUniqueInstanceTargetName(target: IEnvironmentTarget): boolean {
+        const name = target.name.toLowerCase();
+        const config = this.ensureV4WorkspaceConfig();
+        return config.environmentTargets.filter((item) => item.name.toLowerCase() === name).length === 1;
     }
 
     private resolveExistingGlobalInstanceRef(managedInstanceId: unknown): string {

--- a/packages/cli/tests/unit/config-service.test.ts
+++ b/packages/cli/tests/unit/config-service.test.ts
@@ -714,6 +714,71 @@ describe('ConfigService', () => {
         expect(resolved.workflowDir).not.toContain('n8n_1234567890');
     });
 
+    it('reuses managed instance targets and avoids generated name collisions with connected targets', () => {
+        const configService = new ConfigService(workspaceRoot);
+        (configService as any).manager.upsertInstance({
+            id: 'dev-instance',
+            name: 'Development',
+            mode: 'managed-local-docker',
+            baseUrl: 'https://dev.example.test',
+        }, { setActive: false });
+
+        const existingTarget = configService.addInstanceTarget({
+            name: 'Development',
+            url: 'https://connected.example.test',
+        });
+        const target = configService.ensureManagedInstanceTarget({
+            name: 'Development',
+            managedInstanceId: 'dev-instance',
+        });
+        const reused = configService.ensureManagedInstanceTarget({
+            name: 'Development',
+            managedInstanceId: 'dev-instance',
+        });
+
+        expect(target).toMatchObject({ name: 'Development 2', managedInstanceId: 'dev-instance' });
+        expect(reused.id).toBe(target.id);
+        expect(configService.listInstanceTargets()).toEqual(expect.arrayContaining([
+            expect.objectContaining({ id: existingTarget.id, name: 'Development', kind: 'external-instance', url: 'https://connected.example.test' }),
+            expect.objectContaining({ id: target.id, name: 'Development 2', managedInstanceId: 'dev-instance' }),
+        ]));
+    });
+
+    it('loads existing configs with duplicate instance target names when environments reference target IDs', () => {
+        writeFileSync(path.join(workspaceRoot, 'n8nac-config.json'), JSON.stringify({
+            version: 4,
+            environmentTargets: [{
+                id: 'development-connected',
+                name: 'Development',
+                kind: 'external-instance',
+                url: 'https://connected.example.test',
+            }, {
+                id: 'development-managed',
+                name: 'Development',
+                kind: 'managed-instance',
+                managedInstanceId: 'dev-instance',
+            }],
+            environments: [{
+                id: 'dev',
+                name: 'dev',
+                environmentTargetId: 'development-managed',
+                syncFolder: 'workflows',
+            }],
+        }));
+
+        (new ConfigService(workspaceRoot) as any).manager.upsertInstance({
+            id: 'dev-instance',
+            name: 'Development',
+            mode: 'managed-local-docker',
+            baseUrl: 'https://dev.example.test',
+        }, { setActive: false });
+
+        const config = new ConfigService(workspaceRoot).getWorkspaceConfig();
+
+        expect(config.environmentTargets?.filter((target) => target.name === 'Development')).toHaveLength(2);
+        expect(config.environments?.[0]).toMatchObject({ environmentTargetId: 'development-managed' });
+    });
+
     it('prefers managed base URL over public tunnel URL for API resolution', () => {
         const configService = new ConfigService(workspaceRoot);
         (configService as any).manager.upsertInstance({

--- a/packages/cli/tests/unit/config-service.test.ts
+++ b/packages/cli/tests/unit/config-service.test.ts
@@ -10,6 +10,8 @@ describe('ConfigService', () => {
     let previousXdgConfigHome: string | undefined;
     let previousN8nApiKey: string | undefined;
     let previousTargetApiKey: string | undefined;
+    let previousTargetDevelopmentApiKey: string | undefined;
+    let previousTargetManagedDevelopmentApiKey: string | undefined;
     let managerHome: string;
     let workspaceRoot: string;
 
@@ -18,12 +20,16 @@ describe('ConfigService', () => {
         previousXdgConfigHome = process.env.XDG_CONFIG_HOME;
         previousN8nApiKey = process.env.N8N_API_KEY;
         previousTargetApiKey = process.env.N8NAC_TARGET_PRODUCTION_N8N_API_KEY;
+        previousTargetDevelopmentApiKey = process.env.N8NAC_TARGET_DEVELOPMENT_API_KEY;
+        previousTargetManagedDevelopmentApiKey = process.env.N8NAC_TARGET_DEVELOPMENT_MANAGED_API_KEY;
         managerHome = mkdtempSync(path.join(tmpdir(), 'n8nac-manager-home-'));
         workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-workspace-'));
         process.env.N8N_MANAGER_HOME = managerHome;
         process.env.XDG_CONFIG_HOME = managerHome;
         delete process.env.N8N_API_KEY;
         delete process.env.N8NAC_TARGET_PRODUCTION_N8N_API_KEY;
+        delete process.env.N8NAC_TARGET_DEVELOPMENT_API_KEY;
+        delete process.env.N8NAC_TARGET_DEVELOPMENT_MANAGED_API_KEY;
     });
 
     afterEach(() => {
@@ -46,6 +52,16 @@ describe('ConfigService', () => {
             delete process.env.N8NAC_TARGET_PRODUCTION_N8N_API_KEY;
         } else {
             process.env.N8NAC_TARGET_PRODUCTION_N8N_API_KEY = previousTargetApiKey;
+        }
+        if (previousTargetDevelopmentApiKey === undefined) {
+            delete process.env.N8NAC_TARGET_DEVELOPMENT_API_KEY;
+        } else {
+            process.env.N8NAC_TARGET_DEVELOPMENT_API_KEY = previousTargetDevelopmentApiKey;
+        }
+        if (previousTargetManagedDevelopmentApiKey === undefined) {
+            delete process.env.N8NAC_TARGET_DEVELOPMENT_MANAGED_API_KEY;
+        } else {
+            process.env.N8NAC_TARGET_DEVELOPMENT_MANAGED_API_KEY = previousTargetManagedDevelopmentApiKey;
         }
     });
 
@@ -777,6 +793,50 @@ describe('ConfigService', () => {
 
         expect(config.environmentTargets?.filter((target) => target.name === 'Development')).toHaveLength(2);
         expect(config.environments?.[0]).toMatchObject({ environmentTargetId: 'development-managed' });
+    });
+
+    it('ignores name-based target API key variables when instance target names are ambiguous', () => {
+        const configService = new ConfigService(workspaceRoot);
+        (configService as any).manager.upsertInstance({
+            id: 'dev-instance',
+            name: 'Development',
+            mode: 'managed-local-docker',
+            baseUrl: 'https://dev.example.test',
+        }, { setActive: false });
+        (configService as any).manager.saveApiKey('dev-instance', 'managed-key');
+        writeFileSync(path.join(workspaceRoot, 'n8nac-config.json'), JSON.stringify({
+            version: 4,
+            environmentTargets: [{
+                id: 'development-connected',
+                name: 'Development',
+                kind: 'external-instance',
+                url: 'https://connected.example.test',
+            }, {
+                id: 'development-managed',
+                name: 'Development',
+                kind: 'managed-instance',
+                managedInstanceId: 'dev-instance',
+            }],
+            environments: [{
+                id: 'dev',
+                name: 'dev',
+                environmentTargetId: 'development-managed',
+                syncFolder: 'workflows',
+            }],
+        }));
+        process.env.N8NAC_TARGET_DEVELOPMENT_API_KEY = 'ambiguous-key';
+
+        const resolved = new ConfigService(workspaceRoot).resolveEnvironment('dev');
+
+        expect(resolved.apiKey).toBe('managed-key');
+        expect(resolved.apiKeySource).toBe('global');
+
+        process.env.N8NAC_TARGET_DEVELOPMENT_MANAGED_API_KEY = 'id-specific-key';
+
+        const resolvedWithIdKey = new ConfigService(workspaceRoot).resolveEnvironment('dev');
+
+        expect(resolvedWithIdKey.apiKey).toBe('id-specific-key');
+        expect(resolvedWithIdKey.apiKeySource).toBe('env');
     });
 
     it('prefers managed base URL over public tunnel URL for API resolution', () => {

--- a/packages/vscode-extension/src/ui/configuration-webview.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview.ts
@@ -333,8 +333,7 @@ export class ConfigurationWebview {
             const instance = (await globalFacade.listInstances()).find((item) => item.id === instanceId);
             if (!instance) throw new Error(`Unknown n8n instance preset: ${instanceId}`);
             if (instance.mode === 'managed-local-docker') {
-              const existingTarget = configService.listInstanceTargets().find((target) => target.kind === 'managed-instance' && target.managedInstanceId === instanceId);
-              environmentTargetId = existingTarget?.id || configService.addInstanceTarget({
+              environmentTargetId = configService.ensureManagedInstanceTarget({
                 name: instance.name || instanceId,
                 managedInstanceId: instanceId,
               }).id;


### PR DESCRIPTION
## Summary
- Allow existing v4 configs to load when instance target display names collide, while keeping target IDs strictly unique.
- Reuse or auto-name managed instance targets to avoid creating new name collisions from VS Code or CLI flows.
- Add config-service coverage for duplicate target names and managed/connected target collision handling.

## Validation
- npx vitest run tests/unit/config-service.test.ts
- npm run compile (packages/vscode-extension)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized creation/reuse of managed-local environment targets for consistent behavior across CLI and VS Code extension.
* **Bug Fixes**
  * Enforced unique instance-target identifiers and tightened environment API-key selection to avoid ambiguous/incorrect credential resolution.
* **Chores**
  * Persisted managed instance API keys into the manager secret store and expanded legacy API-key lookup locations.
* **Tests**
  * Added unit tests covering target reuse, name collisions, and credential-selection edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/448?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->