### PR TITLE
fix(vscode): replay session history into agent prompts

### DIFF
--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -801,7 +801,7 @@ export class AgentRuntimeController implements vscode.Disposable {
         const sessions = await this.getSessionRuntime();
         sessions.service.setCheckpointer(handle.checkpointer);
         const agent = handle.agent;
-        const messages = [{ role: 'user', content: await this.buildInvocationPrompt(input) }];
+        const messages = this.buildConversationMessages(initialEntries, await this.buildInvocationPrompt(input));
         const contextWindowTokens = await this.resolveContextWindow(providerConfig.provider, providerConfig.model, providerConfig.apiKey, providerConfig.baseUrl);
         const config = {
             ...sessions.service.buildSessionConfig(input.sessionId || ''),
@@ -1084,6 +1084,26 @@ export class AgentRuntimeController implements vscode.Disposable {
             input.prompt.trim(),
         ].filter(Boolean);
         return blocks.join('\n\n');
+    }
+
+    private buildConversationMessages(
+        entries: AgentTimelineEntry[],
+        invocationPrompt: string,
+    ): Array<{ role: 'user' | 'assistant'; content: string }> {
+        const messages: Array<{ role: 'user' | 'assistant'; content: string }> = [];
+        for (const entry of entries) {
+            if (entry.kind === 'user-message') {
+                const text = entry.text.trim();
+                if (text) messages.push({ role: 'user', content: text });
+                continue;
+            }
+            if (entry.kind === 'assistant-body') {
+                const text = this.sanitizeAssistantText(entry.text);
+                if (text) messages.push({ role: 'assistant', content: text });
+            }
+        }
+        messages.push({ role: 'user', content: invocationPrompt });
+        return messages;
     }
 
     private formatNodeContexts(nodeContexts: AgentNodeContext[]): string | undefined {


### PR DESCRIPTION
### Motivation
- The Agent Workbench UI can rehydrate conversation history after VS Code restarts while the embedded runtime/checkpointer may not, causing new runs to appear as fresh conversations.
- The intent is to preserve conversational continuity by replaying the visible persisted turns into the provider `messages` before sending the structured invocation prompt.

### Description
- Replace the single-message invocation (`{ role: 'user', content: await buildInvocationPrompt(...) }`) with a composed `messages` array built by a new `buildConversationMessages(...)` helper. 
- `buildConversationMessages` walks `AgentTimelineEntry[]` and replays `user-message` and `assistant-body` turns (assistant text is sanitized) and appends the structured invocation prompt as the final user message.
- The new `messages` array is passed to the provider runtime (`(agent as any).streamEvents({ messages }, config)`), keeping the existing invocation prompt last so workflow/node context remains explicit.
- Changes are in `packages/vscode-extension/src/services/agent-runtime-controller.ts` (added private method and swapped how `messages` is constructed).

### Testing
- Ran `pnpm -C packages/vscode-extension test -- agent-runtime-controller`; the run failed during compilation due to missing workspace dependencies/type packages (pre-existing environment issue such as unresolved `vscode`, `commander`, etc.), not caused by this patch.
- No other automated tests were executed in this environment due to the compile-time dependency failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0855f6f5308331b1868466ad9cc2bc)