### PR TITLE
fix(vscode): correct provider connection state and model fallback isolation

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1019,7 +1019,10 @@ async function listAgentModelOptions(providerId: string): Promise<Array<Record<s
     const definition = YAGR_PROVIDER_DEFINITIONS[provider];
     const config = vscode.workspace.getConfiguration('n8n.agent');
     const selectedProvider = normalizeYagrProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
-    const currentModel = String(config.get<string>('model') || '').trim() || definition.defaultModel;
+    const selectedModel = String(config.get<string>('model') || '').trim();
+    const currentModel = provider === selectedProvider
+        ? (selectedModel || definition.defaultModel)
+        : definition.defaultModel;
     const liveModels = await requireYagrProviderService().fetchAvailableModels(provider).catch(() => []);
     return [...new Set([...(liveModels.length ? liveModels : []), definition.defaultModel, currentModel].filter(Boolean))]
         .map((model) => ({

--- a/packages/vscode-extension/src/services/yagr-provider-service.ts
+++ b/packages/vscode-extension/src/services/yagr-provider-service.ts
@@ -222,7 +222,7 @@ export class YagrProviderService {
             const hasStoredCredential = Boolean(await this.getStoredCredential(provider));
             const providerDisabled = disabledProviders.has(provider);
             const hasEnvironmentCredential = !providerDisabled && this.hasEnvironmentCredential(provider);
-            const connected = !providerDisabled && (hasStoredCredential || hasEnvironmentCredential || provider === selectedProvider);
+            const connected = !providerDisabled && (hasStoredCredential || hasEnvironmentCredential);
             return {
                 id: provider,
                 label: definition.label,


### PR DESCRIPTION
### Motivation
- Fix UI confusion where a provider would appear `Connected` simply because it was the selected provider, even when its credentials were removed. 
- Prevent model lists for one provider from showing the currently-configured model of a different provider, which produced inconsistent model choices in the extension.

### Description
- Change connection-state computation in `YagrProviderService.listProviderConnectionStates` so `connected` is true only when a stored secret or an environment credential exists, not because the provider is selected (`packages/vscode-extension/src/services/yagr-provider-service.ts`).
- Change model option generation in `listAgentModelOptions` to derive `currentModel` only from the selected provider, so non-selected providers no longer receive the other provider’s configured model as a fallback (`packages/vscode-extension/src/extension.ts`).
- Kept behavior for preserving `selected` and `model` fields for the selected provider so UI continues to highlight the active configuration.

### Testing
- Ran the extension test command `npm --prefix packages/vscode-extension test`, which invokes `tsc -b` then the unit tests, to validate the change.
- The test run failed due to missing workspace dependencies/type resolution across packages (pre-existing environment setup issues), so no unit test failures attributable to these focused changes were observed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08563c532483318b02d890530de0be)