### PR TITLE
[codex] fix webview reload message collision

### DIFF
--- a/packages/vscode-extension/src/ui/webview-html.ts
+++ b/packages/vscode-extension/src/ui/webview-html.ts
@@ -12,11 +12,14 @@
  *     are all enforced in the parent-webview JavaScript (this file), which is
  *     extension-controlled and inaccessible to iframe code.
  */
+export const WORKFLOW_WEBVIEW_RELOAD_MESSAGE = 'n8nac.workflow.reload';
+
 export function buildWebviewHtml(workflowId: string, url: string): string {
     // Escape workflowId for safe interpolation in HTML and JS contexts
     const htmlSafe = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
     const safeWorkflowIdHtml = htmlSafe(workflowId);
     const safeWorkflowIdJs = JSON.stringify(workflowId);
+    const reloadMessageTypeJs = JSON.stringify(WORKFLOW_WEBVIEW_RELOAD_MESSAGE);
 
     // url is the proxy URL pointing to the n8n workflow
     let iframePermissionOrigin = 'src';
@@ -217,7 +220,7 @@ export function buildWebviewHtml(workflowId: string, url: string): string {
                     const message = event.data;
                     if (!message || typeof message !== 'object') return;
 
-                    if (message.type === 'reload') {
+                    if (message.type === ${reloadMessageTypeJs}) {
                         const softRefreshWorked = attemptSoftRefresh();
                         if (!softRefreshWorked) {
                             performSeamlessRefresh();

--- a/packages/vscode-extension/src/ui/workflow-webview.ts
+++ b/packages/vscode-extension/src/ui/workflow-webview.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { IWorkflowStatus } from 'n8nac';
-import { buildWebviewHtml } from './webview-html.js';
+import { buildWebviewHtml, WORKFLOW_WEBVIEW_RELOAD_MESSAGE } from './webview-html.js';
 import { workflowWebviewRegistry } from '../services/workflow-webview-registry.js';
 export { buildWebviewHtml } from './webview-html.js';
 
@@ -18,7 +18,7 @@ export class WorkflowWebview {
         this._workflowId = workflowId;
         this._registryDisposable = workflowWebviewRegistry.register({
             getWorkflowId: () => this._workflowId,
-            reloadWorkflow: () => this._panel.webview.postMessage({ type: 'reload' }),
+            reloadWorkflow: () => this._panel.webview.postMessage({ type: WORKFLOW_WEBVIEW_RELOAD_MESSAGE }),
         });
         this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
         this._panel.webview.html = this.getHtmlForWebview(workflowId, url);

--- a/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
+++ b/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
@@ -262,6 +262,8 @@ test('Parent webview HTML: seamless reload forces iframe navigation', () => {
     const { buildWebviewHtml } = require('../../src/ui/webview-html.js');
     const html: string = buildWebviewHtml('wf-1', 'http://localhost:5678/workflow/wf-1');
 
+    assert.ok(html.includes('message.type === "n8nac.workflow.reload"'), 'Reload command must use a namespaced extension message');
+    assert.ok(!html.includes("message.type === 'reload'"), 'Generic iframe reload messages must not trigger a parent reload');
     assert.ok(html.includes('_n8nacRefresh'), 'Reload must add a cache-busting query param');
     assert.ok(html.includes('pendingFrame.src = reloadUrl.toString()'), 'Reload must assign a fresh iframe URL');
 });


### PR DESCRIPTION
## Summary

Fixes an unintended workflow webview refresh that could occur when the embedded n8n iframe posts a generic `reload` message during normal interaction.

## Root Cause

The parent VS Code webview listened for `{ type: 'reload' }`, which is too broad for a window message channel shared with the embedded iframe. If n8n posts its own `reload` message while the user clicks or interacts inside the board, the extension can mistake that iframe message for an extension-driven refresh request.

## Changes

- Namespaced the extension-owned workflow reload message as `n8nac.workflow.reload`.
- Reused the shared reload message constant between the extension host and generated parent webview HTML.
- Added a regression assertion that generic `reload` messages no longer trigger the parent refresh path.

## Validation

- `npm test --workspace packages/vscode-extension`
- 65 unit tests passed.