### PR TITLE
[codex] Use stable environment sync slugs

### DIFF
--- a/docs/docs/usage/cli.md
+++ b/docs/docs/usage/cli.md
@@ -53,7 +53,7 @@ For a compact overview, see the [Command Glossary](/docs/usage/commands).
 ### Remote n8n environment
 
 ```bash
-n8nac env add Dev --base-url https://n8n.example.com --sync-folder workflows/dev
+n8nac env add Dev --base-url https://n8n.example.com --sync-folder workflows
 n8nac env auth set Dev --api-key-stdin
 n8nac env use Dev
 n8nac update-ai
@@ -63,7 +63,7 @@ n8nac update-ai
 
 ```bash
 n8n-manager instance list
-n8nac env add Local --managed-instance <id> --sync-folder workflows/local
+n8nac env add Local --managed-instance <id> --sync-folder workflows
 n8nac env use Local
 n8nac update-ai
 ```
@@ -83,8 +83,8 @@ Use `env` for normal workspace configuration.
 ```bash
 n8nac env list
 n8nac env status
-n8nac env add Dev --base-url <url> --sync-folder workflows/dev
-n8nac env add Local --managed-instance <id> --sync-folder workflows/local
+n8nac env add Dev --base-url <url> --sync-folder workflows
+n8nac env add Local --managed-instance <id> --sync-folder workflows
 n8nac env use Dev
 n8nac env auth set Dev --api-key-stdin
 n8nac env remove Dev
@@ -95,7 +95,7 @@ n8nac env remove Dev
 Remote environments store the URL in `n8nac-config.json`, but the API key stays local.
 
 ```bash
-n8nac env add Staging --base-url https://staging.example.com --sync-folder workflows/staging
+n8nac env add Staging --base-url https://staging.example.com --sync-folder workflows
 n8nac env auth set Staging --api-key-stdin
 ```
 
@@ -105,7 +105,7 @@ These workspace environments reference a local `n8n-manager` instance.
 
 ```bash
 n8n-manager instance list
-n8nac env add Local --managed-instance <id> --sync-folder workflows/local
+n8nac env add Local --managed-instance <id> --sync-folder workflows
 ```
 
 The workspace does not copy Docker paths, tunnel state, logs, or local secrets.
@@ -246,10 +246,11 @@ Current config is environment-based and safe to commit when it contains no secre
     {
       "id": "dev",
       "name": "Dev",
+      "syncSlug": "dev",
       "environmentTargetId": "dev",
       "projectId": "personal",
       "projectName": "Personal",
-      "syncFolder": "workflows/dev"
+      "syncFolder": "workflows"
     }
   ],
   "environmentTargets": [
@@ -264,6 +265,8 @@ Current config is environment-based and safe to commit when it contains no secre
 ```
 
 API keys are stored locally with `n8nac env auth set <env> --api-key-stdin`.
+
+`syncSlug` is generated from the environment name when the environment is created. It is stable after creation, so changing the environment display name, target instance, or target project does not move the workflow directory. Existing legacy workflow directories are still used until a matching slug directory exists.
 
 In config examples, `kind: "external-instance"` is the persisted target kind for a remote n8n URL. Prefer the user-facing term "remote n8n environment" outside raw config discussions.
 

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -73,6 +73,8 @@ export type IEnvironmentTarget = IManagedEnvironmentTarget | IExternalEnvironmen
 export interface IWorkspaceEnvironment {
     id: string;
     name: string;
+    syncSlug?: string;
+    legacyWorkflowDir?: string;
     environmentTargetId: string;
     projectId?: string;
     projectName?: string;
@@ -534,6 +536,7 @@ export class ConfigService {
         const environment: IWorkspaceEnvironment = {
             id,
             name,
+            syncSlug: this.uniqueEnvironmentSyncSlug(name, config.environments),
             environmentTargetId: target.id,
             projectId: cleanOptional(input.projectId),
             projectName: cleanOptional(input.projectName),
@@ -554,18 +557,23 @@ export class ConfigService {
     updateEnvironment(nameOrId: string, patch: Partial<Pick<IWorkspaceEnvironment, 'name' | 'projectId' | 'projectName' | 'syncFolder' | 'folderSync' | 'customNodesPath' | 'description'>> & { environmentTarget?: string }): IWorkspaceEnvironment {
         const config = this.ensureV4WorkspaceConfig();
         const environment = this.findEnvironment(config, nameOrId);
+        const currentTarget = this.findInstanceTarget(config, environment.environmentTargetId);
         const target = patch.environmentTarget ? this.findInstanceTarget(config, patch.environmentTarget) : undefined;
         const nextName = cleanOptional(patch.name) || environment.name;
         if (nextName.toLowerCase() !== environment.name.toLowerCase()) {
             this.assertUniqueName(nextName, config.environments.filter((item) => item.id !== environment.id), 'environment');
         }
+        const nextSyncFolder = patch.syncFolder !== undefined ? cleanRequired(patch.syncFolder, 'Sync folder') : environment.syncFolder;
+        const syncFolderChanged = this.resolveWorkspacePath(nextSyncFolder) !== this.resolveWorkspacePath(environment.syncFolder);
+        const legacyWorkflowDir = syncFolderChanged ? undefined : this.resolveEnvironmentLegacyWorkflowDir(environment, currentTarget);
         const nextEnvironment: IWorkspaceEnvironment = stripUndefined({
             ...environment,
             name: nextName,
+            legacyWorkflowDir,
             environmentTargetId: target?.id || environment.environmentTargetId,
             projectId: patch.projectId !== undefined ? cleanOptional(patch.projectId) : environment.projectId,
             projectName: patch.projectName !== undefined ? cleanOptional(patch.projectName) : environment.projectName,
-            syncFolder: patch.syncFolder !== undefined ? cleanRequired(patch.syncFolder, 'Sync folder') : environment.syncFolder,
+            syncFolder: nextSyncFolder,
             folderSync: patch.folderSync ?? environment.folderSync,
             customNodesPath: patch.customNodesPath ?? environment.customNodesPath,
             description: patch.description ?? environment.description,
@@ -639,10 +647,13 @@ export class ConfigService {
                     instanceUserIdentifier,
                     workflowDir: this.buildEnvironmentWorkflowDir({
                         syncFolder: resolved.syncFolder,
+                        syncSlug: resolved.environment.syncSlug,
+                        legacyWorkflowDir: resolved.environment.legacyWorkflowDir,
                         environmentId: resolved.environmentId,
                         instanceIdentifier,
                         instanceUserIdentifier,
                         projectId: resolved.projectId,
+                        projectName: resolved.projectName,
                     }),
                 };
             }
@@ -691,10 +702,13 @@ export class ConfigService {
             syncFolder,
             workflowDir: this.buildEnvironmentWorkflowDir({
                 syncFolder,
+                syncSlug: resolved.environment.syncSlug,
+                legacyWorkflowDir: resolved.environment.legacyWorkflowDir,
                 environmentId: resolved.environmentId,
                 instanceIdentifier,
                 instanceUserIdentifier,
                 projectId,
+                projectName,
             }),
         };
     }
@@ -1174,6 +1188,7 @@ export class ConfigService {
             syncFolder: asString(raw.syncFolder) || activeInstance?.syncFolder,
             projectId: asString(raw.projectId) || activeInstance?.projectId,
             projectName: asString(raw.projectName) || activeInstance?.projectName,
+            workflowDir: asString(raw.workflowDir) || activeInstance?.workflowDir,
             customNodesPath: asString(raw.customNodesPath) || activeInstance?.customNodesPath,
             folderSync: asBoolean(raw.folderSync) ?? activeInstance?.folderSync,
         });
@@ -1268,6 +1283,7 @@ export class ConfigService {
                     projectId: legacy.projectId || plan.workspace.projectId,
                     projectName: legacy.projectName || plan.workspace.projectName,
                     syncFolder,
+                    legacyWorkflowDir: legacy.workflowDir || plan.workspace.workflowDir,
                     customNodesPath: legacy.customNodesPath || plan.workspace.customNodesPath,
                     folderSync: legacy.folderSync ?? plan.workspace.folderSync,
                 }));
@@ -1862,7 +1878,7 @@ export class ConfigService {
         const rawInstanceTargets = rawTargets as unknown[];
         const rawEnvironments = raw.environments as unknown[];
         const environmentTargets = rawInstanceTargets.map((target, index) => this.sanitizeInstanceTarget(target, index));
-        const environments = rawEnvironments.map((environment, index) => this.sanitizeEnvironment(environment, index));
+        const environments = this.ensureEnvironmentSyncSlugs(rawEnvironments.map((environment, index) => this.sanitizeEnvironment(environment, index)));
         this.assertUniqueIds(environmentTargets, 'instance target');
         this.assertUniqueIdsAndNames(environments, 'environment');
         const targetIds = new Set(environmentTargets.map((target) => target.id));
@@ -1939,6 +1955,30 @@ export class ConfigService {
         }
     }
 
+    private ensureEnvironmentSyncSlugs(environments: IWorkspaceEnvironment[]): IWorkspaceEnvironment[] {
+        const usedSlugs = new Set<string>();
+        const normalized = environments.map((environment) => {
+            const syncSlug = environment.syncSlug
+                ? this.createEnvironmentSyncSlug(environment.syncSlug)
+                : undefined;
+            if (syncSlug) {
+                const key = syncSlug.toLowerCase();
+                if (usedSlugs.has(key)) {
+                    throw new Error(`Invalid v4 workspace config: duplicate environment sync slug "${syncSlug}".`);
+                }
+                usedSlugs.add(key);
+            }
+            return { ...environment, syncSlug };
+        });
+
+        return normalized.map((environment) => {
+            if (environment.syncSlug) return environment;
+            const syncSlug = this.uniqueEnvironmentSyncSlug(environment.name, [], usedSlugs);
+            usedSlugs.add(syncSlug.toLowerCase());
+            return { ...environment, syncSlug };
+        });
+    }
+
     private sanitizeEnvironment(environment: any, index: number): IWorkspaceEnvironment {
         if (!environment || typeof environment !== 'object') {
             throw new Error(`Invalid v4 workspace config: environment at index ${index} must be an object.`);
@@ -1953,6 +1993,8 @@ export class ConfigService {
         return stripUndefined({
             id,
             name,
+            syncSlug: cleanOptional(environment.syncSlug),
+            legacyWorkflowDir: cleanOptional(environment.legacyWorkflowDir),
             environmentTargetId,
             projectId: cleanOptional(environment.projectId),
             projectName: cleanOptional(environment.projectName),
@@ -1981,6 +2023,7 @@ export class ConfigService {
             ? [stripUndefined({
                 id: 'default',
                 name: 'Default',
+                syncSlug: this.createEnvironmentSyncSlug('Default'),
                 environmentTargetId: 'default-instance',
                 projectId: overrides.projectId,
                 projectName: overrides.projectName,
@@ -2084,10 +2127,13 @@ export class ConfigService {
                 instanceUserIdentifier: identity.instanceUserIdentifier,
                 workflowDir: this.buildEnvironmentWorkflowDir({
                     syncFolder,
+                    syncSlug: environment.syncSlug,
+                    legacyWorkflowDir: environment.legacyWorkflowDir,
                     environmentId: environment.id,
                     instanceIdentifier: identity.instanceIdentifier,
                     instanceUserIdentifier: identity.instanceUserIdentifier,
                     projectId,
+                    projectName,
                 }),
                 folderSync: environment.folderSync ?? false,
                 customNodesPath: environment.customNodesPath,
@@ -2128,10 +2174,13 @@ export class ConfigService {
             instanceUserIdentifier: identity.instanceUserIdentifier,
             workflowDir: this.buildEnvironmentWorkflowDir({
                 syncFolder,
+                syncSlug: environment.syncSlug,
+                legacyWorkflowDir: environment.legacyWorkflowDir,
                 environmentId: environment.id,
                 instanceIdentifier: identity.instanceIdentifier,
                 instanceUserIdentifier: identity.instanceUserIdentifier,
                 projectId: environment.projectId,
+                projectName: environment.projectName,
             }),
             folderSync: environment.folderSync ?? false,
             customNodesPath: environment.customNodesPath,
@@ -2346,6 +2395,21 @@ export class ConfigService {
         let counter = 2;
         while (existingIds.includes(`${base}-${counter}`)) counter += 1;
         return `${base}-${counter}`;
+    }
+
+    private uniqueEnvironmentSyncSlug(baseName: string, environments: Array<Pick<IWorkspaceEnvironment, 'syncSlug'>>, usedSlugs = new Set<string>()): string {
+        for (const environment of environments) {
+            if (environment.syncSlug) usedSlugs.add(this.createEnvironmentSyncSlug(environment.syncSlug).toLowerCase());
+        }
+        const base = this.createEnvironmentSyncSlug(baseName);
+        if (!usedSlugs.has(base.toLowerCase())) return base;
+        let counter = 2;
+        while (usedSlugs.has(`${base}-${counter}`.toLowerCase())) counter += 1;
+        return `${base}-${counter}`;
+    }
+
+    private createEnvironmentSyncSlug(value: string): string {
+        return this.slugId(value);
     }
 
     private uniqueDisplayName(baseName: string, existingNames: Set<string>): string {
@@ -2623,21 +2687,89 @@ export class ConfigService {
 
     private buildEnvironmentWorkflowDir(input: {
         syncFolder?: string;
+        syncSlug?: string;
+        legacyWorkflowDir?: string;
         environmentId?: string;
         instanceIdentifier?: string;
         instanceUserIdentifier?: string;
         projectId?: string;
+        projectName?: string;
     }): string | undefined {
-        if (!input.syncFolder || !input.environmentId || !input.instanceIdentifier || !input.instanceUserIdentifier || !input.projectId) {
-            return undefined;
+        if (input.syncFolder && input.syncSlug) {
+            const slugWorkflowDir = path.join(input.syncFolder, input.syncSlug);
+            const existingLegacyDir = this.findExistingLegacyWorkflowDir(input, slugWorkflowDir);
+            return existingLegacyDir || slugWorkflowDir;
         }
+        return this.buildLegacyEnvironmentWorkflowDir(input);
+    }
 
-        return path.join(input.syncFolder, createWorkflowDirNameV1({
+    private findExistingLegacyWorkflowDir(input: {
+        syncFolder?: string;
+        legacyWorkflowDir?: string;
+        environmentId?: string;
+        instanceIdentifier?: string;
+        instanceUserIdentifier?: string;
+        projectId?: string;
+        projectName?: string;
+    }, slugWorkflowDir: string): string | undefined {
+        if (fs.existsSync(slugWorkflowDir)) return undefined;
+        const configuredLegacyDir = input.legacyWorkflowDir
+            ? this.resolveWorkspacePath(input.legacyWorkflowDir)
+            : undefined;
+        if (configuredLegacyDir && fs.existsSync(configuredLegacyDir)) {
+            return configuredLegacyDir;
+        }
+        return this.getLegacyEnvironmentWorkflowDirs(input).find((directory) => fs.existsSync(directory));
+    }
+
+    private resolveEnvironmentLegacyWorkflowDir(environment: IWorkspaceEnvironment, target: IEnvironmentTarget): string | undefined {
+        const syncFolder = this.resolveWorkspacePath(environment.syncFolder);
+        const slugWorkflowDir = environment.syncSlug
+            ? path.join(syncFolder, environment.syncSlug)
+            : undefined;
+        const resolved = this.resolveEnvironmentFromTarget(environment, target, 'explicit');
+        const workflowDir = resolved.workflowDir;
+        if (!workflowDir || workflowDir === slugWorkflowDir || !fs.existsSync(workflowDir)) {
+            return environment.legacyWorkflowDir;
+        }
+        return path.isAbsolute(workflowDir)
+            ? path.relative(this.workspaceRoot, workflowDir)
+            : workflowDir;
+    }
+
+    private buildLegacyEnvironmentWorkflowDir(input: {
+        syncFolder?: string;
+        environmentId?: string;
+        instanceIdentifier?: string;
+        instanceUserIdentifier?: string;
+        projectId?: string;
+        projectName?: string;
+    }): string | undefined {
+        return this.getLegacyEnvironmentWorkflowDirs(input)[0];
+    }
+
+    private getLegacyEnvironmentWorkflowDirs(input: {
+        syncFolder?: string;
+        environmentId?: string;
+        instanceIdentifier?: string;
+        instanceUserIdentifier?: string;
+        projectId?: string;
+        projectName?: string;
+    }): string[] {
+        const dirs: string[] = [];
+        if (!input.syncFolder) return dirs;
+        if (input.environmentId && input.instanceIdentifier && input.instanceUserIdentifier && input.projectId) {
+            dirs.push(path.join(input.syncFolder, createWorkflowDirNameV1({
             environmentId: input.environmentId,
             instanceIdentifier: input.instanceIdentifier,
             instanceUserIdentifier: input.instanceUserIdentifier,
             projectId: input.projectId,
-        }));
+            })));
+        }
+        if (input.instanceIdentifier && input.projectName) {
+            dirs.push(path.join(input.syncFolder, input.instanceIdentifier, createProjectSlug(input.projectName)));
+        }
+        return [...new Set(dirs)];
     }
 
     private findConfigRoot(startDir: string): string {

--- a/packages/cli/tests/unit/config-service.test.ts
+++ b/packages/cli/tests/unit/config-service.test.ts
@@ -463,6 +463,7 @@ describe('ConfigService', () => {
                 id: 'legacy-prod',
                 name: 'Legacy Prod',
                 host: 'https://legacy.example.test',
+                workflowDir: 'legacy/custom-prod',
             }],
         }, null, 2));
 
@@ -480,7 +481,7 @@ describe('ConfigService', () => {
         expect((configService as any).manager.getInstance('global-external')).toBeUndefined();
         expect(persisted.version).toBe(4);
         expect(persisted.environments).toEqual(expect.arrayContaining([
-            expect.objectContaining({ id: 'default', name: 'Default' }),
+            expect.objectContaining({ id: 'default', name: 'Default', legacyWorkflowDir: 'legacy/custom-prod' }),
             expect.objectContaining({ id: 'global-external', name: 'Global External' }),
         ]));
     });
@@ -700,18 +701,13 @@ describe('ConfigService', () => {
         configService.pinEnvironment(environment.id);
 
         const resolved = configService.resolveEnvironment('Dev');
-        const expectedWorkflowDir = path.join(workspaceRoot, 'workflows', createWorkflowDirNameV1({
-            environmentId: environment.id,
-            instanceIdentifier: resolved.instanceIdentifier!,
-            instanceUserIdentifier: resolved.instanceUserIdentifier!,
-            projectId: 'personal',
-        }));
+        const expectedWorkflowDir = path.join(workspaceRoot, 'workflows', 'dev');
 
         expect(configService.getWorkspaceConfig()).toMatchObject({
             version: 4,
             activeEnvironmentId: environment.id,
             environmentTargets: expect.arrayContaining([expect.objectContaining({ id: target.id, name: 'Dev Target', kind: 'managed-instance', managedInstanceId: 'dev-instance' })]),
-            environments: expect.arrayContaining([expect.objectContaining({ id: environment.id, name: 'Dev', environmentTargetId: target.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows', workflowDir: expectedWorkflowDir })]),
+            environments: expect.arrayContaining([expect.objectContaining({ id: environment.id, name: 'Dev', syncSlug: 'dev', environmentTargetId: target.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows', workflowDir: expectedWorkflowDir })]),
         });
         expect(resolved).toMatchObject({
             environmentId: environment.id,
@@ -728,6 +724,130 @@ describe('ConfigService', () => {
         expect(resolved.workflowDir).not.toContain('Dev');
         expect(resolved.workflowDir).not.toContain('Personal');
         expect(resolved.workflowDir).not.toContain('n8n_1234567890');
+    });
+
+    it('keeps the environment sync directory stable when target, project, or display name changes', () => {
+        const configService = new ConfigService(workspaceRoot);
+        const firstTarget = configService.addInstanceTarget({ name: 'Dev Target', url: 'https://dev.example.test' });
+        const secondTarget = configService.addInstanceTarget({ name: 'Team Target', url: 'https://team.example.test' });
+        const environment = configService.addEnvironment({
+            name: 'Customer Dev',
+            environmentTarget: firstTarget.id,
+            projectId: 'personal',
+            projectName: 'Personal',
+            syncFolder: 'workflows',
+        });
+
+        const originalWorkflowDir = configService.resolveEnvironment(environment.id).workflowDir;
+        expect(originalWorkflowDir).toBe(path.join(workspaceRoot, 'workflows', 'customer-dev'));
+
+        configService.updateEnvironment(environment.id, {
+            name: 'Renamed Customer Dev',
+            environmentTarget: secondTarget.id,
+            projectId: 'team',
+            projectName: 'Team',
+        });
+
+        const resolved = configService.resolveEnvironment(environment.id);
+        expect(resolved.workflowDir).toBe(originalWorkflowDir);
+        expect(resolved.environment.syncSlug).toBe('customer-dev');
+        expect(resolved.environmentName).toBe('Renamed Customer Dev');
+        expect(resolved.environmentTargetId).toBe(secondTarget.id);
+        expect(resolved.projectId).toBe('team');
+    });
+
+    it('uses an existing legacy v4 workflow directory when a slugged replacement has not been created yet', () => {
+        const legacyDirName = createWorkflowDirNameV1({
+            environmentId: 'dev',
+            instanceIdentifier: 'inst_1234567890',
+            instanceUserIdentifier: 'user_abcdef1234',
+            projectId: 'personal',
+        });
+        const legacyWorkflowDir = path.join(workspaceRoot, 'workflows', legacyDirName);
+        mkdirSync(legacyWorkflowDir, { recursive: true });
+        writeFileSync(path.join(workspaceRoot, 'n8nac-config.json'), JSON.stringify({
+            version: 4,
+            activeEnvironmentId: 'dev',
+            environmentTargets: [{
+                id: 'target',
+                name: 'Target',
+                kind: 'external-instance',
+                url: 'https://target.example.test',
+                instanceIdentifier: 'inst_1234567890',
+                instanceUserIdentifier: 'user_abcdef1234',
+            }, {
+                id: 'target-2',
+                name: 'Target 2',
+                kind: 'external-instance',
+                url: 'https://target-2.example.test',
+                instanceIdentifier: 'inst_2222222222',
+                instanceUserIdentifier: 'user_2222222222',
+            }],
+            environments: [{
+                id: 'dev',
+                name: 'Dev',
+                environmentTargetId: 'target',
+                projectId: 'personal',
+                projectName: 'Personal',
+                syncFolder: 'workflows',
+            }],
+        }));
+
+        const configService = new ConfigService(workspaceRoot);
+        const resolved = configService.resolveEnvironment('Dev');
+        expect(resolved.environment.syncSlug).toBe('dev');
+        expect(resolved.workflowDir).toBe(legacyWorkflowDir);
+
+        configService.updateEnvironment('Dev', {
+            environmentTarget: 'target-2',
+            projectId: 'team',
+            projectName: 'Team',
+        });
+        const retargeted = configService.resolveEnvironment('Dev');
+        expect(retargeted.workflowDir).toBe(legacyWorkflowDir);
+        expect(retargeted.environment.legacyWorkflowDir).toBe(path.relative(workspaceRoot, legacyWorkflowDir));
+
+        const slugWorkflowDir = path.join(workspaceRoot, 'workflows', 'dev');
+        mkdirSync(slugWorkflowDir, { recursive: true });
+        expect(new ConfigService(workspaceRoot).resolveEnvironment('Dev').workflowDir).toBe(slugWorkflowDir);
+    });
+
+    it('clears a preserved legacy workflow directory when the sync root changes', () => {
+        const legacyDirName = createWorkflowDirNameV1({
+            environmentId: 'dev',
+            instanceIdentifier: 'inst_1234567890',
+            instanceUserIdentifier: 'user_abcdef1234',
+            projectId: 'personal',
+        });
+        const legacyWorkflowDir = path.join(workspaceRoot, 'workflows', legacyDirName);
+        mkdirSync(legacyWorkflowDir, { recursive: true });
+        writeFileSync(path.join(workspaceRoot, 'n8nac-config.json'), JSON.stringify({
+            version: 4,
+            activeEnvironmentId: 'dev',
+            environmentTargets: [{
+                id: 'target',
+                name: 'Target',
+                kind: 'external-instance',
+                url: 'https://target.example.test',
+                instanceIdentifier: 'inst_1234567890',
+                instanceUserIdentifier: 'user_abcdef1234',
+            }],
+            environments: [{
+                id: 'dev',
+                name: 'Dev',
+                environmentTargetId: 'target',
+                projectId: 'personal',
+                projectName: 'Personal',
+                syncFolder: 'workflows',
+            }],
+        }));
+
+        const configService = new ConfigService(workspaceRoot);
+        configService.updateEnvironment('Dev', { syncFolder: 'other-workflows' });
+
+        const resolved = configService.resolveEnvironment('Dev');
+        expect(resolved.workflowDir).toBe(path.join(workspaceRoot, 'other-workflows', 'dev'));
+        expect(resolved.environment.legacyWorkflowDir).toBeUndefined();
     });
 
     it('reuses managed instance targets and avoids generated name collisions with connected targets', () => {
@@ -1049,6 +1169,30 @@ describe('ConfigService', () => {
         expect(configService.updateEnvironment('Prod', {
             syncFolder: 'workflows/shared',
         }).syncFolder).toBe('workflows/shared');
+    });
+
+    it('backfills missing sync slugs without colliding with later explicit slugs', () => {
+        writeFileSync(path.join(workspaceRoot, 'n8nac-config.json'), JSON.stringify({
+            version: 4,
+            environmentTargets: [{ id: 'target', name: 'Target', kind: 'external-instance', url: 'https://target.example.test' }],
+            environments: [{
+                id: 'dev',
+                name: 'Dev',
+                environmentTargetId: 'target',
+                syncFolder: 'workflows',
+            }, {
+                id: 'prod',
+                name: 'Prod',
+                syncSlug: 'dev',
+                environmentTargetId: 'target',
+                syncFolder: 'workflows',
+            }],
+        }));
+
+        expect(new ConfigService(workspaceRoot).getWorkspaceConfig().environments).toEqual(expect.arrayContaining([
+            expect.objectContaining({ id: 'dev', syncSlug: 'dev-2' }),
+            expect.objectContaining({ id: 'prod', syncSlug: 'dev' }),
+        ]));
     });
 
     it('rejects clearing required environment sync folder on update', () => {


### PR DESCRIPTION
## Summary

- add a persistent `syncSlug` to workspace environments and use it as the workflow sync subdirectory
- keep the slug stable when the environment display name, target instance, or target project changes
- preserve compatibility by resolving to an existing legacy workflow directory until the slug directory exists
- document the new config field and migration behavior

Closes #466

## Validation

- `npm run test:unit --workspace=n8nac -- tests/unit/config-service.test.ts`
- `npm run build --workspace=n8nac`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-environment syncSlug and a base workflows directory (e.g., workflows/<syncSlug>) to keep workflow paths stable.

* **Bug Fixes**
  * Resolution prefers stable slugged directories, falls back to legacy directories until slugs exist, preserves existing workflows, and clears legacy dirs when sync root changes.

* **Documentation**
  * CLI docs updated with examples and notes about syncSlug behavior and legacy handling.

* **Tests**
  * Added tests for slug stability, legacy-directory fallback, backfilling missing slugs, and related resolutions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->