### PR TITLE
Native environment promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Then sync workflows explicitly:
 npx --yes n8nac list
 npx --yes n8nac pull <workflow-id>
 npx --yes n8nac push workflows/dev/my-workflow.workflow.ts --verify
+npx --yes n8nac promote --from Dev --to Prod --dry-run
 ```
 
 [CLI guide](https://n8nascode.dev/docs/usage/cli/) · [n8n-manager guide](https://n8nascode.dev/docs/usage/n8n-manager/)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ npx --yes n8nac push workflows/dev/my-workflow.workflow.ts --verify
 npx --yes n8nac promote --from Dev --to Prod --dry-run
 ```
 
-Use `promote` to move workflow source from one environment sync folder to another. Pass a workflow path for a single workflow, or omit it to promote every `*.workflow.ts` file in the source environment, including nested folders. Promotion rewrites target project metadata, remaps credentials and supported Execute Workflow references, records stable source-to-target bindings in `n8nac-promotion.json`, and pushes by default unless `--no-push` is set. `--dry-run` performs discovery for an accurate create/update plan, but does not write files, push, or update the promotion config.
+Use `promote` to move workflow source from one environment `workflowsPath` to another. Pass a workflow path for a single workflow, or omit it to promote every `*.workflow.ts` file in the source environment, including nested folders. Promotion rewrites target project metadata, remaps credentials and supported Execute Workflow references, records stable source-to-target bindings in `n8nac-promotion.json`, and pushes by default unless `--no-push` is set. `--dry-run` performs discovery for an accurate create/update plan, but does not write files, push, or update the promotion config.
 
 [CLI guide](https://n8nascode.dev/docs/usage/cli/) · [n8n-manager guide](https://n8nascode.dev/docs/usage/n8n-manager/)
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ npx --yes n8nac push workflows/dev/my-workflow.workflow.ts --verify
 npx --yes n8nac promote --from Dev --to Prod --dry-run
 ```
 
+Use `promote` to move workflow source from one environment sync folder to another. Pass a workflow path for a single workflow, or omit it to promote every `*.workflow.ts` file in the source environment, including nested folders. Promotion rewrites target project metadata, remaps credentials and supported Execute Workflow references, records stable source-to-target bindings in `n8nac-promotion.json`, and pushes by default unless `--no-push` is set. `--dry-run` performs discovery for an accurate create/update plan, but does not write files, push, or update the promotion config.
+
 [CLI guide](https://n8nascode.dev/docs/usage/cli/) · [n8n-manager guide](https://n8nascode.dev/docs/usage/n8n-manager/)
 
 ## Command Groups

--- a/docs/docs/usage/cli.md
+++ b/docs/docs/usage/cli.md
@@ -169,6 +169,18 @@ n8nac push workflows/dev/my-workflow.workflow.ts --verify
 
 Push uploads one local workflow and uses optimistic concurrency checks.
 
+### `promote`
+
+```bash
+n8nac promote workflows/dev/my-workflow.workflow.ts --from Dev --to Prod --dry-run
+n8nac promote workflows/dev/my-workflow.workflow.ts --from Dev --to Prod
+n8nac promote --from Dev --to Prod --dry-run
+```
+
+Promote copies workflows from one workspace environment to another, remaps target workflow metadata, credential IDs, and supported Execute Workflow references, then pushes to the target environment unless `--no-push` is used.
+
+Promotion stores discovered source-to-target bindings in `n8nac-promotion.json`. Existing bindings are reused first, target names are used for initial discovery, and missing or ambiguous references block the promotion before push.
+
 ### `resolve`
 
 ```bash

--- a/docs/docs/usage/cli.md
+++ b/docs/docs/usage/cli.md
@@ -175,11 +175,89 @@ Push uploads one local workflow and uses optimistic concurrency checks.
 n8nac promote workflows/dev/my-workflow.workflow.ts --from Dev --to Prod --dry-run
 n8nac promote workflows/dev/my-workflow.workflow.ts --from Dev --to Prod
 n8nac promote --from Dev --to Prod --dry-run
+n8nac promote --from Dev --to Prod --no-push
+n8nac promote --from Dev --to Prod --promotion-config config/promotion.json --json
 ```
 
-Promote copies workflows from one workspace environment to another, remaps target workflow metadata, credential IDs, and supported Execute Workflow references, then pushes to the target environment unless `--no-push` is used.
+Promote copies TypeScript workflows from one workspace environment to another, adapts them for the target environment, and pushes them to n8n unless `--no-push` is used.
 
-Promotion stores discovered source-to-target bindings in `n8nac-promotion.json`. Existing bindings are reused first, target names are used for initial discovery, and missing or ambiguous references block the promotion before push.
+The positional path is optional:
+
+- With a path, `promote` handles one `*.workflow.ts` file inside the source environment sync folder.
+- Without a path, `promote` recursively finds all non-hidden `*.workflow.ts` files in the source environment sync folder and preserves their relative paths in the target environment.
+
+Promotion adapts workflows before writing or pushing:
+
+- target project metadata is rewritten to the target environment project
+- source workflow IDs and archived/home-project metadata are removed for new target workflows
+- known target workflow IDs are reused for updates
+- credential references are remapped by saved binding, explicit override, or unique target credential match by type and name
+- supported Execute Workflow references are remapped by saved binding, source workflow relation, explicit override, or unique target workflow name match
+
+Promotion stores discovered source-to-target bindings in `n8nac-promotion.json` by default. Existing bindings are reused first, target inventory discovery is used for initial create/update planning, and missing or ambiguous references block promotion before push.
+
+Options:
+
+| Option | Effect |
+|---|---|
+| `--from <environment>` | Source environment name or ID |
+| `--to <environment>` | Target environment name or ID |
+| `--dry-run` | Show the planned promotion without writing workflow files, pushing, or saving bindings |
+| `--no-push` | Write adapted files to the target sync folder without pushing them to n8n |
+| `--overwrite` | Replace an existing local target file when no target workflow ID is known |
+| `--promotion-config <path>` | Read and write promotion bindings from a custom config path |
+| `--json` | Print the promotion result as JSON |
+
+`--dry-run` still reads the target workflow inventory so the plan can report `create` vs `update` accurately. It does not write local workflow files, call push, or update `n8nac-promotion.json`.
+
+The promotion config has a stable v1 shape:
+
+```json
+{
+  "version": 1,
+  "routes": {
+    "Dev->Prod": {
+      "bindings": {
+        "workflows": {
+          "source-workflow-id": "target-workflow-id"
+        },
+        "credentials": {
+          "source-credential-id": "target-credential-id"
+        }
+      },
+      "workflowOverrides": {},
+      "credentialOverrides": {},
+      "nameRules": []
+    }
+  }
+}
+```
+
+Use overrides when a target name is ambiguous or intentionally different:
+
+```json
+{
+  "version": 1,
+  "routes": {
+    "Dev->Prod": {
+      "workflowOverrides": {
+        "source-workflow-id": { "targetId": "prod-workflow-id" },
+        "Source Workflow Name": { "targetName": "Production Workflow Name" }
+      },
+      "credentialOverrides": {
+        "httpBasicAuth::source-credential-id": { "targetId": "prod-credential-id" },
+        "httpBasicAuth::Shared Credential": { "targetName": "Production Credential" }
+      },
+      "nameRules": [
+        { "kind": "workflow", "from": " Dev$", "to": " Prod" },
+        { "kind": "credential", "from": " Dev$", "to": " Prod" }
+      ]
+    }
+  }
+}
+```
+
+Promotion does not create credentials in the target environment. Create or map target credentials first, or use `n8nac credentials ...` helpers. After a pushed single-workflow promotion, the CLI prints a `workflow credential-required` command so you can check target credential readiness.
 
 ### `resolve`
 

--- a/docs/docs/usage/cli.md
+++ b/docs/docs/usage/cli.md
@@ -183,8 +183,8 @@ Promote copies TypeScript workflows from one workspace environment to another, a
 
 The positional path is optional:
 
-- With a path, `promote` handles one `*.workflow.ts` file inside the source environment sync folder.
-- Without a path, `promote` recursively finds all non-hidden `*.workflow.ts` files in the source environment sync folder and preserves their relative paths in the target environment.
+- With a path, `promote` handles one `*.workflow.ts` file inside the source environment `workflowsPath`.
+- Without a path, `promote` recursively finds all non-hidden `*.workflow.ts` files in the source environment `workflowsPath` and preserves their relative paths in the target environment.
 
 Promotion adapts workflows before writing or pushing:
 
@@ -203,7 +203,7 @@ Options:
 | `--from <environment>` | Source environment name or ID |
 | `--to <environment>` | Target environment name or ID |
 | `--dry-run` | Show the planned promotion without writing workflow files, pushing, or saving bindings |
-| `--no-push` | Write adapted files to the target sync folder without pushing them to n8n |
+| `--no-push` | Write adapted files to the target `workflowsPath` without pushing them to n8n |
 | `--overwrite` | Replace an existing local target file when no target workflow ID is known |
 | `--promotion-config <path>` | Read and write promotion bindings from a custom config path |
 | `--json` | Print the promotion result as JSON |

--- a/docs/docs/usage/commands.md
+++ b/docs/docs/usage/commands.md
@@ -75,6 +75,7 @@ After an environment exists, normal workflow operations stay in `n8nac`:
 n8nac list
 n8nac pull <workflow-id>
 n8nac push <path-to-workflow.workflow.ts> --verify
+n8nac promote --from Dev --to Prod --dry-run
 n8nac resolve <workflow-id> --mode keep-current
 n8nac resolve <workflow-id> --mode keep-incoming
 ```

--- a/docs/docs/usage/commands.md
+++ b/docs/docs/usage/commands.md
@@ -75,10 +75,13 @@ After an environment exists, normal workflow operations stay in `n8nac`:
 n8nac list
 n8nac pull <workflow-id>
 n8nac push <path-to-workflow.workflow.ts> --verify
+n8nac promote <path-to-workflow.workflow.ts> --from Dev --to Prod
 n8nac promote --from Dev --to Prod --dry-run
 n8nac resolve <workflow-id> --mode keep-current
 n8nac resolve <workflow-id> --mode keep-incoming
 ```
+
+Use `promote` to move workflow source between workspace environments. The path is optional: pass one workflow file for a targeted promotion, or omit it to recursively promote every `*.workflow.ts` file in the source environment sync folder. Promotion remaps target project metadata, credentials, and supported Execute Workflow references, saves stable bindings in `n8nac-promotion.json`, and pushes by default unless `--no-push` is used.
 
 ## AI Context And Skills
 

--- a/docs/docs/usage/commands.md
+++ b/docs/docs/usage/commands.md
@@ -81,7 +81,7 @@ n8nac resolve <workflow-id> --mode keep-current
 n8nac resolve <workflow-id> --mode keep-incoming
 ```
 
-Use `promote` to move workflow source between workspace environments. The path is optional: pass one workflow file for a targeted promotion, or omit it to recursively promote every `*.workflow.ts` file in the source environment sync folder. Promotion remaps target project metadata, credentials, and supported Execute Workflow references, saves stable bindings in `n8nac-promotion.json`, and pushes by default unless `--no-push` is used.
+Use `promote` to move workflow source between workspace environments. The path is optional: pass one workflow file for a targeted promotion, or omit it to recursively promote every `*.workflow.ts` file in the source environment `workflowsPath`. Promotion remaps target project metadata, credentials, and supported Execute Workflow references, saves stable bindings in `n8nac-promotion.json`, and pushes by default unless `--no-push` is used.
 
 ## AI Context And Skills
 

--- a/docs/docs/usage/index.md
+++ b/docs/docs/usage/index.md
@@ -36,6 +36,7 @@ n8nac env use Dev
 n8nac list
 n8nac pull <workflow-id>
 n8nac push workflows/dev/my-workflow.workflow.ts --verify
+n8nac promote --from Dev --to Prod --dry-run
 ```
 
 [CLI Guide](/docs/usage/cli)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -109,7 +109,7 @@ n8nac promote --from Dev --to Prod --dry-run
 n8nac promote --from Dev --to Prod --no-push
 ```
 
-`promote` copies TypeScript workflows from one workspace environment to another. When a path is provided, it promotes that single workflow. When the path is omitted, it recursively promotes all `*.workflow.ts` files in the source environment sync folder and preserves their relative paths in the target environment.
+`promote` copies TypeScript workflows from one workspace environment to another. When a path is provided, it promotes that single workflow. When the path is omitted, it recursively promotes all `*.workflow.ts` files in the source environment `workflowsPath` and preserves their relative paths in the target environment.
 
 During promotion, `n8nac` rewrites target project metadata, strips source workflow identity for new target workflows, reuses known target workflow IDs for updates, remaps credential IDs by binding, override, or target inventory lookup, and remaps supported Execute Workflow references.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -93,11 +93,39 @@ Dry-run with `--json` first, then apply with `--write` after reviewing the unifi
 n8nac list
 n8nac pull <workflow-id>
 n8nac push workflows/dev/my-workflow.workflow.ts --verify
+n8nac promote workflows/dev/my-workflow.workflow.ts --from Dev --to Prod --dry-run
+n8nac promote --from Dev --to Prod --dry-run
 n8nac resolve <workflow-id> --mode keep-current
 n8nac resolve <workflow-id> --mode keep-incoming
 ```
 
 Sync is Git-like and explicit. `pull` and `push` block on conflicts instead of silently overwriting work.
+
+### Promote Between Environments
+
+```bash
+n8nac promote workflows/dev/my-workflow.workflow.ts --from Dev --to Prod
+n8nac promote --from Dev --to Prod --dry-run
+n8nac promote --from Dev --to Prod --no-push
+```
+
+`promote` copies TypeScript workflows from one workspace environment to another. When a path is provided, it promotes that single workflow. When the path is omitted, it recursively promotes all `*.workflow.ts` files in the source environment sync folder and preserves their relative paths in the target environment.
+
+During promotion, `n8nac` rewrites target project metadata, strips source workflow identity for new target workflows, reuses known target workflow IDs for updates, remaps credential IDs by binding, override, or target inventory lookup, and remaps supported Execute Workflow references.
+
+Promotion stores stable source-to-target workflow and credential bindings in `n8nac-promotion.json` by default. Use `--promotion-config <path>` to choose a different file. `--dry-run` inspects the target environment so the plan can report create vs update accurately, but it does not write workflow files, push to n8n, or update the promotion config.
+
+Useful flags:
+
+| Flag | Effect |
+|---|---|
+| `--dry-run` | Show the planned promotion without writing files, pushing, or saving bindings |
+| `--no-push` | Write adapted target files locally without pushing them to n8n |
+| `--overwrite` | Allow replacing an existing local target file when no target workflow ID is known |
+| `--promotion-config <path>` | Read and write promotion bindings from a custom config path |
+| `--json` | Print the promotion result as JSON |
+
+Missing or ambiguous credentials and workflow references block promotion before push. After a pushed single-workflow promotion, the CLI prints a `workflow credential-required` command to check target credential readiness.
 
 ## Workflow Helpers
 

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -145,6 +145,9 @@ export class PromoteCommand {
     ) {}
 
     async run(sourceWorkflowPath: string | undefined, options: PromoteOptions): Promise<PromoteResult> {
+        this.targetWorkflowInventory = undefined;
+        this.targetCredentialInventory = undefined;
+
         const source = await this.configService.prepareEnvironment(options.from);
         const target = await this.configService.prepareEnvironment(options.to);
         if (source.environmentId === target.environmentId) {
@@ -257,10 +260,16 @@ export class PromoteCommand {
         if (!fs.existsSync(sourceRoot)) {
             throw new Error(`Source environment sync scope does not exist: ${sourceRoot}`);
         }
-        return fs.readdirSync(sourceRoot)
-            .filter((filename) => filename.endsWith('.workflow.ts') && !filename.startsWith('.'))
-            .sort()
-            .map((filename) => path.join(sourceRoot, filename));
+
+        const walk = (directory: string): string[] => fs.readdirSync(directory, { withFileTypes: true })
+            .flatMap((entry) => {
+                if (entry.name.startsWith('.')) return [];
+                const entryPath = path.join(directory, entry.name);
+                if (entry.isDirectory()) return walk(entryPath);
+                return entry.name.endsWith('.workflow.ts') ? [entryPath] : [];
+            });
+
+        return walk(sourceRoot).sort();
     }
 
     private initializeTargetActions(sources: PromotionSourceWorkflow[], route: PromotionRouteConfig): void {
@@ -280,9 +289,7 @@ export class PromoteCommand {
         indexes: PromotionIndexes,
         options: PromoteOptions,
     ): Promise<void> {
-        const shouldDiscover = !options.dryRun;
-        if (!shouldDiscover) return;
-
+        const shouldPersistBindings = !options.dryRun;
         const workflows = await this.getTargetWorkflows(target);
         indexes.targetWorkflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
         indexes.targetWorkflowsByName = groupWorkflowsByName(workflows);
@@ -294,7 +301,7 @@ export class PromoteCommand {
             if (targetWorkflow) {
                 item.targetWorkflowId = targetWorkflow.id;
                 item.action = 'update';
-                route.bindings!.workflows![item.sourceKey] = targetWorkflow.id;
+                if (shouldPersistBindings) route.bindings!.workflows![item.sourceKey] = targetWorkflow.id;
                 continue;
             }
 
@@ -303,7 +310,7 @@ export class PromoteCommand {
             if (matches.length === 1) {
                 item.targetWorkflowId = matches[0].id;
                 item.action = 'update';
-                route.bindings!.workflows![item.sourceKey] = matches[0].id;
+                if (shouldPersistBindings) route.bindings!.workflows![item.sourceKey] = matches[0].id;
             }
         }
     }

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -195,9 +195,7 @@ export class PromoteCommand {
             this.printResult(result, options);
             throw new Error(`Promotion blocked by ${applyProblems.length} problem${applyProblems.length === 1 ? '' : 's'}.`);
         }
-        if (!options.dryRun) {
-            this.savePromotionConfig(configPath, config);
-        }
+        this.savePromotionConfig(configPath, config);
         const result = this.buildResult(source, target, routeKey, configPath, applied, options);
         this.printResult(result, options);
         return result;
@@ -769,7 +767,11 @@ export class PromoteCommand {
         let next = value;
         for (const rule of route.nameRules ?? []) {
             if (rule.kind && rule.kind !== kind) continue;
-            next = next.replace(new RegExp(rule.from), rule.to);
+            try {
+                next = next.replace(new RegExp(rule.from), rule.to);
+            } catch {
+                throw new Error(`Invalid ${rule.kind || 'promotion'} nameRule pattern "${rule.from}" for ${kind} promotion.`);
+            }
         }
         return next;
     }

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -1,7 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
+import { TypeScriptParser, WorkflowBuilder } from '@n8n-as-code/transformer';
 import { ConfigService, type IResolvedWorkspaceEnvironment } from '../services/config-service.js';
+import { N8nApiClient, type IWorkflow } from '../core/index.js';
+import { WorkflowTransformerAdapter } from '../core/services/workflow-transformer-adapter.js';
 import { SyncCommand } from './sync.js';
 
 export interface PromoteOptions {
@@ -11,6 +14,37 @@ export interface PromoteOptions {
     push?: boolean;
     overwrite?: boolean;
     json?: boolean;
+    promotionConfig?: string;
+}
+
+export interface PromotionSubstitution {
+    kind: 'credential' | 'workflow' | 'metadata';
+    nodeName?: string;
+    field?: string;
+    fromId?: string;
+    fromName?: string;
+    toId?: string;
+    toName?: string;
+    status: 'mapped' | 'pending-create' | 'unchanged';
+}
+
+export interface PromotionProblem {
+    kind: 'credential' | 'workflow' | 'target-file';
+    message: string;
+    nodeName?: string;
+    ref?: string;
+}
+
+export interface PromotionWorkflowResult {
+    sourcePath: string;
+    targetPath: string;
+    sourceWorkflowId?: string;
+    sourceWorkflowName: string;
+    targetWorkflowId?: string;
+    action: 'create' | 'update';
+    status: 'planned' | 'written' | 'pushed' | 'blocked';
+    substitutions: PromotionSubstitution[];
+    problems: PromotionProblem[];
 }
 
 export interface PromoteResult {
@@ -24,12 +58,93 @@ export interface PromoteResult {
     workflowId?: string;
     credentialCheckCommand?: string;
     dryRun: boolean;
+    routeKey: string;
+    configPath: string;
+    summary: {
+        planned: number;
+        created: number;
+        updated: number;
+        blocked: number;
+        credentialMappings: number;
+        workflowMappings: number;
+    };
+    workflows: PromotionWorkflowResult[];
 }
 
-export class PromoteCommand {
-    constructor(private readonly configService = new ConfigService()) {}
+export interface PromotionCommandDependencies {
+    createClient?: (environment: IResolvedWorkspaceEnvironment) => PromotionRuntimeClient;
+    pushWorkflow?: (targetEnvironment: IResolvedWorkspaceEnvironment, targetPath: string) => Promise<string | undefined>;
+}
 
-    async run(sourceWorkflowPath: string, options: PromoteOptions): Promise<PromoteResult> {
+export interface PromotionRuntimeClient {
+    getAllWorkflows(projectId?: string): Promise<IWorkflow[]>;
+    listCredentials(): Promise<Array<Record<string, unknown>>>;
+}
+
+interface PromotionConfig {
+    version: 1;
+    routes: Record<string, PromotionRouteConfig>;
+}
+
+interface PromotionRouteConfig {
+    bindings?: {
+        workflows?: Record<string, string>;
+        credentials?: Record<string, string>;
+    };
+    workflowOverrides?: Record<string, PromotionOverride>;
+    credentialOverrides?: Record<string, PromotionOverride>;
+    nameRules?: PromotionNameRule[];
+}
+
+interface PromotionOverride {
+    targetId?: string;
+    targetName?: string;
+}
+
+interface PromotionNameRule {
+    kind?: 'credential' | 'workflow';
+    from: string;
+    to: string;
+}
+
+interface PromotionSourceWorkflow {
+    sourcePath: string;
+    targetPath: string;
+    workflow: IWorkflow;
+    sourceKey: string;
+    targetExists: boolean;
+    targetWorkflowId?: string;
+    action: 'create' | 'update';
+}
+
+interface PromotionIndexes {
+    sourceById: Map<string, PromotionSourceWorkflow>;
+    sourceByName: Map<string, PromotionSourceWorkflow[]>;
+    targetWorkflowsById?: Map<string, IWorkflow>;
+    targetWorkflowsByName?: Map<string, IWorkflow[]>;
+    targetCredentialsById?: Map<string, Record<string, unknown>>;
+    targetCredentialsByKey?: Map<string, Array<Record<string, unknown>>>;
+}
+
+interface WorkflowTransformResult {
+    workflow: IWorkflow;
+    substitutions: PromotionSubstitution[];
+    problems: PromotionProblem[];
+    pendingWorkflowSourceKeys: string[];
+}
+
+const EXECUTE_WORKFLOW_TYPE_SUFFIX = 'executeworkflow';
+
+export class PromoteCommand {
+    private targetWorkflowInventory?: Promise<IWorkflow[]>;
+    private targetCredentialInventory?: Promise<Array<Record<string, unknown>>>;
+
+    constructor(
+        private readonly configService = new ConfigService(),
+        private readonly dependencies: PromotionCommandDependencies = {},
+    ) {}
+
+    async run(sourceWorkflowPath: string | undefined, options: PromoteOptions): Promise<PromoteResult> {
         const source = await this.configService.prepareEnvironment(options.from);
         const target = await this.configService.prepareEnvironment(options.to);
         if (source.environmentId === target.environmentId) {
@@ -38,82 +153,533 @@ export class PromoteCommand {
 
         const sourceRoot = this.getEnvironmentWorkflowRoot(source);
         const targetRoot = this.getEnvironmentWorkflowRoot(target);
-        const sourcePath = path.resolve(sourceWorkflowPath);
-        if (!fs.existsSync(sourcePath)) {
-            throw new Error(`Source workflow not found: ${sourcePath}`);
-        }
-        const sourceRootRealPath = this.realpathExisting(sourceRoot);
-        const sourceRealPath = this.realpathExisting(sourcePath);
-        if (!this.isPathInside(sourceRealPath, sourceRootRealPath)) {
-            throw new Error(`Source workflow must be inside the source environment sync scope: ${sourceRoot}`);
-        }
-        if (!sourcePath.endsWith('.workflow.ts')) {
-            throw new Error('Promotion currently supports TypeScript workflow files (*.workflow.ts).');
+        const configPath = this.resolvePromotionConfigPath(options.promotionConfig);
+        const config = this.loadPromotionConfig(configPath);
+        const routeKey = `${source.environmentName}->${target.environmentName}`;
+        const route = this.ensureRoute(config, routeKey);
+
+        const sources = await this.loadSourceWorkflows(sourceWorkflowPath, sourceRoot, targetRoot);
+        this.initializeTargetActions(sources, route);
+
+        const indexes: PromotionIndexes = {
+            sourceById: new Map(),
+            sourceByName: new Map(),
+        };
+        for (const item of sources) {
+            if (item.workflow.id) indexes.sourceById.set(item.workflow.id, item);
+            const byName = indexes.sourceByName.get(item.workflow.name) ?? [];
+            byName.push(item);
+            indexes.sourceByName.set(item.workflow.name, byName);
         }
 
-        const relativePath = path.relative(sourceRoot, sourcePath);
-        const targetPath = path.resolve(targetRoot, relativePath);
-        if (!this.isPathInside(targetPath, targetRoot)) {
-            throw new Error('Resolved target path escapes the target environment sync scope.');
+        await this.discoverTargetWorkflowIds(sources, target, route, indexes, options);
+
+        const planned = await this.planWorkflows(sources, target, route, indexes);
+        const blockingProblems = planned.flatMap((workflow) => workflow.problems);
+        if (blockingProblems.length > 0) {
+            const result = this.buildResult(source, target, routeKey, configPath, planned, options);
+            this.printResult(result, options);
+            throw new Error(`Promotion blocked by ${blockingProblems.length} problem${blockingProblems.length === 1 ? '' : 's'}.`);
         }
-        const targetRootRealPath = fs.existsSync(targetRoot) ? this.realpathExisting(targetRoot) : path.resolve(targetRoot);
-        const targetParentRealPath = this.realpathExistingParent(path.dirname(targetPath));
-        if (fs.existsSync(targetRoot) && targetParentRealPath && !this.isPathInside(targetParentRealPath, targetRootRealPath)) {
-            throw new Error('Resolved target path escapes the target environment sync scope.');
-        }
-        const targetExists = fs.existsSync(targetPath);
-        if (targetExists && !this.isPathInside(this.realpathExisting(targetPath), targetRootRealPath)) {
-            throw new Error('Resolved target path escapes the target environment sync scope.');
-        }
-        if (targetExists && !options.overwrite && !options.dryRun) {
-            throw new Error(`Target workflow already exists: ${targetPath}. Re-run with --overwrite to replace it.`);
-        }
-        const targetWorkflowId = targetExists ? readWorkflowDecoratorProperty(fs.readFileSync(targetPath, 'utf8'), 'id') : undefined;
-        const adapted = adaptWorkflowForPromotion(fs.readFileSync(sourcePath, 'utf8'), {
-            targetWorkflowId,
-            targetProjectId: target.projectId,
-            targetProjectName: target.projectName,
-        });
-        const result: PromoteResult = {
-            sourceEnvironmentId: source.environmentId,
-            sourceEnvironmentName: source.environmentName,
-            targetEnvironmentId: target.environmentId,
-            targetEnvironmentName: target.environmentName,
-            sourcePath,
-            targetPath,
-            pushed: false,
-            dryRun: Boolean(options.dryRun),
-        };
 
         if (options.dryRun) {
+            const result = this.buildResult(source, target, routeKey, configPath, planned, options);
             this.printResult(result, options);
             return result;
         }
 
-        fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-        fs.writeFileSync(targetPath, adapted, 'utf8');
+        const applied = await this.applyPromotion(sources, target, route, indexes, options);
+        const applyProblems = applied.flatMap((workflow) => workflow.problems);
+        if (applyProblems.length > 0) {
+            const result = this.buildResult(source, target, routeKey, configPath, applied, options);
+            this.printResult(result, options);
+            throw new Error(`Promotion blocked by ${applyProblems.length} problem${applyProblems.length === 1 ? '' : 's'}.`);
+        }
+        if (!options.dryRun) {
+            this.savePromotionConfig(configPath, config);
+        }
+        const result = this.buildResult(source, target, routeKey, configPath, applied, options);
+        this.printResult(result, options);
+        return result;
+    }
 
-        if (options.push !== false) {
-            const previousEnvironment = process.env.N8NAC_ENVIRONMENT;
-            try {
-                process.env.N8NAC_ENVIRONMENT = target.environmentId;
-                const workflowId = await new SyncCommand().pushOne(targetPath);
-                result.workflowId = workflowId;
-                result.pushed = Boolean(workflowId);
-                result.credentialCheckCommand = workflowId
-                    ? `n8nac --env ${quoteShellArg(target.environmentName)} workflow credential-required ${quoteShellArg(workflowId)}`
-                    : undefined;
-            } finally {
-                if (previousEnvironment === undefined) {
-                    delete process.env.N8NAC_ENVIRONMENT;
-                } else {
-                    process.env.N8NAC_ENVIRONMENT = previousEnvironment;
+    private async loadSourceWorkflows(sourceWorkflowPath: string | undefined, sourceRoot: string, targetRoot: string): Promise<PromotionSourceWorkflow[]> {
+        const sourcePaths = sourceWorkflowPath
+            ? [this.resolveSourceWorkflowPath(sourceWorkflowPath, sourceRoot)]
+            : this.listSourceWorkflowPaths(sourceRoot);
+        if (sourcePaths.length === 0) {
+            throw new Error(`No TypeScript workflow files found in source environment sync scope: ${sourceRoot}`);
+        }
+
+        const sourceRootRealPath = this.realpathExisting(sourceRoot);
+        const targetRootRealPath = fs.existsSync(targetRoot) ? this.realpathExisting(targetRoot) : path.resolve(targetRoot);
+        const sources: PromotionSourceWorkflow[] = [];
+
+        for (const sourcePath of sourcePaths) {
+            const sourceRealPath = this.realpathExisting(sourcePath);
+            if (!this.isPathInside(sourceRealPath, sourceRootRealPath)) {
+                throw new Error(`Source workflow must be inside the source environment sync scope: ${sourceRoot}`);
+            }
+            const relativePath = path.relative(sourceRoot, sourcePath);
+            const targetPath = path.resolve(targetRoot, relativePath);
+            this.assertTargetPath(targetPath, targetRoot, targetRootRealPath);
+
+            const targetExists = fs.existsSync(targetPath);
+            if (targetExists && !this.isPathInside(this.realpathExisting(targetPath), targetRootRealPath)) {
+                throw new Error('Resolved target path escapes the target environment sync scope.');
+            }
+            const workflow = await compileWorkflowForPromotion(fs.readFileSync(sourcePath, 'utf8'));
+            const sourceKey = workflow.id || workflow.name;
+            sources.push({
+                sourcePath,
+                targetPath,
+                workflow,
+                sourceKey,
+                targetExists,
+                targetWorkflowId: targetExists ? readWorkflowDecoratorProperty(fs.readFileSync(targetPath, 'utf8'), 'id') : undefined,
+                action: 'create',
+            });
+        }
+
+        return sources;
+    }
+
+    private resolveSourceWorkflowPath(sourceWorkflowPath: string, sourceRoot: string): string {
+        const sourcePath = path.resolve(sourceWorkflowPath);
+        if (!fs.existsSync(sourcePath)) {
+            throw new Error(`Source workflow not found: ${sourcePath}`);
+        }
+        if (!sourcePath.endsWith('.workflow.ts')) {
+            throw new Error('Promotion currently supports TypeScript workflow files (*.workflow.ts).');
+        }
+        return sourcePath;
+    }
+
+    private listSourceWorkflowPaths(sourceRoot: string): string[] {
+        if (!fs.existsSync(sourceRoot)) {
+            throw new Error(`Source environment sync scope does not exist: ${sourceRoot}`);
+        }
+        return fs.readdirSync(sourceRoot)
+            .filter((filename) => filename.endsWith('.workflow.ts') && !filename.startsWith('.'))
+            .sort()
+            .map((filename) => path.join(sourceRoot, filename));
+    }
+
+    private initializeTargetActions(sources: PromotionSourceWorkflow[], route: PromotionRouteConfig): void {
+        for (const item of sources) {
+            const binding = route.bindings?.workflows?.[item.sourceKey];
+            if (binding) {
+                item.targetWorkflowId = binding;
+            }
+            item.action = item.targetWorkflowId ? 'update' : 'create';
+        }
+    }
+
+    private async discoverTargetWorkflowIds(
+        sources: PromotionSourceWorkflow[],
+        target: IResolvedWorkspaceEnvironment,
+        route: PromotionRouteConfig,
+        indexes: PromotionIndexes,
+        options: PromoteOptions,
+    ): Promise<void> {
+        const shouldDiscover = options.push !== false && !options.dryRun;
+        if (!shouldDiscover) return;
+
+        const workflows = await this.getTargetWorkflows(target);
+        indexes.targetWorkflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
+        indexes.targetWorkflowsByName = groupWorkflowsByName(workflows);
+
+        for (const item of sources) {
+            if (item.targetWorkflowId) continue;
+            const override = this.findOverride(route.workflowOverrides, item.sourceKey, item.workflow.name);
+            const targetWorkflow = this.resolveWorkflowOverride(override, indexes);
+            if (targetWorkflow) {
+                item.targetWorkflowId = targetWorkflow.id;
+                item.action = 'update';
+                route.bindings!.workflows![item.sourceKey] = targetWorkflow.id;
+                continue;
+            }
+
+            const targetName = this.applyNameRules(item.workflow.name, 'workflow', route);
+            const matches = indexes.targetWorkflowsByName.get(targetName) ?? [];
+            if (matches.length === 1) {
+                item.targetWorkflowId = matches[0].id;
+                item.action = 'update';
+                route.bindings!.workflows![item.sourceKey] = matches[0].id;
+            }
+        }
+    }
+
+    private async planWorkflows(
+        sources: PromotionSourceWorkflow[],
+        target: IResolvedWorkspaceEnvironment,
+        route: PromotionRouteConfig,
+        indexes: PromotionIndexes,
+    ): Promise<PromotionWorkflowResult[]> {
+        const planned: PromotionWorkflowResult[] = [];
+        for (const item of sources) {
+            const transformed = await this.transformWorkflow(item, target, route, indexes);
+            planned.push({
+                sourcePath: item.sourcePath,
+                targetPath: item.targetPath,
+                sourceWorkflowId: item.workflow.id || undefined,
+                sourceWorkflowName: item.workflow.name,
+                targetWorkflowId: item.targetWorkflowId,
+                action: item.action,
+                status: transformed.problems.length > 0 ? 'blocked' : 'planned',
+                substitutions: transformed.substitutions,
+                problems: transformed.problems,
+            });
+        }
+        return planned;
+    }
+
+    private async applyPromotion(
+        sources: PromotionSourceWorkflow[],
+        target: IResolvedWorkspaceEnvironment,
+        route: PromotionRouteConfig,
+        indexes: PromotionIndexes,
+        options: PromoteOptions,
+    ): Promise<PromotionWorkflowResult[]> {
+        const remaining = new Map(sources.map((item) => [item.sourceKey, item]));
+        const applied: PromotionWorkflowResult[] = [];
+
+        while (remaining.size > 0) {
+            let progressed = false;
+
+            for (const item of Array.from(remaining.values())) {
+                const transformed = await this.transformWorkflow(item, target, route, indexes);
+                const pending = transformed.pendingWorkflowSourceKeys.filter((sourceKey) => remaining.has(sourceKey));
+                if (pending.length > 0) {
+                    continue;
                 }
+                if (transformed.problems.length > 0) {
+                    applied.push(this.workflowResult(item, transformed, 'blocked'));
+                    remaining.delete(item.sourceKey);
+                    progressed = true;
+                    continue;
+                }
+                if (item.targetExists && !item.targetWorkflowId && !options.overwrite) {
+                    applied.push(this.workflowResult(item, transformed, 'blocked', [{
+                        kind: 'target-file',
+                        message: `Target workflow already exists: ${item.targetPath}. Re-run with --overwrite to replace it.`,
+                    }]));
+                    remaining.delete(item.sourceKey);
+                    progressed = true;
+                    continue;
+                }
+
+                const targetTs = await WorkflowTransformerAdapter.convertToTypeScript(transformed.workflow, {
+                    format: true,
+                    commentStyle: 'verbose',
+                });
+                fs.mkdirSync(path.dirname(item.targetPath), { recursive: true });
+                fs.writeFileSync(item.targetPath, targetTs, 'utf8');
+
+                let pushedWorkflowId: string | undefined;
+                if (options.push !== false) {
+                    pushedWorkflowId = await this.pushWorkflow(target, item.targetPath);
+                    if (pushedWorkflowId) {
+                        item.targetWorkflowId = pushedWorkflowId;
+                        route.bindings!.workflows![item.sourceKey] = pushedWorkflowId;
+                    }
+                } else if (item.targetWorkflowId) {
+                    route.bindings!.workflows![item.sourceKey] = item.targetWorkflowId;
+                }
+
+                applied.push({
+                    ...this.workflowResult(item, transformed, pushedWorkflowId ? 'pushed' : 'written'),
+                    targetWorkflowId: pushedWorkflowId || item.targetWorkflowId,
+                });
+                remaining.delete(item.sourceKey);
+                progressed = true;
+            }
+
+            if (!progressed) {
+                for (const item of remaining.values()) {
+                    const transformed = await this.transformWorkflow(item, target, route, indexes);
+                    applied.push(this.workflowResult(item, transformed, 'blocked', [{
+                        kind: 'workflow',
+                        message: 'Cannot resolve workflow reference order. Check for first-deploy circular Execute Workflow references.',
+                    }]));
+                }
+                break;
             }
         }
 
-        this.printResult(result, options);
-        return result;
+        return sources.map((sourceItem) => applied.find((item) => item.sourcePath === sourceItem.sourcePath)!).filter(Boolean);
+    }
+
+    private workflowResult(
+        item: PromotionSourceWorkflow,
+        transformed: WorkflowTransformResult,
+        status: PromotionWorkflowResult['status'],
+        extraProblems: PromotionProblem[] = [],
+    ): PromotionWorkflowResult {
+        return {
+            sourcePath: item.sourcePath,
+            targetPath: item.targetPath,
+            sourceWorkflowId: item.workflow.id || undefined,
+            sourceWorkflowName: item.workflow.name,
+            targetWorkflowId: item.targetWorkflowId,
+            action: item.action,
+            status: extraProblems.length > 0 ? 'blocked' : status,
+            substitutions: transformed.substitutions,
+            problems: [...transformed.problems, ...extraProblems],
+        };
+    }
+
+    private async transformWorkflow(
+        item: PromotionSourceWorkflow,
+        target: IResolvedWorkspaceEnvironment,
+        route: PromotionRouteConfig,
+        indexes: PromotionIndexes,
+    ): Promise<WorkflowTransformResult> {
+        const workflow = cloneWorkflow(item.workflow);
+        const substitutions: PromotionSubstitution[] = [];
+        const problems: PromotionProblem[] = [];
+        const pendingWorkflowSourceKeys: string[] = [];
+
+        if (item.targetWorkflowId) {
+            workflow.id = item.targetWorkflowId;
+        } else {
+            delete (workflow as any).id;
+        }
+        workflow.projectId = target.projectId;
+        workflow.projectName = target.projectName;
+        delete (workflow as any).homeProject;
+        delete (workflow as any).isArchived;
+
+        substitutions.push({
+            kind: 'metadata',
+            field: 'workflow.id',
+            fromId: item.workflow.id || undefined,
+            toId: item.targetWorkflowId,
+            status: item.targetWorkflowId ? 'mapped' : 'unchanged',
+        });
+
+        for (const node of workflow.nodes ?? []) {
+            await this.remapNodeCredentials(node, target, route, indexes, substitutions, problems);
+            await this.remapWorkflowReferences(node, target, route, indexes, substitutions, problems, pendingWorkflowSourceKeys);
+        }
+
+        return { workflow, substitutions, problems, pendingWorkflowSourceKeys };
+    }
+
+    private async remapNodeCredentials(
+        node: any,
+        target: IResolvedWorkspaceEnvironment,
+        route: PromotionRouteConfig,
+        indexes: PromotionIndexes,
+        substitutions: PromotionSubstitution[],
+        problems: PromotionProblem[],
+    ): Promise<void> {
+        if (!node.credentials || typeof node.credentials !== 'object') return;
+        for (const [credentialType, credentialRef] of Object.entries(node.credentials as Record<string, any>)) {
+            const sourceId = String(credentialRef?.id ?? '').trim();
+            const sourceName = String(credentialRef?.name ?? '').trim();
+            const targetCredential = await this.resolveTargetCredential(target, route, indexes, credentialType, sourceId, sourceName);
+            if (!targetCredential) {
+                problems.push({
+                    kind: 'credential',
+                    nodeName: node.name,
+                    ref: sourceId || sourceName,
+                    message: `Cannot resolve credential "${sourceName || sourceId}" of type "${credentialType}" in target environment.`,
+                });
+                continue;
+            }
+            const targetId = String(targetCredential.id ?? '').trim();
+            const targetName = String(targetCredential.name ?? '').trim();
+            node.credentials[credentialType] = { id: targetId, name: targetName };
+            if (sourceId) route.bindings!.credentials![sourceId] = targetId;
+            substitutions.push({
+                kind: 'credential',
+                nodeName: node.name,
+                field: credentialType,
+                fromId: sourceId || undefined,
+                fromName: sourceName || undefined,
+                toId: targetId,
+                toName: targetName,
+                status: 'mapped',
+            });
+        }
+    }
+
+    private async resolveTargetCredential(
+        target: IResolvedWorkspaceEnvironment,
+        route: PromotionRouteConfig,
+        indexes: PromotionIndexes,
+        credentialType: string,
+        sourceId: string,
+        sourceName: string,
+    ): Promise<Record<string, unknown> | undefined> {
+        await this.ensureTargetCredentialIndexes(target, indexes);
+        if (sourceId) {
+            const boundId = route.bindings?.credentials?.[sourceId];
+            if (boundId) {
+                return indexes.targetCredentialsById!.get(boundId);
+            }
+        }
+
+        const override = this.findOverride(route.credentialOverrides, `${credentialType}::${sourceId}`, `${credentialType}::${sourceName}`, sourceId, sourceName);
+        if (override?.targetId) {
+            return indexes.targetCredentialsById!.get(override.targetId);
+        }
+        if (override?.targetName) {
+            const matches = indexes.targetCredentialsByKey!.get(`${credentialType}::${override.targetName}`) ?? [];
+            if (matches.length === 1) return matches[0];
+            return undefined;
+        }
+
+        const targetName = this.applyNameRules(sourceName, 'credential', route);
+        const matches = indexes.targetCredentialsByKey!.get(`${credentialType}::${targetName}`) ?? [];
+        if (matches.length === 1) return matches[0];
+        return undefined;
+    }
+
+    private async remapWorkflowReferences(
+        node: any,
+        target: IResolvedWorkspaceEnvironment,
+        route: PromotionRouteConfig,
+        indexes: PromotionIndexes,
+        substitutions: PromotionSubstitution[],
+        problems: PromotionProblem[],
+        pendingWorkflowSourceKeys: string[],
+    ): Promise<void> {
+        const nodeType = String(node.type ?? '').toLowerCase().split('.').pop();
+        if (nodeType !== EXECUTE_WORKFLOW_TYPE_SUFFIX) return;
+
+        const refs = findWorkflowReferenceFields(node.parameters);
+        for (const ref of refs) {
+            const resolved = await this.resolveWorkflowReference(ref.value, target, route, indexes);
+            if (resolved.status === 'mapped') {
+                ref.set(resolved.targetId);
+                substitutions.push({
+                    kind: 'workflow',
+                    nodeName: node.name,
+                    field: ref.path,
+                    fromId: ref.value,
+                    fromName: resolved.sourceName,
+                    toId: resolved.targetId,
+                    toName: resolved.targetName,
+                    status: 'mapped',
+                });
+                continue;
+            }
+            if (resolved.status === 'pending-create') {
+                pendingWorkflowSourceKeys.push(resolved.sourceKey);
+                substitutions.push({
+                    kind: 'workflow',
+                    nodeName: node.name,
+                    field: ref.path,
+                    fromId: ref.value,
+                    fromName: resolved.sourceName,
+                    status: 'pending-create',
+                });
+                continue;
+            }
+            problems.push({
+                kind: 'workflow',
+                nodeName: node.name,
+                ref: ref.value,
+                message: `Cannot resolve workflow reference "${ref.value}" in target environment.`,
+            });
+        }
+    }
+
+    private async resolveWorkflowReference(
+        sourceRef: string,
+        target: IResolvedWorkspaceEnvironment,
+        route: PromotionRouteConfig,
+        indexes: PromotionIndexes,
+    ): Promise<
+        | { status: 'mapped'; targetId: string; targetName?: string; sourceName?: string }
+        | { status: 'pending-create'; sourceKey: string; sourceName?: string }
+        | { status: 'missing' }
+    > {
+        const boundId = route.bindings?.workflows?.[sourceRef];
+        if (boundId) return { status: 'mapped', targetId: boundId };
+
+        const sourceItem = indexes.sourceById.get(sourceRef) ?? unique(indexes.sourceByName.get(sourceRef));
+        if (sourceItem) {
+            const targetId = sourceItem.targetWorkflowId || route.bindings?.workflows?.[sourceItem.sourceKey];
+            if (targetId) {
+                return { status: 'mapped', targetId, sourceName: sourceItem.workflow.name };
+            }
+            return { status: 'pending-create', sourceKey: sourceItem.sourceKey, sourceName: sourceItem.workflow.name };
+        }
+
+        const override = this.findOverride(route.workflowOverrides, sourceRef);
+        if (override) {
+            await this.ensureTargetWorkflowIndexes(target, indexes);
+            const workflow = this.resolveWorkflowOverride(override, indexes);
+            if (workflow) return { status: 'mapped', targetId: workflow.id, targetName: workflow.name };
+        }
+
+        await this.ensureTargetWorkflowIndexes(target, indexes);
+        const targetName = this.applyNameRules(sourceRef, 'workflow', route);
+        const matches = indexes.targetWorkflowsByName!.get(targetName) ?? [];
+        if (matches.length === 1) {
+            return { status: 'mapped', targetId: matches[0].id, targetName: matches[0].name };
+        }
+        return { status: 'missing' };
+    }
+
+    private async ensureTargetWorkflowIndexes(target: IResolvedWorkspaceEnvironment, indexes: PromotionIndexes): Promise<void> {
+        if (indexes.targetWorkflowsById && indexes.targetWorkflowsByName) return;
+        const workflows = await this.getTargetWorkflows(target);
+        indexes.targetWorkflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
+        indexes.targetWorkflowsByName = groupWorkflowsByName(workflows);
+    }
+
+    private async ensureTargetCredentialIndexes(target: IResolvedWorkspaceEnvironment, indexes: PromotionIndexes): Promise<void> {
+        if (indexes.targetCredentialsById && indexes.targetCredentialsByKey) return;
+        const credentials = await this.getTargetCredentials(target);
+        indexes.targetCredentialsById = new Map(credentials.map((credential) => [String(credential.id ?? ''), credential]));
+        indexes.targetCredentialsByKey = new Map();
+        for (const credential of credentials) {
+            const type = String(credential.type ?? '').trim();
+            const name = String(credential.name ?? '').trim();
+            const key = `${type}::${name}`;
+            const existing = indexes.targetCredentialsByKey.get(key) ?? [];
+            existing.push(credential);
+            indexes.targetCredentialsByKey.set(key, existing);
+        }
+    }
+
+    private async getTargetWorkflows(target: IResolvedWorkspaceEnvironment): Promise<IWorkflow[]> {
+        this.targetWorkflowInventory ??= this.getClient(target).getAllWorkflows(target.projectId);
+        return this.targetWorkflowInventory;
+    }
+
+    private async getTargetCredentials(target: IResolvedWorkspaceEnvironment): Promise<Array<Record<string, unknown>>> {
+        this.targetCredentialInventory ??= this.getClient(target).listCredentials();
+        return this.targetCredentialInventory;
+    }
+
+    private getClient(environment: IResolvedWorkspaceEnvironment): PromotionRuntimeClient {
+        if (this.dependencies.createClient) return this.dependencies.createClient(environment);
+        if (!environment.host || !environment.apiKey) {
+            throw new Error(`Environment "${environment.environmentName}" needs a host and API key before promotion can inspect target references.`);
+        }
+        return new N8nApiClient({ host: environment.host, apiKey: environment.apiKey });
+    }
+
+    private async pushWorkflow(target: IResolvedWorkspaceEnvironment, targetPath: string): Promise<string | undefined> {
+        if (this.dependencies.pushWorkflow) {
+            return this.dependencies.pushWorkflow(target, targetPath);
+        }
+        const previousEnvironment = process.env.N8NAC_ENVIRONMENT;
+        try {
+            process.env.N8NAC_ENVIRONMENT = target.environmentId;
+            return await new SyncCommand().pushOne(targetPath);
+        } finally {
+            if (previousEnvironment === undefined) {
+                delete process.env.N8NAC_ENVIRONMENT;
+            } else {
+                process.env.N8NAC_ENVIRONMENT = previousEnvironment;
+            }
+        }
     }
 
     private getEnvironmentWorkflowRoot(environment: IResolvedWorkspaceEnvironment): string {
@@ -121,6 +687,16 @@ export class PromoteCommand {
             throw new Error(`Environment "${environment.environmentName}" is missing a resolved workflow directory. Check its API key, project, and instance identifier.`);
         }
         return path.resolve(environment.workflowDir);
+    }
+
+    private assertTargetPath(targetPath: string, targetRoot: string, targetRootRealPath: string): void {
+        if (!this.isPathInside(targetPath, targetRoot)) {
+            throw new Error('Resolved target path escapes the target environment sync scope.');
+        }
+        const targetParentRealPath = this.realpathExistingParent(path.dirname(targetPath));
+        if (fs.existsSync(targetRoot) && targetParentRealPath && !this.isPathInside(targetParentRealPath, targetRootRealPath)) {
+            throw new Error('Resolved target path escapes the target environment sync scope.');
+        }
     }
 
     private isPathInside(candidate: string, root: string): boolean {
@@ -142,22 +718,139 @@ export class PromoteCommand {
         return this.realpathExisting(current);
     }
 
+    private resolvePromotionConfigPath(configPath?: string): string {
+        return path.resolve(configPath || path.join(process.cwd(), 'n8nac-promotion.json'));
+    }
+
+    private loadPromotionConfig(configPath: string): PromotionConfig {
+        if (!fs.existsSync(configPath)) {
+            return { version: 1, routes: {} };
+        }
+        const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as PromotionConfig;
+        if (parsed.version !== 1 || !parsed.routes || typeof parsed.routes !== 'object') {
+            throw new Error(`Invalid promotion config: ${configPath}`);
+        }
+        return parsed;
+    }
+
+    private savePromotionConfig(configPath: string, config: PromotionConfig): void {
+        fs.mkdirSync(path.dirname(configPath), { recursive: true });
+        fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+    }
+
+    private ensureRoute(config: PromotionConfig, routeKey: string): PromotionRouteConfig {
+        const route = config.routes[routeKey] ?? {};
+        route.bindings ??= {};
+        route.bindings.workflows ??= {};
+        route.bindings.credentials ??= {};
+        route.workflowOverrides ??= {};
+        route.credentialOverrides ??= {};
+        route.nameRules ??= [];
+        config.routes[routeKey] = route;
+        return route;
+    }
+
+    private findOverride(overrides: Record<string, PromotionOverride> | undefined, ...keys: string[]): PromotionOverride | undefined {
+        if (!overrides) return undefined;
+        for (const key of keys) {
+            if (key && overrides[key]) return overrides[key];
+        }
+        return undefined;
+    }
+
+    private resolveWorkflowOverride(override: PromotionOverride | undefined, indexes: PromotionIndexes): IWorkflow | undefined {
+        if (!override) return undefined;
+        if (override.targetId) return indexes.targetWorkflowsById?.get(override.targetId);
+        if (override.targetName) return unique(indexes.targetWorkflowsByName?.get(override.targetName));
+        return undefined;
+    }
+
+    private applyNameRules(value: string, kind: 'credential' | 'workflow', route: PromotionRouteConfig): string {
+        let next = value;
+        for (const rule of route.nameRules ?? []) {
+            if (rule.kind && rule.kind !== kind) continue;
+            next = next.replace(new RegExp(rule.from), rule.to);
+        }
+        return next;
+    }
+
+    private buildResult(
+        source: IResolvedWorkspaceEnvironment,
+        target: IResolvedWorkspaceEnvironment,
+        routeKey: string,
+        configPath: string,
+        workflows: PromotionWorkflowResult[],
+        options: PromoteOptions,
+    ): PromoteResult {
+        const first = workflows[0];
+        return {
+            sourceEnvironmentId: source.environmentId,
+            sourceEnvironmentName: source.environmentName,
+            targetEnvironmentId: target.environmentId,
+            targetEnvironmentName: target.environmentName,
+            sourcePath: first?.sourcePath || '',
+            targetPath: first?.targetPath || '',
+            pushed: workflows.some((workflow) => workflow.status === 'pushed'),
+            workflowId: workflows.length === 1 ? workflows[0].targetWorkflowId : undefined,
+            credentialCheckCommand: workflows.length === 1 && workflows[0].targetWorkflowId
+                ? `n8nac --env ${quoteShellArg(target.environmentName)} workflow credential-required ${quoteShellArg(workflows[0].targetWorkflowId!)}`
+                : undefined,
+            dryRun: Boolean(options.dryRun),
+            routeKey,
+            configPath,
+            summary: {
+                planned: workflows.length,
+                created: workflows.filter((workflow) => workflow.action === 'create').length,
+                updated: workflows.filter((workflow) => workflow.action === 'update').length,
+                blocked: workflows.filter((workflow) => workflow.status === 'blocked' || workflow.problems.length > 0).length,
+                credentialMappings: workflows.reduce((count, workflow) => count + workflow.substitutions.filter((item) => item.kind === 'credential' && item.status === 'mapped').length, 0),
+                workflowMappings: workflows.reduce((count, workflow) => count + workflow.substitutions.filter((item) => item.kind === 'workflow' && item.status === 'mapped').length, 0),
+            },
+            workflows,
+        };
+    }
+
     private printResult(result: PromoteResult, options: PromoteOptions): void {
         if (options.json) {
             console.log(JSON.stringify(result, null, 2));
             return;
         }
         const action = result.dryRun ? 'Would promote' : result.pushed ? 'Promoted and pushed' : 'Promoted';
-        console.log(chalk.green(`✔ ${action} workflow from ${result.sourceEnvironmentName} to ${result.targetEnvironmentName}.`));
-        console.log(chalk.dim(`  ${result.sourcePath}`));
-        console.log(chalk.dim(`  -> ${result.targetPath}`));
-        if (result.workflowId) {
-            console.log(chalk.dim(`  remote workflow: ${result.workflowId}`));
+        const countLabel = result.workflows.length === 1 ? 'workflow' : 'workflows';
+        console.log(chalk.green(`✔ ${action} ${result.workflows.length} ${countLabel} from ${result.sourceEnvironmentName} to ${result.targetEnvironmentName}.`));
+        console.log(chalk.dim(`  route: ${result.routeKey}`));
+        for (const workflow of result.workflows) {
+            const statusIcon = workflow.problems.length > 0 ? 'blocked' : workflow.action;
+            console.log(chalk.dim(`  ${statusIcon}: ${workflow.sourcePath}`));
+            console.log(chalk.dim(`    -> ${workflow.targetPath}`));
+            if (workflow.targetWorkflowId) {
+                console.log(chalk.dim(`    remote workflow: ${workflow.targetWorkflowId}`));
+            }
+            for (const substitution of workflow.substitutions.filter((item) => item.kind !== 'metadata')) {
+                const from = substitution.fromName || substitution.fromId || 'unknown';
+                const to = substitution.toName || substitution.toId || 'pending';
+                console.log(chalk.dim(`    ${substitution.kind}: ${from} -> ${to}`));
+            }
+            for (const problem of workflow.problems) {
+                console.log(chalk.yellow(`    ${problem.kind}: ${problem.message}`));
+            }
         }
         if (result.credentialCheckCommand) {
             console.log(chalk.yellow(`  Check target credentials: ${result.credentialCheckCommand}`));
         }
     }
+}
+
+export async function compileWorkflowForPromotion(content: string): Promise<IWorkflow> {
+    const parser = new TypeScriptParser();
+    const ast = await parser.parseCode(content);
+    const workflow = new WorkflowBuilder().build(ast) as any;
+    if (Array.isArray(workflow.tags)) {
+        workflow.tags = workflow.tags.map((tag: string | { id?: string; name?: string }) =>
+            typeof tag === 'string' ? { id: tag, name: tag } : tag
+        );
+    }
+    return workflow as IWorkflow;
 }
 
 export function adaptWorkflowForPromotion(content: string, options: { targetWorkflowId?: string; targetProjectId?: string; targetProjectName?: string } = {}): string {
@@ -183,6 +876,60 @@ export function readWorkflowDecoratorProperty(content: string, property: string)
     if (!decorator) return undefined;
     const match = decorator.match(new RegExp(`${property}\\s*:\\s*(['"])(.*?)\\1`, 'm'));
     return match?.[2];
+}
+
+function findWorkflowReferenceFields(parameters: any): Array<{ path: string; value: string; set: (value: string) => void }> {
+    const refs: Array<{ path: string; value: string; set: (value: string) => void }> = [];
+    const visit = (value: any, currentPath: string): void => {
+        if (!value || typeof value !== 'object') return;
+        for (const [key, child] of Object.entries(value)) {
+            const nextPath = currentPath ? `${currentPath}.${key}` : key;
+            const normalizedKey = key.toLowerCase();
+            if ((normalizedKey === 'workflowid' || normalizedKey === 'workflow') && typeof child === 'string' && child.trim()) {
+                refs.push({
+                    path: nextPath,
+                    value: child,
+                    set: (nextValue: string) => {
+                        value[key] = nextValue;
+                    },
+                });
+                continue;
+            }
+            if ((normalizedKey === 'workflowid' || normalizedKey === 'workflow') && child && typeof child === 'object') {
+                const objectValue = (child as any).value;
+                if (typeof objectValue === 'string' && objectValue.trim()) {
+                    refs.push({
+                        path: `${nextPath}.value`,
+                        value: objectValue,
+                        set: (nextValue: string) => {
+                            (child as any).value = nextValue;
+                        },
+                    });
+                }
+            }
+            visit(child, nextPath);
+        }
+    };
+    visit(parameters, '');
+    return refs;
+}
+
+function cloneWorkflow(workflow: IWorkflow): IWorkflow {
+    return JSON.parse(JSON.stringify(workflow));
+}
+
+function groupWorkflowsByName(workflows: IWorkflow[]): Map<string, IWorkflow[]> {
+    const byName = new Map<string, IWorkflow[]>();
+    for (const workflow of workflows) {
+        const existing = byName.get(workflow.name) ?? [];
+        existing.push(workflow);
+        byName.set(workflow.name, existing);
+    }
+    return byName;
+}
+
+function unique<T>(items: T[] | undefined): T | undefined {
+    return items && items.length === 1 ? items[0] : undefined;
 }
 
 function stripWorkflowDecoratorProperty(content: string, property: string): string {

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -282,7 +282,7 @@ export class PromoteCommand {
         indexes: PromotionIndexes,
         options: PromoteOptions,
     ): Promise<void> {
-        const shouldDiscover = options.push !== false && !options.dryRun;
+        const shouldDiscover = !options.dryRun;
         if (!shouldDiscover) return;
 
         const workflows = await this.getTargetWorkflows(target);

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -209,7 +209,7 @@ export class PromoteCommand {
             ? [this.resolveSourceWorkflowPath(sourceWorkflowPath, sourceRoot)]
             : this.listSourceWorkflowPaths(sourceRoot);
         if (sourcePaths.length === 0) {
-            throw new Error(`No TypeScript workflow files found in source environment sync scope: ${sourceRoot}`);
+            throw new Error(`No TypeScript workflow files found in source environment workflowsPath: ${sourceRoot}`);
         }
 
         const sourceRootRealPath = this.realpathExisting(sourceRoot);
@@ -219,7 +219,7 @@ export class PromoteCommand {
         for (const sourcePath of sourcePaths) {
             const sourceRealPath = this.realpathExisting(sourcePath);
             if (!this.isPathInside(sourceRealPath, sourceRootRealPath)) {
-                throw new Error(`Source workflow must be inside the source environment sync scope: ${sourceRoot}`);
+                throw new Error(`Source workflow must be inside the source environment workflowsPath: ${sourceRoot}`);
             }
             const relativePath = path.relative(sourceRoot, sourcePath);
             const targetPath = path.resolve(targetRoot, relativePath);
@@ -227,7 +227,7 @@ export class PromoteCommand {
 
             const targetExists = fs.existsSync(targetPath);
             if (targetExists && !this.isPathInside(this.realpathExisting(targetPath), targetRootRealPath)) {
-                throw new Error('Resolved target path escapes the target environment sync scope.');
+                throw new Error('Resolved target path escapes the target environment workflowsPath.');
             }
             const workflow = await compileWorkflowForPromotion(fs.readFileSync(sourcePath, 'utf8'));
             const sourceKey = workflow.id || workflow.name;
@@ -258,7 +258,7 @@ export class PromoteCommand {
 
     private listSourceWorkflowPaths(sourceRoot: string): string[] {
         if (!fs.existsSync(sourceRoot)) {
-            throw new Error(`Source environment sync scope does not exist: ${sourceRoot}`);
+            throw new Error(`Source environment workflowsPath does not exist: ${sourceRoot}`);
         }
 
         const walk = (directory: string): string[] => fs.readdirSync(directory, { withFileTypes: true })
@@ -688,19 +688,20 @@ export class PromoteCommand {
     }
 
     private getEnvironmentWorkflowRoot(environment: IResolvedWorkspaceEnvironment): string {
-        if (!environment.workflowDir) {
-            throw new Error(`Environment "${environment.environmentName}" is missing a resolved workflow directory. Check its API key, project, and instance identifier.`);
+        const workflowsPath = environment.workflowsPath || environment.workflowDir;
+        if (!workflowsPath) {
+            throw new Error(`Environment "${environment.environmentName}" is missing a resolved workflowsPath. Check its API key, project, and instance identifier.`);
         }
-        return path.resolve(environment.workflowDir);
+        return path.resolve(workflowsPath);
     }
 
     private assertTargetPath(targetPath: string, targetRoot: string, targetRootRealPath: string): void {
         if (!this.isPathInside(targetPath, targetRoot)) {
-            throw new Error('Resolved target path escapes the target environment sync scope.');
+            throw new Error('Resolved target path escapes the target environment workflowsPath.');
         }
         const targetParentRealPath = this.realpathExistingParent(path.dirname(targetPath));
         if (fs.existsSync(targetRoot) && targetParentRealPath && !this.isPathInside(targetParentRealPath, targetRootRealPath)) {
-            throw new Error('Resolved target path escapes the target environment sync scope.');
+            throw new Error('Resolved target path escapes the target environment workflowsPath.');
         }
     }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1195,12 +1195,13 @@ program.command('push')
 
 program.command('promote')
     .description('Promote a local workflow file from one workspace environment to another')
-    .argument('<path>', 'Workflow file path inside the source environment sync scope')
+    .argument('[path]', 'Workflow file path inside the source environment sync scope. Omit to promote all source workflows.')
     .requiredOption('--from <environment>', 'Source environment name or ID')
     .requiredOption('--to <environment>', 'Target environment name or ID')
     .option('--dry-run', 'Show the planned promotion without writing or pushing')
     .option('--no-push', 'Copy/adapt the workflow into the target environment without pushing')
     .option('--overwrite', 'Overwrite the target local workflow file if it already exists')
+    .option('--promotion-config <path>', 'Promotion config path', 'n8nac-promotion.json')
     .option('--json', 'Output promotion result as JSON')
     .action(async (pathArg, options) => {
         try {
@@ -1210,6 +1211,7 @@ program.command('promote')
                 dryRun: options.dryRun,
                 push: options.push,
                 overwrite: options.overwrite,
+                promotionConfig: options.promotionConfig,
                 json: options.json,
             });
         } catch (error: any) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1195,7 +1195,7 @@ program.command('push')
 
 program.command('promote')
     .description('Promote a local workflow file from one workspace environment to another')
-    .argument('[path]', 'Workflow file path inside the source environment sync scope. Omit to promote all source workflows.')
+    .argument('[path]', 'Workflow file path inside the source environment workflowsPath. Omit to promote all source workflows.')
     .requiredOption('--from <environment>', 'Source environment name or ID')
     .requiredOption('--to <environment>', 'Target environment name or ID')
     .option('--dry-run', 'Show the planned promotion without writing or pushing')

--- a/packages/cli/tests/unit/promote-command.test.ts
+++ b/packages/cli/tests/unit/promote-command.test.ts
@@ -73,12 +73,14 @@ export class PromotedWorkflow {}
             writeFileSync(sourcePath, workflow, 'utf8');
             writeFileSync(path.join(targetDir, 'one.workflow.ts'), workflow, 'utf8');
 
-            await expect(new PromoteCommand(configService).run(sourcePath, { from: 'Dev', to: 'Prod', dryRun: true, promotionConfig: path.join(workspaceRoot, 'n8nac-promotion.json') })).resolves.toMatchObject({
+            const promotionConfigPath = path.join(workspaceRoot, 'n8nac-promotion.json');
+            await expect(new PromoteCommand(configService).run(sourcePath, { from: 'Dev', to: 'Prod', dryRun: true, promotionConfig: promotionConfigPath })).resolves.toMatchObject({
                 targetEnvironmentName: 'Prod',
                 targetPath: path.join(targetDir, 'one.workflow.ts'),
                 dryRun: true,
                 pushed: false,
             });
+            expect(existsSync(promotionConfigPath)).toBe(false);
         } finally {
             if (previousManagerHome === undefined) {
                 delete process.env.N8N_MANAGER_HOME;

--- a/packages/cli/tests/unit/promote-command.test.ts
+++ b/packages/cli/tests/unit/promote-command.test.ts
@@ -119,7 +119,12 @@ export class PromotedWorkflow {}
             writeFileSync(sourcePath, "@workflow({ name: 'Source' })\nexport class Source {}\n", 'utf8');
             writeFileSync(targetPath, "@workflow({ id: 'target-id', name: 'Target' })\nexport class Target {}\n", 'utf8');
 
-            await expect(new PromoteCommand(configService).run(sourcePath, { from: 'Dev', to: 'Prod', push: false, promotionConfig: path.join(workspaceRoot, 'n8nac-promotion.json') })).resolves.toMatchObject({
+            await expect(new PromoteCommand(configService, {
+                createClient: () => ({
+                    getAllWorkflows: async () => [],
+                    listCredentials: async () => [],
+                }),
+            }).run(sourcePath, { from: 'Dev', to: 'Prod', push: false, promotionConfig: path.join(workspaceRoot, 'n8nac-promotion.json') })).resolves.toMatchObject({
                 targetEnvironmentName: 'Prod',
                 targetPath,
                 pushed: false,
@@ -164,7 +169,12 @@ export class PromotedWorkflow {}
             writeFileSync(path.join(sourceDir, 'one.workflow.ts'), "@workflow({ name: 'One', active: false })\nexport class One {}\n", 'utf8');
             writeFileSync(path.join(sourceDir, 'two.workflow.ts'), "@workflow({ name: 'Two', active: false })\nexport class Two {}\n", 'utf8');
 
-            const result = await new PromoteCommand(configService).run(undefined, {
+            const result = await new PromoteCommand(configService, {
+                createClient: () => ({
+                    getAllWorkflows: async () => [],
+                    listCredentials: async () => [],
+                }),
+            }).run(undefined, {
                 from: 'Dev',
                 to: 'Prod',
                 push: false,
@@ -243,6 +253,61 @@ export class CredentialWorkflow {
             expect(promoted).toContain("name: 'Shared Credential'");
             const promotionConfig = JSON.parse(readFileSync(path.join(workspaceRoot, 'n8nac-promotion.json'), 'utf8'));
             expect(promotionConfig.routes['Dev->Prod'].bindings.credentials['source-cred']).toBe('target-cred');
+        } finally {
+            if (previousManagerHome === undefined) {
+                delete process.env.N8N_MANAGER_HOME;
+            } else {
+                process.env.N8N_MANAGER_HOME = previousManagerHome;
+            }
+        }
+    });
+
+    it('discovers existing remote target workflow ids for no-push promotions', async () => {
+        const previousManagerHome = process.env.N8N_MANAGER_HOME;
+        const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-workspace-'));
+        process.env.N8N_MANAGER_HOME = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-manager-'));
+        try {
+            const globalWorkspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-global-'));
+            const globalConfigService = new ConfigService(globalWorkspaceRoot);
+            globalConfigService.saveLocalConfig({
+                host: 'https://dev.example.test',
+                instanceIdentifier: 'n8n_1111111111',
+            }, { instanceId: 'dev-instance', instanceName: 'Dev', apiKey: 'dev-key' });
+            globalConfigService.saveLocalConfig({
+                host: 'https://prod.example.test',
+                instanceIdentifier: 'n8n_2222222222',
+            }, { instanceId: 'prod-instance', instanceName: 'Prod', apiKey: 'prod-key', setActive: false });
+
+            const configService = new ConfigService(workspaceRoot);
+            const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
+            const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/prod' });
+
+            const sourceDir = configService.resolveEnvironment('Dev').workflowDir!;
+            const targetDir = configService.resolveEnvironment('Prod').workflowDir!;
+            mkdirSync(sourceDir, { recursive: true });
+            const sourcePath = path.join(sourceDir, 'remote-existing.workflow.ts');
+            writeFileSync(sourcePath, "@workflow({ id: 'source-wf', name: 'Remote Existing', active: false })\nexport class RemoteExisting {}\n", 'utf8');
+
+            const result = await new PromoteCommand(configService, {
+                createClient: () => ({
+                    getAllWorkflows: async () => [
+                        { id: 'target-wf', name: 'Remote Existing', active: false, nodes: [], connections: {} },
+                    ],
+                    listCredentials: async () => [],
+                }),
+            }).run(sourcePath, {
+                from: 'Dev',
+                to: 'Prod',
+                push: false,
+                promotionConfig: path.join(workspaceRoot, 'n8nac-promotion.json'),
+            });
+
+            expect(result.workflowId).toBe('target-wf');
+            expect(readFileSync(path.join(targetDir, 'remote-existing.workflow.ts'), 'utf8')).toContain("id: 'target-wf'");
+            const promotionConfig = JSON.parse(readFileSync(path.join(workspaceRoot, 'n8nac-promotion.json'), 'utf8'));
+            expect(promotionConfig.routes['Dev->Prod'].bindings.workflows['source-wf']).toBe('target-wf');
         } finally {
             if (previousManagerHome === undefined) {
                 delete process.env.N8N_MANAGER_HOME;

--- a/packages/cli/tests/unit/promote-command.test.ts
+++ b/packages/cli/tests/unit/promote-command.test.ts
@@ -74,7 +74,12 @@ export class PromotedWorkflow {}
             writeFileSync(path.join(targetDir, 'one.workflow.ts'), workflow, 'utf8');
 
             const promotionConfigPath = path.join(workspaceRoot, 'n8nac-promotion.json');
-            await expect(new PromoteCommand(configService).run(sourcePath, { from: 'Dev', to: 'Prod', dryRun: true, promotionConfig: promotionConfigPath })).resolves.toMatchObject({
+            await expect(new PromoteCommand(configService, {
+                createClient: () => ({
+                    getAllWorkflows: async () => [],
+                    listCredentials: async () => [],
+                }),
+            }).run(sourcePath, { from: 'Dev', to: 'Prod', dryRun: true, promotionConfig: promotionConfigPath })).resolves.toMatchObject({
                 targetEnvironmentName: 'Prod',
                 targetPath: path.join(targetDir, 'one.workflow.ts'),
                 dryRun: true,
@@ -168,8 +173,12 @@ export class PromotedWorkflow {}
             const sourceDir = configService.resolveEnvironment('Dev').workflowDir!;
             const targetDir = configService.resolveEnvironment('Prod').workflowDir!;
             mkdirSync(sourceDir, { recursive: true });
+            mkdirSync(path.join(sourceDir, 'nested'), { recursive: true });
+            mkdirSync(path.join(sourceDir, '.ignored'), { recursive: true });
             writeFileSync(path.join(sourceDir, 'one.workflow.ts'), "@workflow({ name: 'One', active: false })\nexport class One {}\n", 'utf8');
             writeFileSync(path.join(sourceDir, 'two.workflow.ts'), "@workflow({ name: 'Two', active: false })\nexport class Two {}\n", 'utf8');
+            writeFileSync(path.join(sourceDir, 'nested', 'three.workflow.ts'), "@workflow({ name: 'Three', active: false })\nexport class Three {}\n", 'utf8');
+            writeFileSync(path.join(sourceDir, '.ignored', 'hidden.workflow.ts'), "@workflow({ name: 'Hidden', active: false })\nexport class Hidden {}\n", 'utf8');
 
             const result = await new PromoteCommand(configService, {
                 createClient: () => ({
@@ -183,9 +192,11 @@ export class PromotedWorkflow {}
                 promotionConfig: path.join(workspaceRoot, 'n8nac-promotion.json'),
             });
 
-            expect(result.summary.planned).toBe(2);
+            expect(result.summary.planned).toBe(3);
             expect(existsSync(path.join(targetDir, 'one.workflow.ts'))).toBe(true);
             expect(existsSync(path.join(targetDir, 'two.workflow.ts'))).toBe(true);
+            expect(existsSync(path.join(targetDir, 'nested', 'three.workflow.ts'))).toBe(true);
+            expect(existsSync(path.join(targetDir, '.ignored', 'hidden.workflow.ts'))).toBe(false);
         } finally {
             if (previousManagerHome === undefined) {
                 delete process.env.N8N_MANAGER_HOME;
@@ -310,6 +321,126 @@ export class CredentialWorkflow {
             expect(readFileSync(path.join(targetDir, 'remote-existing.workflow.ts'), 'utf8')).toContain("id: 'target-wf'");
             const promotionConfig = JSON.parse(readFileSync(path.join(workspaceRoot, 'n8nac-promotion.json'), 'utf8'));
             expect(promotionConfig.routes['Dev->Prod'].bindings.workflows['source-wf']).toBe('target-wf');
+        } finally {
+            if (previousManagerHome === undefined) {
+                delete process.env.N8N_MANAGER_HOME;
+            } else {
+                process.env.N8N_MANAGER_HOME = previousManagerHome;
+            }
+        }
+    });
+
+    it('discovers existing remote target workflow ids during dry-run without persisting bindings', async () => {
+        const previousManagerHome = process.env.N8N_MANAGER_HOME;
+        const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-workspace-'));
+        process.env.N8N_MANAGER_HOME = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-manager-'));
+        try {
+            const globalWorkspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-global-'));
+            const globalConfigService = new ConfigService(globalWorkspaceRoot);
+            globalConfigService.saveLocalConfig({
+                host: 'https://dev.example.test',
+                instanceIdentifier: 'n8n_1111111111',
+            }, { instanceId: 'dev-instance', instanceName: 'Dev', apiKey: 'dev-key' });
+            globalConfigService.saveLocalConfig({
+                host: 'https://prod.example.test',
+                instanceIdentifier: 'n8n_2222222222',
+            }, { instanceId: 'prod-instance', instanceName: 'Prod', apiKey: 'prod-key', setActive: false });
+
+            const configService = new ConfigService(workspaceRoot);
+            const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
+            const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/prod' });
+
+            const sourceDir = configService.resolveEnvironment('Dev').workflowDir!;
+            mkdirSync(sourceDir, { recursive: true });
+            const sourcePath = path.join(sourceDir, 'dry-run-existing.workflow.ts');
+            writeFileSync(sourcePath, "@workflow({ id: 'source-dry-run', name: 'Dry Run Existing', active: false })\nexport class DryRunExisting {}\n", 'utf8');
+
+            const promotionConfigPath = path.join(workspaceRoot, 'n8nac-promotion.json');
+            const result = await new PromoteCommand(configService, {
+                createClient: () => ({
+                    getAllWorkflows: async () => [
+                        { id: 'target-dry-run', name: 'Dry Run Existing', active: false, nodes: [], connections: {} },
+                    ],
+                    listCredentials: async () => [],
+                }),
+            }).run(sourcePath, {
+                from: 'Dev',
+                to: 'Prod',
+                dryRun: true,
+                promotionConfig: promotionConfigPath,
+            });
+
+            expect(result.workflowId).toBe('target-dry-run');
+            expect(result.workflows[0].action).toBe('update');
+            expect(existsSync(promotionConfigPath)).toBe(false);
+        } finally {
+            if (previousManagerHome === undefined) {
+                delete process.env.N8N_MANAGER_HOME;
+            } else {
+                process.env.N8N_MANAGER_HOME = previousManagerHome;
+            }
+        }
+    });
+
+    it('refreshes target inventories between runs on the same command instance', async () => {
+        const previousManagerHome = process.env.N8N_MANAGER_HOME;
+        const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-workspace-'));
+        process.env.N8N_MANAGER_HOME = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-manager-'));
+        try {
+            const globalWorkspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-global-'));
+            const globalConfigService = new ConfigService(globalWorkspaceRoot);
+            globalConfigService.saveLocalConfig({
+                host: 'https://dev.example.test',
+                instanceIdentifier: 'n8n_1111111111',
+            }, { instanceId: 'dev-instance', instanceName: 'Dev', apiKey: 'dev-key' });
+            globalConfigService.saveLocalConfig({
+                host: 'https://prod.example.test',
+                instanceIdentifier: 'n8n_2222222222',
+            }, { instanceId: 'prod-instance', instanceName: 'Prod', apiKey: 'prod-key', setActive: false });
+            globalConfigService.saveLocalConfig({
+                host: 'https://staging.example.test',
+                instanceIdentifier: 'n8n_3333333333',
+            }, { instanceId: 'staging-instance', instanceName: 'Staging', apiKey: 'staging-key', setActive: false });
+
+            const configService = new ConfigService(workspaceRoot);
+            const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
+            const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
+            const stagingTarget = configService.addInstanceTarget({ name: 'Staging Target', managedInstanceId: 'staging-instance' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/prod' });
+            configService.addEnvironment({ name: 'Staging', environmentTarget: stagingTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/staging' });
+
+            const sourceDir = configService.resolveEnvironment('Dev').workflowDir!;
+            mkdirSync(sourceDir, { recursive: true });
+            const sourcePath = path.join(sourceDir, 'reusable.workflow.ts');
+            writeFileSync(sourcePath, "@workflow({ id: 'source-reusable', name: 'Reusable', active: false })\nexport class Reusable {}\n", 'utf8');
+
+            const command = new PromoteCommand(configService, {
+                createClient: (environment) => ({
+                    getAllWorkflows: async () => environment.environmentName === 'Prod'
+                        ? [{ id: 'prod-wf', name: 'Reusable', active: false, nodes: [], connections: {} }]
+                        : [{ id: 'staging-wf', name: 'Reusable', active: false, nodes: [], connections: {} }],
+                    listCredentials: async () => [],
+                }),
+            });
+
+            const prodResult = await command.run(sourcePath, {
+                from: 'Dev',
+                to: 'Prod',
+                dryRun: true,
+                promotionConfig: path.join(workspaceRoot, 'n8nac-promotion-prod.json'),
+            });
+            const stagingResult = await command.run(sourcePath, {
+                from: 'Dev',
+                to: 'Staging',
+                dryRun: true,
+                promotionConfig: path.join(workspaceRoot, 'n8nac-promotion-staging.json'),
+            });
+
+            expect(prodResult.workflowId).toBe('prod-wf');
+            expect(stagingResult.workflowId).toBe('staging-wf');
         } finally {
             if (previousManagerHome === undefined) {
                 delete process.env.N8N_MANAGER_HOME;

--- a/packages/cli/tests/unit/promote-command.test.ts
+++ b/packages/cli/tests/unit/promote-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { ConfigService } from '../../src/services/config-service.js';
@@ -73,7 +73,7 @@ export class PromotedWorkflow {}
             writeFileSync(sourcePath, workflow, 'utf8');
             writeFileSync(path.join(targetDir, 'one.workflow.ts'), workflow, 'utf8');
 
-            await expect(new PromoteCommand(configService).run(sourcePath, { from: 'Dev', to: 'Prod', dryRun: true })).resolves.toMatchObject({
+            await expect(new PromoteCommand(configService).run(sourcePath, { from: 'Dev', to: 'Prod', dryRun: true, promotionConfig: path.join(workspaceRoot, 'n8nac-promotion.json') })).resolves.toMatchObject({
                 targetEnvironmentName: 'Prod',
                 targetPath: path.join(targetDir, 'one.workflow.ts'),
                 dryRun: true,
@@ -88,7 +88,7 @@ export class PromotedWorkflow {}
         }
     });
 
-    it('requires overwrite before replacing an existing target workflow file', async () => {
+    it('reuses an existing target workflow id without requiring overwrite', async () => {
         const previousManagerHome = process.env.N8N_MANAGER_HOME;
         const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-workspace-'));
         process.env.N8N_MANAGER_HOME = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-manager-'));
@@ -119,16 +119,201 @@ export class PromotedWorkflow {}
             writeFileSync(sourcePath, "@workflow({ name: 'Source' })\nexport class Source {}\n", 'utf8');
             writeFileSync(targetPath, "@workflow({ id: 'target-id', name: 'Target' })\nexport class Target {}\n", 'utf8');
 
-            await expect(new PromoteCommand(configService).run(sourcePath, { from: 'Dev', to: 'Prod', push: false })).rejects.toThrow(/--overwrite/);
-            expect(readFileSync(targetPath, 'utf8')).toContain("name: 'Target'");
-
-            await expect(new PromoteCommand(configService).run(sourcePath, { from: 'Dev', to: 'Prod', push: false, overwrite: true })).resolves.toMatchObject({
+            await expect(new PromoteCommand(configService).run(sourcePath, { from: 'Dev', to: 'Prod', push: false, promotionConfig: path.join(workspaceRoot, 'n8nac-promotion.json') })).resolves.toMatchObject({
                 targetEnvironmentName: 'Prod',
                 targetPath,
                 pushed: false,
+                workflowId: 'target-id',
             });
             expect(readFileSync(targetPath, 'utf8')).toContain("id: 'target-id'");
             expect(readFileSync(targetPath, 'utf8')).toContain("name: 'Source'");
+        } finally {
+            if (previousManagerHome === undefined) {
+                delete process.env.N8N_MANAGER_HOME;
+            } else {
+                process.env.N8N_MANAGER_HOME = previousManagerHome;
+            }
+        }
+    });
+
+    it('promotes all source workflows when no path is provided', async () => {
+        const previousManagerHome = process.env.N8N_MANAGER_HOME;
+        const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-workspace-'));
+        process.env.N8N_MANAGER_HOME = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-manager-'));
+        try {
+            const globalWorkspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-global-'));
+            const globalConfigService = new ConfigService(globalWorkspaceRoot);
+            globalConfigService.saveLocalConfig({
+                host: 'https://dev.example.test',
+                instanceIdentifier: 'n8n_1111111111',
+            }, { instanceId: 'dev-instance', instanceName: 'Dev', apiKey: 'dev-key' });
+            globalConfigService.saveLocalConfig({
+                host: 'https://prod.example.test',
+                instanceIdentifier: 'n8n_2222222222',
+            }, { instanceId: 'prod-instance', instanceName: 'Prod', apiKey: 'prod-key', setActive: false });
+
+            const configService = new ConfigService(workspaceRoot);
+            const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
+            const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/prod' });
+
+            const sourceDir = configService.resolveEnvironment('Dev').workflowDir!;
+            const targetDir = configService.resolveEnvironment('Prod').workflowDir!;
+            mkdirSync(sourceDir, { recursive: true });
+            writeFileSync(path.join(sourceDir, 'one.workflow.ts'), "@workflow({ name: 'One', active: false })\nexport class One {}\n", 'utf8');
+            writeFileSync(path.join(sourceDir, 'two.workflow.ts'), "@workflow({ name: 'Two', active: false })\nexport class Two {}\n", 'utf8');
+
+            const result = await new PromoteCommand(configService).run(undefined, {
+                from: 'Dev',
+                to: 'Prod',
+                push: false,
+                promotionConfig: path.join(workspaceRoot, 'n8nac-promotion.json'),
+            });
+
+            expect(result.summary.planned).toBe(2);
+            expect(existsSync(path.join(targetDir, 'one.workflow.ts'))).toBe(true);
+            expect(existsSync(path.join(targetDir, 'two.workflow.ts'))).toBe(true);
+        } finally {
+            if (previousManagerHome === undefined) {
+                delete process.env.N8N_MANAGER_HOME;
+            } else {
+                process.env.N8N_MANAGER_HOME = previousManagerHome;
+            }
+        }
+    });
+
+    it('remaps credentials by type and name using the target inventory', async () => {
+        const previousManagerHome = process.env.N8N_MANAGER_HOME;
+        const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-workspace-'));
+        process.env.N8N_MANAGER_HOME = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-manager-'));
+        try {
+            const globalWorkspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-global-'));
+            const globalConfigService = new ConfigService(globalWorkspaceRoot);
+            globalConfigService.saveLocalConfig({
+                host: 'https://dev.example.test',
+                instanceIdentifier: 'n8n_1111111111',
+            }, { instanceId: 'dev-instance', instanceName: 'Dev', apiKey: 'dev-key' });
+            globalConfigService.saveLocalConfig({
+                host: 'https://prod.example.test',
+                instanceIdentifier: 'n8n_2222222222',
+            }, { instanceId: 'prod-instance', instanceName: 'Prod', apiKey: 'prod-key', setActive: false });
+
+            const configService = new ConfigService(workspaceRoot);
+            const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
+            const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/prod' });
+
+            const sourceDir = configService.resolveEnvironment('Dev').workflowDir!;
+            const targetDir = configService.resolveEnvironment('Prod').workflowDir!;
+            mkdirSync(sourceDir, { recursive: true });
+            const sourcePath = path.join(sourceDir, 'credential.workflow.ts');
+            writeFileSync(sourcePath, `import { workflow, node } from '@n8n-as-code/transformer';
+
+@workflow({ id: 'source-wf', name: 'Credential Workflow', active: false })
+export class CredentialWorkflow {
+  @node({
+    name: 'HTTP Request',
+    type: 'n8n-nodes-base.httpRequest',
+    version: 4,
+    position: [100, 100],
+    credentials: { httpBasicAuth: { id: 'source-cred', name: 'Shared Credential' } }
+  })
+  HttpRequest = { url: 'https://example.com', method: 'GET' };
+}
+`, 'utf8');
+
+            await new PromoteCommand(configService, {
+                createClient: () => ({
+                    getAllWorkflows: async () => [],
+                    listCredentials: async () => [
+                        { id: 'target-cred', name: 'Shared Credential', type: 'httpBasicAuth' },
+                    ],
+                }),
+            }).run(sourcePath, {
+                from: 'Dev',
+                to: 'Prod',
+                push: false,
+                promotionConfig: path.join(workspaceRoot, 'n8nac-promotion.json'),
+            });
+
+            const promoted = readFileSync(path.join(targetDir, 'credential.workflow.ts'), 'utf8');
+            expect(promoted).toContain("id: 'target-cred'");
+            expect(promoted).toContain("name: 'Shared Credential'");
+            const promotionConfig = JSON.parse(readFileSync(path.join(workspaceRoot, 'n8nac-promotion.json'), 'utf8'));
+            expect(promotionConfig.routes['Dev->Prod'].bindings.credentials['source-cred']).toBe('target-cred');
+        } finally {
+            if (previousManagerHome === undefined) {
+                delete process.env.N8N_MANAGER_HOME;
+            } else {
+                process.env.N8N_MANAGER_HOME = previousManagerHome;
+            }
+        }
+    });
+
+    it('creates referenced workflows first and remaps execute-workflow ids', async () => {
+        const previousManagerHome = process.env.N8N_MANAGER_HOME;
+        const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-workspace-'));
+        process.env.N8N_MANAGER_HOME = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-manager-'));
+        try {
+            const globalWorkspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-global-'));
+            const globalConfigService = new ConfigService(globalWorkspaceRoot);
+            globalConfigService.saveLocalConfig({
+                host: 'https://dev.example.test',
+                instanceIdentifier: 'n8n_1111111111',
+            }, { instanceId: 'dev-instance', instanceName: 'Dev', apiKey: 'dev-key' });
+            globalConfigService.saveLocalConfig({
+                host: 'https://prod.example.test',
+                instanceIdentifier: 'n8n_2222222222',
+            }, { instanceId: 'prod-instance', instanceName: 'Prod', apiKey: 'prod-key', setActive: false });
+
+            const configService = new ConfigService(workspaceRoot);
+            const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
+            const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/prod' });
+
+            const sourceDir = configService.resolveEnvironment('Dev').workflowDir!;
+            const targetDir = configService.resolveEnvironment('Prod').workflowDir!;
+            mkdirSync(sourceDir, { recursive: true });
+            writeFileSync(path.join(sourceDir, 'caller.workflow.ts'), `import { workflow, node } from '@n8n-as-code/transformer';
+
+@workflow({ id: 'source-caller', name: 'Caller', active: false })
+export class CallerWorkflow {
+  @node({
+    name: 'Execute Workflow',
+    type: 'n8n-nodes-base.executeWorkflow',
+    version: 1,
+    position: [100, 100]
+  })
+  ExecuteWorkflow = { workflowId: 'source-child' };
+}
+`, 'utf8');
+            writeFileSync(path.join(sourceDir, 'child.workflow.ts'), "@workflow({ id: 'source-child', name: 'Child', active: false })\nexport class ChildWorkflow {}\n", 'utf8');
+
+            const pushed: string[] = [];
+            await new PromoteCommand(configService, {
+                createClient: () => ({
+                    getAllWorkflows: async () => [],
+                    listCredentials: async () => [],
+                }),
+                pushWorkflow: async (_target, targetPath) => {
+                    pushed.push(path.basename(targetPath));
+                    return targetPath.includes('child.workflow.ts') ? 'target-child' : 'target-caller';
+                },
+            }).run(undefined, {
+                from: 'Dev',
+                to: 'Prod',
+                promotionConfig: path.join(workspaceRoot, 'n8nac-promotion.json'),
+            });
+
+            expect(pushed).toEqual(['child.workflow.ts', 'caller.workflow.ts']);
+            const promotedCaller = readFileSync(path.join(targetDir, 'caller.workflow.ts'), 'utf8');
+            expect(promotedCaller).toContain("workflowId: 'target-child'");
+            const promotionConfig = JSON.parse(readFileSync(path.join(workspaceRoot, 'n8nac-promotion.json'), 'utf8'));
+            expect(promotionConfig.routes['Dev->Prod'].bindings.workflows['source-child']).toBe('target-child');
+            expect(promotionConfig.routes['Dev->Prod'].bindings.workflows['source-caller']).toBe('target-caller');
         } finally {
             if (previousManagerHome === undefined) {
                 delete process.env.N8N_MANAGER_HOME;

--- a/packages/cli/tests/unit/promote-command.test.ts
+++ b/packages/cli/tests/unit/promote-command.test.ts
@@ -61,11 +61,11 @@ export class PromotedWorkflow {}
             const configService = new ConfigService(workspaceRoot);
             const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
             const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
-            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/dev' });
-            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/prod' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/prod' });
 
-            const sourceDir = configService.resolveEnvironment('Dev').workflowDir!;
-            const targetDir = configService.resolveEnvironment('Prod').workflowDir!;
+            const sourceDir = configService.resolveEnvironment('Dev').workflowsPath!;
+            const targetDir = configService.resolveEnvironment('Prod').workflowsPath!;
             mkdirSync(sourceDir, { recursive: true });
             mkdirSync(targetDir, { recursive: true });
             const workflow = "@workflow({ name: 'One' })\nexport class One {}\n";
@@ -114,11 +114,11 @@ export class PromotedWorkflow {}
             const configService = new ConfigService(workspaceRoot);
             const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
             const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
-            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/dev' });
-            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/prod' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/prod' });
 
-            const sourceDir = configService.resolveEnvironment('Dev').workflowDir!;
-            const targetDir = configService.resolveEnvironment('Prod').workflowDir!;
+            const sourceDir = configService.resolveEnvironment('Dev').workflowsPath!;
+            const targetDir = configService.resolveEnvironment('Prod').workflowsPath!;
             mkdirSync(sourceDir, { recursive: true });
             mkdirSync(targetDir, { recursive: true });
             const sourcePath = path.join(sourceDir, 'one.workflow.ts');
@@ -167,11 +167,11 @@ export class PromotedWorkflow {}
             const configService = new ConfigService(workspaceRoot);
             const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
             const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
-            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/dev' });
-            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/prod' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/prod' });
 
-            const sourceDir = configService.resolveEnvironment('Dev').workflowDir!;
-            const targetDir = configService.resolveEnvironment('Prod').workflowDir!;
+            const sourceDir = configService.resolveEnvironment('Dev').workflowsPath!;
+            const targetDir = configService.resolveEnvironment('Prod').workflowsPath!;
             mkdirSync(sourceDir, { recursive: true });
             mkdirSync(path.join(sourceDir, 'nested'), { recursive: true });
             mkdirSync(path.join(sourceDir, '.ignored'), { recursive: true });
@@ -225,11 +225,11 @@ export class PromotedWorkflow {}
             const configService = new ConfigService(workspaceRoot);
             const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
             const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
-            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/dev' });
-            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/prod' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/prod' });
 
-            const sourceDir = configService.resolveEnvironment('Dev').workflowDir!;
-            const targetDir = configService.resolveEnvironment('Prod').workflowDir!;
+            const sourceDir = configService.resolveEnvironment('Dev').workflowsPath!;
+            const targetDir = configService.resolveEnvironment('Prod').workflowsPath!;
             mkdirSync(sourceDir, { recursive: true });
             const sourcePath = path.join(sourceDir, 'credential.workflow.ts');
             writeFileSync(sourcePath, `import { workflow, node } from '@n8n-as-code/transformer';
@@ -294,11 +294,11 @@ export class CredentialWorkflow {
             const configService = new ConfigService(workspaceRoot);
             const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
             const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
-            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/dev' });
-            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/prod' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/prod' });
 
-            const sourceDir = configService.resolveEnvironment('Dev').workflowDir!;
-            const targetDir = configService.resolveEnvironment('Prod').workflowDir!;
+            const sourceDir = configService.resolveEnvironment('Dev').workflowsPath!;
+            const targetDir = configService.resolveEnvironment('Prod').workflowsPath!;
             mkdirSync(sourceDir, { recursive: true });
             const sourcePath = path.join(sourceDir, 'remote-existing.workflow.ts');
             writeFileSync(sourcePath, "@workflow({ id: 'source-wf', name: 'Remote Existing', active: false })\nexport class RemoteExisting {}\n", 'utf8');
@@ -349,10 +349,10 @@ export class CredentialWorkflow {
             const configService = new ConfigService(workspaceRoot);
             const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
             const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
-            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/dev' });
-            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/prod' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/prod' });
 
-            const sourceDir = configService.resolveEnvironment('Dev').workflowDir!;
+            const sourceDir = configService.resolveEnvironment('Dev').workflowsPath!;
             mkdirSync(sourceDir, { recursive: true });
             const sourcePath = path.join(sourceDir, 'dry-run-existing.workflow.ts');
             writeFileSync(sourcePath, "@workflow({ id: 'source-dry-run', name: 'Dry Run Existing', active: false })\nexport class DryRunExisting {}\n", 'utf8');
@@ -408,11 +408,11 @@ export class CredentialWorkflow {
             const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
             const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
             const stagingTarget = configService.addInstanceTarget({ name: 'Staging Target', managedInstanceId: 'staging-instance' });
-            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/dev' });
-            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/prod' });
-            configService.addEnvironment({ name: 'Staging', environmentTarget: stagingTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/staging' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/prod' });
+            configService.addEnvironment({ name: 'Staging', environmentTarget: stagingTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/staging' });
 
-            const sourceDir = configService.resolveEnvironment('Dev').workflowDir!;
+            const sourceDir = configService.resolveEnvironment('Dev').workflowsPath!;
             mkdirSync(sourceDir, { recursive: true });
             const sourcePath = path.join(sourceDir, 'reusable.workflow.ts');
             writeFileSync(sourcePath, "@workflow({ id: 'source-reusable', name: 'Reusable', active: false })\nexport class Reusable {}\n", 'utf8');
@@ -469,11 +469,11 @@ export class CredentialWorkflow {
             const configService = new ConfigService(workspaceRoot);
             const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
             const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
-            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/dev' });
-            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', syncFolder: 'workflows/prod' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/prod' });
 
-            const sourceDir = configService.resolveEnvironment('Dev').workflowDir!;
-            const targetDir = configService.resolveEnvironment('Prod').workflowDir!;
+            const sourceDir = configService.resolveEnvironment('Dev').workflowsPath!;
+            const targetDir = configService.resolveEnvironment('Prod').workflowsPath!;
             mkdirSync(sourceDir, { recursive: true });
             writeFileSync(path.join(sourceDir, 'caller.workflow.ts'), `import { workflow, node } from '@n8n-as-code/transformer';
 

--- a/plans/native-environment-promotion.md
+++ b/plans/native-environment-promotion.md
@@ -1,0 +1,84 @@
+# Native Environment Promotion Plan
+
+## Summary
+
+Implement native multi-environment promotion for `n8nac promote` while preserving the current single-workflow flow.
+
+Supported entrypoints:
+
+```bash
+n8nac promote <path> --from Dev --to Prod
+n8nac promote --from Dev --to Prod --dry-run
+```
+
+Promotion uses local `.workflow.ts` files from the source environment sync scope as the source of truth. It plans the target changes first, resolves environment-specific workflow and credential IDs, transforms workflows through structured JSON, then writes target workflow files and pushes them unless `--no-push` is used.
+
+The identity model is "state plus names": discover target objects by stable names for the first promotion, then persist source-to-target bindings in `n8nac-promotion.json` so later promotions update the same target objects.
+
+## Key Changes
+
+- Extend `n8nac promote` so the positional workflow path is optional.
+- Keep single-file promotion compatibility when a path is provided.
+- Promote all direct `.workflow.ts` files from the source workflow directory when no path is provided.
+- Add optional `--promotion-config <path>`, defaulting to `n8nac-promotion.json`.
+- Add a planning phase that loads source/target environments, inventories workflows and credentials, resolves bindings, and reports missing or ambiguous references before writing.
+- Add structured remapping for:
+  - workflow metadata (`id`, project metadata, archived metadata),
+  - node credential references,
+  - supported workflow-to-workflow references in Execute Workflow nodes.
+- Persist promotion routes and bindings in `n8nac-promotion.json`.
+
+## Configuration
+
+`n8nac-promotion.json` starts with this v1 shape:
+
+```json
+{
+  "version": 1,
+  "routes": {
+    "Dev->Prod": {
+      "bindings": {
+        "workflows": {},
+        "credentials": {}
+      },
+      "workflowOverrides": {},
+      "credentialOverrides": {},
+      "nameRules": []
+    }
+  }
+}
+```
+
+Rules:
+
+- Existing bindings win.
+- Overrides are used for explicit exceptions.
+- Unique target name matches are used for first discovery.
+- Name rules are optional conveniences, not the source of truth.
+- Missing or ambiguous references block promotion by default.
+- Credentials are never created automatically in v1.
+
+## CLI Behavior
+
+- `--dry-run` does not write workflow files, does not push, and does not update `n8nac-promotion.json`.
+- Normal promotion writes transformed files into the target workflow directory and pushes them unless `--no-push` is set.
+- Successful pushes update promotion bindings with the target workflow IDs.
+- `--overwrite` is only required when a target file exists but cannot be associated with a resolved target workflow.
+- `--json` returns a structured plan/result with summary counts, workflow actions, substitutions, and blocking problems.
+
+## Tests
+
+- Unit tests for path compatibility and environment-wide promotion selection.
+- Unit tests for dry-run side effects.
+- Unit tests for credential mapping by type/name, overrides, ambiguity, and missing credentials.
+- Unit tests for workflow binding, target-name discovery, and first-create behavior.
+- Unit tests for workflow transformation through TS -> JSON -> TS.
+- CLI-level tests with mocked clients; no live n8n dependency.
+
+## Assumptions
+
+- V1 supports TypeScript workflow files only.
+- The local source sync scope is the source of truth, not the remote source instance.
+- Execute Workflow node references are the only workflow-to-workflow references remapped in v1.
+- Promotion keeps the workflow `active` value from the source workflow.
+- Credentials must already exist in the target environment or be mapped through overrides.


### PR DESCRIPTION
## Summary

Implements native multi-environment promotion in n8nac.

The PR started with the implementation plan in `plans/native-environment-promotion.md`, then adds the promotion engine, CLI surface, docs, and unit coverage.

Closes #467 when merged.

## Current status

- [x] Plan committed
- [x] Promotion engine implementation
- [x] Tests
- [x] Docs update

## Verification

- `npm run build --workspace=n8nac`
- `npx vitest run packages/cli/tests/unit/promote-command.test.ts`
- `npm run test:unit --workspace=n8nac`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-environment workflow promotion with planning, credential and workflow-reference remapping, optional push, and dry-run preview.
  * Accepts an optional workflow path and a promotion config file (config persisted between runs; path configurable).

* **Documentation**
  * New and updated CLI docs, usage examples, and Quick Start example demonstrating promote --dry-run and promotion config usage.

* **Tests**
  * Expanded unit tests covering planning, remapping, push ordering, discovery, and config-driven scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->