### PR TITLE
[codex] Fix SSO workflow webview auth handoff

### DIFF
--- a/packages/vscode-extension/src/services/proxy-service.ts
+++ b/packages/vscode-extension/src/services/proxy-service.ts
@@ -1,9 +1,15 @@
 import * as http from 'http';
 import * as os from 'os';
 import httpProxy = require('http-proxy');
-import * as vscode from 'vscode';
+import type * as vscode from 'vscode';
 import { AddressInfo } from 'net';
+import { randomUUID } from 'crypto';
 import { WebSocket, WebSocketServer } from 'ws';
+
+type ExternalAuthRequest = {
+    token: string;
+    targetUrl: string;
+};
 
 export class ProxyService {
     private server: http.Server | undefined;
@@ -17,6 +23,10 @@ export class ProxyService {
 
     private cookieJar = new Map<string, string>();
     private htmlRoutes = new Map<string, string>();
+    private externalAuthSessions = new Map<string, number>();
+
+    private readonly externalAuthRoutePrefix = '/__n8nac-external-auth/';
+    private readonly externalAuthSessionTtlMs = 15 * 60 * 1000;
 
     constructor() { }
 
@@ -41,21 +51,27 @@ export class ProxyService {
         return this.publicBaseUrl || `http://localhost:${this.port}`;
     }
 
-    private rewriteProxyLocation(location: string): string {
+    private rewriteProxyLocation(location: string, sourceUrl = this.target, externalAuthToken?: string): string {
         const proxyBaseUrl = this.getProxyBaseUrl();
         try {
             const targetUrl = new URL(this.target);
             const targetBasePath = this.trimTrailingSlash(targetUrl.pathname);
+            const sourceBaseUrl = new URL(sourceUrl || this.target);
 
             if (location.startsWith('/') && !location.startsWith('//')) {
-                const locationUrl = new URL(location, targetUrl.origin);
+                const locationUrl = new URL(location, sourceBaseUrl.origin);
+                if (locationUrl.origin !== targetUrl.origin) {
+                    return externalAuthToken ? this.buildExternalAuthProxyUrl(locationUrl.toString(), externalAuthToken) : location;
+                }
                 const remainingPath = this.stripTargetBasePath(locationUrl.pathname, targetBasePath);
                 return `${proxyBaseUrl}${remainingPath}${locationUrl.search}${locationUrl.hash}`;
             }
 
-            const locationUrl = new URL(location);
+            const locationUrl = location.startsWith('//')
+                ? new URL(`${sourceBaseUrl.protocol}${location}`)
+                : new URL(location);
             if (locationUrl.origin !== targetUrl.origin) {
-                return location;
+                return externalAuthToken ? this.buildExternalAuthProxyUrl(locationUrl.toString(), externalAuthToken) : location;
             }
 
             if (!this.urlPathMatchesBase(locationUrl.pathname, targetBasePath)) {
@@ -108,6 +124,15 @@ export class ProxyService {
         }
     }
 
+    private async openExternalUrl(url: string): Promise<void> {
+        try {
+            const vscodeRuntime = await import('vscode');
+            await vscodeRuntime.env.openExternal(vscodeRuntime.Uri.parse(url));
+        } catch (error: any) {
+            this.log(`[Proxy] Unable to open external authentication URL: ${error?.message || String(error)}`);
+        }
+    }
+
     private getStorageKey(): string {
         // Use a base64 encoded version of the target URL to avoid issues with special characters in keys
         return `n8n-cookies-${Buffer.from(this.target).toString('base64')}`;
@@ -124,6 +149,141 @@ export class ProxyService {
             hash = hash & hash; // Convert to 32bit integer
         }
         return 10000 + (Math.abs(hash) % 50000);
+    }
+
+    private cleanupExternalAuthSessions(): void {
+        const now = Date.now();
+        for (const [token, expiresAt] of this.externalAuthSessions) {
+            if (expiresAt <= now) {
+                this.externalAuthSessions.delete(token);
+            }
+        }
+    }
+
+    private createExternalAuthSession(): string {
+        this.cleanupExternalAuthSessions();
+        const token = randomUUID();
+        this.externalAuthSessions.set(token, Date.now() + this.externalAuthSessionTtlMs);
+        return token;
+    }
+
+    private isExternalAuthSessionValid(token: string): boolean {
+        this.cleanupExternalAuthSessions();
+        return Boolean(token && this.externalAuthSessions.has(token));
+    }
+
+    private buildExternalAuthProxyUrl(targetUrl: string, token = this.createExternalAuthSession()): string {
+        return `${this.getProxyBaseUrl()}${this.externalAuthRoutePrefix}${encodeURIComponent(token)}?url=${encodeURIComponent(targetUrl)}`;
+    }
+
+    private parseExternalAuthProxyRequest(requestUrl?: string): ExternalAuthRequest | undefined {
+        try {
+            const url = new URL(requestUrl ?? '/', `http://localhost:${this.port || 0}`);
+            if (!url.pathname.startsWith(this.externalAuthRoutePrefix)) {
+                return undefined;
+            }
+
+            const token = decodeURIComponent(url.pathname.slice(this.externalAuthRoutePrefix.length));
+            const targetUrl = url.searchParams.get('url') || '';
+            if (!this.isExternalAuthSessionValid(token)) {
+                return undefined;
+            }
+
+            const parsedTargetUrl = new URL(targetUrl);
+            if (!['http:', 'https:'].includes(parsedTargetUrl.protocol)) {
+                return undefined;
+            }
+
+            return { token, targetUrl: parsedTargetUrl.toString() };
+        } catch {
+            return undefined;
+        }
+    }
+
+    private isExternalN8nRedirect(location: string): boolean {
+        try {
+            const targetUrl = new URL(this.target);
+            const locationUrl = new URL(location, targetUrl.origin);
+            return locationUrl.origin !== targetUrl.origin;
+        } catch {
+            return false;
+        }
+    }
+
+    private createExternalAuthHandoff(location: string, returnUrl: string): { authProxyUrl: string; html: string } | undefined {
+        if (!this.isExternalN8nRedirect(location)) {
+            return undefined;
+        }
+
+        const targetUrl = new URL(location, new URL(this.target).origin).toString();
+        const authProxyUrl = this.buildExternalAuthProxyUrl(targetUrl);
+        return {
+            authProxyUrl,
+            html: this.buildExternalAuthHandoffHtml(authProxyUrl, returnUrl),
+        };
+    }
+
+    private buildExternalAuthHandoffHtml(authProxyUrl: string, returnUrl: string): string {
+        const htmlSafe = (value: string) => value
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+        const authUrlHtml = htmlSafe(authProxyUrl);
+        const returnUrlHtml = htmlSafe(returnUrl);
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>n8n sign-in</title>
+  <style>
+    html, body { margin: 0; min-height: 100%; background: #1e1e1e; color: #f3f3f3; font-family: system-ui, -apple-system, sans-serif; }
+    body { display: grid; place-items: center; padding: 24px; box-sizing: border-box; }
+    main { max-width: 520px; text-align: center; }
+    h1 { font-size: 20px; line-height: 1.35; margin: 0 0 12px; font-weight: 600; }
+    p { margin: 0 0 20px; color: #c8c8c8; line-height: 1.5; }
+    a { color: #ffffff; }
+    .actions { display: flex; gap: 10px; justify-content: center; flex-wrap: wrap; }
+    .button { display: inline-flex; align-items: center; justify-content: center; min-height: 34px; padding: 0 14px; border-radius: 4px; background: #0e639c; color: #fff; text-decoration: none; font-size: 13px; }
+    .secondary { background: #3c3c3c; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Continue n8n sign-in in your browser</h1>
+    <p>Your SSO provider needs to run outside the embedded workflow view. After sign-in completes, return here and retry the workflow.</p>
+    <div class="actions">
+      <a class="button" href="${authUrlHtml}" target="_blank" rel="noreferrer">Open browser sign-in</a>
+      <a class="button secondary" href="${returnUrlHtml}">Retry workflow</a>
+    </div>
+  </main>
+</body>
+</html>`;
+    }
+
+    private handleExternalAuthProxyRequest(req: http.IncomingMessage, res: http.ServerResponse): boolean {
+        const authRequest = this.parseExternalAuthProxyRequest(req.url);
+        if (!authRequest || !this.proxy) {
+            return false;
+        }
+
+        const targetUrl = new URL(authRequest.targetUrl);
+        (req as http.IncomingMessage & { __n8nacExternalAuth?: ExternalAuthRequest }).__n8nacExternalAuth = authRequest;
+        req.url = `${targetUrl.pathname}${targetUrl.search}`;
+        delete req.headers['accept-encoding'];
+        req.headers['host'] = targetUrl.host;
+        req.headers['origin'] = targetUrl.origin;
+        res.setHeader('access-control-allow-origin', '*');
+        res.setHeader('access-control-allow-credentials', 'true');
+
+        this.proxy.web(req, res, {
+            target: targetUrl.origin,
+            changeOrigin: true,
+            secure: false,
+            buffer: undefined,
+        });
+        return true;
     }
 
     private async saveCookies() {
@@ -204,7 +364,8 @@ export class ProxyService {
         });
 
         // Strip headers that block iframe embedding and manage cookies
-        this.proxy.on('proxyRes', (proxyRes, _req, res) => {
+        this.proxy.on('proxyRes', (proxyRes, req, res) => {
+            const externalAuth = (req as http.IncomingMessage & { __n8nacExternalAuth?: ExternalAuthRequest }).__n8nacExternalAuth;
             // Remove headers that prevent iframe embedding
             delete proxyRes.headers['x-frame-options'];
             delete proxyRes.headers['content-security-policy'];
@@ -217,7 +378,28 @@ export class ProxyService {
 
             // Rewrite Location header for redirects
             if (proxyRes.headers['location']) {
-                proxyRes.headers['location'] = this.rewriteProxyLocation(proxyRes.headers['location']);
+                const location = proxyRes.headers['location'];
+                const isRedirect = (proxyRes.statusCode || 0) >= 300 && (proxyRes.statusCode || 0) < 400;
+                if (!externalAuth && isRedirect && this.isExternalN8nRedirect(location)) {
+                    const returnUrl = `${this.getProxyBaseUrl()}${req.url || '/'}`;
+                    const handoff = this.createExternalAuthHandoff(location, returnUrl);
+                    if (handoff) {
+                        const httpRes = res as http.ServerResponse;
+                        void this.openExternalUrl(handoff.authProxyUrl);
+                        proxyRes.resume();
+                        httpRes.writeHead(200, {
+                            'content-type': 'text/html; charset=utf-8',
+                            'cache-control': 'no-store',
+                        });
+                        httpRes.end(handoff.html);
+                        return;
+                    }
+                }
+                proxyRes.headers['location'] = this.rewriteProxyLocation(
+                    location,
+                    externalAuth?.targetUrl ?? this.target,
+                    externalAuth?.token,
+                );
             }
 
             // CRITICAL: Capture and Fix cookies for iframe/webview context
@@ -225,7 +407,7 @@ export class ProxyService {
                 proxyRes.headers['set-cookie'] = proxyRes.headers['set-cookie'].map(cookie => {
                     const eqIdx = cookie.indexOf('=');
                     const scIdx = cookie.indexOf(';');
-                    if (eqIdx !== -1) {
+                    if (!externalAuth && eqIdx !== -1) {
                         const key = cookie.substring(0, eqIdx).trim();
                         const valuePart = cookie.substring(0, scIdx !== -1 ? scIdx : undefined).trim();
                         this.cookieJar.set(key, valuePart);
@@ -262,7 +444,9 @@ export class ProxyService {
                         const charsetMatch = contentType.match(/charset=([^\s;]+)/i);
                         const charset = (charsetMatch?.[1] || 'utf-8') as BufferEncoding;
                         let html = raw.toString(charset);
-                        html = this.injectClipboardBridge(html, isMacOS);
+                        if (!externalAuth) {
+                            html = this.injectClipboardBridge(html, isMacOS);
+                        }
                         const encoded = Buffer.from(html, charset);
                         delete proxyRes.headers['content-length'];
                         delete proxyRes.headers['content-encoding'];
@@ -294,6 +478,10 @@ export class ProxyService {
         });
 
         this.server = http.createServer((req, res) => {
+            if (this.handleExternalAuthProxyRequest(req, res)) {
+                return;
+            }
+
             const routeHtml = this.getRegisteredHtmlRoute(req.url);
             if (routeHtml && req.method === 'GET') {
                 res.writeHead(200, {

--- a/packages/vscode-extension/src/services/proxy-service.ts
+++ b/packages/vscode-extension/src/services/proxy-service.ts
@@ -11,6 +11,11 @@ type ExternalAuthRequest = {
     targetUrl: string;
 };
 
+type ExternalAuthSession = {
+    expiresAt: number;
+    expectedTargetUrl: string;
+};
+
 export class ProxyService {
     private server: http.Server | undefined;
     private proxy: httpProxy | undefined;
@@ -23,7 +28,8 @@ export class ProxyService {
 
     private cookieJar = new Map<string, string>();
     private htmlRoutes = new Map<string, string>();
-    private externalAuthSessions = new Map<string, number>();
+    private externalAuthSessions = new Map<string, ExternalAuthSession>();
+    private lastWorkflowProxyUrl: string | undefined;
 
     private readonly externalAuthRoutePrefix = '/__n8nac-external-auth/';
     private readonly externalAuthSessionTtlMs = 15 * 60 * 1000;
@@ -63,6 +69,9 @@ export class ProxyService {
                 if (locationUrl.origin !== targetUrl.origin) {
                     return externalAuthToken ? this.buildExternalAuthProxyUrl(locationUrl.toString(), externalAuthToken) : location;
                 }
+                if (externalAuthToken) {
+                    this.externalAuthSessions.delete(externalAuthToken);
+                }
                 const remainingPath = this.stripTargetBasePath(locationUrl.pathname, targetBasePath);
                 return `${proxyBaseUrl}${remainingPath}${locationUrl.search}${locationUrl.hash}`;
             }
@@ -72,6 +81,10 @@ export class ProxyService {
                 : new URL(location);
             if (locationUrl.origin !== targetUrl.origin) {
                 return externalAuthToken ? this.buildExternalAuthProxyUrl(locationUrl.toString(), externalAuthToken) : location;
+            }
+
+            if (externalAuthToken) {
+                this.externalAuthSessions.delete(externalAuthToken);
             }
 
             if (!this.urlPathMatchesBase(locationUrl.pathname, targetBasePath)) {
@@ -153,27 +166,40 @@ export class ProxyService {
 
     private cleanupExternalAuthSessions(): void {
         const now = Date.now();
-        for (const [token, expiresAt] of this.externalAuthSessions) {
-            if (expiresAt <= now) {
+        for (const [token, session] of this.externalAuthSessions) {
+            if (session.expiresAt <= now) {
                 this.externalAuthSessions.delete(token);
             }
         }
     }
 
-    private createExternalAuthSession(): string {
+    private createExternalAuthSession(expectedTargetUrl: string): string {
         this.cleanupExternalAuthSessions();
         const token = randomUUID();
-        this.externalAuthSessions.set(token, Date.now() + this.externalAuthSessionTtlMs);
+        this.externalAuthSessions.set(token, {
+            expiresAt: Date.now() + this.externalAuthSessionTtlMs,
+            expectedTargetUrl: this.normalizeExternalAuthTargetUrl(expectedTargetUrl),
+        });
         return token;
     }
 
-    private isExternalAuthSessionValid(token: string): boolean {
+    private getExternalAuthSession(token: string): ExternalAuthSession | undefined {
         this.cleanupExternalAuthSessions();
-        return Boolean(token && this.externalAuthSessions.has(token));
+        return token ? this.externalAuthSessions.get(token) : undefined;
     }
 
-    private buildExternalAuthProxyUrl(targetUrl: string, token = this.createExternalAuthSession()): string {
-        return `${this.getProxyBaseUrl()}${this.externalAuthRoutePrefix}${encodeURIComponent(token)}?url=${encodeURIComponent(targetUrl)}`;
+    private normalizeExternalAuthTargetUrl(targetUrl: string): string {
+        return new URL(targetUrl).toString();
+    }
+
+    private buildExternalAuthProxyUrl(targetUrl: string, token?: string): string {
+        const normalizedTargetUrl = this.normalizeExternalAuthTargetUrl(targetUrl);
+        const sessionToken = token || this.createExternalAuthSession(normalizedTargetUrl);
+        const session = this.getExternalAuthSession(sessionToken);
+        if (session) {
+            session.expectedTargetUrl = normalizedTargetUrl;
+        }
+        return `${this.getProxyBaseUrl()}${this.externalAuthRoutePrefix}${encodeURIComponent(sessionToken)}?url=${encodeURIComponent(normalizedTargetUrl)}`;
     }
 
     private parseExternalAuthProxyRequest(requestUrl?: string): ExternalAuthRequest | undefined {
@@ -185,7 +211,8 @@ export class ProxyService {
 
             const token = decodeURIComponent(url.pathname.slice(this.externalAuthRoutePrefix.length));
             const targetUrl = url.searchParams.get('url') || '';
-            if (!this.isExternalAuthSessionValid(token)) {
+            const session = this.getExternalAuthSession(token);
+            if (!session) {
                 return undefined;
             }
 
@@ -193,8 +220,12 @@ export class ProxyService {
             if (!['http:', 'https:'].includes(parsedTargetUrl.protocol)) {
                 return undefined;
             }
+            const normalizedTargetUrl = parsedTargetUrl.toString();
+            if (normalizedTargetUrl !== session.expectedTargetUrl) {
+                return undefined;
+            }
 
-            return { token, targetUrl: parsedTargetUrl.toString() };
+            return { token, targetUrl: normalizedTargetUrl };
         } catch {
             return undefined;
         }
@@ -221,6 +252,43 @@ export class ProxyService {
             authProxyUrl,
             html: this.buildExternalAuthHandoffHtml(authProxyUrl, returnUrl),
         };
+    }
+
+    private buildProxyRequestUrl(requestUrl?: string): string {
+        const path = requestUrl && requestUrl.startsWith('/') ? requestUrl : `/${requestUrl || ''}`;
+        return `${this.getProxyBaseUrl()}${path}`;
+    }
+
+    private rememberWorkflowProxyUrl(requestUrl?: string): void {
+        try {
+            const url = new URL(requestUrl ?? '/', `http://localhost:${this.port || 0}`);
+            if (url.pathname.startsWith('/workflow/')) {
+                this.lastWorkflowProxyUrl = this.buildProxyRequestUrl(`${url.pathname}${url.search}`);
+            }
+        } catch {
+            // ignore malformed request URLs
+        }
+    }
+
+    private getWorkflowRetryUrl(req: http.IncomingMessage): string {
+        const referrer = typeof req.headers.referer === 'string' ? req.headers.referer : undefined;
+        const proxyBaseUrl = new URL(this.getProxyBaseUrl());
+        if (referrer) {
+            try {
+                const referrerUrl = new URL(referrer);
+                const proxyBasePath = this.trimTrailingSlash(proxyBaseUrl.pathname);
+                const referrerPath = proxyBasePath && referrerUrl.pathname.startsWith(`${proxyBasePath}/`)
+                    ? referrerUrl.pathname.slice(proxyBasePath.length)
+                    : referrerUrl.pathname;
+                if (referrerUrl.origin === proxyBaseUrl.origin && referrerPath.startsWith('/workflow/')) {
+                    return referrerUrl.toString();
+                }
+            } catch {
+                // ignore malformed referrers
+            }
+        }
+
+        return this.lastWorkflowProxyUrl || this.buildProxyRequestUrl(req.url);
     }
 
     private buildExternalAuthHandoffHtml(authProxyUrl: string, returnUrl: string): string {
@@ -342,6 +410,8 @@ export class ProxyService {
         // Reset state
         this.cookieJar.clear();
         this.htmlRoutes.clear();
+        this.externalAuthSessions.clear();
+        this.lastWorkflowProxyUrl = undefined;
         this.setPublicBaseUrl(undefined);
         this.target = normalizedTarget;
         this.port = stablePort;
@@ -381,7 +451,7 @@ export class ProxyService {
                 const location = proxyRes.headers['location'];
                 const isRedirect = (proxyRes.statusCode || 0) >= 300 && (proxyRes.statusCode || 0) < 400;
                 if (!externalAuth && isRedirect && this.isExternalN8nRedirect(location)) {
-                    const returnUrl = `${this.getProxyBaseUrl()}${req.url || '/'}`;
+                    const returnUrl = this.getWorkflowRetryUrl(req);
                     const handoff = this.createExternalAuthHandoff(location, returnUrl);
                     if (handoff) {
                         const httpRes = res as http.ServerResponse;
@@ -507,6 +577,7 @@ export class ProxyService {
             if (this.proxy) {
                 // Request uncompressed responses so HTML bridge injection can safely mutate the body.
                 delete req.headers['accept-encoding'];
+                this.rememberWorkflowProxyUrl(req.url);
 
                 const mergedCookies = this.buildMergedCookieHeader(req.headers.cookie);
                 if (mergedCookies) {

--- a/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
+++ b/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
@@ -229,7 +229,7 @@ test('ProxyService: external auth redirects remain proxied until n8n callback re
     const service = new ProxyService();
     (service as any).target = 'https://n8n.example.test';
     service.setPublicBaseUrl('https://code.example.test/proxy/25444');
-    const token = (service as any).createExternalAuthSession();
+    const token = (service as any).createExternalAuthSession('https://idp.example.test/login');
 
     const nextIdpUrl = (service as any).rewriteProxyLocation(
         '/oauth/authorize?next=1',
@@ -249,11 +249,86 @@ test('ProxyService: external auth redirects remain proxied until n8n callback re
             .includes(encodeURIComponent('https://idp.example.test/factor')),
         'Protocol-relative IdP redirects should remain in the auth proxy flow',
     );
+    const absoluteIdpUrl = (service as any).rewriteProxyLocation(
+        'https://idp.example.test/consent?step=2',
+        'https://idp.example.test/login',
+        token,
+    );
+    assert.ok(
+        absoluteIdpUrl.startsWith('https://code.example.test/proxy/25444/__n8nac-external-auth/'),
+        'Absolute IdP redirects should continue through the auth proxy',
+    );
+    assert.ok(
+        absoluteIdpUrl.includes(encodeURIComponent('https://idp.example.test/consent?step=2')),
+        'Absolute IdP redirects should carry the exact IdP URL',
+    );
 
     assert.equal(
         (service as any).rewriteProxyLocation('https://n8n.example.test/workflow/wf-1', 'https://idp.example.test/login', token),
         'https://code.example.test/proxy/25444/workflow/wf-1',
         'n8n callbacks should return to the normal workflow proxy route',
+    );
+});
+
+test('ProxyService: external auth tokens only proxy their expected target URL', () => {
+    const { ProxyService } = require('../../src/services/proxy-service.js');
+    const service = new ProxyService();
+    (service as any).target = 'https://n8n.example.test';
+    service.setPublicBaseUrl('https://code.example.test/proxy/25444');
+
+    const token = (service as any).createExternalAuthSession('https://idp.example.test/login?state=abc');
+
+    assert.deepEqual(
+        (service as any).parseExternalAuthProxyRequest(`/__n8nac-external-auth/${token}?url=${encodeURIComponent('https://idp.example.test/login?state=abc')}`),
+        { token, targetUrl: 'https://idp.example.test/login?state=abc' },
+    );
+    assert.equal(
+        (service as any).parseExternalAuthProxyRequest(`/__n8nac-external-auth/${token}?url=${encodeURIComponent('https://evil.example.test/steal')}`),
+        undefined,
+        'A valid token must not be reusable for arbitrary external URLs',
+    );
+
+    const nextUrl = (service as any).rewriteProxyLocation('https://idp.example.test/consent', 'https://idp.example.test/login?state=abc', token);
+    assert.ok(nextUrl.includes(encodeURIComponent('https://idp.example.test/consent')), 'Trusted redirects advance the expected target URL');
+    assert.equal(
+        (service as any).parseExternalAuthProxyRequest(`/__n8nac-external-auth/${token}?url=${encodeURIComponent('https://idp.example.test/login?state=abc')}`),
+        undefined,
+        'The previous IdP URL should no longer be accepted after the redirect target advances',
+    );
+    assert.deepEqual(
+        (service as any).parseExternalAuthProxyRequest(`/__n8nac-external-auth/${token}?url=${encodeURIComponent('https://idp.example.test/consent')}`),
+        { token, targetUrl: 'https://idp.example.test/consent' },
+    );
+});
+
+test('ProxyService: external auth handoff retries the last workflow URL', () => {
+    const { ProxyService } = require('../../src/services/proxy-service.js');
+    const service = new ProxyService();
+    (service as any).target = 'https://n8n.example.test';
+    (service as any).port = 25444;
+    service.setPublicBaseUrl('https://code.example.test/proxy/25444');
+
+    (service as any).rememberWorkflowProxyUrl('/workflow/wf-1?_n8nacBridge=123');
+    const retryFromMemory = (service as any).getWorkflowRetryUrl({
+        url: '/sso/saml/login',
+        headers: {},
+    });
+    assert.equal(
+        retryFromMemory,
+        'https://code.example.test/proxy/25444/workflow/wf-1?_n8nacBridge=123',
+        'Retry should prefer the remembered workflow URL over the SSO endpoint',
+    );
+
+    const retryFromReferrer = (service as any).getWorkflowRetryUrl({
+        url: '/sso/saml/login',
+        headers: {
+            referer: 'https://code.example.test/proxy/25444/workflow/wf-2?_n8nacBridge=456',
+        },
+    });
+    assert.equal(
+        retryFromReferrer,
+        'https://code.example.test/proxy/25444/workflow/wf-2?_n8nacBridge=456',
+        'Retry should use a workflow referrer when available',
     );
 });
 

--- a/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
+++ b/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
@@ -201,6 +201,62 @@ test('ProxyService: redirects match target base paths on URL boundaries', () => 
     );
 });
 
+test('ProxyService: external n8n redirects create browser auth handoff URLs', () => {
+    const { ProxyService } = require('../../src/services/proxy-service.js');
+    const service = new ProxyService();
+    (service as any).target = 'https://n8n.example.test';
+    service.setPublicBaseUrl('https://code.example.test/proxy/25444');
+
+    const handoff = (service as any).createExternalAuthHandoff(
+        'https://idp.example.test/sso?state=abc',
+        'https://code.example.test/proxy/25444/workflow/wf-1',
+    );
+
+    assert.ok(handoff, 'External redirects should produce a handoff page');
+    assert.ok(
+        handoff.authProxyUrl.startsWith('https://code.example.test/proxy/25444/__n8nac-external-auth/'),
+        'Auth URL should stay on the workflow proxy so callback cookies can be captured',
+    );
+    assert.ok(
+        handoff.authProxyUrl.includes(encodeURIComponent('https://idp.example.test/sso?state=abc')),
+        'Auth URL should carry the external SSO target',
+    );
+    assert.ok(handoff.html.includes('Continue n8n sign-in in your browser'), 'Handoff page should explain the browser sign-in step');
+});
+
+test('ProxyService: external auth redirects remain proxied until n8n callback returns', () => {
+    const { ProxyService } = require('../../src/services/proxy-service.js');
+    const service = new ProxyService();
+    (service as any).target = 'https://n8n.example.test';
+    service.setPublicBaseUrl('https://code.example.test/proxy/25444');
+    const token = (service as any).createExternalAuthSession();
+
+    const nextIdpUrl = (service as any).rewriteProxyLocation(
+        '/oauth/authorize?next=1',
+        'https://idp.example.test/login',
+        token,
+    );
+    assert.ok(
+        nextIdpUrl.startsWith('https://code.example.test/proxy/25444/__n8nac-external-auth/'),
+        'Relative IdP redirects should continue through the auth proxy',
+    );
+    assert.ok(
+        nextIdpUrl.includes(encodeURIComponent('https://idp.example.test/oauth/authorize?next=1')),
+        'Relative IdP redirects should resolve against the current IdP origin',
+    );
+    assert.ok(
+        (service as any).rewriteProxyLocation('//idp.example.test/factor', 'https://idp.example.test/login', token)
+            .includes(encodeURIComponent('https://idp.example.test/factor')),
+        'Protocol-relative IdP redirects should remain in the auth proxy flow',
+    );
+
+    assert.equal(
+        (service as any).rewriteProxyLocation('https://n8n.example.test/workflow/wf-1', 'https://idp.example.test/login', token),
+        'https://code.example.test/proxy/25444/workflow/wf-1',
+        'n8n callbacks should return to the normal workflow proxy route',
+    );
+});
+
 // ── 3 : parent webview HTML — grant token & rate-limit markers ──────────────
 // buildWebviewHtml is a pure function (no vscode dependency) that generates
 // the parent-webview HTML. We assert on the security-relevant parts of the


### PR DESCRIPTION
## Summary

Fixes #465.

When the embedded workflow view is redirected from n8n to an external SSO identity provider, many providers refuse to render inside the VS Code webview iframe. That left the workflow panel on a blank/black page after the user clicked "Continue with SSO".

This change detects external auth redirects from the proxied n8n workflow route and starts a browser-based handoff instead. The SSO URL is opened through a short-lived proxy route so redirects can continue through the same proxy until the flow returns to n8n, while the embedded webview stays on a small retry page. Once browser sign-in completes, the user can retry the workflow view and reuse the captured n8n session cookies.

## What changed

- Added short-lived external auth proxy sessions for SSO redirects.
- Added a webview handoff page that explains the browser sign-in step and offers a workflow retry link.
- Kept IdP redirect chains proxied, including relative and protocol-relative redirects, until the flow returns to n8n.
- Avoided injecting the n8n clipboard/node bridge into external IdP HTML.
- Made the VS Code runtime import lazy so proxy helpers remain testable under the plain Node unit runner.
- Added unit coverage for the SSO redirect handoff and callback rewriting behavior.

## Testing

Automated:

```bash
npm run test --workspace=packages/vscode-extension
```

Result: 67/67 tests passing.

Manual SSO validation is the important remaining check because this depends on an n8n instance configured with SSO and an IdP that blocks iframe embedding. Suggested manual path:

1. Install/run this VS Code extension build on Windows 11, matching the reporter's environment as closely as possible.
2. Configure an n8n 2.9.4 instance with SSO enabled and no existing n8n web session in the workflow webview.
3. Click `Open in n8n` for a workflow.
4. In the workflow panel, click `Continue with SSO`.
5. Confirm the system browser opens the SSO flow instead of the webview going black.
6. Complete SSO in the browser.
7. Return to VS Code and click `Retry workflow` or reopen `Open in n8n`.
8. Confirm the workflow loads in the embedded panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External authentication handoff flows: users can sign in with external identity providers while preserving workflow context; single-use session tokens with TTL secure the handoff.
  * Cross-origin redirect handling routes IdP redirects through the handoff flow and prefers the last known workflow URL for retry return.

* **Tests**
  * Expanded coverage for external auth handoffs, redirect routing, session token scope, and retry behavior.
* **Bug Fix**
  * Clipboard-injection is skipped during the external-auth handoff to avoid interference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->