### PR TITLE
[codex] Fix n8n AggregateError connection failures

### DIFF
--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -1252,7 +1252,8 @@ export class N8nApiClient {
                 params: query ?? (['GET', 'HEAD'].includes(method) ? (body as any) : undefined),
                 validateStatus: () => true, // Don't throw on non-2xx
                 timeout: 30_000,             // Prevent indefinite hangs (e.g. chat trigger awaiting first message)
-                // Reuse the shared httpsAgent (same TLS policy as API calls).
+                // Reuse the shared agents (same DNS/TLS policy as API calls).
+                httpAgent: this.httpAgent,
                 httpsAgent: this.httpsAgent,
                 // Do NOT send the n8n API key when hitting the webhook URL.
                 // The webhook is a public endpoint and the API key header would

--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -1,6 +1,28 @@
 import axios, { AxiosInstance } from 'axios';
+import * as dns from 'dns';
+import * as http from 'http';
 import * as https from 'https';
 import { IN8nCredentials, IWorkflow, IProject, ITag, ITriggerInfo, ITestPlan, ITestResult, TriggerType, IInferredPayload, IInferredPayloadField, IExecutionDetails, IExecutionList, IExecutionSummary, ExecutionStatus } from '../types.js';
+
+type AgentLookup = NonNullable<http.AgentOptions['lookup']>;
+
+function createIpv4FirstLookup(): AgentLookup {
+    return ((hostname, options, callback) => {
+        const lookupOptions = { ...options, verbatim: false };
+        dns.lookup(hostname, lookupOptions, (error, address, family) => {
+            if (error) {
+                callback(error, address, family);
+                return;
+            }
+            if (Array.isArray(address)) {
+                const sorted = [...address].sort((left, right) => left.family === right.family ? 0 : left.family === 4 ? -1 : 1);
+                callback(null, sorted, family);
+                return;
+            }
+            callback(null, address, family);
+        });
+    }) as AgentLookup;
+}
 
 export class N8nApiClient {
     private client: AxiosInstance;
@@ -8,7 +30,8 @@ export class N8nApiClient {
     private projectsCache: Map<string, IProject> | null = null;
     private projectsCachePromise: Promise<Map<string, IProject>> | null = null;
     private static readonly PERSONAL_PROJECT_PLACEHOLDER_ID = 'personal';
-    /** Shared HTTPS agent – allows self-signed certs in local/dev environments */
+    /** Shared agents keep DNS/TLS behavior consistent for API, health, and webhook calls. */
+    private httpAgent: http.Agent;
     private httpsAgent: https.Agent;
 
     constructor(credentials: IN8nCredentials) {
@@ -19,8 +42,11 @@ export class N8nApiClient {
         }
 
         // Allow self-signed certificates by default to avoid issues in local environments.
-        // The same agent is reused for webhook test calls so TLS behaviour is consistent.
-        this.httpsAgent = new https.Agent({ rejectUnauthorized: false });
+        // Prefer IPv4 when both A and AAAA records exist; remote self-hosted n8n instances
+        // often publish IPv6 records that are unreachable from the extension host.
+        const lookup = createIpv4FirstLookup();
+        this.httpAgent = new http.Agent({ lookup });
+        this.httpsAgent = new https.Agent({ rejectUnauthorized: false, lookup });
 
         this.client = axios.create({
             baseURL: host,
@@ -29,6 +55,7 @@ export class N8nApiClient {
                 'Content-Type': 'application/json',
                 'User-Agent': 'n8n-as-code'
             },
+            httpAgent: this.httpAgent,
             httpsAgent: this.httpsAgent,
         });
     }
@@ -125,6 +152,7 @@ export class N8nApiClient {
         try {
             const baseURL = this.client.defaults.baseURL;
             const res = await axios.get(`${baseURL}/`, {
+                httpAgent: this.httpAgent,
                 httpsAgent: this.httpsAgent,
                 timeout: 10_000,
                 responseType: 'text',
@@ -825,7 +853,12 @@ export class N8nApiClient {
 
             // 2. Scraping Root Page as fallback (Using raw axios to avoid API headers)
             const baseURL = this.client.defaults.baseURL;
-            const res = await axios.get(`${baseURL}/`);
+            const res = await axios.get(`${baseURL}/`, {
+                httpAgent: this.httpAgent,
+                httpsAgent: this.httpsAgent,
+                timeout: 10_000,
+                responseType: 'text',
+            });
             const html = res.data;
 
             // Look for "release":"n8n@X.Y.Z" probably inside n8n:config:sentry meta (Base64 encoded)

--- a/packages/cli/tests/unit/n8n-api-client.test.ts
+++ b/packages/cli/tests/unit/n8n-api-client.test.ts
@@ -454,6 +454,8 @@ describe('N8nApiClient test workflow support', () => {
             url: 'https://n8n.local/webhook-test/wf',
             data: undefined,
             params: { chatInput: 'hello' },
+            httpAgent: expect.anything(),
+            httpsAgent: expect.anything(),
         }));
     });
 

--- a/packages/cli/tests/unit/n8n-api-client.test.ts
+++ b/packages/cli/tests/unit/n8n-api-client.test.ts
@@ -11,8 +11,15 @@ const { mockAxiosCall, mockAxiosGet, mockAxiosPost, mockAxiosPut, mockAxiosDelet
     mockAxiosCreate: vi.fn(),
 }));
 
+type MockAxiosCreateConfig = {
+    baseURL?: string;
+    headers?: Record<string, string>;
+    httpAgent?: unknown;
+    httpsAgent?: unknown;
+};
+
 vi.mock('axios', () => {
-    mockAxiosCreate.mockImplementation((config?: { baseURL?: string; headers?: Record<string, string> }) => ({
+    mockAxiosCreate.mockImplementation((config?: MockAxiosCreateConfig) => ({
         defaults: { baseURL: config?.baseURL ?? '' },
         get: mockAxiosGet,
         post: mockAxiosPost,
@@ -37,13 +44,24 @@ describe('N8nApiClient test workflow support', () => {
         mockAxiosPut.mockReset();
         mockAxiosDelete.mockReset();
         mockAxiosCreate.mockReset();
-        mockAxiosCreate.mockImplementation((config?: { baseURL?: string; headers?: Record<string, string> }) => ({
+        mockAxiosCreate.mockImplementation((config?: MockAxiosCreateConfig) => ({
             defaults: { baseURL: config?.baseURL ?? '' },
             get: mockAxiosGet,
             post: mockAxiosPost,
             put: mockAxiosPut,
             delete: mockAxiosDelete,
         }));
+    });
+
+    it('configures shared agents with IPv4-first DNS lookup', () => {
+        new N8nApiClient({ host: 'https://n8n.local/', apiKey: 'secret' });
+
+        const config = mockAxiosCreate.mock.calls[0][0];
+        expect(config.httpAgent).toBeDefined();
+        expect(config.httpsAgent).toBeDefined();
+        expect(typeof config.httpAgent.options.lookup).toBe('function');
+        expect(config.httpsAgent.options.lookup).toBe(config.httpAgent.options.lookup);
+        expect(config.httpsAgent.options.rejectUnauthorized).toBe(false);
     });
 
     it('asserts API access through the authenticated workflows endpoint', async () => {
@@ -75,6 +93,23 @@ describe('N8nApiClient test workflow support', () => {
         await expect(client.getInstanceIdentity()).resolves.toEqual({ id: 'instance-from-html' });
 
         expect(mockAxiosCall).toHaveBeenCalledWith('https://n8n.local/', expect.objectContaining({
+            httpAgent: expect.anything(),
+            httpsAgent: expect.anything(),
+            timeout: 10_000,
+            responseType: 'text',
+        }));
+    });
+
+    it('uses shared agents when scraping the root page for health fallback', async () => {
+        mockAxiosGet.mockRejectedValueOnce(new Error('healthz unavailable'));
+        mockAxiosCall.mockResolvedValueOnce({ data: '{"release":"n8n@2.20.9"}' });
+        const client = new N8nApiClient({ host: 'https://n8n.local/', apiKey: 'secret' });
+
+        await expect(client.getHealth()).resolves.toEqual({ version: '2.20.9' });
+
+        expect(mockAxiosCall).toHaveBeenCalledWith('https://n8n.local/', expect.objectContaining({
+            httpAgent: expect.anything(),
+            httpsAgent: expect.anything(),
             timeout: 10_000,
             responseType: 'text',
         }));


### PR DESCRIPTION
## Summary

Fixes #460 by making the n8n API client use shared HTTP/HTTPS agents with IPv4-first DNS resolution. Remote self-hosted n8n instances can publish both A and AAAA records even when IPv6 is not reachable from the VS Code extension host; in that case Node/axios can surface a vague `AggregateError` during initialization.

The same agents are now reused for API calls, HTML identity fallback, health fallback, and webhook test calls so connection behavior is consistent.

## Impact

Users connecting to remote self-hosted n8n instances should avoid the `Initialization failed: Cannot connect to n8n ... AggregateError` failure when the host has an unreachable IPv6 route but a working IPv4 route.

## Validation

- `npm run build:cli`
- `npx vitest run packages/cli/tests/unit/n8n-api-client.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network reliability by preferring IPv4 and reusing shared HTTP/HTTPS agents across API calls, health checks, and webhook requests for consistent DNS/TLS behavior.

* **Tests**
  * Expanded tests to validate shared agent usage, IPv4-first lookup behavior, and consistent network options for API, health/version checks, and webhook requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->