### PR TITLE
feat(agent-workbench): implement parallel chat threads

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:cli": "cd packages/cli && npm run build",
     "build:mcp": "cd packages/mcp && npm run build",
     "build:claude-plugin": "npm run build --workspace=packages/skills && npm run build:adapters --workspace=packages/skills",
-    "build:extension": "cd packages/vscode-extension && npm run build",
+    "build:extension": "node scripts/ensure-extension-skills-assets.cjs && cd packages/vscode-extension && npm run build",
     "extension:install": "node scripts/build-and-install.js",
     "extension:dev": "node scripts/setup-dev-link.js",
     "release:plan": "node scripts/release/workspace-release.mjs stable-pr",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -210,19 +210,32 @@ const getVersion = () => {
  * Resolve the skills assets directory bundled with @n8n-as-code/skills
  */
 const getSkillsAssetsDir = (): string => {
+    const hasRequiredAssets = (candidate: string): boolean => (
+        existsSync(join(candidate, 'n8n-nodes-technical.json'))
+        && existsSync(join(candidate, 'workflows-index.json'))
+    );
+
     // Allow override via environment
-    if (process.env.N8N_AS_CODE_ASSETS_DIR) {
+    if (process.env.N8N_AS_CODE_ASSETS_DIR && hasRequiredAssets(process.env.N8N_AS_CODE_ASSETS_DIR)) {
         return process.env.N8N_AS_CODE_ASSETS_DIR;
     }
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const candidates: string[] = [];
     try {
         const require = createRequire(import.meta.url);
         const skillsPkg = require.resolve('@n8n-as-code/skills/package.json');
-        return join(dirname(skillsPkg), 'dist', 'assets');
-    } catch {
-        // Fallback: skills lives next to cli in a monorepo
-        const __dirname = dirname(fileURLToPath(import.meta.url));
-        return join(__dirname, '..', '..', 'skills', 'dist', 'assets');
-    }
+        const skillsRoot = dirname(skillsPkg);
+        candidates.push(
+            join(skillsRoot, 'dist', 'assets'),
+            join(skillsRoot, 'src', 'assets'),
+        );
+    } catch { /* fall through to monorepo candidates */ }
+    candidates.push(
+        join(__dirname, '..', '..', 'skills', 'dist', 'assets'),
+        join(__dirname, '..', '..', 'skills', 'src', 'assets'),
+        join(__dirname, '..', '..', 'vscode-extension', 'assets'),
+    );
+    return candidates.find(hasRequiredAssets) || candidates[0];
 };
 
 const getSkillsCliEntry = (): string => {

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -49,5 +49,5 @@
     "publishConfig": {
         "access": "public"
     },
-    "n8nVersion": "2.21.4"
+    "n8nVersion": "2.21.5"
 }

--- a/packages/skills/src/cli.ts
+++ b/packages/skills/src/cli.ts
@@ -30,18 +30,28 @@ const getVersion = () => {
 };
 
 const getAssetsDir = () => {
-    if (process.env.N8N_AS_CODE_ASSETS_DIR) {
+    const hasRequiredAssets = (candidate: string): boolean => (
+        fs.existsSync(join(candidate, 'n8n-nodes-technical.json'))
+        && fs.existsSync(join(candidate, 'workflows-index.json'))
+    );
+
+    if (process.env.N8N_AS_CODE_ASSETS_DIR && hasRequiredAssets(process.env.N8N_AS_CODE_ASSETS_DIR)) {
         return process.env.N8N_AS_CODE_ASSETS_DIR;
     }
 
     // Fallback 1: subfolder assets (Standard NPM install: dist/cli.js + dist/assets/ OR dev: src/cli.ts + src/assets/)
     const localAssets = join(_dirname, 'assets');
-    if (fs.existsSync(join(localAssets, 'n8n-docs-complete.json'))) {
+    if (hasRequiredAssets(localAssets)) {
         return localAssets;
     }
 
     // Fallback 2: parent's sibling assets (VS Code Extension: out/skills/cli.js -> assets/)
-    return join(_dirname, '../../assets');
+    const candidates = [
+        join(_dirname, '../../assets'),
+        join(_dirname, '../../vscode-extension/assets'),
+        join(_dirname, '../dist/assets'),
+    ];
+    return candidates.find(hasRequiredAssets) || candidates[0];
 };
 
 const assetsDir = getAssetsDir();

--- a/packages/vscode-extension/esbuild.config.js
+++ b/packages/vscode-extension/esbuild.config.js
@@ -25,7 +25,6 @@ const runtimeDependencyRoots = [
     '@langchain/langgraph-checkpoint',
     '@langchain/mistralai',
     '@langchain/openai',
-    '@yagr/provider-runtime',
 ];
 const bundledSkillsAssetFiles = new Set([
     'n8n-docs-complete.json',
@@ -263,7 +262,7 @@ const extensionBuild = esbuild.build({
     entryPoints: ['./src/extension.ts'],
     bundle: true,
     outfile: 'out/extension.js',
-    external: ['vscode', 'prettier', 'deepagents', 'langchain', '@langchain/*', '@yagr/provider-runtime'],
+    external: ['vscode', 'prettier', 'deepagents', 'langchain', '@langchain/*'],
     format: 'cjs',
     platform: 'node',
     logOverride: {

--- a/packages/vscode-extension/esbuild.config.js
+++ b/packages/vscode-extension/esbuild.config.js
@@ -154,23 +154,24 @@ const copySkillsAssets = {
     name: 'copy-skills-assets',
     setup(build) {
         build.onEnd(() => {
-            const skillsAssetsDir = path.join(
-                __dirname,
-                'node_modules',
-                '@n8n-as-code',
-                'skills',
-                'dist',
-                'assets'
+            const assetDirCandidates = [
+                path.join(__dirname, 'node_modules', '@n8n-as-code', 'skills', 'dist', 'assets'),
+                path.join(__dirname, '..', 'skills', 'dist', 'assets'),
+                path.join(__dirname, '..', 'skills', 'src', 'assets'),
+                path.join(__dirname, 'assets'),
+            ];
+            const hasRequiredSkillsAssets = dir => (
+                bundledSkillsAssetFiles.size > 0
+                && [...bundledSkillsAssetFiles].every(file => fs.existsSync(path.join(dir, file)))
             );
-
-            // Fallback to local workspace for development
-            const fallbackAssetsDir = path.join(__dirname, '..', 'skills', 'dist', 'assets');
-
-            const sourceDir = fs.existsSync(skillsAssetsDir) ? skillsAssetsDir : fallbackAssetsDir;
+            const sourceDir = assetDirCandidates.find(hasRequiredSkillsAssets);
             const targetDir = path.join(__dirname, 'assets');
 
-            if (!fs.existsSync(sourceDir)) {
-                console.warn('⚠️  skills assets not found, skipping copy');
+            if (!sourceDir) {
+                throw new Error(
+                    'skills assets not found; run `npm run build:extension` from the repository root. Checked:\n' +
+                    assetDirCandidates.map(p => `  ${p}`).join('\n')
+                );
             } else {
                 // Create target directory
                 if (!fs.existsSync(targetDir)) {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -432,7 +432,6 @@
     "@n8n-as-code/telemetry": "2.0.0",
     "@n8n-as-code/workflow-core": "2.0.0",
     "@reduxjs/toolkit": "^2.11.2",
-    "@yagr/provider-runtime": "^0.1.2",
     "deepagents": "^1.10.2",
     "http-proxy": "^1.18.1",
     "langchain": "^1.4.1",

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -399,6 +399,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
         registerTelemetryCommand('n8n.openAgentWorkbench', async (arg: any) => {
             const runtime = requireAgentRuntimeController();
+            if (arg && typeof arg === 'object' && typeof arg.sessionId === 'string') {
+                telemetryClient?.track('vscode_workflow_view_opened', { mode: 'agent-workbench', workflow_state: arg.workflow ? 'workflow-context' : 'existing-session' });
+                await openAgentWorkbench(context, arg.workflow, arg.sessionId);
+                return;
+            }
             const wf = findWorkflowByCommandArg(arg);
             if (wf) {
                 const sessionId = await getOrCreateAgentSessionForWorkflow(wf);

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -23,15 +23,15 @@ import { ProxyService } from './services/proxy-service.js';
 import { AgentRuntimeController } from './services/agent-runtime-controller.js';
 import type { AgentWorkflowContext } from './services/agent-runtime-controller.js';
 import {
-    YagrProviderService,
-    YAGR_PROVIDER_DEFINITIONS,
-    YAGR_REASONING_EFFORTS,
-    YAGR_SELECTABLE_PROVIDERS,
-    normalizeYagrProviderId,
+    AgentProviderService,
+    AGENT_PROVIDER_DEFINITIONS,
+    AGENT_REASONING_EFFORTS,
+    AGENT_SELECTABLE_PROVIDERS,
+    normalizeAgentProviderId,
     providerSupportsReasoningEffort,
-    type YagrModelProvider,
-    type YagrReasoningEffort,
-} from './services/yagr-provider-service.js';
+    type AgentModelProvider,
+    type AgentProviderReasoningEffort,
+} from './services/agent-provider-service.js';
 import {
     N8nConfigurationController,
     type N8nConfigurationChangeEvent,
@@ -103,7 +103,7 @@ let initializingPromise: Promise<void> | undefined;
 let runtimeDisposables: vscode.Disposable[] = [];
 let configurationController: N8nConfigurationController | undefined;
 let agentRuntimeController: AgentRuntimeController | undefined;
-let yagrProviderService: YagrProviderService | undefined;
+let agentProviderService: AgentProviderService | undefined;
 let suppressNextConfigurationReaction = false;
 let failedAutoInitRuntimeSignature: string | undefined;
 let failedAutoInitConnectionKey: string | undefined;
@@ -278,7 +278,7 @@ export async function activate(context: vscode.ExtensionContext) {
     proxyService.setOutputChannel(outputChannel);
     proxyService.setSecrets(context.secrets);
     agentRuntimeController = new AgentRuntimeController(context, outputChannel);
-    yagrProviderService = new YagrProviderService(context);
+    agentProviderService = new AgentProviderService(context);
     context.subscriptions.push(agentRuntimeController);
     configurationController = new N8nConfigurationController(outputChannel);
     context.subscriptions.push(
@@ -1014,7 +1014,7 @@ async function listAgentWorkflowNodes(workflowContext: AgentWorkflowContext): Pr
 }
 
 async function listAgentProviderOptions(): Promise<Array<Record<string, unknown>>> {
-    const states = await requireYagrProviderService().listProviderConnectionStates();
+    const states = await requireAgentProviderService().listProviderConnectionStates();
     return states.filter((state) => state.connected || state.selected).map((state) => ({
         id: state.id,
         label: state.label,
@@ -1028,15 +1028,15 @@ async function listAgentProviderOptions(): Promise<Array<Record<string, unknown>
 }
 
 async function listAgentModelOptions(providerId: string): Promise<Array<Record<string, unknown>>> {
-    const provider = normalizeYagrProviderId(providerId) || 'openai';
-    const definition = YAGR_PROVIDER_DEFINITIONS[provider];
+    const provider = normalizeAgentProviderId(providerId) || 'openai';
+    const definition = AGENT_PROVIDER_DEFINITIONS[provider];
     const config = vscode.workspace.getConfiguration('n8n.agent');
-    const selectedProvider = normalizeYagrProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
+    const selectedProvider = normalizeAgentProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
     const selectedModel = String(config.get<string>('model') || '').trim();
     const currentModel = provider === selectedProvider
         ? (selectedModel || definition.defaultModel)
         : definition.defaultModel;
-    const liveModels = await requireYagrProviderService().fetchAvailableModels(provider).catch(() => []);
+    const liveModels = await requireAgentProviderService().fetchAvailableModels(provider).catch(() => []);
     return [...new Set([...(liveModels.length ? liveModels : []), definition.defaultModel, currentModel].filter(Boolean))]
         .map((model) => ({
             id: model,
@@ -1049,19 +1049,19 @@ async function listAgentModelOptions(providerId: string): Promise<Array<Record<s
 }
 
 async function selectAgentProviderModel(providerId: string, model: string): Promise<void> {
-    const provider = normalizeYagrProviderId(providerId) || 'openai';
-    const trimmedModel = model.trim() || YAGR_PROVIDER_DEFINITIONS[provider].defaultModel;
+    const provider = normalizeAgentProviderId(providerId) || 'openai';
+    const trimmedModel = model.trim() || AGENT_PROVIDER_DEFINITIONS[provider].defaultModel;
     const config = vscode.workspace.getConfiguration('n8n.agent');
     await config.update('provider', provider, vscode.ConfigurationTarget.Global);
     await config.update('model', trimmedModel, vscode.ConfigurationTarget.Global);
-    await requireYagrProviderService().syncReasoningEffortConfiguration(provider, trimmedModel);
+    await requireAgentProviderService().syncReasoningEffortConfiguration(provider, trimmedModel);
 }
 
 async function selectInlineAgentReasoningEffort(effort: string): Promise<void> {
-    const normalized = YAGR_REASONING_EFFORTS.includes(effort as YagrReasoningEffort) ? effort as YagrReasoningEffort : undefined;
+    const normalized = AGENT_REASONING_EFFORTS.includes(effort as AgentProviderReasoningEffort) ? effort as AgentProviderReasoningEffort : undefined;
     if (!normalized) return;
     const config = vscode.workspace.getConfiguration('n8n.agent');
-    const provider = normalizeYagrProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
+    const provider = normalizeAgentProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
     const model = String(config.get<string>('model') || '').trim() || undefined;
     if (!providerSupportsReasoningEffort(provider, model)) {
         await config.update('reasoningEffort', undefined, vscode.ConfigurationTarget.Global);
@@ -1271,11 +1271,11 @@ function requireAgentRuntimeController(): AgentRuntimeController {
     return agentRuntimeController;
 }
 
-function requireYagrProviderService(): YagrProviderService {
-    if (!yagrProviderService) {
-        throw new Error('n8n Yagr provider service is not initialized.');
+function requireAgentProviderService(): AgentProviderService {
+    if (!agentProviderService) {
+        throw new Error('n8n agent provider service is not initialized.');
     }
-    return yagrProviderService;
+    return agentProviderService;
 }
 
 async function setAgentProviderApiKey(context: vscode.ExtensionContext): Promise<void> {
@@ -1283,17 +1283,17 @@ async function setAgentProviderApiKey(context: vscode.ExtensionContext): Promise
 }
 
 async function setupAgentProvider(context: vscode.ExtensionContext): Promise<void> {
-    const service = requireYagrProviderService();
+    const service = requireAgentProviderService();
     const config = vscode.workspace.getConfiguration('n8n.agent');
-    const currentProvider = normalizeYagrProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
+    const currentProvider = normalizeAgentProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
     const picked = await vscode.window.showQuickPick(
-        YAGR_SELECTABLE_PROVIDERS.map((provider) => ({
+        AGENT_SELECTABLE_PROVIDERS.map((provider) => ({
             provider,
-            label: YAGR_PROVIDER_DEFINITIONS[provider].label,
-            description: YAGR_PROVIDER_DEFINITIONS[provider].description,
-            detail: YAGR_PROVIDER_DEFINITIONS[provider].authKind === 'oauth-device'
+            label: AGENT_PROVIDER_DEFINITIONS[provider].label,
+            description: AGENT_PROVIDER_DEFINITIONS[provider].description,
+            detail: AGENT_PROVIDER_DEFINITIONS[provider].authKind === 'oauth-device'
                 ? 'OAuth device flow'
-                : YAGR_PROVIDER_DEFINITIONS[provider].requiresApiKey
+                : AGENT_PROVIDER_DEFINITIONS[provider].requiresApiKey
                     ? 'API key'
                     : 'Account credential',
             picked: provider === currentProvider,
@@ -1310,9 +1310,9 @@ async function setupAgentProvider(context: vscode.ExtensionContext): Promise<voi
     }
 
     try {
-        const configured = await service.setupProvider(picked.provider as YagrModelProvider);
+        const configured = await service.setupProvider(picked.provider as AgentModelProvider);
         if (!configured) return;
-        await service.selectModel(picked.provider as YagrModelProvider);
+        await service.selectModel(picked.provider as AgentModelProvider);
         vscode.window.showInformationMessage(`Configured n8n Agent provider: ${picked.label}.`);
     } catch (error: any) {
         vscode.window.showErrorMessage(`Provider setup failed: ${error?.message || String(error)}`);
@@ -1320,14 +1320,14 @@ async function setupAgentProvider(context: vscode.ExtensionContext): Promise<voi
 }
 
 async function selectAgentModel(): Promise<void> {
-    const service = requireYagrProviderService();
+    const service = requireAgentProviderService();
     const config = vscode.workspace.getConfiguration('n8n.agent');
-    const currentProvider = normalizeYagrProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
+    const currentProvider = normalizeAgentProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
     const pickedProvider = await vscode.window.showQuickPick(
-        YAGR_SELECTABLE_PROVIDERS.map((provider) => ({
+        AGENT_SELECTABLE_PROVIDERS.map((provider) => ({
             provider,
-            label: YAGR_PROVIDER_DEFINITIONS[provider].label,
-            description: YAGR_PROVIDER_DEFINITIONS[provider].description,
+            label: AGENT_PROVIDER_DEFINITIONS[provider].label,
+            description: AGENT_PROVIDER_DEFINITIONS[provider].description,
             picked: provider === currentProvider,
         })),
         {
@@ -1337,7 +1337,7 @@ async function selectAgentModel(): Promise<void> {
         },
     );
     if (!pickedProvider) return;
-    const provider = pickedProvider.provider as YagrModelProvider;
+    const provider = pickedProvider.provider as AgentModelProvider;
     try {
         await config.update('provider', provider, vscode.ConfigurationTarget.Global);
         await service.selectModel(provider);
@@ -1347,9 +1347,9 @@ async function selectAgentModel(): Promise<void> {
 }
 
 async function selectAgentReasoningEffort(): Promise<void> {
-    const service = requireYagrProviderService();
+    const service = requireAgentProviderService();
     const config = vscode.workspace.getConfiguration('n8n.agent');
-    const provider = normalizeYagrProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
+    const provider = normalizeAgentProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
     const model = String(config.get<string>('model') || '').trim() || undefined;
     try {
         await service.selectReasoningEffort(provider, model);

--- a/packages/vscode-extension/src/services/agent-provider-runtime/chat-codex-oauth.ts
+++ b/packages/vscode-extension/src/services/agent-provider-runtime/chat-codex-oauth.ts
@@ -1,0 +1,717 @@
+import type {
+  JSONSchema7,
+  LanguageModelV1FunctionTool,
+  LanguageModelV1Prompt,
+  LanguageModelV1StreamPart,
+  LanguageModelV1ToolChoice,
+} from './provider-types.js';
+import {
+  BaseChatModel,
+  type BaseChatModelCallOptions,
+  type BaseChatModelParams,
+  type BindToolsInput,
+} from '@langchain/core/language_models/chat_models';
+import { AIMessage, HumanMessage, SystemMessage, ToolMessage, AIMessageChunk, type BaseMessage } from '@langchain/core/messages';
+import type { ToolCall } from '@langchain/core/messages/tool';
+import { ChatGenerationChunk, type ChatResult } from '@langchain/core/outputs';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import type { Runnable } from '@langchain/core/runnables';
+import { z } from 'zod';
+import { createOpenAiAccountLanguageModel, CodexReasoningEffort, ensureCodexSessionId, getDefaultCodexReasoningEffort } from './openai-account.js';
+
+interface ChatCodexOAuthCallOptions extends BaseChatModelCallOptions {
+  tools?: LanguageModelV1FunctionTool[];
+  reasoningEffort?: CodexReasoningEffort;
+}
+
+export class ChatCodexOAuth extends BaseChatModel<ChatCodexOAuthCallOptions> {
+  static lc_name() {
+    return 'ChatCodexOAuth';
+  }
+
+  readonly model: string;
+
+  readonly reasoningEffort: CodexReasoningEffort;
+
+  readonly sessionId: string;
+
+    private readonly boundTools?: LanguageModelV1FunctionTool[];
+
+    private readonly boundCallOptions?: Partial<ChatCodexOAuthCallOptions>;
+
+    private readonly accessToken?: string;
+
+    private previousPrompt?: LanguageModelV1Prompt;
+
+  private previousResponseId?: string;
+
+  constructor(
+    fields: BaseChatModelParams & {
+      model: string;
+      reasoningEffort?: CodexReasoningEffort;
+      sessionId?: string;
+      boundTools?: LanguageModelV1FunctionTool[];
+      boundCallOptions?: Partial<ChatCodexOAuthCallOptions>;
+      accessToken?: string;
+      previousPrompt?: LanguageModelV1Prompt;
+      previousResponseId?: string;
+    },
+  ) {
+    super(fields);
+    this.model = fields.model;
+    this.reasoningEffort = fields.reasoningEffort ?? getDefaultCodexReasoningEffort(fields.model);
+    this.sessionId = ensureCodexSessionId(fields.sessionId);
+    this.boundTools = fields.boundTools;
+    this.boundCallOptions = fields.boundCallOptions;
+    this.accessToken = fields.accessToken;
+    this.previousPrompt = fields.previousPrompt;
+    this.previousResponseId = fields.previousResponseId;
+  }
+
+  _llmType(): string {
+    return 'chat-codex-oauth';
+  }
+
+  override _identifyingParams(): Record<string, unknown> {
+    return {
+        provider: 'openai-codex-auth',
+        model: this.model,
+        reasoningEffort: this.reasoningEffort,
+        sessionId: this.sessionId,
+      };
+  }
+
+  override bindTools(tools: BindToolsInput[], kwargs?: Partial<ChatCodexOAuthCallOptions>): Runnable {
+    const normalizedTools = tools
+      .map(toLanguageModelTool)
+      .filter((tool): tool is LanguageModelV1FunctionTool => Boolean(tool));
+    const boundCallOptions = {
+      ...(kwargs ?? {}),
+    };
+    return new ChatCodexOAuth({
+      model: this.model,
+      reasoningEffort: this.reasoningEffort,
+      sessionId: this.sessionId,
+      disableStreaming: this.disableStreaming,
+      outputVersion: this.outputVersion,
+      boundTools: normalizedTools,
+      boundCallOptions,
+      accessToken: this.accessToken,
+      previousPrompt: this.previousPrompt,
+      previousResponseId: this.previousResponseId,
+      ...(kwargs?.callbacks ? { callbacks: kwargs.callbacks } : {}),
+      ...(kwargs?.tags ? { tags: kwargs.tags } : {}),
+      ...(kwargs?.metadata ? { metadata: kwargs.metadata } : {}),
+    }) as unknown as Runnable;
+  }
+
+  async _generate(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    _runManager?: CallbackManagerForLLMRun,
+  ): Promise<ChatResult> {
+    const model = createOpenAiAccountLanguageModel(this.model, this.reasoningEffort, this.sessionId, this.accessToken);
+    const boundToolChoice = this.boundCallOptions?.tool_choice;
+    const prompt = toLanguageModelPrompt(messages);
+    const incremental = buildIncrementalPrompt(this.previousPrompt, prompt, this.previousResponseId);
+    const result = await model.doGenerate({
+      inputFormat: 'prompt',
+      mode: {
+        type: 'regular',
+        tools: options.tools ?? this.boundTools ?? [],
+        toolChoice: normalizeToolChoice(options.tool_choice ?? boundToolChoice),
+      },
+      prompt: incremental.prompt,
+        ...(incremental.previousResponseId ? { headers: { 'x-n8n-previous-response-id': incremental.previousResponseId } } : {}),
+      abortSignal: options.signal,
+    });
+    this.previousPrompt = prompt;
+    this.previousResponseId = result.response?.id;
+
+    const text = result.text ?? '';
+
+    const toolCalls = (result.toolCalls ?? []).map<ToolCall>((toolCall) => ({
+      id: toolCall.toolCallId,
+      name: toolCall.toolName,
+      args: parseToolArgs(toolCall.toolName, toolCall.args),
+    }));
+
+    const aiMessage = new AIMessage({
+      content: text,
+      tool_calls: toolCalls,
+      additional_kwargs: {
+        ...(result.response?.assistantPhase ? { phase: result.response.assistantPhase } : {}),
+        ...(result.response?.rawOutputItems ? { codex_output_items: result.response.rawOutputItems } : {}),
+      },
+      response_metadata: {
+        ...(result.response?.assistantPhase ? { phase: result.response.assistantPhase } : {}),
+        ...(result.response?.rawOutputItems ? { codex_output_items: result.response.rawOutputItems } : {}),
+      },
+      usage_metadata: result.usage
+        ? {
+            input_tokens: result.usage.promptTokens,
+            output_tokens: result.usage.completionTokens,
+            total_tokens: result.usage.promptTokens + result.usage.completionTokens,
+          }
+        : undefined,
+    });
+
+    return {
+      generations: [{
+        text,
+        message: aiMessage,
+        generationInfo: {
+          finishReason: result.finishReason,
+          warnings: result.warnings,
+        },
+      }],
+      llmOutput: {
+        finishReason: result.finishReason,
+        usage: result.usage,
+        warnings: result.warnings,
+      },
+    };
+  }
+
+  async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun,
+  ): AsyncGenerator<ChatGenerationChunk> {
+    const DEBUG_STREAM = process.env.DEBUG_CODEX_STREAM === '1';
+    if (DEBUG_STREAM) console.error('[DEBUG_CODEX_STREAM] _streamResponseChunks() called');
+
+    const model = createOpenAiAccountLanguageModel(this.model, this.reasoningEffort, this.sessionId, this.accessToken);
+    const boundToolChoice = this.boundCallOptions?.tool_choice;
+
+    if (DEBUG_STREAM) console.error('[DEBUG_CODEX_STREAM] Calling model.doStream()');
+
+    const prompt = toLanguageModelPrompt(messages);
+    const incremental = buildIncrementalPrompt(this.previousPrompt, prompt, this.previousResponseId);
+    const result = await model.doStream({
+      inputFormat: 'prompt',
+      mode: {
+        type: 'regular',
+        tools: options.tools ?? this.boundTools ?? [],
+        toolChoice: normalizeToolChoice(options.tool_choice ?? boundToolChoice),
+      },
+      prompt: incremental.prompt,
+      ...(incremental.previousResponseId ? { headers: { 'x-n8n-previous-response-id': incremental.previousResponseId } } : {}),
+      abortSignal: options.signal,
+    });
+
+    if (DEBUG_STREAM) console.error('[DEBUG_CODEX_STREAM] doStream() returned, getting reader');
+
+    const reader = result.stream.getReader();
+    const toolCallIndexes = new Map<string, number>();
+    const getToolCallIndex = (toolCallId: string): number => {
+      const existing = toolCallIndexes.get(toolCallId);
+      if (existing !== undefined) {
+        return existing;
+      }
+      const next = toolCallIndexes.size;
+      toolCallIndexes.set(toolCallId, next);
+      return next;
+    };
+
+    try {
+      if (DEBUG_STREAM) console.error('[DEBUG_CODEX_STREAM] Reading stream...');
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          if (DEBUG_STREAM) console.error('[DEBUG_CODEX_STREAM] Stream done');
+          break;
+        }
+
+        if (DEBUG_STREAM) console.error('[DEBUG_CODEX_STREAM] Got part:', JSON.stringify(value).slice(0, 200));
+
+        const part = value as LanguageModelV1StreamPart;
+
+        if (part.type === 'text-delta') {
+          if (DEBUG_STREAM) console.error('[DEBUG_CODEX_STREAM] Yielding text-delta:', part.textDelta);
+          const message = new AIMessageChunk({
+            content: part.textDelta,
+            additional_kwargs: {},
+          });
+          const chunk = new ChatGenerationChunk({
+            message,
+            text: part.textDelta,
+          });
+          yield chunk;
+          await runManager?.handleLLMNewToken(part.textDelta, { prompt: 0, completion: 0 }, undefined, undefined, undefined, { chunk });
+        } else if (part.type === 'tool-call-delta') {
+          const index = getToolCallIndex(part.toolCallId);
+          const message = new AIMessageChunk({
+            content: '',
+            tool_call_chunks: [{
+              name: part.toolName,
+              args: part.argsTextDelta,
+              id: part.toolCallId,
+              index,
+              type: 'tool_call_chunk' as const,
+            }],
+            additional_kwargs: {
+              tool_calls: [{
+                id: part.toolCallId,
+                index,
+                function: {
+                  name: part.toolName,
+                  arguments: part.argsTextDelta,
+                },
+              }],
+            },
+          } as ConstructorParameters<typeof AIMessageChunk>[0]);
+          yield new ChatGenerationChunk({ message, text: '' });
+        } else if (part.type === 'tool-call') {
+          const index = getToolCallIndex(part.toolCallId);
+          const parsedArgs = parseToolArgs(part.toolName, part.args);
+          const message = new AIMessageChunk({
+            content: '',
+            tool_calls: [{
+              name: part.toolName,
+              args: parsedArgs,
+              id: part.toolCallId,
+              type: 'tool_call' as const,
+            }],
+            tool_call_chunks: [{
+              name: part.toolName,
+              args: part.args,
+              id: part.toolCallId,
+              index,
+              type: 'tool_call_chunk' as const,
+            }],
+            additional_kwargs: {
+              tool_calls: [{
+                id: part.toolCallId,
+                index,
+                function: {
+                  name: part.toolName,
+                  arguments: part.args,
+                },
+              }],
+            },
+          } as ConstructorParameters<typeof AIMessageChunk>[0]);
+          yield new ChatGenerationChunk({ message, text: '' });
+        } else if (part.type === 'finish') {
+          this.previousPrompt = prompt;
+          this.previousResponseId = part.providerMetadata?.responseId;
+          if (DEBUG_STREAM) console.error('[DEBUG_CODEX_STREAM] Got finish:', part.finishReason);
+          yield new ChatGenerationChunk({
+            message: new AIMessageChunk({
+              content: '',
+              usage_metadata: {
+                input_tokens: part.usage.promptTokens,
+                output_tokens: part.usage.completionTokens,
+                total_tokens: part.usage.promptTokens + part.usage.completionTokens,
+              },
+              response_metadata: {
+                finishReason: part.finishReason,
+                ...(part.providerMetadata?.assistantPhase ? { phase: part.providerMetadata.assistantPhase } : {}),
+                ...(part.providerMetadata?.rawOutputItems ? { codex_output_items: part.providerMetadata.rawOutputItems } : {}),
+              },
+              additional_kwargs: {
+                ...(part.providerMetadata?.assistantPhase ? { phase: part.providerMetadata.assistantPhase } : {}),
+                ...(part.providerMetadata?.rawOutputItems ? { codex_output_items: part.providerMetadata.rawOutputItems } : {}),
+              },
+            }),
+            text: '',
+            generationInfo: {
+              finishReason: part.finishReason,
+            },
+          });
+          return;
+        } else if (part.type === 'error') {
+          throw new Error(`Codex stream error: ${part.error}`);
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+}
+
+function buildIncrementalPrompt(
+  previousPrompt: LanguageModelV1Prompt | undefined,
+  nextPrompt: LanguageModelV1Prompt,
+  previousResponseId: string | undefined,
+): { prompt: LanguageModelV1Prompt; previousResponseId?: string } {
+  if (!previousPrompt || !previousResponseId || previousPrompt.length >= nextPrompt.length) {
+    return { prompt: nextPrompt };
+  }
+
+  const samePrefix = previousPrompt.every((message, index) => JSON.stringify(message) === JSON.stringify(nextPrompt[index]));
+  if (!samePrefix) {
+    return { prompt: nextPrompt };
+  }
+
+  let deltaPrompt = nextPrompt.slice(previousPrompt.length);
+  while (deltaPrompt[0]?.role === 'assistant') {
+    deltaPrompt = deltaPrompt.slice(1);
+  }
+  if (deltaPrompt.length === 0) {
+    return { prompt: nextPrompt };
+  }
+
+  return {
+    prompt: deltaPrompt,
+    previousResponseId,
+  };
+}
+
+function toLanguageModelPrompt(messages: BaseMessage[]): LanguageModelV1Prompt {
+  return messages.map((message) => {
+    if (SystemMessage.isInstance(message)) {
+      return {
+        role: 'system',
+        content: stringifyMessageContent(message.content),
+      };
+    }
+
+    if (HumanMessage.isInstance(message)) {
+      return {
+        role: 'user',
+        content: [{ type: 'text', text: stringifyMessageContent(message.content) }],
+      };
+    }
+
+    if (ToolMessage.isInstance(message)) {
+      return {
+        role: 'tool',
+        content: [{
+          type: 'tool-result',
+          toolCallId: message.tool_call_id,
+          toolName: message.name || 'tool',
+          result: stringifyMessageContent(message.content),
+          isError: message.status === 'error',
+        }],
+      };
+    }
+
+    if (AIMessage.isInstance(message)) {
+      const content = [] as Array<{ type: 'text'; text: string } | { type: 'tool-call'; toolCallId: string; toolName: string; args: unknown }>;
+      const text = stringifyMessageContent(message.content);
+      if (text) {
+        content.push({ type: 'text', text });
+      }
+      for (const toolCall of message.tool_calls ?? []) {
+        content.push({
+          type: 'tool-call',
+          toolCallId: toolCall.id || toolCall.name,
+          toolName: toolCall.name,
+          args: toolCall.args,
+        });
+      }
+      return {
+        role: 'assistant',
+        content,
+        ...extractAssistantPhase(message),
+        ...extractRawOutputItems(message),
+      };
+    }
+
+    return {
+      role: 'user',
+      content: [{ type: 'text', text: stringifyMessageContent(message.content) }],
+    };
+  });
+}
+
+function extractAssistantPhase(message: AIMessage): { phase?: string } {
+  const additionalPhase = message.additional_kwargs && typeof message.additional_kwargs === 'object'
+    ? (message.additional_kwargs as { phase?: unknown }).phase
+    : undefined;
+  if (typeof additionalPhase === 'string' && additionalPhase.trim()) {
+    return { phase: additionalPhase.trim() };
+  }
+
+  const responsePhase = message.response_metadata && typeof message.response_metadata === 'object'
+    ? (message.response_metadata as { phase?: unknown }).phase
+    : undefined;
+  if (typeof responsePhase === 'string' && responsePhase.trim()) {
+    return { phase: responsePhase.trim() };
+  }
+
+  return {};
+}
+
+function extractRawOutputItems(message: AIMessage): { rawOutputItems?: Array<Record<string, unknown>> } {
+  const fromAdditional = message.additional_kwargs && typeof message.additional_kwargs === 'object'
+    ? (message.additional_kwargs as { codex_output_items?: unknown }).codex_output_items
+    : undefined;
+  if (Array.isArray(fromAdditional)) {
+    return { rawOutputItems: fromAdditional.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object') };
+  }
+
+  const fromResponse = message.response_metadata && typeof message.response_metadata === 'object'
+    ? (message.response_metadata as { codex_output_items?: unknown }).codex_output_items
+    : undefined;
+  if (Array.isArray(fromResponse)) {
+    return { rawOutputItems: fromResponse.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object') };
+  }
+
+  return {};
+}
+
+function stringifyMessageContent(content: unknown): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part === 'string') {
+          return part;
+        }
+        if (part && typeof part === 'object' && 'text' in part && typeof (part as { text?: unknown }).text === 'string') {
+          return (part as { text: string }).text;
+        }
+        return '';
+      })
+      .join('\n')
+      .trim();
+  }
+
+  return content == null ? '' : String(content);
+}
+
+function normalizeToolChoice(toolChoice: ChatCodexOAuthCallOptions['tool_choice']): LanguageModelV1ToolChoice | undefined {
+  if (!toolChoice || toolChoice === 'auto') {
+    return undefined;
+  }
+
+  if (toolChoice === 'any') {
+    return { type: 'required' };
+  }
+
+  if (toolChoice === 'none') {
+    return { type: 'none' };
+  }
+
+  if (typeof toolChoice === 'string') {
+    return { type: 'tool', toolName: toolChoice };
+  }
+
+  return undefined;
+}
+
+function parseToolArgs(toolName: string, args: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(args);
+    const normalized = parsed && typeof parsed === 'object' ? parsed as Record<string, unknown> : {};
+    if (toolName === 'edit_file' && normalized.replace_all === null) {
+      delete normalized.replace_all;
+    }
+    return normalized;
+  } catch {
+    return {};
+  }
+}
+
+function toLanguageModelTool(input: BindToolsInput): LanguageModelV1FunctionTool | undefined {
+  if (!input || typeof input !== 'object') {
+    return undefined;
+  }
+
+  const candidate = input as {
+    name?: unknown;
+    description?: unknown;
+    parameters?: unknown;
+    schema?: unknown;
+  };
+  const name = typeof candidate.name === 'string' ? candidate.name : undefined;
+  if (!name) {
+    return undefined;
+  }
+
+  const parameters = toJsonSchema(candidate.parameters ?? candidate.schema);
+  return {
+    type: 'function',
+    name,
+    description: typeof candidate.description === 'string' ? candidate.description : undefined,
+    parameters,
+    strict: true,
+  };
+}
+
+function toJsonSchema(schema: unknown): JSONSchema7 {
+  if (schema instanceof z.ZodType) {
+    return normalizeJsonSchema(zodToJsonSchema(schema));
+  }
+
+  if (isSerializedZodSchema(schema)) {
+    return normalizeJsonSchema(serializedZodToJsonSchema(schema));
+  }
+
+  if (schema && typeof schema === 'object') {
+    return normalizeJsonSchema(schema as JSONSchema7);
+  }
+
+  return normalizeJsonSchema({
+    type: 'object',
+    properties: {},
+    additionalProperties: true,
+  });
+}
+
+function zodToJsonSchema(schema: z.ZodTypeAny): JSONSchema7 {
+  if (schema instanceof z.ZodOptional || schema instanceof z.ZodNullable || schema instanceof z.ZodDefault) {
+    return zodToJsonSchema(schema._def.innerType);
+  }
+
+  if (schema instanceof z.ZodString) {
+    return { type: 'string' };
+  }
+
+  if (schema instanceof z.ZodNumber) {
+    return { type: 'number' };
+  }
+
+  if (schema instanceof z.ZodBoolean) {
+    return { type: 'boolean' };
+  }
+
+  if (schema instanceof z.ZodEnum) {
+    return { type: 'string', enum: [...schema._def.values] };
+  }
+
+  if (schema instanceof z.ZodLiteral) {
+    return { enum: [schema._def.value] };
+  }
+
+  if (schema instanceof z.ZodArray) {
+    return {
+      type: 'array',
+      items: zodToJsonSchema(schema._def.type),
+    };
+  }
+
+  if (schema instanceof z.ZodUnion) {
+    return {
+      anyOf: schema._def.options.map((option: z.ZodTypeAny) => zodToJsonSchema(option)),
+    };
+  }
+
+  if (schema instanceof z.ZodObject) {
+    const shape = schema._def.shape();
+    const properties = Object.fromEntries(
+      Object.entries(shape).map(([key, value]) => [key, zodToJsonSchema(value as z.ZodTypeAny)]),
+    );
+    const required = Object.entries(shape)
+      .filter(([, value]) => !isOptionalZodSchema(value as z.ZodTypeAny))
+      .map(([key]) => key);
+    return {
+      type: 'object',
+      properties,
+      additionalProperties: false,
+      ...(required.length > 0 ? { required } : {}),
+    };
+  }
+
+  return {};
+}
+
+function isOptionalZodSchema(schema: z.ZodTypeAny): boolean {
+  return schema instanceof z.ZodOptional || schema instanceof z.ZodDefault;
+}
+
+function isSerializedZodSchema(schema: unknown): schema is { def: { type?: string; [key: string]: unknown } } {
+  return Boolean(
+    schema
+      && typeof schema === 'object'
+      && 'def' in (schema as Record<string, unknown>)
+      && typeof (schema as { def?: unknown }).def === 'object',
+  );
+}
+
+function serializedZodToJsonSchema(schema: { def: { type?: string; [key: string]: unknown } }): JSONSchema7 {
+  const def = schema.def;
+  switch (def.type) {
+    case 'string':
+      return { type: 'string' };
+    case 'number':
+      return { type: 'number' };
+    case 'boolean':
+      return { type: 'boolean' };
+    case 'literal':
+      return { enum: [def.value] as JSONSchema7['enum'] };
+    case 'enum':
+      return { type: 'string', enum: Array.isArray(def.values) ? [...def.values] : [] };
+    case 'nullable':
+    case 'optional':
+    case 'default':
+      return serializedInnerTypeToJsonSchema(def.innerType);
+    case 'array':
+      return {
+        type: 'array',
+        items: serializedInnerTypeToJsonSchema(def.type),
+      };
+    case 'union':
+      return {
+        anyOf: Array.isArray(def.options)
+          ? def.options.map((option: z.ZodTypeAny) => serializedInnerTypeToJsonSchema(option))
+          : [],
+      };
+    case 'object': {
+      const shapeRecord = typeof def.shape === 'function' ? def.shape() : def.shape;
+      const shape = shapeRecord && typeof shapeRecord === 'object' ? shapeRecord as Record<string, unknown> : {};
+      const properties = Object.fromEntries(
+        Object.entries(shape).map(([key, value]) => [key, serializedInnerTypeToJsonSchema(value)]),
+      );
+      const required = Object.entries(shape)
+        .filter(([, value]) => !isSerializedOptionalSchema(value))
+        .map(([key]) => key);
+      return {
+        type: 'object',
+        properties,
+        additionalProperties: false,
+        ...(required.length > 0 ? { required } : {}),
+      };
+    }
+    default:
+      return {};
+  }
+}
+
+function serializedInnerTypeToJsonSchema(value: unknown): JSONSchema7 {
+  return isSerializedZodSchema(value)
+    ? serializedZodToJsonSchema(value)
+    : toJsonSchema(value);
+}
+
+function isSerializedOptionalSchema(value: unknown): boolean {
+  return isSerializedZodSchema(value) && (value.def.type === 'optional' || value.def.type === 'default');
+}
+
+function normalizeJsonSchema(schema: JSONSchema7): JSONSchema7 {
+  const normalized: JSONSchema7 = { ...schema };
+
+  if (normalized.type === 'object') {
+    normalized.properties = normalized.properties ?? {};
+  }
+
+  if (normalized.items && typeof normalized.items === 'object' && !Array.isArray(normalized.items)) {
+    normalized.items = normalizeJsonSchema(normalized.items as JSONSchema7);
+  }
+
+  if (Array.isArray(normalized.anyOf)) {
+    normalized.anyOf = normalized.anyOf.map((entry) =>
+      entry && typeof entry === 'object' && !Array.isArray(entry)
+        ? normalizeJsonSchema(entry as JSONSchema7)
+        : entry,
+    );
+  }
+
+  if (normalized.properties) {
+    normalized.properties = Object.fromEntries(
+      Object.entries(normalized.properties).map(([key, value]) => [
+        key,
+        value && typeof value === 'object' && !Array.isArray(value)
+          ? normalizeJsonSchema(value as JSONSchema7)
+          : value,
+      ]),
+    );
+  }
+
+  return normalized;
+}

--- a/packages/vscode-extension/src/services/agent-provider-runtime/chat-codex-oauth.ts
+++ b/packages/vscode-extension/src/services/agent-provider-runtime/chat-codex-oauth.ts
@@ -16,7 +16,7 @@ import type { ToolCall } from '@langchain/core/messages/tool';
 import { ChatGenerationChunk, type ChatResult } from '@langchain/core/outputs';
 import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
 import type { Runnable } from '@langchain/core/runnables';
-import { z } from 'zod';
+import { toJsonSchema as langChainToJsonSchema } from '@langchain/core/utils/json_schema';
 import { createOpenAiAccountLanguageModel, CodexReasoningEffort, ensureCodexSessionId, getDefaultCodexReasoningEffort } from './openai-account.js';
 
 interface ChatCodexOAuthCallOptions extends BaseChatModelCallOptions {
@@ -535,152 +535,19 @@ function toLanguageModelTool(input: BindToolsInput): LanguageModelV1FunctionTool
 }
 
 function toJsonSchema(schema: unknown): JSONSchema7 {
-  if (schema instanceof z.ZodType) {
-    return normalizeJsonSchema(zodToJsonSchema(schema));
-  }
-
-  if (isSerializedZodSchema(schema)) {
-    return normalizeJsonSchema(serializedZodToJsonSchema(schema));
-  }
-
-  if (schema && typeof schema === 'object') {
-    return normalizeJsonSchema(schema as JSONSchema7);
-  }
-
-  return normalizeJsonSchema({
-    type: 'object',
-    properties: {},
-    additionalProperties: true,
-  });
+  const converted = schema && typeof schema === 'object'
+    ? langChainToJsonSchema(schema as Parameters<typeof langChainToJsonSchema>[0])
+    : undefined;
+  return normalizeJsonSchemaRoot(converted as JSONSchema7 | undefined);
 }
 
-function zodToJsonSchema(schema: z.ZodTypeAny): JSONSchema7 {
-  if (schema instanceof z.ZodOptional || schema instanceof z.ZodNullable || schema instanceof z.ZodDefault) {
-    return zodToJsonSchema(schema._def.innerType);
-  }
-
-  if (schema instanceof z.ZodString) {
-    return { type: 'string' };
-  }
-
-  if (schema instanceof z.ZodNumber) {
-    return { type: 'number' };
-  }
-
-  if (schema instanceof z.ZodBoolean) {
-    return { type: 'boolean' };
-  }
-
-  if (schema instanceof z.ZodEnum) {
-    return { type: 'string', enum: [...schema._def.values] };
-  }
-
-  if (schema instanceof z.ZodLiteral) {
-    return { enum: [schema._def.value] };
-  }
-
-  if (schema instanceof z.ZodArray) {
-    return {
-      type: 'array',
-      items: zodToJsonSchema(schema._def.type),
-    };
-  }
-
-  if (schema instanceof z.ZodUnion) {
-    return {
-      anyOf: schema._def.options.map((option: z.ZodTypeAny) => zodToJsonSchema(option)),
-    };
-  }
-
-  if (schema instanceof z.ZodObject) {
-    const shape = schema._def.shape();
-    const properties = Object.fromEntries(
-      Object.entries(shape).map(([key, value]) => [key, zodToJsonSchema(value as z.ZodTypeAny)]),
-    );
-    const required = Object.entries(shape)
-      .filter(([, value]) => !isOptionalZodSchema(value as z.ZodTypeAny))
-      .map(([key]) => key);
-    return {
-      type: 'object',
-      properties,
-      additionalProperties: false,
-      ...(required.length > 0 ? { required } : {}),
-    };
-  }
-
-  return {};
-}
-
-function isOptionalZodSchema(schema: z.ZodTypeAny): boolean {
-  return schema instanceof z.ZodOptional || schema instanceof z.ZodDefault;
-}
-
-function isSerializedZodSchema(schema: unknown): schema is { def: { type?: string; [key: string]: unknown } } {
-  return Boolean(
-    schema
-      && typeof schema === 'object'
-      && 'def' in (schema as Record<string, unknown>)
-      && typeof (schema as { def?: unknown }).def === 'object',
-  );
-}
-
-function serializedZodToJsonSchema(schema: { def: { type?: string; [key: string]: unknown } }): JSONSchema7 {
-  const def = schema.def;
-  switch (def.type) {
-    case 'string':
-      return { type: 'string' };
-    case 'number':
-      return { type: 'number' };
-    case 'boolean':
-      return { type: 'boolean' };
-    case 'literal':
-      return { enum: [def.value] as JSONSchema7['enum'] };
-    case 'enum':
-      return { type: 'string', enum: Array.isArray(def.values) ? [...def.values] : [] };
-    case 'nullable':
-    case 'optional':
-    case 'default':
-      return serializedInnerTypeToJsonSchema(def.innerType);
-    case 'array':
-      return {
-        type: 'array',
-        items: serializedInnerTypeToJsonSchema(def.type),
-      };
-    case 'union':
-      return {
-        anyOf: Array.isArray(def.options)
-          ? def.options.map((option: z.ZodTypeAny) => serializedInnerTypeToJsonSchema(option))
-          : [],
-      };
-    case 'object': {
-      const shapeRecord = typeof def.shape === 'function' ? def.shape() : def.shape;
-      const shape = shapeRecord && typeof shapeRecord === 'object' ? shapeRecord as Record<string, unknown> : {};
-      const properties = Object.fromEntries(
-        Object.entries(shape).map(([key, value]) => [key, serializedInnerTypeToJsonSchema(value)]),
-      );
-      const required = Object.entries(shape)
-        .filter(([, value]) => !isSerializedOptionalSchema(value))
-        .map(([key]) => key);
-      return {
-        type: 'object',
-        properties,
-        additionalProperties: false,
-        ...(required.length > 0 ? { required } : {}),
-      };
-    }
-    default:
-      return {};
-  }
-}
-
-function serializedInnerTypeToJsonSchema(value: unknown): JSONSchema7 {
-  return isSerializedZodSchema(value)
-    ? serializedZodToJsonSchema(value)
-    : toJsonSchema(value);
-}
-
-function isSerializedOptionalSchema(value: unknown): boolean {
-  return isSerializedZodSchema(value) && (value.def.type === 'optional' || value.def.type === 'default');
+function normalizeJsonSchemaRoot(schema: JSONSchema7 | undefined): JSONSchema7 {
+  const normalized = normalizeJsonSchema(schema && typeof schema === 'object' && !Array.isArray(schema)
+    ? schema
+    : { type: 'object', properties: {}, additionalProperties: true });
+  return normalized.type === 'object'
+    ? normalized
+    : { type: 'object', properties: {}, additionalProperties: true };
 }
 
 function normalizeJsonSchema(schema: JSONSchema7): JSONSchema7 {

--- a/packages/vscode-extension/src/services/agent-provider-runtime/copilot-account.ts
+++ b/packages/vscode-extension/src/services/agent-provider-runtime/copilot-account.ts
@@ -1,0 +1,162 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export const DEFAULT_COPILOT_API_BASE_URL = 'https://api.individual.githubcopilot.com';
+export const GITHUB_COPILOT_DEFAULT_MODEL = 'gpt-4.1';
+
+const COPILOT_TOKEN_URL = 'https://api.github.com/copilot_internal/v2/token';
+const COPILOT_USER_AGENT = 'GitHubCopilotChat/0.26.7';
+const COPILOT_EDITOR_VERSION = 'vscode/1.96.2';
+const COPILOT_EDITOR_PLUGIN_VERSION = 'copilot-chat/0.26.7';
+
+interface CachedCopilotToken {
+  token: string;
+  expiresAt: number;
+  updatedAt: number;
+}
+
+export async function resolveCopilotApiToken(githubToken: string): Promise<{
+  token: string;
+  expiresAt: number;
+  baseUrl: string;
+}> {
+  const cachePath = getCopilotTokenCachePath();
+  const cached = readCachedCopilotToken(cachePath);
+  if (cached && isCopilotTokenUsable(cached)) {
+    return {
+      token: cached.token,
+      expiresAt: cached.expiresAt,
+      baseUrl: deriveCopilotApiBaseUrlFromToken(cached.token) ?? DEFAULT_COPILOT_API_BASE_URL,
+    };
+  }
+
+  const response = await fetch(COPILOT_TOKEN_URL, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${githubToken}`,
+      'User-Agent': COPILOT_USER_AGENT,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Copilot token exchange failed: HTTP ${response.status}`);
+  }
+
+  const payload = parseCopilotTokenResponse(await response.json());
+  writeCachedCopilotToken(cachePath, {
+    token: payload.token,
+    expiresAt: payload.expiresAt,
+    updatedAt: Date.now(),
+  });
+
+  return {
+    token: payload.token,
+    expiresAt: payload.expiresAt,
+    baseUrl: deriveCopilotApiBaseUrlFromToken(payload.token) ?? DEFAULT_COPILOT_API_BASE_URL,
+  };
+}
+
+export async function fetchGitHubCopilotModels(githubToken: string): Promise<string[]> {
+  const runtimeAuth = await resolveCopilotApiToken(githubToken);
+  const response = await fetch(`${runtimeAuth.baseUrl}/models`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${runtimeAuth.token}`,
+      Accept: 'application/json',
+      'User-Agent': COPILOT_USER_AGENT,
+      'Editor-Version': COPILOT_EDITOR_VERSION,
+      'Editor-Plugin-Version': COPILOT_EDITOR_PLUGIN_VERSION,
+    },
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    const detail = body.trim();
+    throw new Error(detail || `GitHub Copilot model discovery failed: HTTP ${response.status}`);
+  }
+
+  const payload = await response.json() as { data?: Array<{ id?: string }> };
+  const models = (payload.data ?? [])
+    .map((entry) => entry.id?.trim())
+    .filter((entry): entry is string => Boolean(entry))
+    .sort((a, b) => a.localeCompare(b));
+  return [...new Set(models)];
+}
+
+function getCopilotTokenCachePath(): string {
+  const override = readOptionalString(process.env.N8N_COPILOT_TOKEN_CACHE_PATH);
+  if (override) {
+    return override;
+  }
+  return path.join(os.homedir(), '.n8n-as-code', 'copilot-runtime-token.json');
+}
+
+function readCachedCopilotToken(cachePath: string): CachedCopilotToken | undefined {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cachePath, 'utf8')) as Partial<CachedCopilotToken>;
+    if (typeof parsed.token !== 'string' || typeof parsed.expiresAt !== 'number') {
+      return undefined;
+    }
+    return {
+      token: parsed.token,
+      expiresAt: parsed.expiresAt,
+      updatedAt: typeof parsed.updatedAt === 'number' ? parsed.updatedAt : 0,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function writeCachedCopilotToken(cachePath: string, token: CachedCopilotToken): void {
+  try {
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    fs.writeFileSync(cachePath, JSON.stringify(token, null, 2), { mode: 0o600 });
+  } catch {
+    // Non-fatal: a failed cache write should not block the current run.
+  }
+}
+
+function isCopilotTokenUsable(token: CachedCopilotToken): boolean {
+  return typeof token.token === 'string' && token.token.length > 0 && token.expiresAt > Date.now() + 60_000;
+}
+
+function parseCopilotTokenResponse(payload: unknown): { token: string; expiresAt: number } {
+  const record = payload && typeof payload === 'object' ? payload as Record<string, unknown> : {};
+  const token = readOptionalString(record.token);
+  if (!token) {
+    throw new Error('Copilot token exchange returned no token.');
+  }
+  const expiresAtSeconds = typeof record.expires_at === 'number' ? record.expires_at : undefined;
+  const expiresInSeconds = typeof record.expires_in === 'number' ? record.expires_in : undefined;
+  const expiresAt = expiresAtSeconds
+    ? expiresAtSeconds * 1000
+    : Date.now() + ((expiresInSeconds ?? 300) * 1000);
+  return { token, expiresAt };
+}
+
+function deriveCopilotApiBaseUrlFromToken(token: string): string | undefined {
+  const payload = parseJwtPayload(token);
+  const endpoints = payload?.endpoints;
+  if (!endpoints || typeof endpoints !== 'object') {
+    return undefined;
+  }
+  const api = (endpoints as Record<string, unknown>).api;
+  return readOptionalString(api);
+}
+
+function parseJwtPayload(token: string): Record<string, unknown> | undefined {
+  try {
+    const [, payload] = token.split('.');
+    if (!payload) {
+      return undefined;
+    }
+    return JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}

--- a/packages/vscode-extension/src/services/agent-provider-runtime/create-langchain-model.ts
+++ b/packages/vscode-extension/src/services/agent-provider-runtime/create-langchain-model.ts
@@ -1,0 +1,90 @@
+import { ChatAnthropic } from '@langchain/anthropic';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import type { BaseMessageChunk } from '@langchain/core/messages';
+import { ChatOpenAI, ChatOpenAICompletions } from '@langchain/openai';
+import { ChatCodexOAuth } from './chat-codex-oauth.js';
+import { DEFAULT_COPILOT_API_BASE_URL, resolveCopilotApiToken } from './copilot-account.js';
+import type { CodexReasoningEffort } from './openai-account.js';
+
+export type LocalAgentProvider =
+  | 'openai-oauth'
+  | 'copilot-proxy'
+  | 'minimax'
+  | 'minimax-token-plan';
+
+export interface LocalLangChainModelConfig {
+  provider: LocalAgentProvider;
+  model: string;
+  apiKey?: string;
+  baseUrl?: string;
+  reasoningEffort?: CodexReasoningEffort;
+}
+
+const COPILOT_DEFAULT_HEADERS = {
+  'Editor-Version': 'vscode/1.95.3',
+  'Editor-Plugin-Version': 'copilot-chat/0.22.4',
+  'Openai-Intent': 'conversation-panel',
+};
+
+class CopilotCompletionsModel extends ChatOpenAICompletions {
+  protected override _convertCompletionsDeltaToBaseMessageChunk(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delta: Record<string, any>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rawResponse: any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    defaultRole?: any,
+  ): BaseMessageChunk {
+    const chunk = super._convertCompletionsDeltaToBaseMessageChunk(delta, rawResponse, defaultRole);
+    const reasoningText = delta?.reasoning_text;
+    if (typeof reasoningText === 'string' && reasoningText.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (chunk as any).additional_kwargs = {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...((chunk as any).additional_kwargs ?? {}),
+        reasoning_content: reasoningText,
+      };
+    }
+    return chunk;
+  }
+}
+
+export async function createLocalProviderLangChainModel(config: LocalLangChainModelConfig): Promise<BaseChatModel> {
+  switch (config.provider) {
+    case 'openai-oauth':
+      return new ChatCodexOAuth({
+        model: config.model,
+        reasoningEffort: config.reasoningEffort,
+        accessToken: config.apiKey,
+      });
+
+    case 'copilot-proxy': {
+      if (!config.apiKey) {
+        throw new Error('GitHub Copilot provider is not connected.');
+      }
+      const runtimeAuth = await resolveCopilotApiToken(config.apiKey);
+      const isGeminiModel = /^gemini/i.test(config.model);
+      const copilotFields = {
+        apiKey: runtimeAuth.token,
+        model: config.model,
+        configuration: {
+          baseURL: config.baseUrl || runtimeAuth.baseUrl || DEFAULT_COPILOT_API_BASE_URL,
+          defaultHeaders: COPILOT_DEFAULT_HEADERS,
+        },
+        ...(isGeminiModel ? { modelKwargs: { thinking_budget: 1024 } } : {}),
+      };
+      return new ChatOpenAI({
+        ...copilotFields,
+        completions: new CopilotCompletionsModel(copilotFields),
+      });
+    }
+
+    case 'minimax':
+    case 'minimax-token-plan':
+      return new ChatAnthropic({
+        apiKey: config.apiKey,
+        model: config.model,
+        anthropicApiUrl: config.baseUrl ?? 'https://api.minimax.io/anthropic',
+      });
+  }
+}

--- a/packages/vscode-extension/src/services/agent-provider-runtime/openai-account.ts
+++ b/packages/vscode-extension/src/services/agent-provider-runtime/openai-account.ts
@@ -1,0 +1,1492 @@
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
+import type {
+  LanguageModelV1,
+  LanguageModelV1CallOptions,
+  LanguageModelV1CallWarning,
+  LanguageModelV1FunctionTool,
+  LanguageModelV1FunctionToolCall,
+  LanguageModelV1Prompt,
+  LanguageModelV1StreamPart,
+  LanguageModelV1ToolChoice,
+} from './provider-types.js';
+import { normalizeFunctionToolParametersSchema } from './tool-schema.js';
+import { CODEX_UPSTREAM_TIMEOUT_MS, RETRY_CONFIG, withRetry, timeoutSignal } from './utils.js';
+
+export const OPENAI_ACCOUNT_BASE_URL = 'https://chatgpt.com/backend-api';
+export const OPENAI_ACCOUNT_DEFAULT_MODEL = 'gpt-5.4';
+
+/**
+ * The originator value sent in the `originator` header.
+ * Matches the value used by the official Codex CLI, so the backend
+ * can attribute requests to a known client family.
+ */
+const CODEX_ORIGINATOR = 'codex_cli_rs';
+const CODEX_INSTALLATION_ID_FILENAME = 'codex_installation_id';
+const CODEX_DEFAULT_INSTRUCTIONS = `You are Codex, based on GPT-5. You are running as a coding agent inside the n8n Workbench on the user's computer.
+
+Prefer acting with the available tools over prolonged deliberation. In the Workbench, use the dedicated file tools for reading and editing files instead of shell commands when possible, and use shell tools primarily for commands, package managers, git, and runtime checks.`;
+
+/**
+ * Reasoning effort level for Codex responses API.
+ * Corresponds to the `reasoning_effort` parameter accepted by the API.
+ * - 'none': No reasoning (fastest)
+ * - 'minimal': Minimal reasoning (~5-10% of budget)
+ * - 'low': Low reasoning (~10-20% of max_completion_tokens)
+ * - 'medium': Medium reasoning (~50% of max_completion_tokens) — default
+ * - 'high': High reasoning (~80% of max_completion_tokens)
+ * - 'xhigh': Extra high reasoning (~95% of max_completion_tokens)
+ */
+export const CODEX_REASONING_EFFORT_OPTIONS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'] as const;
+export type CodexReasoningEffort = typeof CODEX_REASONING_EFFORT_OPTIONS[number];
+
+export function getDefaultCodexReasoningEffort(modelId: string): CodexReasoningEffort {
+  return /^gpt-5\.4(?:$|[-.])/i.test(modelId) ? 'none' : 'medium';
+}
+
+function toCodexReasoningPayload(modelId: string, reasoningEffort: CodexReasoningEffort): Record<string, unknown> {
+  if (reasoningEffort === 'none') {
+    return {};
+  }
+
+  const effort = reasoningEffort === 'minimal'
+    ? 'low'
+    : reasoningEffort === 'xhigh'
+      ? 'high'
+      : reasoningEffort;
+
+  return {
+    reasoning: {
+      effort,
+      ...(/^gpt-5/i.test(modelId) ? { summary: 'auto' } : {}),
+    },
+  };
+}
+
+/** Endpoint path for Codex responses on the ChatGPT backend. */
+const CODEX_RESPONSES_PATH = '/codex/responses';
+const CODEX_MODELS_PATH = '/codex/models';
+
+/** In-memory cache for model discovery with ETag support. */
+interface ModelDiscoveryCache {
+  models: string[];
+  etag: string | null;
+  timestamp: number;
+}
+
+let modelDiscoveryCache: ModelDiscoveryCache | null = null;
+const MODEL_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/** JWT claim namespace used by OpenAI to embed ChatGPT account metadata. */
+const JWT_ACCOUNT_CLAIM = 'https://api.openai.com/auth';
+
+// ─── OAuth / PKCE constants ────────────────────────────────────────────────────
+
+const CODEX_ISSUER = 'https://auth.openai.com';
+const CODEX_TOKEN_ENDPOINT = 'https://auth.openai.com/oauth/token';
+const CODEX_DEVICE_AUTHORIZATION_ENDPOINT = 'https://auth.openai.com/api/accounts/deviceauth/usercode';
+const CODEX_DEVICE_TOKEN_ENDPOINT = 'https://auth.openai.com/api/accounts/deviceauth/token';
+const CODEX_DEVICE_REDIRECT_URI = 'https://auth.openai.com/deviceauth/callback';
+const CODEX_DEVICE_POLLING_SAFETY_MARGIN_MS = 3000;
+const CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+const CODEX_CALLBACK_PORT = 1455;
+const CODEX_CALLBACK_PATH = '/auth/callback';
+const CODEX_REDIRECT_URI = `http://localhost:${CODEX_CALLBACK_PORT}${CODEX_CALLBACK_PATH}`;
+const CODEX_SCOPES = 'openid profile email offline_access';
+
+export interface CodexAuthChallenge {
+  authUrl: string;
+  callbackServerStarted: boolean;
+}
+
+export interface CodexDeviceAuthChallenge {
+  verificationUri: string;
+  verificationUriComplete?: string;
+  userCode: string;
+  deviceAuthId: string;
+  intervalMs: number;
+  expiresAt: number;
+}
+
+interface PendingCodexCallbackServer {
+  expectedState: string;
+  verifier: string;
+  server: http.Server;
+  waitForCode: Promise<{ code: string; verifier: string }>;
+  timeout: NodeJS.Timeout;
+}
+
+let pendingCodexCallbackServer: PendingCodexCallbackServer | undefined;
+// Survives stopCodexCallbackServer() so completeCodexAuth() can still await it.
+let pendingCodexResult: Promise<{ code: string; verifier: string }> | undefined;
+// Persists even when the callback server fails to bind, so pasted redirect URLs
+// can still be validated when callbackServerStarted: false.
+let pendingCodexState: string | undefined;
+let pendingCodexVerifier: string | undefined;
+
+function generateCodexPkce(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(32).toString('hex');
+  const challenge = createHash('sha256').update(verifier).digest('base64url');
+  return { verifier, challenge };
+}
+
+function stopCodexCallbackServer(): void {
+  if (pendingCodexCallbackServer) {
+    clearTimeout(pendingCodexCallbackServer.timeout);
+    pendingCodexCallbackServer.server.close();
+    pendingCodexCallbackServer = undefined;
+    // Note: pendingCodexResult, pendingCodexState, pendingCodexVerifier are intentionally preserved.
+  }
+}
+
+async function startCodexCallbackServer(state: string, verifier: string): Promise<boolean> {
+  // Persist state/verifier before attempting to bind, so pasted redirect URLs
+  // remain valid even when the server fails to start (e.g. port in use / headless).
+  pendingCodexState = state;
+  pendingCodexVerifier = verifier;
+  stopCodexCallbackServer();
+
+  let resolveCode: ((value: { code: string; verifier: string }) => void) | undefined;
+  let rejectCode: ((error: Error) => void) | undefined;
+  const waitForCode = new Promise<{ code: string; verifier: string }>((resolve, reject) => {
+    resolveCode = resolve;
+    rejectCode = reject;
+  });
+
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? '/', CODEX_REDIRECT_URI);
+    if (url.pathname !== CODEX_CALLBACK_PATH) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not Found');
+      return;
+    }
+    const returnedState = url.searchParams.get('state');
+    const code = url.searchParams.get('code');
+    const error = url.searchParams.get('error');
+
+    if (error || returnedState !== state || !code) {
+      res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end('<html><body><h3>Sign-in failed.</h3><p>Return to the terminal and try again.</p></body></html>');
+      rejectCode?.(new Error(error ?? 'OAuth callback: invalid state or missing code.'));
+      stopCodexCallbackServer();
+      return;
+    }
+
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end('<html><body><h3>OpenAI account connected.</h3><p>You can return to the n8n Workbench setup wizard.</p></body></html>');
+    resolveCode?.({ code, verifier });
+    stopCodexCallbackServer();
+  });
+
+  const timeout = setTimeout(() => {
+    rejectCode?.(new Error('OpenAI OAuth callback timed out. Please retry.'));
+    stopCodexCallbackServer();
+  }, 3 * 60_000);
+
+  pendingCodexCallbackServer = { expectedState: state, verifier, server, waitForCode, timeout };
+  pendingCodexResult = waitForCode;
+
+  const started = await new Promise<boolean>((resolve) => {
+    server.once('error', (err) => {
+      rejectCode?.(err instanceof Error ? err : new Error(String(err)));
+      stopCodexCallbackServer();
+      resolve(false);
+    });
+    server.listen(CODEX_CALLBACK_PORT, '127.0.0.1', () => resolve(true));
+  });
+
+  return started;
+}
+
+export async function beginCodexAuth(): Promise<CodexAuthChallenge> {
+  const state = randomBytes(16).toString('hex');
+  const { verifier, challenge } = generateCodexPkce();
+
+  const serverStarted = await startCodexCallbackServer(state, verifier);
+
+  const url = new URL(`${CODEX_ISSUER}/oauth/authorize`);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('client_id', CODEX_CLIENT_ID);
+  url.searchParams.set('redirect_uri', CODEX_REDIRECT_URI);
+  url.searchParams.set('scope', CODEX_SCOPES);
+  url.searchParams.set('code_challenge', challenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('id_token_add_organizations', 'true');
+  url.searchParams.set('codex_cli_simplified_flow', 'true');
+  url.searchParams.set('originator', 'n8n-workbench');
+  url.searchParams.set('state', state);
+
+  return { authUrl: url.toString(), callbackServerStarted: serverStarted };
+}
+
+export async function beginCodexDeviceAuth(): Promise<CodexDeviceAuthChallenge> {
+  const response = await fetch(CODEX_DEVICE_AUTHORIZATION_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ client_id: CODEX_CLIENT_ID }),
+  });
+
+  if (!response.ok) {
+    let errorCode: string | undefined;
+    let errorDescription: string | undefined;
+    try {
+      const errorPayload = await response.json() as { error?: string; error_description?: string; message?: string };
+      errorCode = errorPayload.error;
+      errorDescription = errorPayload.error_description ?? errorPayload.message;
+    } catch {
+      // Ignore non-JSON error responses.
+    }
+
+    throw new Error(errorDescription
+      ? `OpenAI device login failed: ${errorDescription}`
+      : errorCode
+        ? `OpenAI device login failed: ${errorCode}`
+        : `OpenAI device login failed: HTTP ${response.status}`);
+  }
+
+  const device = await response.json() as {
+    device_auth_id?: string;
+    user_code?: string;
+    interval?: string;
+    expires_in?: number;
+  };
+
+  if (!device.device_auth_id || !device.user_code) {
+    throw new Error('OpenAI device login returned an incomplete challenge.');
+  }
+
+  const intervalSeconds = Number.parseInt(device.interval ?? '5', 10);
+  const intervalMs = Math.max(Number.isFinite(intervalSeconds) ? intervalSeconds : 5, 1) * 1000;
+
+  return {
+    verificationUri: `${CODEX_ISSUER}/codex/device`,
+    verificationUriComplete: undefined,
+    userCode: device.user_code,
+    deviceAuthId: device.device_auth_id,
+    intervalMs,
+    expiresAt: Date.now() + ((device.expires_in ?? 600) * 1000),
+  };
+}
+
+function persistCodexSession(tokens: {
+  access_token: string;
+  refresh_token?: string;
+  id_token?: string;
+  expires_in?: number;
+}): OpenAiAccountSession {
+  const authPath = getCodexAuthPath();
+  fs.mkdirSync(path.dirname(authPath), { recursive: true });
+  fs.writeFileSync(authPath, JSON.stringify({
+    auth_mode: 'chatgpt',
+    tokens,
+    last_refresh: new Date().toISOString(),
+  }, null, 2), { mode: 0o600 });
+
+  return {
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token,
+    source: 'codex',
+  };
+}
+
+function readManualCodexCallback(input: string): { code: string; verifier: string } | undefined {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const expectedState = pendingCodexState;
+  const verifier = pendingCodexVerifier;
+  if (!expectedState || !verifier) {
+    throw new Error('No pending OpenAI OAuth session. Restart the sign-in flow.');
+  }
+
+  let callbackUrl: URL;
+  try {
+    callbackUrl = new URL(trimmed, CODEX_REDIRECT_URI);
+  } catch {
+    throw new Error('Paste the full OpenAI callback URL after signing in.');
+  }
+
+  const returnedState = callbackUrl.searchParams.get('state');
+  const code = callbackUrl.searchParams.get('code');
+  const error = callbackUrl.searchParams.get('error');
+  if (error || returnedState !== expectedState || !code) {
+    throw new Error(error ?? 'OAuth callback: invalid state or missing code.');
+  }
+
+  stopCodexCallbackServer();
+  pendingCodexResult = undefined;
+  pendingCodexState = undefined;
+  pendingCodexVerifier = undefined;
+  return { code, verifier };
+}
+
+export async function completeCodexAuth(input = ''): Promise<OpenAiAccountSession> {
+  const manualResult = readManualCodexCallback(input);
+  if (manualResult) {
+    const { code, verifier } = manualResult;
+    const body = new URLSearchParams();
+    body.set('grant_type', 'authorization_code');
+    body.set('code', code);
+    body.set('redirect_uri', CODEX_REDIRECT_URI);
+    body.set('client_id', CODEX_CLIENT_ID);
+    body.set('code_verifier', verifier);
+
+    const tokenRes = await fetch(CODEX_TOKEN_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+
+    if (!tokenRes.ok) {
+      throw new Error(`OpenAI token exchange failed: HTTP ${tokenRes.status}`);
+    }
+
+    const tokens = await tokenRes.json() as {
+      access_token: string;
+      refresh_token?: string;
+      id_token?: string;
+      expires_in?: number;
+    };
+
+    if (!tokens.access_token) {
+      throw new Error('OpenAI token exchange returned no access_token.');
+    }
+
+    return persistCodexSession(tokens);
+  }
+
+  // The callback server may have already fired and cleared pendingCodexCallbackServer,
+  // but the promise is preserved in pendingCodexResult.
+  const resultPromise = pendingCodexCallbackServer?.waitForCode ?? pendingCodexResult;
+  if (!resultPromise) {
+    const existing = readCodexSession();
+    if (existing) return existing;
+    throw new Error('No pending OpenAI OAuth session. Restart the sign-in flow.');
+  }
+  pendingCodexResult = undefined;
+
+  const { code, verifier } = await resultPromise;
+
+  // Exchange code for tokens.
+  const body = new URLSearchParams();
+  body.set('grant_type', 'authorization_code');
+  body.set('code', code);
+  body.set('redirect_uri', CODEX_REDIRECT_URI);
+  body.set('client_id', CODEX_CLIENT_ID);
+  body.set('code_verifier', verifier);
+
+  const tokenRes = await fetch(CODEX_TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+
+  if (!tokenRes.ok) {
+    throw new Error(`OpenAI token exchange failed: HTTP ${tokenRes.status}`);
+  }
+
+  const tokens = await tokenRes.json() as {
+    access_token: string;
+    refresh_token?: string;
+    id_token?: string;
+    expires_in?: number;
+  };
+
+  if (!tokens.access_token) {
+    throw new Error('OpenAI token exchange returned no access_token.');
+  }
+
+  return persistCodexSession(tokens);
+}
+
+export async function completeCodexDeviceAuth(challenge: {
+  deviceAuthId: string;
+  userCode: string;
+  intervalMs: number;
+  expiresAt: number;
+}): Promise<OpenAiAccountSession> {
+  const intervalMs = Math.max(1000, challenge.intervalMs);
+
+  while (Date.now() < challenge.expiresAt) {
+    const response = await fetch(CODEX_DEVICE_TOKEN_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        device_auth_id: challenge.deviceAuthId,
+        user_code: challenge.userCode,
+      }),
+    });
+
+    if (response.ok) {
+      const deviceToken = await response.json() as {
+        authorization_code?: string;
+        code_verifier?: string;
+      };
+      if (!deviceToken.authorization_code || !deviceToken.code_verifier) {
+        throw new Error('OpenAI device login returned an incomplete authorization result.');
+      }
+
+      const body = new URLSearchParams();
+      body.set('grant_type', 'authorization_code');
+      body.set('code', deviceToken.authorization_code);
+      body.set('redirect_uri', CODEX_DEVICE_REDIRECT_URI);
+      body.set('client_id', CODEX_CLIENT_ID);
+      body.set('code_verifier', deviceToken.code_verifier);
+
+      const tokenResponse = await fetch(CODEX_TOKEN_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+      });
+
+      if (!tokenResponse.ok) {
+        throw new Error(`OpenAI token exchange failed: HTTP ${tokenResponse.status}`);
+      }
+
+      const tokens = await tokenResponse.json() as {
+        access_token?: string;
+        refresh_token?: string;
+        id_token?: string;
+        expires_in?: number;
+      };
+      if (!tokens.access_token) {
+        throw new Error('OpenAI device login returned no access_token.');
+      }
+      return persistCodexSession(tokens as {
+        access_token: string;
+        refresh_token?: string;
+        id_token?: string;
+        expires_in?: number;
+      });
+    }
+
+    if (response.status !== 403 && response.status !== 404) {
+      let payload: { error?: string; error_description?: string; message?: string } | undefined;
+      try {
+        payload = await response.json() as { error?: string; error_description?: string; message?: string };
+      } catch {
+        payload = undefined;
+      }
+      throw new Error(payload?.error_description || payload?.message || payload?.error || `OpenAI device flow failed: HTTP ${response.status}`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs + CODEX_DEVICE_POLLING_SAFETY_MARGIN_MS));
+  }
+
+  throw new Error('OpenAI device code expired. Retry setup.');
+}
+
+// ─── Interfaces ────────────────────────────────────────────────────────────────
+
+interface CodexAuthFile {
+  auth_mode?: string;
+  last_refresh?: string;
+  tokens?: {
+    access_token?: string;
+    refresh_token?: string;
+    account_id?: string;
+  };
+}
+
+export interface OpenAiAccountSession {
+  accessToken: string;
+  refreshToken?: string;
+  email?: string;
+  /** Always 'codex' — session is read from the Codex CLI auth file. */
+  source: 'codex';
+}
+
+// ─── Path helpers ──────────────────────────────────────────────────────────────
+
+/** Path to the Codex CLI auth file. Override with N8N_CODEX_AUTH_PATH for tests. */
+export function getCodexAuthPath(): string {
+  return process.env.N8N_CODEX_AUTH_PATH || path.join(os.homedir(), '.codex', 'auth.json');
+}
+
+// ─── Session readers ───────────────────────────────────────────────────────────
+
+function readCodexSession(): OpenAiAccountSession | undefined {
+  const authPath = getCodexAuthPath();
+  if (!fs.existsSync(authPath)) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(authPath, 'utf8')) as CodexAuthFile;
+    const accessToken = parsed.tokens?.access_token?.trim();
+    if (!accessToken) {
+      return undefined;
+    }
+    return {
+      accessToken,
+      refreshToken: parsed.tokens?.refresh_token?.trim() || undefined,
+      source: 'codex',
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+// ─── Token refresh ──────────────────────────────────────────────────────────────
+
+/** Returns the expiry time (in seconds since epoch) from an access token's JWT payload. */
+function getTokenExpiry(accessToken: string): number | undefined {
+  try {
+    const parts = accessToken.split('.');
+    if (parts.length !== 3) return undefined;
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64').toString('utf8')) as Record<string, unknown>;
+    const exp = payload['exp'];
+    return typeof exp === 'number' ? exp : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Returns true when the token expires within `minValiditySeconds` from now. */
+function isTokenExpiringSoon(accessToken: string, minValiditySeconds = 60): boolean {
+  const expiry = getTokenExpiry(accessToken);
+  if (expiry === undefined) return false;
+  return Date.now() / 1000 + minValiditySeconds > expiry;
+}
+
+/** Refreshes the access token using the stored refresh token.
+ *  Updates ~/.codex/auth.json with the new tokens. */
+async function refreshCodexToken(refreshToken: string): Promise<OpenAiAccountSession> {
+  const body = new URLSearchParams();
+  body.set('grant_type', 'refresh_token');
+  body.set('refresh_token', refreshToken);
+  body.set('client_id', CODEX_CLIENT_ID);
+
+  const res = await fetch(CODEX_TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Token refresh failed: HTTP ${res.status}`);
+  }
+
+  const tokens = await res.json() as {
+    access_token: string;
+    refresh_token?: string;
+    expires_in?: number;
+  };
+
+  if (!tokens.access_token) {
+    throw new Error('Token refresh returned no access_token.');
+  }
+
+  // Persist updated tokens to ~/.codex/auth.json
+  const authPath = getCodexAuthPath();
+  const existing: CodexAuthFile = fs.existsSync(authPath)
+    ? JSON.parse(fs.readFileSync(authPath, 'utf8')) as CodexAuthFile
+    : { tokens: {} };
+
+  existing.tokens = {
+    access_token: tokens.access_token,
+    refresh_token: tokens.refresh_token ?? refreshToken,
+    account_id: existing.tokens?.account_id,
+  };
+  existing.last_refresh = new Date().toISOString();
+
+  fs.mkdirSync(path.dirname(authPath), { recursive: true });
+  fs.writeFileSync(authPath, JSON.stringify(existing, null, 2), { mode: 0o600 });
+
+  return {
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token ?? refreshToken,
+    source: 'codex',
+  };
+}
+
+/** Reads the session and automatically refreshes if the access token is expiring soon. */
+export async function ensureOpenAiAccountSession(accessToken?: string): Promise<OpenAiAccountSession | undefined> {
+  const explicitAccessToken = accessToken?.trim();
+  if (explicitAccessToken) {
+    return {
+      accessToken: explicitAccessToken,
+      source: 'codex',
+    };
+  }
+
+  const session = readCodexSession();
+  if (!session) return undefined;
+
+  // Check if token is expired or about to expire (within 60s)
+  if (isTokenExpiringSoon(session.accessToken)) {
+    if (session.refreshToken) {
+      try {
+        return await refreshCodexToken(session.refreshToken);
+      } catch {
+        // Refresh failed — return stale session and let the API call fail naturally
+      }
+    }
+    // If refresh failed or no refresh token, still return the session
+    // The API call will fail naturally if the token is truly expired
+  }
+
+  return session;
+}
+
+// ─── Public session API ────────────────────────────────────────────────────────
+
+export function getOpenAiAccountSession(): OpenAiAccountSession | undefined {
+  return readCodexSession();
+}
+
+// ─── Model discovery ───────────────────────────────────────────────────────────
+
+/**
+ * Fetches available models from the ChatGPT Codex backend with ETag caching.
+ *
+ * Discovery policy — all models compatible with the ChatGPT/Codex OAuth plan,
+ * shown in the account's model selector (visibility = "list").  This includes
+ * models regardless of their `supported_in_api` flag, because some plans expose
+ * models that are not yet surfaced in the standalone API but are usable through
+ * the ChatGPT UI and the Codex relay.
+ *
+ * Filter chain applied to the `/codex/models` payload:
+ *   1. non-empty slug
+ *   2. visibility === "list"  (excludes internal / hidden entries)
+ *   3. no further filter on `supported_in_api`
+ *   4. sorted by ascending `priority`
+ *
+ * Falls back to the in-memory cache on network failure or 304 Not Modified.
+ * Returns `[]` if the cache is empty and the network call fails.
+ */
+export async function fetchOpenAiAccountModels(accessToken: string): Promise<string[]> {
+  const now = Date.now();
+
+  // Return cached data if still valid (within TTL and have ETag for conditional request)
+  if (modelDiscoveryCache && (now - modelDiscoveryCache.timestamp) < MODEL_CACHE_TTL_MS) {
+    return modelDiscoveryCache.models;
+  }
+
+  try {
+    const headers: Record<string, string> = {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    };
+
+    try {
+      const accountId = extractChatGptAccountId(accessToken);
+      headers['chatgpt-account-id'] = accountId;
+    } catch {
+      // Account ID not available in token, proceed without it
+    }
+
+    // Include If-None-Match if we have an ETag from previous request
+    if (modelDiscoveryCache?.etag) {
+      headers['If-None-Match'] = modelDiscoveryCache.etag;
+    }
+
+    const response = await fetch(`${OPENAI_ACCOUNT_BASE_URL}${CODEX_MODELS_PATH}?client_version=1.0.0`, { headers });
+
+    if (response.status === 304 && modelDiscoveryCache) {
+      // Not modified - update timestamp and return cached data
+      modelDiscoveryCache.timestamp = now;
+      return modelDiscoveryCache.models;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Model discovery failed: ${response.status} ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as {
+      models?: Array<{
+        slug?: string;
+        visibility?: string;
+        supported_in_api?: boolean;
+        priority?: number;
+      }>;
+    };
+    const models = (data.models ?? [])
+      .filter((model) => typeof model.slug === 'string' && model.slug.trim().length > 0)
+      .filter((model) => (model.visibility ?? 'list') === 'list')
+      .sort((left, right) => (left.priority ?? Number.MAX_SAFE_INTEGER) - (right.priority ?? Number.MAX_SAFE_INTEGER))
+      .map((model) => model.slug!.trim());
+
+    if (models.length === 0) {
+      // API returned no compatible models, don't overwrite cache with an empty list.
+      return modelDiscoveryCache?.models ?? [];
+    }
+
+    // Update cache
+    modelDiscoveryCache = {
+      models,
+      etag: response.headers.get('ETag') ?? modelDiscoveryCache?.etag ?? null,
+      timestamp: now,
+    };
+
+    return models;
+  } catch (error) {
+    // On error, return cached data if available. Avoid inventing models the account may not support.
+    if (modelDiscoveryCache?.models.length) {
+      return modelDiscoveryCache.models;
+    }
+    console.warn(`[openai-account] Model discovery failed: ${error instanceof Error ? error.message : String(error)}.`);
+    return [];
+  }
+}
+
+// ─── Runtime validation ─────────────────────────────────────────────────────────
+
+export async function validateOpenAiAccountRuntime(modelId = OPENAI_ACCOUNT_DEFAULT_MODEL): Promise<{
+  ok: boolean;
+  text?: string;
+  error?: string;
+}> {
+  if (process.env.N8N_SKIP_CODEX_RUNTIME_VALIDATION === '1') {
+    return { ok: true, text: 'OK' };
+  }
+
+  const session = await ensureOpenAiAccountSession();
+  if (!session) {
+    return { ok: false, error: 'No OpenAI account session found.' };
+  }
+
+  try {
+    const result = await runOpenAiAccountCompletion(modelId, {
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'Reply with exactly OK.' }] }],
+    });
+    return {
+      ok: result.text.trim().toUpperCase().includes('OK'),
+      text: result.text,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes('429') || message.includes('RESOURCE_EXHAUSTED')) {
+      return { ok: true, text: 'Quota exhausted for current model; runtime endpoint is reachable.' };
+    }
+    return { ok: false, error: message };
+  }
+}
+
+// ─── Language model ────────────────────────────────────────────────────────────
+
+export function createOpenAiAccountLanguageModel(
+  modelId: string,
+  reasoningEffort: CodexReasoningEffort = getDefaultCodexReasoningEffort(modelId),
+  sessionId?: string,
+  accessToken?: string,
+): LanguageModelV1 {
+  return {
+    specificationVersion: 'v1',
+    provider: 'openai-oauth.account',
+    modelId,
+    defaultObjectGenerationMode: undefined,
+    supportsImageUrls: false,
+    supportsStructuredOutputs: false,
+    async doGenerate(options) {
+      const execution = await runOpenAiAccountCompletion(modelId, options, reasoningEffort, sessionId, accessToken);
+      return {
+        text: execution.text,
+        finishReason: execution.finishReason,
+        usage: execution.usage,
+        ...(execution.toolCalls ? { toolCalls: execution.toolCalls } : {}),
+        rawCall: {
+          rawPrompt: options.prompt,
+          rawSettings: { modelId },
+        },
+        warnings: execution.warnings,
+        response: {
+          timestamp: new Date(),
+          modelId,
+          ...(execution.responseId ? { id: execution.responseId } : {}),
+          ...(execution.assistantPhase ? { assistantPhase: execution.assistantPhase } : {}),
+          ...(execution.rawOutputItems ? { rawOutputItems: execution.rawOutputItems } : {}),
+        },
+      };
+    },
+    async doStream(options) {
+      const session = await ensureOpenAiAccountSession(accessToken);
+      if (!session) {
+        throw new Error('OpenAI account session not found. Run `codex --login` to sign in.');
+      }
+
+      const regularMode = options.mode.type === 'regular' ? options.mode : undefined;
+      const tools = getFunctionTools(options.mode);
+      const accountId = extractChatGptAccountId(session.accessToken);
+      const { instructions, input } = convertPromptToCodexInput(options.prompt);
+      const reasoning = toCodexReasoningPayload(modelId, reasoningEffort);
+      const previousResponseId = readOptionalString(options.headers?.['x-n8n-previous-response-id']);
+      const codexIdentity = buildCodexIdentity(sessionId);
+
+      const body = {
+        model: modelId,
+        store: false,
+        stream: true,
+        instructions: ensureCodexInstructions(instructions),
+        input,
+        ...reasoning,
+        include: ['reasoning.encrypted_content'],
+        client_metadata: codexIdentity.clientMetadata,
+        ...(previousResponseId ? { previous_response_id: previousResponseId } : {}),
+        ...(tools.length > 0 ? { tools: toCodexTools(tools), tool_choice: toCodexToolChoice(regularMode?.toolChoice), parallel_tool_calls: true } : { tool_choice: 'auto' }),
+      };
+
+      const response = await withRetry(async () => {
+        const response = await fetch(`${OPENAI_ACCOUNT_BASE_URL}${CODEX_RESPONSES_PATH}`, {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${session.accessToken}`,
+            'chatgpt-account-id': accountId,
+            'OpenAI-Beta': 'responses=experimental',
+            'originator': CODEX_ORIGINATOR,
+            'User-Agent': buildCodexUserAgent(),
+            'x-client-request-id': codexIdentity.requestId,
+            'x-codex-window-id': codexIdentity.windowId,
+            'x-codex-installation-id': codexIdentity.installationId,
+            'accept': 'text/event-stream',
+            'content-type': 'application/json',
+            ...(sessionId ? { 'session_id': sessionId } : {}),
+          },
+          body: JSON.stringify(body),
+          signal: options.abortSignal
+            ? AbortSignal.any([options.abortSignal, timeoutSignal(CODEX_UPSTREAM_TIMEOUT_MS, 'codex-streaming')])
+            : timeoutSignal(CODEX_UPSTREAM_TIMEOUT_MS, 'codex-streaming'),
+        });
+
+        if (!response.ok) {
+          const errText = await response.text();
+          throw new Error(errText.trim() || `Codex completion failed: HTTP ${response.status}`);
+        }
+
+        if (!response.body) {
+          throw new Error('Codex completion returned empty response body.');
+        }
+
+        return response;
+      }, 'Codex streaming completion');
+
+      if (!response.body) {
+        throw new Error('Codex completion returned empty response body.');
+      }
+
+      let inputTokens = 0;
+      let outputTokens = 0;
+      let finishReason: 'stop' | 'error' | 'tool-calls' | 'length' | 'content-filter' | 'other' | 'unknown' = 'unknown';
+      const toolCalls = new Map<string, LanguageModelV1FunctionToolCall>();
+      let responseId: string | undefined;
+      let assistantPhase: string | undefined;
+      let rawOutputItems: Array<Record<string, unknown>> | undefined;
+
+      const stream = new ReadableStream<LanguageModelV1StreamPart>({
+        async pull(controller) {
+          let completed = false;
+          for await (const event of parseCodexSSE(response.body!)) {
+            const type = typeof event.type === 'string' ? event.type : undefined;
+            if (!type) continue;
+
+            if (type === 'response.output_text.delta') {
+              if (typeof event.delta === 'string') {
+                controller.enqueue({ type: 'text-delta', textDelta: event.delta });
+              }
+            } else if (type === 'response.output_item.added' || type === 'response.output_item.done') {
+              const item = readResponseOutputItem(event);
+              const toolCall = extractCodexToolCallFromItem(item, toolCalls.size);
+              if (toolCall) {
+                toolCalls.set(toolCall.toolCallId, toolCall);
+                controller.enqueue({
+                  type: 'tool-call-delta',
+                  toolCallType: 'function',
+                  toolCallId: toolCall.toolCallId,
+                  toolName: toolCall.toolName,
+                  argsTextDelta: toolCall.args,
+                });
+              }
+              if (item && typeof item === 'object' && (item as { type?: unknown }).type === 'message') {
+                const phase = readOptionalString((item as { phase?: unknown }).phase);
+                if (phase) {
+                  assistantPhase = phase;
+                }
+              }
+            } else if (type === 'response.function_call_arguments.delta') {
+              const itemId = readOptionalString(event.item_id) || readOptionalString(event.call_id);
+              if (!itemId) continue;
+              const existing = toolCalls.get(itemId);
+              if (!existing || typeof event.delta !== 'string') continue;
+              const delta = event.delta;
+              const newArgs = `${existing.args}${delta}`;
+              toolCalls.set(itemId, { ...existing, args: newArgs });
+              controller.enqueue({
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: itemId,
+                toolName: existing.toolName,
+                argsTextDelta: delta,
+              });
+            } else if (type === 'response.function_call_arguments.done') {
+              const itemId = readOptionalString(event.item_id) || readOptionalString(event.call_id);
+              if (!itemId) continue;
+              const existing = toolCalls.get(itemId);
+              if (!existing) continue;
+              const finalArgs = readOptionalString(event.arguments) ?? existing.args;
+              toolCalls.set(itemId, { ...existing, args: finalArgs });
+            } else if (type === 'response.completed') {
+              const resp = event.response as {
+                id?: string;
+                usage?: { input_tokens?: number; output_tokens?: number };
+                output?: unknown[];
+              } | undefined;
+              responseId = readOptionalString(resp?.id);
+              inputTokens = resp?.usage?.input_tokens ?? 0;
+              outputTokens = resp?.usage?.output_tokens ?? 0;
+              rawOutputItems = Array.isArray(resp?.output)
+                ? resp.output.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object')
+                : undefined;
+              for (const item of Array.isArray(resp?.output) ? resp.output : []) {
+                const toolCall = extractCodexToolCallFromItem(item, toolCalls.size);
+                if (toolCall) toolCalls.set(toolCall.toolCallId, toolCall);
+              }
+              completed = true;
+              break;
+            } else if (type === 'response.failed') {
+              const resp = event.response as { error?: { message?: string } } | undefined;
+              throw new Error(resp?.error?.message || 'Codex response failed.');
+            } else if (type === 'error') {
+              const msg = typeof event.message === 'string' ? event.message : '';
+              throw new Error(msg || 'Codex stream error.');
+            }
+          }
+
+          finishReason = toolCalls.size > 0 ? 'tool-calls' : 'stop';
+          controller.enqueue({
+            type: 'finish',
+            finishReason,
+            usage: { promptTokens: inputTokens, completionTokens: outputTokens },
+            ...((responseId || assistantPhase || rawOutputItems)
+              ? { providerMetadata: { ...(responseId ? { responseId } : {}), ...(assistantPhase ? { assistantPhase } : {}), ...(rawOutputItems ? { rawOutputItems } : {}) } }
+              : {}),
+          });
+          controller.close();
+          if (!completed) {
+            return;
+          }
+        },
+      });
+
+      return {
+        stream,
+        rawCall: {
+          rawPrompt: options.prompt,
+          rawSettings: { modelId },
+        },
+        warnings: [],
+      };
+    },
+  };
+}
+
+// ─── Inference (Codex Responses API via chatgpt.com/backend-api) ──────────────
+
+async function runOpenAiAccountCompletion(
+  modelId: string,
+  options: Pick<LanguageModelV1CallOptions, 'prompt' | 'mode' | 'inputFormat' | 'headers'>,
+  reasoningEffort: CodexReasoningEffort = getDefaultCodexReasoningEffort(modelId),
+  sessionId?: string,
+  accessToken?: string,
+): Promise<{
+  text: string;
+  finishReason: 'stop' | 'error' | 'tool-calls' | 'length' | 'content-filter' | 'other' | 'unknown';
+  usage: { promptTokens: number; completionTokens: number };
+  toolCalls?: LanguageModelV1FunctionToolCall[];
+  warnings: LanguageModelV1CallWarning[];
+  responseId?: string;
+  assistantPhase?: string;
+  rawOutputItems?: Array<Record<string, unknown>>;
+}> {
+  const session = await ensureOpenAiAccountSession(accessToken);
+  if (!session) {
+    throw new Error('OpenAI account session not found. Run `codex --login` to sign in.');
+  }
+
+  const regularMode = options.mode.type === 'regular' ? options.mode : undefined;
+  const tools = getFunctionTools(options.mode);
+  const warnings = buildCodexWarnings(options, tools);
+  const accountId = extractChatGptAccountId(session.accessToken);
+  const { instructions, input } = convertPromptToCodexInput(options.prompt);
+  const reasoning = toCodexReasoningPayload(modelId, reasoningEffort);
+  const previousResponseId = readOptionalString(options.headers?.['x-n8n-previous-response-id']);
+  const codexIdentity = buildCodexIdentity(sessionId);
+
+  const body = {
+    model: modelId,
+    store: false,
+    stream: true,
+    instructions: ensureCodexInstructions(instructions),
+    input,
+    ...reasoning,
+    include: ['reasoning.encrypted_content'],
+    client_metadata: codexIdentity.clientMetadata,
+    ...(previousResponseId ? { previous_response_id: previousResponseId } : {}),
+    ...(tools.length > 0 ? { tools: toCodexTools(tools), tool_choice: toCodexToolChoice(regularMode?.toolChoice), parallel_tool_calls: true } : { tool_choice: 'auto' }),
+  };
+
+  const rawResponse = await withRetry(async () => {
+    const response = await fetch(`${OPENAI_ACCOUNT_BASE_URL}${CODEX_RESPONSES_PATH}`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${session.accessToken}`,
+        'chatgpt-account-id': accountId,
+        'OpenAI-Beta': 'responses=experimental',
+        'originator': CODEX_ORIGINATOR,
+        'User-Agent': buildCodexUserAgent(),
+        'x-client-request-id': codexIdentity.requestId,
+        'x-codex-window-id': codexIdentity.windowId,
+        'x-codex-installation-id': codexIdentity.installationId,
+        'accept': 'text/event-stream',
+        'content-type': 'application/json',
+        ...(sessionId ? { 'session_id': sessionId } : {}),
+      },
+      body: JSON.stringify(body),
+      signal: timeoutSignal(CODEX_UPSTREAM_TIMEOUT_MS, 'codex-non-streaming'),
+    });
+
+    if (!response.ok) {
+      const errText = await response.text();
+      throw new Error(errText.trim() || `Codex completion failed: HTTP ${response.status}`);
+    }
+
+    if (!response.body) {
+      throw new Error('Codex completion returned empty response body.');
+    }
+
+    return response;
+  }, 'Codex non-streaming completion');
+
+  const responseBody = rawResponse.body as ReadableStream<Uint8Array>;
+
+  let text = '';
+  let inputTokens = 0;
+  let outputTokens = 0;
+  const toolCalls = new Map<string, LanguageModelV1FunctionToolCall>();
+  let responseId: string | undefined;
+  let assistantPhase: string | undefined;
+  let rawOutputItems: Array<Record<string, unknown>> | undefined;
+
+  for await (const event of parseCodexSSE(responseBody)) {
+    const type = typeof event.type === 'string' ? event.type : undefined;
+    if (!type) continue;
+
+    if (type === 'response.output_text.delta') {
+      if (typeof event.delta === 'string') {
+        text += event.delta;
+      }
+    } else if (type === 'response.output_item.added' || type === 'response.output_item.done') {
+      const item = readResponseOutputItem(event);
+      const toolCall = extractCodexToolCallFromItem(item, toolCalls.size);
+      if (toolCall) {
+        toolCalls.set(toolCall.toolCallId, toolCall);
+      }
+      if (item && typeof item === 'object' && (item as { type?: unknown }).type === 'message') {
+        const phase = readOptionalString((item as { phase?: unknown }).phase);
+        if (phase) {
+          assistantPhase = phase;
+        }
+      }
+    } else if (type === 'response.function_call_arguments.delta') {
+      const itemId = readOptionalString(event.item_id) || readOptionalString(event.call_id);
+      if (!itemId) {
+        continue;
+      }
+      const existing = toolCalls.get(itemId);
+      if (!existing || typeof event.delta !== 'string') {
+        continue;
+      }
+      toolCalls.set(itemId, {
+        ...existing,
+        args: `${existing.args}${event.delta}`,
+      });
+    } else if (type === 'response.function_call_arguments.done') {
+      const itemId = readOptionalString(event.item_id) || readOptionalString(event.call_id);
+      if (!itemId) {
+        continue;
+      }
+      const existing = toolCalls.get(itemId);
+      if (!existing) {
+        continue;
+      }
+      const finalArgs = readOptionalString(event.arguments);
+      if (finalArgs) {
+        toolCalls.set(itemId, {
+          ...existing,
+          args: finalArgs,
+        });
+      }
+    } else if (type === 'response.completed') {
+      const resp = event.response as {
+        id?: string;
+        usage?: { input_tokens?: number; output_tokens?: number };
+        output?: unknown[];
+      } | undefined;
+      responseId = readOptionalString(resp?.id);
+      inputTokens = resp?.usage?.input_tokens ?? 0;
+      outputTokens = resp?.usage?.output_tokens ?? 0;
+      rawOutputItems = Array.isArray(resp?.output)
+        ? resp.output.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object')
+        : undefined;
+      for (const item of Array.isArray(resp?.output) ? resp.output : []) {
+        const toolCall = extractCodexToolCallFromItem(item, toolCalls.size);
+        if (toolCall) {
+          toolCalls.set(toolCall.toolCallId, toolCall);
+        }
+      }
+    } else if (type === 'response.failed') {
+      const resp = event.response as { error?: { message?: string } } | undefined;
+      throw new Error(resp?.error?.message || 'Codex response failed.');
+    } else if (type === 'error') {
+      const msg = typeof event.message === 'string' ? event.message : '';
+      throw new Error(msg || 'Codex stream error.');
+    }
+  }
+
+  return {
+    text,
+    finishReason: toolCalls.size > 0 ? 'tool-calls' : 'stop',
+    usage: { promptTokens: inputTokens, completionTokens: outputTokens },
+    ...(toolCalls.size > 0 ? { toolCalls: [...toolCalls.values()] } : {}),
+    warnings,
+    ...(responseId ? { responseId } : {}),
+    ...(assistantPhase ? { assistantPhase } : {}),
+    ...(rawOutputItems ? { rawOutputItems } : {}),
+  };
+}
+
+// ─── Shared helpers ────────────────────────────────────────────────────────────
+
+function extractChatGptAccountId(token: string): string {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) throw new Error('Invalid token');
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64').toString('utf8')) as Record<string, unknown>;
+    const claim = payload[JWT_ACCOUNT_CLAIM] as Record<string, unknown> | undefined;
+    const accountId = claim?.chatgpt_account_id;
+    if (typeof accountId !== 'string' || !accountId) {
+      throw new Error('No chatgpt_account_id in token');
+    }
+    return accountId;
+  } catch {
+    throw new Error('Failed to extract chatgpt_account_id from Codex token. Ensure the token was obtained via `codex --login`.');
+  }
+}
+
+function convertPromptToCodexInput(prompt: LanguageModelV1Prompt): {
+  instructions: string | undefined;
+  input: Array<Record<string, unknown>>;
+} {
+  const instructionParts: string[] = [];
+  const input: Array<Record<string, unknown>> = [];
+
+  for (const message of prompt) {
+    if (message.role === 'system') {
+      if (message.content) {
+        instructionParts.push(message.content);
+      }
+      continue;
+    }
+    if (message.role === 'user') {
+      const text = (message.content as Array<{ type: string; text?: string }>).map((p) => p.type === 'text' ? (p.text ?? '') : `[${p.type}]`).join('\n');
+      input.push({ role: 'user', content: [{ type: 'input_text', text }] });
+    } else if (message.role === 'assistant') {
+      if (Array.isArray(message.rawOutputItems) && message.rawOutputItems.length > 0) {
+        for (const item of message.rawOutputItems) {
+          const sanitized = sanitizeResponsesOutputItem(item);
+          if (sanitized) {
+            input.push(sanitized);
+          }
+        }
+        continue;
+      }
+
+      const text = (message.content as Array<{ type: string; text?: string }>)
+        .filter((p) => p.type === 'text' || p.type === 'reasoning')
+        .map((p) => p.text ?? '')
+        .join('\n')
+        .trim();
+      if (text) {
+        input.push({ role: 'assistant', content: [{ type: 'output_text', text }], ...(message.phase ? { phase: message.phase } : {}) });
+      }
+
+      for (const part of message.content) {
+        if (part.type !== 'tool-call') {
+          continue;
+        }
+        input.push({
+          type: 'function_call',
+          call_id: part.toolCallId,
+          name: part.toolName,
+          arguments: JSON.stringify(part.args ?? {}),
+        });
+      }
+    } else {
+      for (const part of message.content) {
+        input.push({
+          type: 'function_call_output',
+          call_id: part.toolCallId,
+          output: stringifyToolResult(part.result),
+        });
+      }
+    }
+  }
+
+  const instructions = instructionParts
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .join('\n\n') || undefined;
+
+  return { instructions, input };
+}
+
+function sanitizeResponsesOutputItem(item: Record<string, unknown>): Record<string, unknown> | undefined {
+  const sanitized: Record<string, unknown> = { ...item };
+  delete sanitized.id;
+  delete sanitized.status;
+
+  if (Array.isArray(sanitized.content)) {
+    sanitized.content = sanitized.content
+      .filter((part): part is Record<string, unknown> => Boolean(part) && typeof part === 'object')
+      .map((part) => {
+        const nextPart = { ...part };
+        delete nextPart.id;
+        delete nextPart.status;
+        return nextPart;
+      });
+  }
+
+  return sanitized;
+}
+
+export function ensureCodexInstructions(instructions: string | undefined): string {
+  const trimmed = instructions?.trim();
+  if (!trimmed) {
+    return CODEX_DEFAULT_INSTRUCTIONS;
+  }
+  if (trimmed.includes('You are Codex, based on GPT-5.')) {
+    return trimmed;
+  }
+  return `${CODEX_DEFAULT_INSTRUCTIONS}\n\n${trimmed}`;
+}
+
+export function ensureCodexSessionId(sessionId?: string): string {
+  const trimmed = sessionId?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : randomUUID();
+}
+
+function buildCodexIdentity(sessionId?: string): {
+  installationId: string;
+  requestId: string;
+  windowId: string;
+  clientMetadata: Record<string, string>;
+} {
+  const requestId = ensureCodexSessionId(sessionId);
+  const windowId = `${requestId}:0`;
+  const installationId = ensureCodexInstallationId();
+  return {
+    installationId,
+    requestId,
+    windowId,
+    clientMetadata: {
+      'x-codex-installation-id': installationId,
+      'x-codex-window-id': windowId,
+    },
+  };
+}
+
+function ensureCodexInstallationId(): string {
+  const installPath = path.join(os.homedir(), '.n8n-as-code', CODEX_INSTALLATION_ID_FILENAME);
+  try {
+    const existing = fs.readFileSync(installPath, 'utf8').trim();
+    if (existing) {
+      return existing;
+    }
+  } catch {
+    // fall through to generate and persist a new id
+  }
+
+  const installationId = randomUUID();
+  try {
+    fs.mkdirSync(path.dirname(installPath), { recursive: true });
+    fs.writeFileSync(installPath, installationId);
+  } catch {
+    return installationId;
+  }
+  return installationId;
+}
+
+async function* parseCodexSSE(body: ReadableStream<Uint8Array>): AsyncGenerator<Record<string, unknown>> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let idx = buffer.indexOf('\n\n');
+    while (idx !== -1) {
+      const chunk = buffer.slice(0, idx);
+      buffer = buffer.slice(idx + 2);
+      const dataLines = chunk
+        .split('\n')
+        .filter((l) => l.startsWith('data:'))
+        .map((l) => l.slice(5).trim());
+      if (dataLines.length > 0) {
+        const data = dataLines.join('\n').trim();
+        if (data && data !== '[DONE]') {
+          try { yield JSON.parse(data) as Record<string, unknown>; } catch { /* skip malformed */ }
+        }
+      }
+      idx = buffer.indexOf('\n\n');
+    }
+  }
+}
+
+function buildCodexWarnings(
+  options: Pick<LanguageModelV1CallOptions, 'mode'>,
+  functionTools: LanguageModelV1FunctionTool[],
+): LanguageModelV1CallWarning[] {
+  if (options.mode.type !== 'regular' || !options.mode.tools || options.mode.tools.length === 0) {
+    return [];
+  }
+
+  return options.mode.tools
+    .filter((tool) => tool.type !== 'function' || !functionTools.includes(tool))
+    .map((tool) => ({
+      type: 'unsupported-tool' as const,
+      tool,
+      details: 'openai-oauth currently supports only function tools on the Codex backend.',
+    }));
+}
+
+function getFunctionTools(
+  mode: LanguageModelV1CallOptions['mode'],
+): LanguageModelV1FunctionTool[] {
+  if (mode.type !== 'regular' || !Array.isArray(mode.tools) || mode.tools.length === 0) {
+    return [];
+  }
+
+  return mode.tools.filter((tool): tool is LanguageModelV1FunctionTool => tool.type === 'function');
+}
+
+function toCodexTools(tools: LanguageModelV1FunctionTool[]): Array<Record<string, unknown>> {
+  return tools.map((tool) => ({
+    type: 'function',
+    name: tool.name,
+    ...(tool.description ? { description: tool.description } : {}),
+    parameters: normalizeFunctionToolParametersSchema(tool.parameters as Record<string, unknown>, { forceRequiredObjectProperties: true }),
+    strict: tool.strict ?? true,
+  }));
+}
+
+function toCodexToolChoice(
+  toolChoice: LanguageModelV1ToolChoice | undefined,
+): unknown {
+  if (!toolChoice || toolChoice.type === 'auto') {
+    return 'auto';
+  }
+  if (toolChoice.type === 'none' || toolChoice.type === 'required') {
+    return toolChoice.type;
+  }
+  if (toolChoice.type === 'tool') {
+    return {
+      type: 'function',
+      name: toolChoice.toolName,
+    };
+  }
+  return 'auto';
+}
+
+function readResponseOutputItem(event: Record<string, unknown>): unknown {
+  if (event.item && typeof event.item === 'object') {
+    return event.item;
+  }
+  if (event.output_item && typeof event.output_item === 'object') {
+    return event.output_item;
+  }
+  return undefined;
+}
+
+function extractCodexToolCallFromItem(item: unknown, index: number): LanguageModelV1FunctionToolCall | undefined {
+  if (!item || typeof item !== 'object') {
+    return undefined;
+  }
+
+  const record = item as Record<string, unknown>;
+  if (record.type !== 'function_call') {
+    return undefined;
+  }
+
+  const toolName = readOptionalString(record.name);
+  if (!toolName) {
+    return undefined;
+  }
+
+  const toolCallId = readOptionalString(record.call_id)
+    || readOptionalString(record.id)
+    || `openai-account-tool-call-${index + 1}`;
+  const args = typeof record.arguments === 'string'
+    ? record.arguments
+    : JSON.stringify(record.arguments ?? {});
+
+  return {
+    toolCallType: 'function',
+    toolCallId,
+    toolName,
+    args,
+  };
+}
+
+function stringifyToolResult(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value ?? null);
+  } catch {
+    return String(value);
+  }
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function buildCodexUserAgent(): string {
+  const termProgram = process.env.TERM_PROGRAM;
+  const termProgramVersion = process.env.TERM_PROGRAM_VERSION;
+  const termSessionId = process.env.TERM_SESSION_ID;
+  const weztermVersion = process.env.WEZTERM_VERSION;
+  const isKitty = process.env.KITTY_WINDOW_ID || (process.env.TERM || '').includes('kitty');
+  const isAlacritty = process.env.ALACRITTY_SOCKET || process.env.TERM === 'alacritty';
+  const isGnomeTerminal = process.env.GNOME_TERMINAL_SCREEN;
+  const isWindowsTerminal = process.env.WT_SESSION;
+
+  let terminal = 'unknown';
+  if (termProgram) {
+    terminal = termProgramVersion ? `${termProgram}/${termProgramVersion}` : termProgram;
+  } else if (weztermVersion) {
+    terminal = `WezTerm/${weztermVersion}`;
+  } else if (isKitty) {
+    terminal = 'kitty';
+  } else if (isAlacritty) {
+    terminal = 'Alacritty';
+  } else if (isGnomeTerminal) {
+    terminal = 'gnome-terminal';
+  } else if (isWindowsTerminal) {
+    terminal = 'WindowsTerminal';
+  } else if (termSessionId) {
+    terminal = 'Apple_Terminal';
+  } else if (process.env.TERM) {
+    terminal = process.env.TERM || 'unknown';
+  }
+
+  return `${CODEX_ORIGINATOR}/0.0.0 (${os.platform()} ${os.release()}; ${os.arch()}) ${terminal}`;
+}

--- a/packages/vscode-extension/src/services/agent-provider-runtime/provider-types.ts
+++ b/packages/vscode-extension/src/services/agent-provider-runtime/provider-types.ts
@@ -1,0 +1,139 @@
+/**
+ * Local type definitions that replicate the Vercel AI SDK provider interface
+ * (formerly imported from '@ai-sdk/provider'). Keeping them local removes the
+ * runtime dependency entirely, since the openai-oauth/Codex backend is the only
+ * consumer of these types inside the VS Code Workbench.
+ */
+
+// ─── JSON Schema ───────────────────────────────────────────────────────────────
+
+export type JSONSchema7 = {
+  type?: string | string[];
+  properties?: Record<string, JSONSchema7>;
+  required?: string[];
+  additionalProperties?: boolean | JSONSchema7;
+  items?: JSONSchema7 | JSONSchema7[];
+  enum?: unknown[];
+  anyOf?: JSONSchema7[];
+  oneOf?: JSONSchema7[];
+  allOf?: JSONSchema7[];
+  description?: string;
+  default?: unknown;
+  format?: string;
+  [key: string]: unknown;
+};
+
+// ─── Tool types ────────────────────────────────────────────────────────────────
+
+export interface LanguageModelV1FunctionTool {
+  type: 'function';
+  name: string;
+  description?: string;
+  parameters: JSONSchema7;
+  strict?: boolean;
+}
+
+export type LanguageModelV1Tool = LanguageModelV1FunctionTool;
+
+export type LanguageModelV1ToolChoice =
+  | { type: 'auto' }
+  | { type: 'none' }
+  | { type: 'required' }
+  | { type: 'tool'; toolName: string };
+
+export interface LanguageModelV1FunctionToolCall {
+  toolCallType: 'function';
+  toolCallId: string;
+  toolName: string;
+  args: string;
+}
+
+// ─── Prompt types ──────────────────────────────────────────────────────────────
+
+type TextPart = { type: 'text'; text: string };
+type ImagePart = { type: 'image'; image: string | Uint8Array; mimeType?: string };
+type ToolCallPart = { type: 'tool-call'; toolCallId: string; toolName: string; args: unknown };
+type ToolResultPart = { type: 'tool-result'; toolCallId: string; toolName: string; result: unknown; isError?: boolean };
+type AssistantPhase = 'analysis' | 'final' | string;
+type ResponsesOutputItem = Record<string, unknown>;
+
+export type LanguageModelV1Prompt = Array<
+  | { role: 'system'; content: string }
+  | { role: 'user'; content: Array<TextPart | ImagePart> }
+  | { role: 'assistant'; content: Array<TextPart | ToolCallPart>; phase?: AssistantPhase; rawOutputItems?: ResponsesOutputItem[] }
+  | { role: 'tool'; content: Array<ToolResultPart> }
+>;
+
+// ─── Call options ─────────────────────────────────────────────────────────────
+
+export interface LanguageModelV1CallOptions {
+  inputFormat: 'prompt' | 'messages';
+  mode:
+    | { type: 'regular'; tools?: LanguageModelV1Tool[]; toolChoice?: LanguageModelV1ToolChoice }
+    | { type: 'object-json'; schema?: JSONSchema7 }
+    | { type: 'object-tool'; tool: LanguageModelV1FunctionTool };
+  prompt: LanguageModelV1Prompt;
+  abortSignal?: AbortSignal;
+  headers?: Record<string, string | undefined>;
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  stopSequences?: string[];
+}
+
+// ─── Warnings ─────────────────────────────────────────────────────────────────
+
+export type LanguageModelV1CallWarning =
+  | { type: 'unsupported-setting'; setting: string; details?: string }
+  | { type: 'unsupported-tool'; tool: LanguageModelV1Tool; details?: string }
+  | { type: 'other'; message: string };
+
+// ─── Stream parts ─────────────────────────────────────────────────────────────
+
+export type LanguageModelV1StreamPart =
+  | { type: 'text-delta'; textDelta: string }
+  | { type: 'tool-call-delta'; toolCallType: 'function'; toolCallId: string; toolName: string; argsTextDelta: string }
+  | { type: 'tool-call'; toolCallType: 'function'; toolCallId: string; toolName: string; args: string }
+  | { type: 'finish'; finishReason: LanguageModelV1FinishReason; usage: { promptTokens: number; completionTokens: number }; providerMetadata?: { responseId?: string; assistantPhase?: AssistantPhase; rawOutputItems?: ResponsesOutputItem[] } }
+  | { type: 'error'; error: unknown };
+
+// ─── Generate result ──────────────────────────────────────────────────────────
+
+export type LanguageModelV1FinishReason =
+  | 'stop'
+  | 'length'
+  | 'content-filter'
+  | 'tool-calls'
+  | 'error'
+  | 'other'
+  | 'unknown';
+
+export interface LanguageModelV1GenerateResult {
+  text?: string;
+  toolCalls?: LanguageModelV1FunctionToolCall[];
+  finishReason: LanguageModelV1FinishReason;
+  usage: { promptTokens: number; completionTokens: number };
+  rawCall: { rawPrompt: unknown; rawSettings: Record<string, unknown> };
+  warnings?: LanguageModelV1CallWarning[];
+  response?: { timestamp: Date; modelId: string; id?: string; assistantPhase?: AssistantPhase; rawOutputItems?: ResponsesOutputItem[] };
+}
+
+// ─── Language model interface ─────────────────────────────────────────────────
+
+export interface LanguageModelV1 {
+  readonly specificationVersion: 'v1';
+  readonly provider: string;
+  readonly modelId: string;
+  readonly defaultObjectGenerationMode?: 'json' | 'tool' | undefined;
+  readonly supportsImageUrls?: boolean;
+  readonly supportsStructuredOutputs?: boolean;
+  doGenerate(options: LanguageModelV1CallOptions): Promise<LanguageModelV1GenerateResult>;
+  doStream(options: LanguageModelV1CallOptions): Promise<{
+    stream: ReadableStream<LanguageModelV1StreamPart>;
+    rawCall: { rawPrompt: unknown; rawSettings: Record<string, unknown> };
+    warnings?: LanguageModelV1CallWarning[];
+  }>;
+}

--- a/packages/vscode-extension/src/services/agent-provider-runtime/tool-schema.ts
+++ b/packages/vscode-extension/src/services/agent-provider-runtime/tool-schema.ts
@@ -1,0 +1,105 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function appendNullToType(type: unknown): unknown {
+  if (typeof type === 'string') {
+    return type === 'null' ? 'null' : [type, 'null'];
+  }
+
+  if (Array.isArray(type)) {
+    return type.includes('null') ? type : [...type, 'null'];
+  }
+
+  return ['null'];
+}
+
+function makeSchemaNullable(schema: Record<string, unknown>): Record<string, unknown> {
+  if (schema.type !== undefined) {
+    return {
+      ...schema,
+      type: appendNullToType(schema.type),
+    };
+  }
+
+  if (Array.isArray(schema.anyOf)) {
+    const hasNull = schema.anyOf.some((entry) => isRecord(entry) && entry.type === 'null');
+    if (!hasNull) {
+      return {
+        ...schema,
+        anyOf: [...schema.anyOf, { type: 'null' }],
+      };
+    }
+  }
+
+  if (Array.isArray(schema.oneOf)) {
+    const hasNull = schema.oneOf.some((entry) => isRecord(entry) && entry.type === 'null');
+    if (!hasNull) {
+      return {
+        ...schema,
+        oneOf: [...schema.oneOf, { type: 'null' }],
+      };
+    }
+  }
+
+  return {
+    anyOf: [schema, { type: 'null' }],
+  };
+}
+
+function normalizeSchemaNode(schema: unknown, forceRequired: boolean): unknown {
+  if (!isRecord(schema)) {
+    return schema;
+  }
+
+  const normalized: Record<string, unknown> = { ...schema };
+
+  if (Array.isArray(schema.anyOf)) {
+    normalized.anyOf = schema.anyOf.map((entry) => normalizeSchemaNode(entry, forceRequired));
+  }
+
+  if (Array.isArray(schema.oneOf)) {
+    normalized.oneOf = schema.oneOf.map((entry) => normalizeSchemaNode(entry, forceRequired));
+  }
+
+  if (isRecord(schema.items)) {
+    normalized.items = normalizeSchemaNode(schema.items, forceRequired);
+  }
+
+  if (isRecord(schema.properties)) {
+    const properties = Object.fromEntries(
+      Object.entries(schema.properties).map(([key, value]) => [key, normalizeSchemaNode(value, forceRequired)]),
+    );
+    const propertyKeys = Object.keys(properties);
+    const originalRequired = new Set(
+      Array.isArray(schema.required)
+        ? schema.required.filter((entry): entry is string => typeof entry === 'string')
+        : [],
+    );
+
+    if (forceRequired) {
+      for (const key of propertyKeys) {
+        if (!originalRequired.has(key) && isRecord(properties[key])) {
+          properties[key] = makeSchemaNullable(properties[key] as Record<string, unknown>);
+        }
+      }
+    }
+
+    normalized.properties = properties;
+    normalized.required = forceRequired ? propertyKeys : [...originalRequired];
+
+    if (normalized.additionalProperties === undefined) {
+      normalized.additionalProperties = false;
+    }
+  }
+
+  return normalized;
+}
+
+export function normalizeFunctionToolParametersSchema(
+  schema: Record<string, unknown>,
+  options: { forceRequiredObjectProperties?: boolean } = {},
+): Record<string, unknown> {
+  return normalizeSchemaNode(schema, options.forceRequiredObjectProperties === true) as Record<string, unknown>;
+}
+

--- a/packages/vscode-extension/src/services/agent-provider-runtime/utils.ts
+++ b/packages/vscode-extension/src/services/agent-provider-runtime/utils.ts
@@ -1,0 +1,59 @@
+/** Default timeout for upstream Codex API calls (ms). */
+export const CODEX_UPSTREAM_TIMEOUT_MS = parseCodexUpstreamTimeoutMs(
+  process.env.N8N_CODEX_UPSTREAM_TIMEOUT_MS,
+);
+
+/** Default retry configuration for transient failures. */
+export const RETRY_CONFIG = {
+  maxAttempts: 3,
+  initialDelayMs: 500,
+  maxDelayMs: 8_000,
+  backoffMultiplier: 2,
+};
+
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  label: string,
+  options: { retries?: number; delayMs?: number } = {},
+): Promise<T> {
+  let attempt = 0;
+  let delay = options.delayMs ?? RETRY_CONFIG.initialDelayMs;
+  const maxAttempts = options.retries ?? RETRY_CONFIG.maxAttempts;
+
+  while (true) {
+    try {
+      return await fn();
+    } catch (err) {
+      attempt++;
+      if (attempt >= maxAttempts) throw err;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      delay = Math.min(delay * RETRY_CONFIG.backoffMultiplier, RETRY_CONFIG.maxDelayMs);
+    }
+  }
+}
+
+/** Creates an AbortSignal that times out after `timeoutMs`. */
+export function timeoutSignal(timeoutMs: number, _label: string): AbortSignal {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  if (typeof timer.unref === 'function') timer.unref();
+  return controller.signal;
+}
+
+export function parseCodexUpstreamTimeoutMs(value: string | undefined, fallback = 300_000): number {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  return parsed;
+}

--- a/packages/vscode-extension/src/services/agent-provider-service.ts
+++ b/packages/vscode-extension/src/services/agent-provider-service.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 import { getAgentProviderSecretKey } from './agent-runtime-controller.js';
+import { fetchGitHubCopilotModels } from './agent-provider-runtime/copilot-account.js';
 
-export type YagrModelProvider =
+export type AgentModelProvider =
     | 'anthropic'
     | 'openai'
     | 'google'
@@ -15,12 +16,12 @@ export type YagrModelProvider =
 
 export type ProviderAuthKind = 'api-key' | 'oauth-device' | 'setup-token' | 'none';
 
-export type YagrReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+export type AgentProviderReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
 
-export const YAGR_REASONING_EFFORTS: readonly YagrReasoningEffort[] = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'];
+export const AGENT_REASONING_EFFORTS: readonly AgentProviderReasoningEffort[] = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'];
 
-export interface YagrProviderDefinition {
-    id: YagrModelProvider;
+export interface AgentProviderDefinition {
+    id: AgentModelProvider;
     label: string;
     description: string;
     defaultModel: string;
@@ -31,8 +32,8 @@ export interface YagrProviderDefinition {
     canDiscoverModels: boolean;
 }
 
-export interface YagrProviderConnectionState {
-    id: YagrModelProvider;
+export interface AgentProviderConnectionState {
+    id: AgentModelProvider;
     label: string;
     description: string;
     authKind: ProviderAuthKind;
@@ -45,7 +46,7 @@ export interface YagrProviderConnectionState {
     model?: string;
     baseUrl?: string;
     supportsReasoningEffort?: boolean;
-    reasoningEffort?: YagrReasoningEffort;
+    reasoningEffort?: AgentProviderReasoningEffort;
 }
 
 type DeviceChallenge = {
@@ -60,6 +61,15 @@ type DeviceChallenge = {
 const OPENAI_CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 const OPENAI_CODEX_DEVICE_REDIRECT_URI = 'https://auth.openai.com/deviceauth/callback';
 const DISABLED_PROVIDERS_STATE_KEY = 'n8n.agent.disabledProviders';
+const MINIMAX_DISCOVERY_CANDIDATE_MODELS = [
+    'MiniMax-M2.7',
+    'MiniMax-M2.7-highspeed',
+    'MiniMax-M2.5',
+    'MiniMax-M2.5-highspeed',
+    'MiniMax-M2.1',
+    'MiniMax-M2.1-highspeed',
+    'MiniMax-M2',
+] as const;
 
 const MODEL_LIST_MAPPER = (payload: Record<string, unknown>): string[] => {
     const data = Array.isArray(payload.data) ? payload.data : [];
@@ -69,7 +79,7 @@ const MODEL_LIST_MAPPER = (payload: Record<string, unknown>): string[] => {
         .sort((left, right) => left.localeCompare(right));
 };
 
-export const YAGR_PROVIDER_DEFINITIONS: Record<YagrModelProvider, YagrProviderDefinition> = {
+export const AGENT_PROVIDER_DEFINITIONS: Record<AgentModelProvider, AgentProviderDefinition> = {
     anthropic: {
         id: 'anthropic',
         label: 'Claude API',
@@ -180,45 +190,45 @@ export const YAGR_PROVIDER_DEFINITIONS: Record<YagrModelProvider, YagrProviderDe
     },
 };
 
-export const YAGR_SELECTABLE_PROVIDERS = Object.freeze(Object.keys(YAGR_PROVIDER_DEFINITIONS) as YagrModelProvider[]);
+export const AGENT_SELECTABLE_PROVIDERS = Object.freeze(Object.keys(AGENT_PROVIDER_DEFINITIONS) as AgentModelProvider[]);
 
-export function normalizeYagrProviderId(provider?: string): YagrModelProvider | undefined {
+export function normalizeAgentProviderId(provider?: string): AgentModelProvider | undefined {
     const normalized = provider?.trim().toLowerCase();
     if (!normalized) return undefined;
     if (normalized === 'claude') return 'anthropic';
     if (normalized === 'anthropic-proxy') return 'anthropic';
     if (normalized === 'gemini') return 'google';
-    return normalized in YAGR_PROVIDER_DEFINITIONS ? normalized as YagrModelProvider : undefined;
+    return normalized in AGENT_PROVIDER_DEFINITIONS ? normalized as AgentModelProvider : undefined;
 }
 
-export function providerNeedsBaseUrlInput(provider: YagrModelProvider): boolean {
+export function providerNeedsBaseUrlInput(provider: AgentModelProvider): boolean {
     return provider === 'openai-compatible';
 }
 
-export function providerSupportsReasoningEffort(provider: YagrModelProvider, _model?: string): boolean {
+export function providerSupportsReasoningEffort(provider: AgentModelProvider, _model?: string): boolean {
     return provider === 'openai-oauth';
 }
 
-export class YagrProviderService {
+export class AgentProviderService {
     constructor(private readonly context: vscode.ExtensionContext) {}
 
-    getDefinition(provider: string): YagrProviderDefinition {
-        return YAGR_PROVIDER_DEFINITIONS[normalizeYagrProviderId(provider) || 'openai'];
+    getDefinition(provider: string): AgentProviderDefinition {
+        return AGENT_PROVIDER_DEFINITIONS[normalizeAgentProviderId(provider) || 'openai'];
     }
 
-    async getStoredCredential(provider: YagrModelProvider): Promise<string | undefined> {
+    async getStoredCredential(provider: AgentModelProvider): Promise<string | undefined> {
         return this.context.secrets.get(getAgentProviderSecretKey(provider));
     }
 
-    async listProviderConnectionStates(): Promise<YagrProviderConnectionState[]> {
+    async listProviderConnectionStates(): Promise<AgentProviderConnectionState[]> {
         const config = vscode.workspace.getConfiguration('n8n.agent');
-        const selectedProvider = normalizeYagrProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
+        const selectedProvider = normalizeAgentProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
         const selectedModel = String(config.get<string>('model') || '').trim() || undefined;
         const configuredBaseUrl = String(config.get<string>('baseUrl') || '').trim() || undefined;
         const selectedReasoningEffort = this.readReasoningEffort();
         const disabledProviders = this.getDisabledProviders();
-        const states = await Promise.all(YAGR_SELECTABLE_PROVIDERS.map(async (provider) => {
-            const definition = YAGR_PROVIDER_DEFINITIONS[provider];
+        const states = await Promise.all(AGENT_SELECTABLE_PROVIDERS.map(async (provider) => {
+            const definition = AGENT_PROVIDER_DEFINITIONS[provider];
             const hasStoredCredential = Boolean(await this.getStoredCredential(provider));
             const providerDisabled = disabledProviders.has(provider);
             const hasEnvironmentCredential = !providerDisabled && this.hasEnvironmentCredential(provider);
@@ -243,27 +253,27 @@ export class YagrProviderService {
         return states;
     }
 
-    async disconnectProvider(provider: YagrModelProvider): Promise<void> {
+    async disconnectProvider(provider: AgentModelProvider): Promise<void> {
         await this.context.secrets.delete(getAgentProviderSecretKey(provider));
         await this.setProviderDisabled(provider, true);
         const config = vscode.workspace.getConfiguration('n8n.agent');
-        const selectedProvider = normalizeYagrProviderId(String(config.get<string>('provider') || ''));
+        const selectedProvider = normalizeAgentProviderId(String(config.get<string>('provider') || ''));
         if (selectedProvider === provider) {
             await config.update('provider', 'openai', vscode.ConfigurationTarget.Global);
-            await config.update('model', YAGR_PROVIDER_DEFINITIONS.openai.defaultModel, vscode.ConfigurationTarget.Global);
+            await config.update('model', AGENT_PROVIDER_DEFINITIONS.openai.defaultModel, vscode.ConfigurationTarget.Global);
             await config.update('baseUrl', '', vscode.ConfigurationTarget.Global);
             await config.update('reasoningEffort', undefined, vscode.ConfigurationTarget.Global);
         }
     }
 
-    hasEnvironmentCredential(provider: YagrModelProvider): boolean {
-        return YAGR_PROVIDER_DEFINITIONS[provider].envKeys.some((key) => Boolean(process.env[key]?.trim()));
+    hasEnvironmentCredential(provider: AgentModelProvider): boolean {
+        return AGENT_PROVIDER_DEFINITIONS[provider].envKeys.some((key) => Boolean(process.env[key]?.trim()));
     }
 
-    async setupProvider(provider: YagrModelProvider): Promise<boolean> {
-        const definition = YAGR_PROVIDER_DEFINITIONS[provider];
+    async setupProvider(provider: AgentModelProvider): Promise<boolean> {
+        const definition = AGENT_PROVIDER_DEFINITIONS[provider];
         const config = vscode.workspace.getConfiguration('n8n.agent');
-        const previousProvider = normalizeYagrProviderId(String(config.get<string>('provider') || ''));
+        const previousProvider = normalizeAgentProviderId(String(config.get<string>('provider') || ''));
         await this.setProviderDisabled(provider, false);
 
         if (providerNeedsBaseUrlInput(provider)) {
@@ -318,8 +328,8 @@ export class YagrProviderService {
         return true;
     }
 
-    async selectModel(provider: YagrModelProvider): Promise<string | undefined> {
-        const definition = YAGR_PROVIDER_DEFINITIONS[provider];
+    async selectModel(provider: AgentModelProvider): Promise<string | undefined> {
+        const definition = AGENT_PROVIDER_DEFINITIONS[provider];
         const models = await this.fetchAvailableModels(provider).catch(() => []);
         const config = vscode.workspace.getConfiguration('n8n.agent');
         const currentModel = String(config.get<string>('model') || '').trim() || definition.defaultModel;
@@ -337,7 +347,7 @@ export class YagrProviderService {
         return picked.label;
     }
 
-    async selectReasoningEffort(provider: YagrModelProvider, model?: string): Promise<YagrReasoningEffort | undefined> {
+    async selectReasoningEffort(provider: AgentModelProvider, model?: string): Promise<AgentProviderReasoningEffort | undefined> {
         if (!providerSupportsReasoningEffort(provider, model)) {
             const config = vscode.workspace.getConfiguration('n8n.agent');
             await config.update('reasoningEffort', undefined, vscode.ConfigurationTarget.Global);
@@ -348,7 +358,7 @@ export class YagrProviderService {
         const defaultReasoningEffort = await this.getDefaultReasoningEffort(model || String(config.get<string>('model') || '').trim());
         const current = this.readReasoningEffort() || defaultReasoningEffort;
         const picked = await vscode.window.showQuickPick(
-            YAGR_REASONING_EFFORTS.map((effort) => ({
+            AGENT_REASONING_EFFORTS.map((effort) => ({
                 label: effort,
                 picked: effort === current,
                 description: effort === defaultReasoningEffort ? 'Provider default' : undefined,
@@ -360,11 +370,11 @@ export class YagrProviderService {
             },
         );
         if (!picked) return current;
-        await config.update('reasoningEffort', picked.label as YagrReasoningEffort, vscode.ConfigurationTarget.Global);
-        return picked.label as YagrReasoningEffort;
+        await config.update('reasoningEffort', picked.label as AgentProviderReasoningEffort, vscode.ConfigurationTarget.Global);
+        return picked.label as AgentProviderReasoningEffort;
     }
 
-    async syncReasoningEffortConfiguration(provider: YagrModelProvider, model?: string): Promise<YagrReasoningEffort | undefined> {
+    async syncReasoningEffortConfiguration(provider: AgentModelProvider, model?: string): Promise<AgentProviderReasoningEffort | undefined> {
         if (!providerSupportsReasoningEffort(provider, model)) {
             const config = vscode.workspace.getConfiguration('n8n.agent');
             await config.update('reasoningEffort', undefined, vscode.ConfigurationTarget.Global);
@@ -379,8 +389,8 @@ export class YagrProviderService {
         return next;
     }
 
-    async fetchAvailableModels(provider: YagrModelProvider): Promise<string[]> {
-        const definition = YAGR_PROVIDER_DEFINITIONS[provider];
+    async fetchAvailableModels(provider: AgentModelProvider): Promise<string[]> {
+        const definition = AGENT_PROVIDER_DEFINITIONS[provider];
         if (!definition.canDiscoverModels) return [];
         const apiKey = await this.getStoredCredential(provider) || this.readEnvironmentCredential(provider);
         const config = vscode.workspace.getConfiguration('n8n.agent');
@@ -403,16 +413,10 @@ export class YagrProviderService {
             return this.fetchOpenAiOauthModels(apiKey || '');
         }
         if (provider === 'copilot-proxy') {
-            return this.fetchJsonModels(`${definition.defaultBaseUrl}/models`, {
-                Authorization: `Bearer ${apiKey}`,
-                'User-Agent': 'GitHubCopilotChat/0.26.7',
-                'Editor-Version': 'vscode/1.96.2',
-                'Editor-Plugin-Version': 'copilot-chat/0.26.7',
-            });
+            return fetchGitHubCopilotModels(apiKey || '');
         }
         if (provider === 'minimax' || provider === 'minimax-token-plan') {
-            const providerRuntime = await import('@yagr/provider-runtime');
-            return providerRuntime.getProviderPlugin(provider).discovery?.fetchAvailableModels?.({ apiKey, baseUrl }) || [];
+            return this.probeMiniMaxModels(apiKey || '', baseUrl || definition.defaultBaseUrl);
         }
 
         const modelsUrl = provider === 'openai-compatible'
@@ -422,21 +426,56 @@ export class YagrProviderService {
         return this.fetchJsonModels(modelsUrl, apiKey ? { Authorization: `Bearer ${apiKey}` } : {});
     }
 
-    private readEnvironmentCredential(provider: YagrModelProvider): string | undefined {
+    private readEnvironmentCredential(provider: AgentModelProvider): string | undefined {
         if (this.getDisabledProviders().has(provider)) return undefined;
-        for (const key of YAGR_PROVIDER_DEFINITIONS[provider].envKeys) {
+        for (const key of AGENT_PROVIDER_DEFINITIONS[provider].envKeys) {
             const value = process.env[key]?.trim();
             if (value) return value;
         }
         return undefined;
     }
 
-    private getDisabledProviders(): Set<YagrModelProvider> {
-        const disabled = this.context.globalState.get<string[]>(DISABLED_PROVIDERS_STATE_KEY, []);
-        return new Set(disabled.map((provider) => normalizeYagrProviderId(provider)).filter((provider): provider is YagrModelProvider => Boolean(provider)));
+    private async probeMiniMaxModels(apiKey: string, baseUrl?: string): Promise<string[]> {
+        if (!apiKey) return [];
+        const url = this.getMiniMaxCompletionDiscoveryUrl(baseUrl);
+        const checks = await Promise.all(
+            MINIMAX_DISCOVERY_CANDIDATE_MODELS.map(async (model) => {
+                try {
+                    const response = await fetch(url, {
+                        method: 'POST',
+                        headers: {
+                            Authorization: `Bearer ${apiKey}`,
+                            'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify({
+                            model,
+                            messages: [{ role: 'user', content: 'ping' }],
+                            max_tokens: 1,
+                        }),
+                    });
+                    return response.ok ? model : undefined;
+                } catch {
+                    return undefined;
+                }
+            }),
+        );
+        return checks.filter((model): model is typeof MINIMAX_DISCOVERY_CANDIDATE_MODELS[number] => Boolean(model));
     }
 
-    private async setProviderDisabled(provider: YagrModelProvider, disabled: boolean): Promise<void> {
+    private getMiniMaxCompletionDiscoveryUrl(baseUrl?: string): string {
+        const resolvedBaseUrl = baseUrl || AGENT_PROVIDER_DEFINITIONS.minimax.defaultBaseUrl || 'https://api.minimax.io/anthropic';
+        if (resolvedBaseUrl.endsWith('/anthropic')) {
+            return resolvedBaseUrl.replace(/\/anthropic\/?$/, '/v1/chat/completions');
+        }
+        return `${resolvedBaseUrl.replace(/\/$/, '')}/v1/chat/completions`;
+    }
+
+    private getDisabledProviders(): Set<AgentModelProvider> {
+        const disabled = this.context.globalState.get<string[]>(DISABLED_PROVIDERS_STATE_KEY, []);
+        return new Set(disabled.map((provider) => normalizeAgentProviderId(provider)).filter((provider): provider is AgentModelProvider => Boolean(provider)));
+    }
+
+    private async setProviderDisabled(provider: AgentModelProvider, disabled: boolean): Promise<void> {
         const providers = this.getDisabledProviders();
         if (disabled) {
             providers.add(provider);
@@ -453,14 +492,14 @@ export class YagrProviderService {
         return [...new Set(MODEL_LIST_MAPPER(payload))];
     }
 
-    private readReasoningEffort(): YagrReasoningEffort | undefined {
+    private readReasoningEffort(): AgentProviderReasoningEffort | undefined {
         const config = vscode.workspace.getConfiguration('n8n.agent');
         const value = String(config.get<string>('reasoningEffort') || '').trim();
-        return YAGR_REASONING_EFFORTS.includes(value as YagrReasoningEffort) ? value as YagrReasoningEffort : undefined;
+        return AGENT_REASONING_EFFORTS.includes(value as AgentProviderReasoningEffort) ? value as AgentProviderReasoningEffort : undefined;
     }
 
-    private async getDefaultReasoningEffort(model: string): Promise<YagrReasoningEffort> {
-        const modelId = model || YAGR_PROVIDER_DEFINITIONS['openai-oauth'].defaultModel;
+    private async getDefaultReasoningEffort(model: string): Promise<AgentProviderReasoningEffort> {
+        const modelId = model || AGENT_PROVIDER_DEFINITIONS['openai-oauth'].defaultModel;
         return modelId.includes('codex-mini') ? 'minimal' : 'medium';
     }
 
@@ -496,7 +535,7 @@ export class YagrProviderService {
         }
     }
 
-    private async runDeviceFlow(provider: YagrModelProvider): Promise<void> {
+    private async runDeviceFlow(provider: AgentModelProvider): Promise<void> {
         const challenge = provider === 'openai-oauth'
             ? await this.beginOpenAiDeviceAuth()
             : await this.beginGitHubDeviceAuth();
@@ -522,21 +561,21 @@ export class YagrProviderService {
             });
 
             await this.context.secrets.store(getAgentProviderSecretKey(provider), token);
-            vscode.window.showInformationMessage(`${YAGR_PROVIDER_DEFINITIONS[provider].label} connected.`);
+            vscode.window.showInformationMessage(`${AGENT_PROVIDER_DEFINITIONS[provider].label} connected.`);
         } finally {
             authPanel.dispose();
             cancellationSource.dispose();
         }
     }
 
-    private showDeviceFlowModal(provider: YagrModelProvider, challenge: DeviceChallenge, cancellationSource: vscode.CancellationTokenSource): vscode.WebviewPanel {
+    private showDeviceFlowModal(provider: AgentModelProvider, challenge: DeviceChallenge, cancellationSource: vscode.CancellationTokenSource): vscode.WebviewPanel {
         const title = provider === 'openai-oauth' ? 'Connect OpenAI account' : 'Connect GitHub Copilot';
         void vscode.env.clipboard.writeText(challenge.userCode).then(undefined, () => undefined);
         void vscode.env.openExternal(vscode.Uri.parse(challenge.verificationUri));
         return this.showDeviceFlowWebview(title, provider, challenge, cancellationSource);
     }
 
-    private showDeviceFlowWebview(title: string, provider: YagrModelProvider, challenge: DeviceChallenge, cancellationSource: vscode.CancellationTokenSource): vscode.WebviewPanel {
+    private showDeviceFlowWebview(title: string, provider: AgentModelProvider, challenge: DeviceChallenge, cancellationSource: vscode.CancellationTokenSource): vscode.WebviewPanel {
         const panel = vscode.window.createWebviewPanel(
             'n8nAgentDeviceAuth',
             title,
@@ -566,9 +605,9 @@ export class YagrProviderService {
         return panel;
     }
 
-    private buildDeviceFlowHtml(title: string, provider: YagrModelProvider, challenge: DeviceChallenge): string {
+    private buildDeviceFlowHtml(title: string, provider: AgentModelProvider, challenge: DeviceChallenge): string {
         const nonce = this.getNonce();
-        const providerLabel = this.escapeHtml(YAGR_PROVIDER_DEFINITIONS[provider].label);
+        const providerLabel = this.escapeHtml(AGENT_PROVIDER_DEFINITIONS[provider].label);
         const safeTitle = this.escapeHtml(title);
         const code = this.escapeHtml(challenge.userCode);
         const verificationUri = this.escapeHtml(challenge.verificationUri);

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
 import { WorkspaceSnapshotService } from './workspace-snapshot-service.js';
+import { createLocalProviderLangChainModel } from './agent-provider-runtime/create-langchain-model.js';
 
 export interface AgentPromptInput {
     prompt: string;
@@ -319,13 +320,13 @@ type ProviderRuntimeConfig = {
 };
 
 type AgentProviderRegistryModule = {
-    YAGR_MODEL_PROVIDERS: string[];
+    AGENT_MODEL_PROVIDERS: string[];
     normalizeProviderId(provider: string): string | undefined;
     providerRequiresApiKey(provider: string): boolean;
     getProviderDisplayName(provider: string): string;
 };
 
-const YAGR_MODEL_PROVIDERS = Object.freeze([
+const AGENT_MODEL_PROVIDERS = Object.freeze([
     'anthropic',
     'openai',
     'google',
@@ -338,7 +339,7 @@ const YAGR_MODEL_PROVIDERS = Object.freeze([
     'openai-compatible',
 ]);
 
-const YAGR_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+const AGENT_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
     anthropic: 'Claude API',
     openai: 'OpenAI API',
     google: 'Gemini API',
@@ -351,7 +352,7 @@ const YAGR_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
     'openai-compatible': 'OpenAI Compatible',
 };
 
-const YAGR_API_KEY_PROVIDERS = new Set(['anthropic', 'openai', 'google', 'mistral', 'openrouter', 'minimax', 'minimax-token-plan']);
+const AGENT_API_KEY_PROVIDERS = new Set(['anthropic', 'openai', 'google', 'mistral', 'openrouter', 'minimax', 'minimax-token-plan']);
 
 function normalizeAgentProviderId(provider: string | undefined): string | undefined {
     const normalized = provider?.trim().toLowerCase();
@@ -359,14 +360,14 @@ function normalizeAgentProviderId(provider: string | undefined): string | undefi
     if (normalized === 'claude') return 'anthropic';
     if (normalized === 'anthropic-proxy') return 'anthropic';
     if (normalized === 'gemini') return 'google';
-    return YAGR_MODEL_PROVIDERS.includes(normalized) ? normalized : undefined;
+    return AGENT_MODEL_PROVIDERS.includes(normalized) ? normalized : undefined;
 }
 
 const LOCAL_AGENT_PROVIDER_REGISTRY: AgentProviderRegistryModule = {
-    YAGR_MODEL_PROVIDERS: [...YAGR_MODEL_PROVIDERS],
+    AGENT_MODEL_PROVIDERS: [...AGENT_MODEL_PROVIDERS],
     normalizeProviderId: normalizeAgentProviderId,
-    providerRequiresApiKey: (provider: string) => YAGR_API_KEY_PROVIDERS.has(provider),
-    getProviderDisplayName: (provider: string) => YAGR_PROVIDER_DISPLAY_NAMES[provider] || provider,
+    providerRequiresApiKey: (provider: string) => AGENT_API_KEY_PROVIDERS.has(provider),
+    getProviderDisplayName: (provider: string) => AGENT_PROVIDER_DISPLAY_NAMES[provider] || provider,
 };
 
 type CompactionState = {
@@ -1587,6 +1588,9 @@ export class AgentRuntimeController implements vscode.Disposable {
         let messageText = '';
         let hasToolCall = false;
         let visibleFinalEmitted = false;
+        let textVisibilityResolved = false;
+        let pendingVisibleText = '';
+        let isInternalRecoveryMessage = false;
 
         const emitThinkingDone = async () => {
             if (!accumulator.thinkingText) return;
@@ -1603,7 +1607,7 @@ export class AgentRuntimeController implements vscode.Disposable {
             accumulator.thinkingText = '';
             accumulator.thinkingOperationId = undefined;
         };
-        const emitTextDelta = async (delta: string, blockIndex?: number) => {
+        const emitVisibleTextDelta = async (delta: string, blockIndex?: number) => {
             if (!delta) return;
             await emitThinkingDone();
             accumulator.responseText += delta;
@@ -1613,6 +1617,27 @@ export class AgentRuntimeController implements vscode.Disposable {
             }
             callbacks.onProjectionEvent?.('text-delta', `chars=${delta.length} totalChars=${messageText.length}`);
             await callbacks.onStreamEvent({ type: 'text-delta', delta });
+        };
+        const emitTextDelta = async (delta: string, blockIndex?: number) => {
+            if (!delta || isInternalRecoveryMessage) return;
+            if (!textVisibilityResolved) {
+                pendingVisibleText += delta;
+                if (INVALID_TOOL_CALL_RECOVERY_MARKER.startsWith(pendingVisibleText) && pendingVisibleText.length < INVALID_TOOL_CALL_RECOVERY_MARKER.length) {
+                    return;
+                }
+                textVisibilityResolved = true;
+                if (pendingVisibleText.startsWith(INVALID_TOOL_CALL_RECOVERY_MARKER)) {
+                    isInternalRecoveryMessage = true;
+                    pendingVisibleText = '';
+                    blockText.clear();
+                    return;
+                }
+                const visibleText = pendingVisibleText;
+                pendingVisibleText = '';
+                await emitVisibleTextDelta(visibleText, blockIndex);
+                return;
+            }
+            await emitVisibleTextDelta(delta, blockIndex);
         };
         const emitReasoningDelta = async (delta: string) => {
             if (!delta) return;
@@ -1629,6 +1654,7 @@ export class AgentRuntimeController implements vscode.Disposable {
             });
         };
         const emitVisibleFinal = async () => {
+            if (isInternalRecoveryMessage) return;
             const finalText = this.sanitizeAssistantText(messageText);
             if (visibleFinalEmitted || hasToolCall || !finalText) return;
             visibleFinalEmitted = true;
@@ -1747,27 +1773,53 @@ export class AgentRuntimeController implements vscode.Disposable {
     ): Promise<string> {
         if (!this.isAsyncIterable(message.text)) return '';
         let text = '';
+        let pendingText = '';
+        let textVisibilityResolved = false;
+        let isInternalRecoveryMessage = false;
+        const emitVisibleTextDelta = async (delta: string) => {
+            if (!delta) return;
+            if (accumulator.thinkingText) {
+                await callbacks.onStreamEvent({
+                    type: 'operation',
+                    operationId: accumulator.thinkingOperationId || `thinking:${messageKey}`,
+                    label: 'Thinking',
+                    category: 'thinking',
+                    status: 'done',
+                    body: accumulator.thinkingText,
+                    startedAt: Date.now(),
+                    endedAt: Date.now(),
+                });
+                accumulator.thinkingText = '';
+                accumulator.thinkingOperationId = undefined;
+            }
+            accumulator.responseText += delta;
+            text += delta;
+            await callbacks.onStreamEvent({ type: 'text-delta', delta });
+        };
         for await (const delta of message.text) {
             await this.throwIfAborted(callbacks.signal);
             if (typeof delta === 'string' && delta) {
                 callbacks.onProjectionEvent?.('message.text-delta', `chars=${delta.length}`);
-                if (accumulator.thinkingText) {
-                    await callbacks.onStreamEvent({
-                        type: 'operation',
-                        operationId: accumulator.thinkingOperationId || `thinking:${messageKey}`,
-                        label: 'Thinking',
-                        category: 'thinking',
-                        status: 'done',
-                        body: accumulator.thinkingText,
-                        startedAt: Date.now(),
-                        endedAt: Date.now(),
-                    });
-                    accumulator.thinkingText = '';
-                    accumulator.thinkingOperationId = undefined;
+                if (isInternalRecoveryMessage) {
+                    continue;
                 }
-                accumulator.responseText += delta;
-                text += delta;
-                await callbacks.onStreamEvent({ type: 'text-delta', delta });
+                if (!textVisibilityResolved) {
+                    pendingText += delta;
+                    if (INVALID_TOOL_CALL_RECOVERY_MARKER.startsWith(pendingText) && pendingText.length < INVALID_TOOL_CALL_RECOVERY_MARKER.length) {
+                        continue;
+                    }
+                    textVisibilityResolved = true;
+                    if (pendingText.startsWith(INVALID_TOOL_CALL_RECOVERY_MARKER)) {
+                        isInternalRecoveryMessage = true;
+                        pendingText = '';
+                        continue;
+                    }
+                    const visibleText = pendingText;
+                    pendingText = '';
+                    await emitVisibleTextDelta(visibleText);
+                    continue;
+                }
+                await emitVisibleTextDelta(delta);
             }
         }
         return text;
@@ -2208,7 +2260,6 @@ export class AgentRuntimeController implements vscode.Disposable {
             path.join(rootDir, 'README.md'),
             path.join(rootDir, 'readme.md'),
             path.join(rootDir, '.agents', 'AGENTS.md'),
-            path.join(rootDir, '.yagr', 'AGENTS.md'),
         ];
         const existing = await Promise.all(candidates.map(async (candidate) => {
             try {
@@ -2321,22 +2372,14 @@ export class AgentRuntimeController implements vscode.Disposable {
         if (!result || typeof result !== 'object') {
             return typeof result === 'string' ? result : 'The agent completed without producing text.';
         }
+        const assistantText = this.extractAssistantTextFromAgentOutput(result);
+        if (assistantText) return assistantText;
         const record = result as Record<string, unknown>;
         const messages = Array.isArray(record.messages) ? record.messages : [];
         const last = messages[messages.length - 1] as Record<string, unknown> | undefined;
         const content = last?.content ?? record.content ?? record.output;
-        if (typeof content === 'string') {
-            return this.sanitizeAssistantText(content);
-        }
-        if (Array.isArray(content)) {
-            return this.sanitizeAssistantText(content.map((part) => {
-                if (typeof part === 'string') return part;
-                if (part && typeof part === 'object' && typeof (part as Record<string, unknown>).text === 'string') {
-                    return (part as Record<string, string>).text;
-                }
-                return '';
-            }).join(''));
-        }
+        const text = this.extractMessageTextContent(content);
+        if (text.trim()) return this.sanitizeAssistantText(text);
         return 'The agent completed without producing text.';
     }
 
@@ -2352,7 +2395,8 @@ export class AgentRuntimeController implements vscode.Disposable {
         const last = messages[messages.length - 1];
         const lastRole = this.isRecord(last) ? String(last.role || last._getType || last.type || last.name || 'unknown') : 'none';
         const lastTextChars = this.isRecord(last) ? this.extractMessageTextContent(last.content).length : 0;
-        return `keys=${keys || 'none'} messages=${messages.length} lastRole=${lastRole} lastTextChars=${lastTextChars}`;
+        const lastProviderTextChars = this.isRecord(last) ? this.extractProviderOutputItemsText(last).length : 0;
+        return `keys=${keys || 'none'} messages=${messages.length} lastRole=${lastRole} lastTextChars=${lastTextChars} lastProviderTextChars=${lastProviderTextChars}`;
     }
 
     private readMessageEventIndex(event: Record<string, unknown>): number | undefined {
@@ -2426,8 +2470,67 @@ export class AgentRuntimeController implements vscode.Disposable {
         for (let idx = messages.length - 1; idx >= 0; idx -= 1) {
             const message = messages[idx];
             if (!this.isAssistantMessage(message)) continue;
-            const text = this.extractMessageTextContent(this.isRecord(message) ? message.content : undefined);
+            const text = this.extractAssistantMessageText(message);
+            if (this.isInternalRecoveryText(text)) continue;
             if (text.trim()) return this.sanitizeAssistantText(text);
+        }
+        return '';
+    }
+
+    private extractAssistantMessageText(message: unknown): string {
+        if (!this.isRecord(message)) return '';
+        const directText = this.extractMessageTextContent(message.content);
+        if (directText.trim()) return directText;
+        const providerText = this.extractProviderOutputItemsText(message);
+        if (providerText.trim()) return providerText;
+        return '';
+    }
+
+    private isInternalRecoveryText(value: string): boolean {
+        return value.trimStart().startsWith(INVALID_TOOL_CALL_RECOVERY_MARKER);
+    }
+
+    private extractProviderOutputItemsText(message: Record<string, unknown>): string {
+        const candidates: unknown[] = [];
+        const collect = (value: unknown) => {
+            if (!this.isRecord(value)) return;
+            for (const key of ['codex_output_items', 'rawOutputItems', 'output_items', 'outputItems']) {
+                const candidate = value[key];
+                if (Array.isArray(candidate) || this.isRecord(candidate)) {
+                    candidates.push(candidate);
+                }
+            }
+        };
+        collect(message);
+        collect(message.additional_kwargs);
+        collect(message.response_metadata);
+        collect(message.kwargs);
+        collect(message.lc_kwargs);
+        if (this.isRecord(message.kwargs)) {
+            collect(message.kwargs.additional_kwargs);
+            collect(message.kwargs.response_metadata);
+        }
+        if (this.isRecord(message.lc_kwargs)) {
+            collect(message.lc_kwargs.additional_kwargs);
+            collect(message.lc_kwargs.response_metadata);
+        }
+        return candidates.map((candidate) => this.extractProviderOutputItemText(candidate)).join('');
+    }
+
+    private extractProviderOutputItemText(value: unknown): string {
+        if (Array.isArray(value)) {
+            return value.map((item) => this.extractProviderOutputItemText(item)).join('');
+        }
+        if (!this.isRecord(value)) return '';
+        const type = String(value.type || '').toLowerCase();
+        if ((type === 'message' || type === 'output_message') && Array.isArray(value.content)) {
+            return this.extractMessageTextContent(value.content);
+        }
+        if ((type === 'output_text' || type === 'text') && typeof value.text === 'string') {
+            return value.text;
+        }
+        if (Array.isArray(value.content)) {
+            return this.extractMessageTextContent(value.content);
         }
         return '';
     }
@@ -2532,15 +2635,22 @@ export class AgentRuntimeController implements vscode.Disposable {
 
     private extractMessageTextContent(value: unknown): string {
         if (typeof value === 'string') return value;
+        if (this.isRecord(value)) {
+            if (typeof value.text === 'string') return value.text;
+            if (Array.isArray(value.content)) return this.extractMessageTextContent(value.content);
+            return '';
+        }
         if (!Array.isArray(value)) return '';
         return value.map((part) => {
             if (typeof part === 'string') return part;
             if (this.isRecord(part) && typeof part.text === 'string') return part.text;
+            if (this.isRecord(part) && Array.isArray(part.content)) return this.extractMessageTextContent(part.content);
             return '';
         }).join('');
     }
 
     private sanitizeAssistantText(value: string): string {
+        if (this.isInternalRecoveryText(value)) return '';
         return value.replace(ENVIRONMENT_DETAILS_BLOCK_PATTERN, '').trim();
     }
 
@@ -2842,7 +2952,7 @@ export class AgentRuntimeController implements vscode.Disposable {
     ): Promise<void> {
         if (depth > 4) return;
         const relative = path.relative(workspaceRoot, directory).replace(/\\/g, '/');
-        if (relative && /(^|\/)(node_modules|dist|out|\.git|\.kilo|\.yagr)(\/|$)/.test(relative)) {
+        if (relative && /(^|\/)(node_modules|dist|out|\.git|\.kilo)(\/|$)/.test(relative)) {
             return;
         }
         let entries: Array<{ name: string; isDirectory(): boolean; isFile(): boolean }>;
@@ -3316,23 +3426,13 @@ export class AgentRuntimeController implements vscode.Disposable {
         const provider = providerConfig.provider;
         const model = providerConfig.model || this.getDefaultModelForProvider(provider);
         if (provider === 'openai-oauth' || provider === 'copilot-proxy' || provider === 'minimax' || provider === 'minimax-token-plan') {
-            const providerRuntime = await importRuntimeModule('@yagr/provider-runtime');
-            const localConfig = {
-                provider,
-                model,
-                baseUrl: providerConfig.baseUrl,
-                reasoningEffort: providerConfig.reasoningEffort,
-            };
-            const configStore = {
-                getLocalConfig: () => localConfig,
-                getApiKey: (candidate: string) => candidate === provider ? providerConfig.apiKey : undefined,
-            };
-            return providerRuntime.createLangChainModel({
+            return createLocalProviderLangChainModel({
                 provider,
                 model,
                 apiKey: providerConfig.apiKey,
                 baseUrl: providerConfig.baseUrl,
-            }, configStore);
+                reasoningEffort: providerConfig.reasoningEffort,
+            });
         }
 
         if (provider === 'google') {
@@ -3956,13 +4056,20 @@ export class AgentRuntimeController implements vscode.Disposable {
         if (!model) {
             return DEFAULT_CONTEXT_WINDOW_TOKENS;
         }
-        try {
-            const metadata = await importRuntimeModule('@yagr/provider-runtime');
-            const entry = await metadata.primeProviderModelMetadata(provider as any, model, apiKey, baseUrl);
-            return Number(entry?.contextWindow || DEFAULT_CONTEXT_WINDOW_TOKENS);
-        } catch {
-            return DEFAULT_CONTEXT_WINDOW_TOKENS;
+        const normalizedModel = model.toLowerCase();
+        if (provider === 'openai-oauth' || provider === 'openai') {
+            if (/gpt-5/i.test(normalizedModel)) return 400_000;
+            if (/gpt-4\.1|gpt-4o/i.test(normalizedModel)) return 128_000;
         }
+        if (provider === 'copilot-proxy') {
+            if (/gpt-4\.1|gpt-5/i.test(normalizedModel)) return 128_000;
+        }
+        if (provider === 'minimax' || provider === 'minimax-token-plan') {
+            return 200_000;
+        }
+        void apiKey;
+        void baseUrl;
+        return DEFAULT_CONTEXT_WINDOW_TOKENS;
     }
 
     private readReasoningEffort(): AgentReasoningEffort | undefined {

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -770,9 +770,9 @@ class WorkbenchSessionService implements SessionServiceHandle {
 }
 
 export class AgentRuntimeController implements vscode.Disposable {
-    private activeRun: { abortController: AbortController; sessionId: string; abortReason?: 'stop' | 'steer'; visibleDone?: boolean; runStartedAt?: number; visibleFinalAt?: number } | undefined;
+    private readonly activeRuns = new Map<string, { abortController: AbortController; sessionId: string; abortReason?: 'stop' | 'steer'; visibleDone?: boolean; runStartedAt?: number; visibleFinalAt?: number }>();
     private readonly stoppedRuns = new WeakSet<AbortController>();
-    private queuedPrompt: { input: AgentPromptInput; reason: 'pending' | 'steer' } | undefined;
+    private readonly queuedPrompts = new Map<string, { input: AgentPromptInput; reason: 'pending' | 'steer' }>();
     private cachedAgentHandle: { key: string; handle: any } | undefined;
     private sessionRuntimePromise: Promise<SessionRuntime> | undefined;
     private checkpointerPromise: Promise<RuntimeCheckpointer> | undefined;
@@ -816,7 +816,7 @@ export class AgentRuntimeController implements vscode.Disposable {
             activeSessionId: activeRecord.id,
             sessions: await this.listSessionSummaries(scope, activeRecord.id),
             session,
-            isRunning: this.activeRun?.sessionId === activeRecord.id,
+            isRunning: this.activeRuns.has(activeRecord.id),
         };
     }
 
@@ -985,10 +985,8 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     async rewindToUserMessage(sessionId: string, messageId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<{ state: AgentWorkbenchState; prompt: string }> {
-        if (this.activeRun) {
-            throw new Error(this.activeRun.sessionId === sessionId
-                ? 'An agent run is already active for this conversation.'
-                : 'An agent run is already active. Stop it before rewinding.');
+        if (this.activeRuns.has(sessionId)) {
+            throw new Error('An agent run is already active for this conversation.');
         }
         const sessions = await this.getSessionRuntime();
         const entries = this.readSessionEntries(sessions.service, sessionId);
@@ -1025,6 +1023,9 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     async restoreCheckpoint(sessionId: string, checkpointId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
+        if (this.activeRuns.has(sessionId)) {
+            throw new Error('An agent run is already active for this conversation.');
+        }
         const sessions = await this.getSessionRuntime();
         const result = await sessions.service.restoreCheckpoint(sessionId, checkpointId);
         const payloads = this.extractCheckpointPayloads(result);
@@ -1069,15 +1070,13 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     async compactSession(sessionId: string, input: Omit<AgentPromptInput, 'prompt'>): Promise<AgentWorkbenchState> {
-        if (this.activeRun) {
-            throw new Error(this.activeRun.sessionId === sessionId
-                ? 'An agent run is already active for this conversation.'
-                : 'An agent run is already active. Stop it before compacting context.');
+        if (this.activeRuns.has(sessionId)) {
+            throw new Error('An agent run is already active for this conversation.');
         }
         const sessions = await this.getSessionRuntime();
 
         const abortController = new AbortController();
-        this.activeRun = { abortController, sessionId };
+        this.activeRuns.set(sessionId, { abortController, sessionId });
         try {
             let entries = this.readSessionEntries(sessions.service, sessionId);
             const event = await this.summarizeSessionForCompaction(sessionId, input, entries, abortController.signal);
@@ -1098,17 +1097,28 @@ export class AgentRuntimeController implements vscode.Disposable {
             });
             return this.getWorkbenchState({ ...input, sessionId });
         } finally {
-            if (this.activeRun?.abortController === abortController) {
-                this.activeRun = undefined;
+            const activeRun = this.activeRuns.get(sessionId);
+            if (activeRun?.abortController === abortController) {
+                this.activeRuns.delete(sessionId);
             }
         }
     }
 
     async sendPrompt(input: AgentPromptInput, postMessage: AgentWorkbenchPostMessage): Promise<AgentRunResult> {
-        if (this.activeRun) {
-            if (this.activeRun.visibleDone) {
-                const waitMs = this.activeRun.visibleFinalAt ? Date.now() - this.activeRun.visibleFinalAt : undefined;
-                this.outputChannel.appendLine(`[n8n-agent-debug] prompt queued while DeepAgents finalizes sessionId=${this.activeRun.sessionId} waitAfterVisibleMs=${waitMs ?? 'unknown'} reason=pending`);
+        const sessions = await this.getSessionRuntime();
+        const scope = this.getSessionScope(input);
+        const activeRecord = input.sessionId
+            ? sessions.service.ensure(input.sessionId, { title: this.getDefaultSessionTitle(input.workflowName) })
+            : (sessions.service.getActiveForScope(scope) || sessions.service.getOrCreateForScope(scope, {
+                title: this.getDefaultSessionTitle(input.workflowName),
+            }));
+        const targetSessionId = activeRecord.id;
+
+        const activeRun = this.activeRuns.get(targetSessionId);
+        if (activeRun) {
+            if (activeRun.visibleDone) {
+                const waitMs = activeRun.visibleFinalAt ? Date.now() - activeRun.visibleFinalAt : undefined;
+                this.outputChannel.appendLine(`[n8n-agent-debug] prompt queued while DeepAgents finalizes sessionId=${targetSessionId} waitAfterVisibleMs=${waitMs ?? 'unknown'} reason=pending`);
                 return this.queuePrompt(input, postMessage, 'pending');
             }
             await postMessage({
@@ -1123,21 +1133,14 @@ export class AgentRuntimeController implements vscode.Disposable {
             return { workflowChanged: false };
         }
 
-        const sessions = await this.getSessionRuntime();
-        const scope = this.getSessionScope(input);
-        const activeRecord = input.sessionId
-            ? sessions.service.ensure(input.sessionId, { title: this.getDefaultSessionTitle(input.workflowName) })
-            : (sessions.service.getActiveForScope(scope) || sessions.service.getOrCreateForScope(scope, {
-                title: this.getDefaultSessionTitle(input.workflowName),
-            }));
-        const sessionContext = await this.buildSessionState(activeRecord.id, input);
+        const sessionContext = await this.buildSessionState(targetSessionId, input);
         const promptWorkflowContext = sessionContext.workflowContext;
         const promptNodeContexts = sessionContext.nodeContexts.length
             ? sessionContext.nodeContexts
             : this.normalizeNodeContexts(input.nodeContexts || input.nodeContext);
         const promptInput: AgentPromptInput = {
             ...input,
-            sessionId: activeRecord.id,
+            sessionId: targetSessionId,
             workflowId: promptWorkflowContext?.id,
             workflowName: promptWorkflowContext?.name,
             workflowFilename: promptWorkflowContext?.filename,
@@ -1147,16 +1150,17 @@ export class AgentRuntimeController implements vscode.Disposable {
         };
 
         const abortController = new AbortController();
-        this.activeRun = { abortController, sessionId: activeRecord.id, runStartedAt: Date.now() };
+        const nextActiveRun = { abortController, sessionId: targetSessionId, runStartedAt: Date.now() };
+        this.activeRuns.set(targetSessionId, nextActiveRun);
 
         const derivedTitle = activeRecord.title === 'New conversation'
             ? sessions.deriveSessionTitle(prompt, this.getDefaultSessionTitle(input.workflowName))
             : activeRecord.title;
-        sessions.service.touch(activeRecord.id, { title: derivedTitle });
-        sessions.service.setTitle(activeRecord.id, derivedTitle);
+        sessions.service.touch(targetSessionId, { title: derivedTitle });
+        sessions.service.setTitle(targetSessionId, derivedTitle);
 
-        let entries = this.withoutContextUsage(this.readSessionEntries(sessions.service, activeRecord.id));
-        const beforeMessageCheckpoint = await this.saveBeforeUserMessageCheckpoint(sessions.service, activeRecord.id, entries, prompt, input.workspaceRoot);
+        let entries = this.withoutContextUsage(this.readSessionEntries(sessions.service, targetSessionId));
+        const beforeMessageCheckpoint = await this.saveBeforeUserMessageCheckpoint(sessions.service, targetSessionId, entries, prompt, input.workspaceRoot);
         entries = [...entries, {
             kind: 'user-message',
             id: randomUUID(),
@@ -1168,11 +1172,11 @@ export class AgentRuntimeController implements vscode.Disposable {
                 workspaceSnapshotId: beforeMessageCheckpoint.workspaceSnapshotId,
             },
         }];
-        this.writeSessionEntries(sessions.service, activeRecord.id, entries);
+        this.writeSessionEntries(sessions.service, targetSessionId, entries);
 
-        await postMessage({ type: 'agent.state', state: await this.getWorkbenchState({ ...input, sessionId: activeRecord.id }) });
+        await postMessage({ type: 'agent.state', state: await this.getWorkbenchState({ ...input, sessionId: targetSessionId }) });
         await postMessage({ type: 'agent.status', status: 'running', detail: 'Preparing n8n agent runtime...' });
-        await postMessage({ type: 'agent.streamEvent', event: { type: 'start', sessionId: activeRecord.id, message: prompt } });
+        await postMessage({ type: 'agent.streamEvent', event: { type: 'start', sessionId: targetSessionId, message: prompt } });
 
         let result: AgentRunResult = { workflowChanged: false };
         let queuedPrompt: { input: AgentPromptInput; reason: 'pending' | 'steer' } | undefined;
@@ -1180,10 +1184,11 @@ export class AgentRuntimeController implements vscode.Disposable {
         try {
             const runResult = await this.runInitialAgentTurn(promptInput, entries, postMessage, abortController.signal);
             entries = runResult.entries;
-            this.writeSessionEntries(sessions.service, activeRecord.id, entries);
-            if (!this.queuedPrompt && this.activeRun?.abortController === abortController) {
-                this.activeRun = undefined;
-                this.outputChannel.appendLine(`[n8n-agent-debug] agent host idle sessionId=${activeRecord.id}`);
+            this.writeSessionEntries(sessions.service, targetSessionId, entries);
+            const currentActiveRun = this.activeRuns.get(targetSessionId);
+            if (!this.queuedPrompts.has(targetSessionId) && currentActiveRun?.abortController === abortController) {
+                this.activeRuns.delete(targetSessionId);
+                this.outputChannel.appendLine(`[n8n-agent-debug] agent host idle sessionId=${targetSessionId}`);
                 await postMessage({ type: 'agent.status', status: 'idle' });
                 postedIdle = true;
             }
@@ -1191,49 +1196,51 @@ export class AgentRuntimeController implements vscode.Disposable {
                 const inferredWorkflow = await this.inferWorkflowContextFromWorkspace(input.workspaceRoot);
                 if (inferredWorkflow) {
                     entries = this.withWorkflowContext(entries, inferredWorkflow);
-                    this.writeSessionEntries(sessions.service, activeRecord.id, entries);
+                    this.writeSessionEntries(sessions.service, targetSessionId, entries);
                 }
             }
-            await postMessage({ type: 'agent.state', state: await this.getWorkbenchState({ ...input, sessionId: activeRecord.id }) });
+            await postMessage({ type: 'agent.state', state: await this.getWorkbenchState({ ...input, sessionId: targetSessionId }) });
             await postMessage({ type: 'agent.done' });
-            this.outputChannel.appendLine(`[n8n-agent-debug] agent host done sessionId=${activeRecord.id} queuedPrompt=${String(Boolean(this.queuedPrompt))}`);
+            this.outputChannel.appendLine(`[n8n-agent-debug] agent host done sessionId=${targetSessionId} queuedPrompt=${String(Boolean(this.queuedPrompts.has(targetSessionId)))}`);
             result = { workflowChanged: runResult.workflowChanged };
         } catch (error: any) {
             const message = error?.message || String(error);
+            const currentActiveRun = this.activeRuns.get(targetSessionId);
             if (this.stoppedRuns.has(abortController)) {
-                this.outputChannel.appendLine(`[n8n-agent-debug] agent runtime stopped sessionId=${activeRecord.id}`);
-                this.appendRunStoppedNotice(sessions.service, activeRecord.id);
-                this.queuedPrompt = undefined;
+                this.outputChannel.appendLine(`[n8n-agent-debug] agent runtime stopped sessionId=${targetSessionId}`);
+                this.appendRunStoppedNotice(sessions.service, targetSessionId);
+                this.queuedPrompts.delete(targetSessionId);
                 result = { workflowChanged: false };
-            } else if (this.activeRun?.abortController === abortController && this.activeRun.abortReason === 'steer') {
-                this.outputChannel.appendLine(`[n8n-agent-debug] agent runtime steered sessionId=${activeRecord.id}`);
-                const latestEntries = this.withoutContextUsage(this.readSessionEntries(sessions.service, activeRecord.id));
-                this.writeSessionEntries(sessions.service, activeRecord.id, [
+            } else if (currentActiveRun?.abortController === abortController && currentActiveRun.abortReason === 'steer') {
+                this.outputChannel.appendLine(`[n8n-agent-debug] agent runtime steered sessionId=${targetSessionId}`);
+                const latestEntries = this.withoutContextUsage(this.readSessionEntries(sessions.service, targetSessionId));
+                this.writeSessionEntries(sessions.service, targetSessionId, [
                     ...this.finalizePendingOperations(latestEntries, 'done'),
                     this.createSystemNotice('Run steered by a newer message.'),
                 ]);
-                await postMessage({ type: 'agent.state', state: await this.getWorkbenchState({ ...input, sessionId: activeRecord.id }) });
+                await postMessage({ type: 'agent.state', state: await this.getWorkbenchState({ ...input, sessionId: targetSessionId }) });
                 result = { workflowChanged: false };
             } else {
                 this.outputChannel.appendLine(`[n8n-agent] Run failed: ${message}`);
-                const latestEntries = this.withoutContextUsage(this.readSessionEntries(sessions.service, activeRecord.id));
+                const latestEntries = this.withoutContextUsage(this.readSessionEntries(sessions.service, targetSessionId));
                 const failedEntries = [
                     ...this.finalizePendingOperations(latestEntries, 'error'),
                     this.createSystemNotice(`Run failed: ${message}`),
                 ];
-                this.writeSessionEntries(sessions.service, activeRecord.id, failedEntries);
+                this.writeSessionEntries(sessions.service, targetSessionId, failedEntries);
                 await postMessage({ type: 'agent.streamEvent', event: { type: 'error', error: message } });
                 await postMessage({ type: 'agent.error', message });
-                await postMessage({ type: 'agent.state', state: await this.getWorkbenchState({ ...input, sessionId: activeRecord.id }) });
+                await postMessage({ type: 'agent.state', state: await this.getWorkbenchState({ ...input, sessionId: targetSessionId }) });
                 result = { workflowChanged: false };
             }
         } finally {
-            if (this.activeRun?.abortController === abortController) {
-                this.activeRun = undefined;
+            const currentActiveRun = this.activeRuns.get(targetSessionId);
+            if (currentActiveRun?.abortController === abortController) {
+                this.activeRuns.delete(targetSessionId);
             }
-            queuedPrompt = this.queuedPrompt;
+            queuedPrompt = this.queuedPrompts.get(targetSessionId);
             if (queuedPrompt) {
-                this.queuedPrompt = undefined;
+                this.queuedPrompts.delete(targetSessionId);
             } else if (!postedIdle) {
                 await postMessage({ type: 'agent.status', status: 'idle' });
             }
@@ -1250,41 +1257,53 @@ export class AgentRuntimeController implements vscode.Disposable {
         if (!prompt) {
             return { workflowChanged: false };
         }
-        if (!this.activeRun) {
+        const targetSessionId = input.sessionId;
+        if (!targetSessionId) {
             return this.sendPrompt(input, postMessage);
         }
-        this.queuedPrompt = { input: { ...input, prompt }, reason };
-        const waitMs = this.activeRun.visibleFinalAt ? Date.now() - this.activeRun.visibleFinalAt : undefined;
-        this.outputChannel.appendLine(`[n8n-agent-debug] queuePrompt accepted sessionId=${this.activeRun.sessionId} reason=${reason} visibleDone=${String(Boolean(this.activeRun.visibleDone))} waitAfterVisibleMs=${waitMs ?? 'unknown'}`);
+        const activeRun = this.activeRuns.get(targetSessionId);
+        if (!activeRun) {
+            return this.sendPrompt(input, postMessage);
+        }
+        this.queuedPrompts.set(targetSessionId, { input: { ...input, prompt }, reason });
+        const waitMs = activeRun.visibleFinalAt ? Date.now() - activeRun.visibleFinalAt : undefined;
+        this.outputChannel.appendLine(`[n8n-agent-debug] queuePrompt accepted sessionId=${targetSessionId} reason=${reason} visibleDone=${String(Boolean(activeRun.visibleDone))} waitAfterVisibleMs=${waitMs ?? 'unknown'}`);
         if (reason === 'steer') {
-            this.activeRun.abortReason = 'steer';
+            activeRun.abortReason = 'steer';
             await postMessage({ type: 'agent.status', status: 'stopping', detail: 'Steering current run...' });
-            this.activeRun.abortController.abort();
+            activeRun.abortController.abort();
         }
         return { workflowChanged: false };
     }
 
-    async stop(postMessage: AgentWorkbenchPostMessage): Promise<void> {
-        const activeRun = this.activeRun;
+    async stop(postMessage: AgentWorkbenchPostMessage, sessionId?: string): Promise<void> {
+        let activeRun;
+        if (sessionId) {
+            activeRun = this.activeRuns.get(sessionId);
+        } else {
+            activeRun = this.activeRuns.values().next().value;
+        }
         if (!activeRun) {
             await postMessage({ type: 'agent.status', status: 'idle' });
             return;
         }
-        this.queuedPrompt = undefined;
+        const runSessionId = activeRun.sessionId;
+        this.queuedPrompts.delete(runSessionId);
         activeRun.abortReason = 'stop';
         this.stoppedRuns.add(activeRun.abortController);
         activeRun.abortController.abort();
-        if (this.activeRun?.abortController === activeRun.abortController) {
-            this.activeRun = undefined;
-        }
+        this.activeRuns.delete(runSessionId);
         const sessions = await this.getSessionRuntime();
-        this.appendRunStoppedNotice(sessions.service, activeRun.sessionId);
+        this.appendRunStoppedNotice(sessions.service, runSessionId);
         await postMessage({ type: 'agent.status', status: 'idle' });
     }
 
     dispose(): void {
-        this.activeRun?.abortController.abort();
-        this.activeRun = undefined;
+        for (const run of this.activeRuns.values()) {
+            run.abortController.abort();
+        }
+        this.activeRuns.clear();
+        this.queuedPrompts.clear();
         void this.flushSessionWrites();
     }
 
@@ -1411,7 +1430,7 @@ export class AgentRuntimeController implements vscode.Disposable {
                 authoritativeFinalEmitted = true;
                 visibleFinalEmitted = true;
             }
-            const activeRun = this.activeRun;
+            const activeRun = input.sessionId ? this.activeRuns.get(input.sessionId) : undefined;
             if (activeRun && activeRun.sessionId === input.sessionId) {
                 activeRun.visibleDone = true;
                 if (runtimeFinalizing) {

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -147,6 +147,7 @@ export interface AgentWorkbenchState {
 
 export interface AgentRunResult {
     workflowChanged: boolean;
+    workflowContext?: AgentWorkflowContext;
 }
 
 export type AgentStreamEvent =
@@ -1195,17 +1196,20 @@ export class AgentRuntimeController implements vscode.Disposable {
                 await postMessage({ type: 'agent.status', status: 'idle' });
                 postedIdle = true;
             }
-            if (runResult.workflowChanged && !promptWorkflowContext) {
-                const inferredWorkflow = await this.inferWorkflowContextFromWorkspace(input.workspaceRoot);
+            if (runResult.workflowChanged) {
+                const inferredWorkflow = runResult.workflowContext || await this.inferWorkflowContextFromWorkspace(input.workspaceRoot);
                 if (inferredWorkflow) {
-                    entries = this.withWorkflowContext(entries, inferredWorkflow);
-                    this.writeSessionEntries(sessions.service, targetSessionId, entries);
+                    const shouldUpdateWorkflowContext = !promptWorkflowContext || !this.workflowContextsMatch(promptWorkflowContext, inferredWorkflow);
+                    if (shouldUpdateWorkflowContext) {
+                        entries = this.withWorkflowContext(entries, inferredWorkflow);
+                        this.writeSessionEntries(sessions.service, targetSessionId, entries);
+                    }
                 }
             }
             await postMessage({ type: 'agent.state', state: await this.getWorkbenchState({ ...input, sessionId: targetSessionId }) });
             await postMessage({ type: 'agent.done' });
             this.outputChannel.appendLine(`[n8n-agent-debug] agent host done sessionId=${targetSessionId} queuedPrompt=${String(Boolean(this.queuedPrompts.has(targetSessionId)))}`);
-            result = { workflowChanged: runResult.workflowChanged };
+            result = { workflowChanged: runResult.workflowChanged, workflowContext: runResult.workflowContext };
         } catch (error: any) {
             const message = error?.message || String(error);
             const currentActiveRun = this.activeRuns.get(targetSessionId);
@@ -1250,7 +1254,7 @@ export class AgentRuntimeController implements vscode.Disposable {
         }
         if (queuedPrompt) {
             const queuedResult = await this.sendPrompt(queuedPrompt.input, postMessage);
-            return { workflowChanged: result.workflowChanged || queuedResult.workflowChanged };
+            return { workflowChanged: result.workflowChanged || queuedResult.workflowChanged, workflowContext: queuedResult.workflowContext || result.workflowContext };
         }
         return result;
     }
@@ -1311,7 +1315,7 @@ export class AgentRuntimeController implements vscode.Disposable {
         initialEntries: AgentTimelineEntry[],
         postMessage: AgentWorkbenchPostMessage,
         signal: AbortSignal,
-    ): Promise<{ entries: AgentTimelineEntry[]; workflowChanged: boolean }> {
+    ): Promise<{ entries: AgentTimelineEntry[]; workflowChanged: boolean; workflowContext?: AgentWorkflowContext }> {
         await this.throwIfAborted(signal);
 
         const providerRegistry = await this.loadAgentProviderRegistry().catch((error: any) => ({ error: error?.message || String(error) }));
@@ -1399,11 +1403,12 @@ export class AgentRuntimeController implements vscode.Disposable {
         postMessage: AgentWorkbenchPostMessage,
         signal: AbortSignal,
         contextWindowTokens: number,
-    ): Promise<{ entries: AgentTimelineEntry[]; workflowChanged: boolean }> {
+    ): Promise<{ entries: AgentTimelineEntry[]; workflowChanged: boolean; workflowContext?: AgentWorkflowContext }> {
         const runStartedAt = Date.now();
         const accumulator = this.createStreamAccumulator();
         let entries = [...initialEntries];
         let fileModificationDetected = false;
+        const writtenWorkflowPaths = new Set<string>();
         let visibleFinalEmitted = false;
         let authoritativeFinalEmitted = false;
         const loggedProjectionEvents = new Set<string>();
@@ -1416,8 +1421,12 @@ export class AgentRuntimeController implements vscode.Disposable {
             entries = this.applyStreamEvent(entries, streamEvent);
             syncEntries();
             await postMessage({ type: 'agent.streamEvent', event: streamEvent });
-            if (streamEvent.type === 'operation' && streamEvent.status === 'done' && streamEvent.category === 'file-write') {
-                fileModificationDetected = true;
+            if (streamEvent.type === 'operation' && streamEvent.category === 'file-write') {
+                const filePath = this.extractWorkflowFilePathFromOperation(streamEvent);
+                if (filePath) writtenWorkflowPaths.add(filePath);
+                if (streamEvent.status === 'done') {
+                    fileModificationDetected = true;
+                }
             }
         };
         const emitFinalEvent = async (response: string, finalState: string, runtimeFinalizing: boolean) => {
@@ -1505,8 +1514,11 @@ export class AgentRuntimeController implements vscode.Disposable {
         if (fileModificationDetected) {
             this.saveAutoCheckpointAfterFileModificationInBackground(service, input, entries);
         }
+        const workflowContext = fileModificationDetected
+            ? await this.inferWorkflowContextFromWrittenFiles([...writtenWorkflowPaths], input.workspaceRoot)
+            : undefined;
         this.outputChannel.appendLine(`[n8n-agent-debug] agent runtime completed sessionId=${input.sessionId || 'none'} workflowId=${input.workflowId || 'none'} stream=v3 workflowChanged=${String(fileModificationDetected)} elapsedMs=${Date.now() - runStartedAt}`);
-        return { entries, workflowChanged: fileModificationDetected };
+        return { entries, workflowChanged: fileModificationDetected, workflowContext };
     }
 
     private async consumeDeepAgentV3MessageProjection(
@@ -2934,6 +2946,35 @@ export class AgentRuntimeController implements vscode.Disposable {
         for (const candidate of candidates.slice(0, 12)) {
             const context = await this.readWorkflowContextFromTypeScriptFile(candidate.filePath, workspaceRoot);
             if (context) return context;
+        }
+        return undefined;
+    }
+
+    private async inferWorkflowContextFromWrittenFiles(filePaths: string[], workspaceRoot?: string): Promise<AgentWorkflowContext | undefined> {
+        if (!workspaceRoot) return undefined;
+        const seen = new Set<string>();
+        for (const candidate of filePaths) {
+            const resolved = path.isAbsolute(candidate)
+                ? candidate
+                : path.resolve(workspaceRoot, candidate);
+            if (seen.has(resolved)) continue;
+            seen.add(resolved);
+            if (!resolved.endsWith('.workflow.ts')) continue;
+            const relative = path.relative(workspaceRoot, resolved);
+            if (relative.startsWith('..') || path.isAbsolute(relative)) continue;
+            const context = await this.readWorkflowContextFromTypeScriptFile(resolved, workspaceRoot);
+            if (context) return context;
+        }
+        return undefined;
+    }
+
+    private extractWorkflowFilePathFromOperation(event: Extract<AgentStreamEvent, { type: 'operation' }>): string | undefined {
+        for (const candidate of [event.summary, event.body]) {
+            if (typeof candidate !== 'string') continue;
+            const trimmed = candidate.trim();
+            if (!trimmed || !trimmed.endsWith('.workflow.ts')) continue;
+            if (trimmed.includes('\n')) continue;
+            return trimmed;
         }
         return undefined;
     }

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -1113,13 +1113,14 @@ export class AgentRuntimeController implements vscode.Disposable {
                 title: this.getDefaultSessionTitle(input.workflowName),
             }));
         const targetSessionId = activeRecord.id;
+        input.sessionId = targetSessionId;
 
         const activeRun = this.activeRuns.get(targetSessionId);
         if (activeRun) {
             if (activeRun.visibleDone) {
                 const waitMs = activeRun.visibleFinalAt ? Date.now() - activeRun.visibleFinalAt : undefined;
                 this.outputChannel.appendLine(`[n8n-agent-debug] prompt queued while DeepAgents finalizes sessionId=${targetSessionId} waitAfterVisibleMs=${waitMs ?? 'unknown'} reason=pending`);
-                return this.queuePrompt(input, postMessage, 'pending');
+                return this.queuePrompt({ ...input, sessionId: targetSessionId }, postMessage, 'pending');
             }
             await postMessage({
                 type: 'agent.error',
@@ -1292,10 +1293,6 @@ export class AgentRuntimeController implements vscode.Disposable {
         activeRun.abortReason = 'stop';
         this.stoppedRuns.add(activeRun.abortController);
         activeRun.abortController.abort();
-        this.activeRuns.delete(runSessionId);
-        const sessions = await this.getSessionRuntime();
-        this.appendRunStoppedNotice(sessions.service, runSessionId);
-        await postMessage({ type: 'agent.status', status: 'idle' });
     }
 
     dispose(): void {

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -78,6 +78,7 @@ export interface AgentSessionSummary {
     updatedAt: string;
     messageCount: number;
     isActive: boolean;
+    isRunning: boolean;
     isClosed: boolean;
     checkpointCount: number;
     workflowId?: string;
@@ -2696,6 +2697,7 @@ export class AgentRuntimeController implements vscode.Disposable {
                 updatedAt: summary.updatedAt,
                 messageCount: summary.messageCount,
                 isActive: summary.id === activeSessionId,
+                isRunning: this.activeRuns.has(summary.id),
                 isClosed: Boolean(record?.closedAt),
                 checkpointCount: checkpoints.length,
                 workflowId: workflowContext?.id,

--- a/packages/vscode-extension/src/ui/agent-manager-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-manager-webview.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { getAgentProviderSecretKey } from '../services/agent-runtime-controller.js';
-import { YAGR_PROVIDER_DEFINITIONS, normalizeYagrProviderId, providerSupportsReasoningEffort } from '../services/yagr-provider-service.js';
+import { AGENT_PROVIDER_DEFINITIONS, normalizeAgentProviderId, providerSupportsReasoningEffort } from '../services/agent-provider-service.js';
 import { buildAgentManagerHtml } from './agent-manager-html.js';
 
 export class AgentManagerWebview {
@@ -49,8 +49,8 @@ export class AgentManagerWebview {
 
     private async render(): Promise<void> {
         const config = vscode.workspace.getConfiguration('n8n.agent');
-        const provider = normalizeYagrProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
-        const definition = YAGR_PROVIDER_DEFINITIONS[provider];
+        const provider = normalizeAgentProviderId(String(config.get<string>('provider') || 'openai')) || 'openai';
+        const definition = AGENT_PROVIDER_DEFINITIONS[provider];
         this._panel.webview.html = buildAgentManagerHtml({
             provider,
             providerLabel: definition.label,

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -9,7 +9,7 @@ export interface AgentWorkbenchHtmlInput {
     providerModelLabel: string;
 }
 
-export const AGENT_WORKBENCH_BUILD = 'awb-2026.05.20.27-clean-multithread-codex';
+export const AGENT_WORKBENCH_BUILD = 'awb-2026.05.20.31-agent-provider-rename';
 
 function escapeHtml(value: string): string {
     return value

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -2823,6 +2823,20 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             const message = event.data;
             if (!message || typeof message !== 'object') return;
 
+            if (message.type === 'panel.visibility') {
+                const isVisible = Boolean(message.visible);
+                if (!isVisible) {
+                    if (frame && frame.src !== 'about:blank') {
+                        frame.src = 'about:blank';
+                    }
+                } else {
+                    if (frame && frame.src !== workflowUrl && workflowUrl) {
+                        frame.src = workflowUrl;
+                    }
+                }
+                return;
+            }
+
             if (message.type === 'workflow.reload') {
                 vscode.postMessage({ type: 'workflow.reloadAck', workflowId, hasFrame: Boolean(frame), url: workflowReloadUrl || workflowUrl || '' });
                 reloadWorkflowFrame();

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -1,13 +1,15 @@
 export interface AgentWorkbenchHtmlInput {
     workflowId: string;
     workflowName: string;
+    workflowFilename?: string;
+    workflowFilePath?: string;
     workflowAttached?: boolean;
     workflowUrl?: string;
     workflowReloadUrl?: string;
     providerModelLabel: string;
 }
 
-export const AGENT_WORKBENCH_BUILD = 'awb-2026.05.20.5-latency-probe';
+export const AGENT_WORKBENCH_BUILD = 'awb-2026.05.20.27-clean-multithread-codex';
 
 function escapeHtml(value: string): string {
     return value
@@ -37,6 +39,9 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
     const safeProviderModelLabel = escapeHtml(input.providerModelLabel);
     const safeWorkbenchBuild = escapeHtml(AGENT_WORKBENCH_BUILD);
     const workflowIdJs = JSON.stringify(input.workflowId);
+    const workflowNameJs = JSON.stringify(input.workflowName || input.workflowId || 'Current workflow');
+    const workflowFilenameJs = JSON.stringify(input.workflowFilename || '');
+    const workflowFilePathJs = JSON.stringify(input.workflowFilePath || '');
     const workflowUrlJs = JSON.stringify(input.workflowUrl || '');
     const workflowReloadUrlJs = JSON.stringify(input.workflowReloadUrl || input.workflowUrl || '');
 
@@ -1285,8 +1290,14 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
     <script nonce="${nonce}">
         const vscode = acquireVsCodeApi();
         let workflowId = ${workflowIdJs};
+        let workflowName = ${workflowNameJs};
+        let workflowFilename = ${workflowFilenameJs};
+        let workflowFilePath = ${workflowFilePathJs};
         let workflowUrl = ${workflowUrlJs};
         let workflowReloadUrl = ${workflowReloadUrlJs};
+        let openWorkflowContext = workflowId || workflowFilename || workflowFilePath
+            ? { id: workflowId || undefined, name: workflowName, filename: workflowFilename || undefined, filePath: workflowFilePath || undefined }
+            : null;
         let iframeOrigin = ${JSON.stringify(iframePermissionOrigin)};
         const PASTE_RATE_LIMIT_MS = 1000;
         const GRANT_TTL_MS = 5000;
@@ -1295,6 +1306,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         let isRunning = false;
         let currentWorkflowContext = null;
         let currentNodeContexts = [];
+        let availableWorkflowCache = [];
         let activeFilter = 'current';
         let state = null;
         let providerModelCache = {};
@@ -1601,8 +1613,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                     event.preventDefault();
                     event.stopPropagation();
                     if (deleteButton.disabled) return;
-                    const confirmed = window.confirm('Delete this conversation? This cannot be undone.');
-                    if (!confirmed) return;
                     vscode.postMessage({ type: 'agent.session.delete', sessionId: session.id });
                 });
                 badges.appendChild(deleteButton);
@@ -1738,9 +1748,10 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
 
             const list = document.createElement('div');
             list.className = 'inline-popover-list';
-            if (currentWorkflowContext) {
-                const current = inlineOption('This workflow', currentWorkflowContext.name || 'Current workflow', 'Current', 'workflow');
-                current.addEventListener('click', () => startNewSession(currentWorkflowContext));
+            const menuWorkflowContext = currentWorkflowContext || openWorkflowContext;
+            if (menuWorkflowContext) {
+                const current = inlineOption('This workflow', menuWorkflowContext.name || 'Current workflow', 'Current', 'workflow');
+                current.addEventListener('click', () => startNewSession(menuWorkflowContext));
                 list.appendChild(current);
             }
 
@@ -1748,13 +1759,13 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             blank.addEventListener('click', () => startNewSession(null));
             list.appendChild(blank);
 
-            const workflows = Array.isArray(state.availableWorkflows) ? state.availableWorkflows : [];
+            const workflows = Array.isArray(state.availableWorkflows) ? state.availableWorkflows : availableWorkflowCache;
             if (workflows.length) {
                 const divider = document.createElement('div');
                 divider.className = 'inline-divider';
                 list.appendChild(divider);
             }
-            const currentKey = workflowKey(currentWorkflowContext);
+            const currentKey = workflowKey(menuWorkflowContext);
             for (const workflow of workflows) {
                 const key = workflowKey(workflow);
                 if (currentKey && key && key === currentKey) continue;
@@ -2395,6 +2406,9 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         }
 
         function renderAll() {
+            if (state && Array.isArray(state.availableWorkflows)) {
+                availableWorkflowCache = state.availableWorkflows;
+            }
             currentWorkflowContext = state && state.session ? state.session.workflowContext || null : null;
             setNodeContexts(state && state.session ? state.session.nodeContexts || [] : [], false);
             renderSessions();
@@ -2795,7 +2809,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             renderReasoningMenu();
         });
         function startNewSession(workflow) {
-            if (isRunning) return;
             closeHistory();
             closeCheckpointPanel();
             closeInlineMenus();
@@ -2842,6 +2855,12 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 const nextWorkflowUrl = message.url;
                 const shouldUpdateFrame = nextWorkflowUrl !== workflowUrl;
                 workflowId = String(message.workflowId || workflowId);
+                workflowName = String(message.workflowName || workflowName || workflowId || 'Current workflow');
+                workflowFilename = String(message.workflowFilename || workflowFilename || '');
+                workflowFilePath = String(message.workflowFilePath || workflowFilePath || '');
+                openWorkflowContext = workflowId || workflowFilename || workflowFilePath
+                    ? { id: workflowId || undefined, name: workflowName, filename: workflowFilename || undefined, filePath: workflowFilePath || undefined }
+                    : null;
                 workflowUrl = nextWorkflowUrl;
                 workflowReloadUrl = typeof message.reloadUrl === 'string' && message.reloadUrl ? message.reloadUrl : workflowUrl;
                 try { iframeOrigin = new URL(workflowUrl).origin; } catch (e) { iframeOrigin = 'src'; }

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -9,7 +9,7 @@ export interface AgentWorkbenchHtmlInput {
     providerModelLabel: string;
 }
 
-export const AGENT_WORKBENCH_BUILD = 'awb-2026.05.20.31-agent-provider-rename';
+export const AGENT_WORKBENCH_BUILD = 'awb-2026.05.20.32-codex-tool-schema';
 
 function escapeHtml(value: string): string {
     return value

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -9,7 +9,7 @@ export interface AgentWorkbenchHtmlInput {
     providerModelLabel: string;
 }
 
-export const AGENT_WORKBENCH_BUILD = 'awb-2026.05.20.33-workflow-context-assets';
+export const AGENT_WORKBENCH_BUILD = 'awb-2026.05.21.1-last-active-session';
 
 function escapeHtml(value: string): string {
     return value

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -9,7 +9,7 @@ export interface AgentWorkbenchHtmlInput {
     providerModelLabel: string;
 }
 
-export const AGENT_WORKBENCH_BUILD = 'awb-2026.05.20.32-codex-tool-schema';
+export const AGENT_WORKBENCH_BUILD = 'awb-2026.05.20.33-workflow-context-assets';
 
 function escapeHtml(value: string): string {
     return value

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -1378,8 +1378,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             sendButton.disabled = false;
             stopButton.disabled = !running;
             stopButton.classList.toggle('active', running);
-            newSessionButton.disabled = running;
-            newSessionHeaderButton.disabled = running;
             checkpointOpenButton.disabled = running;
             checkpointSaveButton.disabled = running;
             compactContextButton.disabled = running;

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -1596,7 +1596,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 deleteButton.title = 'Delete conversation';
                 deleteButton.setAttribute('aria-label', 'Delete conversation ' + session.title);
                 deleteButton.innerHTML = ${JSON.stringify(trashIcon)};
-                deleteButton.disabled = Boolean(isRunning && session.isActive);
+                deleteButton.disabled = Boolean(session.isRunning);
                 deleteButton.addEventListener('click', (event) => {
                     event.preventDefault();
                     event.stopPropagation();
@@ -1740,13 +1740,11 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             list.className = 'inline-popover-list';
             if (currentWorkflowContext) {
                 const current = inlineOption('This workflow', currentWorkflowContext.name || 'Current workflow', 'Current', 'workflow');
-                current.disabled = isRunning;
                 current.addEventListener('click', () => startNewSession(currentWorkflowContext));
                 list.appendChild(current);
             }
 
             const blank = inlineOption('New workflow', 'Start without workflow context', '', 'workflow');
-            blank.disabled = isRunning;
             blank.addEventListener('click', () => startNewSession(null));
             list.appendChild(blank);
 
@@ -1763,7 +1761,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 const label = workflow.name || workflow.id || workflow.filename || 'Workflow';
                 const detail = [workflow.filename, workflow.id].filter(Boolean).join(' · ') || 'Existing workflow';
                 const option = inlineOption(label, detail, '', 'workflow');
-                option.disabled = isRunning;
                 option.addEventListener('click', () => startNewSession(workflow));
                 list.appendChild(option);
             }

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -29,7 +29,9 @@ interface AgentWorkbenchWorkflowProviders {
 }
 
 export class AgentWorkbenchWebview {
-    public static currentPanel: AgentWorkbenchWebview | undefined;
+    private static readonly _panels = new Map<string, AgentWorkbenchWebview>();
+    private static _lastActiveSessionId: string | undefined;
+    private static _clipboardPasteHandler: ((panel: vscode.WebviewPanel, grantToken: string) => Promise<void>) | undefined;
 
     private readonly _panel: vscode.WebviewPanel;
     private readonly _context: vscode.ExtensionContext;
@@ -45,7 +47,6 @@ export class AgentWorkbenchWebview {
     private _nodeContexts: AgentWorkbenchNodeContext[] = [];
     private _workflowProviders: AgentWorkbenchWorkflowProviders;
     private _activeSessionId: string | undefined;
-    private _onClipboardPasteRequest: ((panel: vscode.WebviewPanel, grantToken: string) => Promise<void>) | undefined;
     private _stateSequence = 0;
 
     private constructor(
@@ -76,7 +77,15 @@ export class AgentWorkbenchWebview {
 
         this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
         this._panel.onDidChangeViewState((event) => {
-            if (event.webviewPanel.visible) {
+            const isVisible = event.webviewPanel.visible;
+            void this._panel.webview.postMessage({
+                type: 'panel.visibility',
+                visible: isVisible,
+            });
+            if (event.webviewPanel.active && this._activeSessionId) {
+                AgentWorkbenchWebview._lastActiveSessionId = this._activeSessionId;
+            }
+            if (isVisible) {
                 void this.postWorkbenchState();
             }
         }, null, this._disposables);
@@ -105,12 +114,14 @@ export class AgentWorkbenchWebview {
     ): void {
         const column = viewColumn || vscode.ViewColumn.One;
 
-        if (AgentWorkbenchWebview.currentPanel) {
-            AgentWorkbenchWebview.currentPanel._panel.reveal(column);
-            AgentWorkbenchWebview.currentPanel._workflowProviders = workflowProviders;
-            AgentWorkbenchWebview.currentPanel._activeSessionId = initialSessionId || AgentWorkbenchWebview.currentPanel._activeSessionId;
-            AgentWorkbenchWebview.currentPanel.update(workflow, workflowFilePath, workflowUrl, workflowReloadUrl, providerModelLabel);
-            return;
+        if (initialSessionId) {
+            const existingPanel = AgentWorkbenchWebview._panels.get(initialSessionId);
+            if (existingPanel) {
+                existingPanel._panel.reveal(column);
+                existingPanel._workflowProviders = workflowProviders;
+                existingPanel.update(workflow, workflowFilePath, workflowUrl, workflowReloadUrl, providerModelLabel);
+                return;
+            }
         }
 
         const panel = vscode.window.createWebviewPanel(
@@ -124,17 +135,19 @@ export class AgentWorkbenchWebview {
             },
         );
 
-        AgentWorkbenchWebview.currentPanel = new AgentWorkbenchWebview(panel, context, workflow, workflowFilePath, workflowUrl, workflowReloadUrl, providerModelLabel, agentRuntime, outputChannel, workflowProviders, initialSessionId);
-    }
-
-    public static onClipboardPasteRequest(handler: (panel: vscode.WebviewPanel, grantToken: string) => Promise<void>): void {
-        if (AgentWorkbenchWebview.currentPanel) {
-            AgentWorkbenchWebview.currentPanel._onClipboardPasteRequest = handler;
+        const workbench = new AgentWorkbenchWebview(panel, context, workflow, workflowFilePath, workflowUrl, workflowReloadUrl, providerModelLabel, agentRuntime, outputChannel, workflowProviders, initialSessionId);
+        if (initialSessionId) {
+            AgentWorkbenchWebview._panels.set(initialSessionId, workbench);
+            AgentWorkbenchWebview._lastActiveSessionId = initialSessionId;
         }
     }
 
+    public static onClipboardPasteRequest(handler: (panel: vscode.WebviewPanel, grantToken: string) => Promise<void>): void {
+        AgentWorkbenchWebview._clipboardPasteHandler = handler;
+    }
+
     public static getCurrentActiveSessionId(): string | undefined {
-        return AgentWorkbenchWebview.currentPanel?._activeSessionId;
+        return AgentWorkbenchWebview._lastActiveSessionId;
     }
 
     public update(workflow: IWorkflowStatus | undefined, workflowFilePath: string | undefined, workflowUrl: string | undefined, workflowReloadUrl: string | undefined, providerModelLabel: string, postState = true): void {
@@ -166,8 +179,11 @@ export class AgentWorkbenchWebview {
     }
 
     public dispose(): void {
-        if (AgentWorkbenchWebview.currentPanel === this) {
-            AgentWorkbenchWebview.currentPanel = undefined;
+        if (this._activeSessionId) {
+            AgentWorkbenchWebview._panels.delete(this._activeSessionId);
+            if (AgentWorkbenchWebview._lastActiveSessionId === this._activeSessionId) {
+                AgentWorkbenchWebview._lastActiveSessionId = undefined;
+            }
         }
         this._registryDisposable?.dispose();
         this._registryDisposable = undefined;
@@ -205,7 +221,7 @@ export class AgentWorkbenchWebview {
         }
 
         if (payload.type === 'clipboard-paste-request' && typeof payload.grantToken === 'string') {
-            void this._onClipboardPasteRequest?.(this._panel, payload.grantToken)
+            void AgentWorkbenchWebview._clipboardPasteHandler?.(this._panel, payload.grantToken)
                 ?.catch(error => console.error('[AgentWorkbench] Clipboard paste handler error', error));
             return;
         }
@@ -294,7 +310,8 @@ export class AgentWorkbenchWebview {
         }
 
         if (payload.type === 'agent.stop') {
-            await this._agentRuntime.stop((event) => this._panel.webview.postMessage(event));
+            const sessionId = typeof payload.sessionId === 'string' ? payload.sessionId : this._activeSessionId;
+            await this._agentRuntime.stop((event) => this._panel.webview.postMessage(event), sessionId);
             return;
         }
 
@@ -319,13 +336,19 @@ export class AgentWorkbenchWebview {
                     nodeContext: undefined,
                     nodeContexts: undefined,
                 };
-            await this.postWorkbenchState(await this._agentRuntime.createSession(input));
+            const state = await this._agentRuntime.createSession(input);
+            await vscode.commands.executeCommand('n8n.openAgentWorkbench', { sessionId: state.activeSessionId, workflow });
             return;
         }
 
         if (payload.type === 'agent.session.select' && typeof payload.sessionId === 'string') {
-            this._activeSessionId = payload.sessionId;
-            await this.postWorkbenchState(await this._agentRuntime.selectSession(payload.sessionId, this.buildWorkbenchInput()));
+            const sessionId = payload.sessionId;
+            const existingPanel = AgentWorkbenchWebview._panels.get(sessionId);
+            if (existingPanel) {
+                existingPanel._panel.reveal();
+            } else {
+                await vscode.commands.executeCommand('n8n.openAgentWorkbench', { sessionId });
+            }
             return;
         }
 
@@ -493,8 +516,20 @@ export class AgentWorkbenchWebview {
         const enrich = options.enrich !== false;
         const stateSequence = ++this._stateSequence;
         const nextState = state ?? await this._agentRuntime.getWorkbenchState(this.buildWorkbenchInput());
-        this._activeSessionId = nextState.activeSessionId;
+        const oldSessionId = this._activeSessionId;
+        const newSessionId = nextState.activeSessionId;
+        this._activeSessionId = newSessionId;
         this._nodeContexts = Array.isArray(nextState.currentNodeContexts) ? nextState.currentNodeContexts : [];
+
+        if (oldSessionId && oldSessionId !== newSessionId) {
+            AgentWorkbenchWebview._panels.delete(oldSessionId);
+        }
+        if (newSessionId) {
+            AgentWorkbenchWebview._panels.set(newSessionId, this);
+            if (this._panel.active) {
+                AgentWorkbenchWebview._lastActiveSessionId = newSessionId;
+            }
+        }
         if (!enrich) {
             await this._panel.webview.postMessage({ type: 'agent.state', state: nextState, stateSequence });
             if (!nextState.isRunning) {

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -547,15 +547,22 @@ export class AgentWorkbenchWebview {
                 AgentWorkbenchWebview._panels.delete(oldSessionId);
             }
         }
+        let ownsNewSession = false;
         if (newSessionId) {
             const existingOwner = AgentWorkbenchWebview._panels.get(newSessionId);
             if (!existingOwner || existingOwner === this) {
                 // Only claim the session if it is unclaimed or already ours.
                 AgentWorkbenchWebview._panels.set(newSessionId, this);
+                ownsNewSession = true;
+            } else {
+                ownsNewSession = false;
             }
-            if (this._panel.active) {
+            if (this._panel.active && ownsNewSession) {
                 AgentWorkbenchWebview._lastActiveSessionId = newSessionId;
             }
+        }
+        if (this._panel.active && !ownsNewSession && AgentWorkbenchWebview._lastActiveSessionId === oldSessionId) {
+            AgentWorkbenchWebview._lastActiveSessionId = undefined;
         }
         if (!enrich) {
             await this._panel.webview.postMessage({ type: 'agent.state', state: nextState, stateSequence });

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -172,6 +172,8 @@ export class AgentWorkbenchWebview {
             type: 'workflow.update',
             workflowId: workflow?.id || '',
             workflowName: workflow?.name || 'New workflow',
+            workflowFilename: workflow?.filename || '',
+            workflowFilePath: workflowFilePath || '',
             url: workflowUrl,
             reloadUrl: workflowReloadUrl,
         });
@@ -361,7 +363,22 @@ export class AgentWorkbenchWebview {
         }
 
         if (payload.type === 'agent.session.delete' && typeof payload.sessionId === 'string') {
-            await this.postWorkbenchState(await this._agentRuntime.deleteSession(payload.sessionId, this.buildWorkbenchInput()));
+            const sessionId = payload.sessionId;
+            const confirmed = await vscode.window.showWarningMessage(
+                'Delete this conversation? This cannot be undone.',
+                { modal: true },
+                'Delete',
+            );
+            if (confirmed !== 'Delete') return;
+            const deletedPanel = AgentWorkbenchWebview._panels.get(sessionId);
+            const state = await this._agentRuntime.deleteSession(sessionId, this.buildWorkbenchInput());
+            if (AgentWorkbenchWebview._panels.get(sessionId) === deletedPanel) {
+                AgentWorkbenchWebview._panels.delete(sessionId);
+            }
+            if (deletedPanel && deletedPanel !== this) {
+                deletedPanel.dispose();
+            }
+            await this.postWorkbenchState(state);
             return;
         }
 
@@ -595,10 +612,17 @@ export class AgentWorkbenchWebview {
 
     private async getWorkflowOptions(): Promise<AgentWorkflowContext[]> {
         const workflows = await this._workflowProviders.listWorkflows().catch(() => []);
-        return workflows.map((workflow) => ({
-            id: workflow.id || undefined,
-            name: workflow.name || workflow.id || workflow.filename || 'Workflow',
-            filename: workflow.filename || undefined,
+        return Promise.all(workflows.map(async (workflow) => {
+            const base = {
+                id: workflow.id || undefined,
+                name: workflow.name || workflow.id || workflow.filename || 'Workflow',
+                filename: workflow.filename || undefined,
+            };
+            const target = await this._workflowProviders.resolveWorkflow(base).catch(() => undefined);
+            return {
+                ...base,
+                filePath: target?.workflowFilePath,
+            };
         }));
     }
 
@@ -670,6 +694,8 @@ export class AgentWorkbenchWebview {
         return buildAgentWorkbenchHtml({
             workflowId: this._workflow?.id || '',
             workflowName: this._workflow?.name || 'New workflow',
+            workflowFilename: this._workflow?.filename,
+            workflowFilePath: this._workflowFilePath,
             workflowAttached: Boolean(this._workflow),
             workflowUrl: this._workflowUrl,
             workflowReloadUrl: this._workflowReloadUrl,

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -180,7 +180,10 @@ export class AgentWorkbenchWebview {
 
     public dispose(): void {
         if (this._activeSessionId) {
-            AgentWorkbenchWebview._panels.delete(this._activeSessionId);
+            // Only clean up map entries that this panel owns to avoid evicting sibling panels.
+            if (AgentWorkbenchWebview._panels.get(this._activeSessionId) === this) {
+                AgentWorkbenchWebview._panels.delete(this._activeSessionId);
+            }
             if (AgentWorkbenchWebview._lastActiveSessionId === this._activeSessionId) {
                 AgentWorkbenchWebview._lastActiveSessionId = undefined;
             }
@@ -522,10 +525,17 @@ export class AgentWorkbenchWebview {
         this._nodeContexts = Array.isArray(nextState.currentNodeContexts) ? nextState.currentNodeContexts : [];
 
         if (oldSessionId && oldSessionId !== newSessionId) {
-            AgentWorkbenchWebview._panels.delete(oldSessionId);
+            // Only remove the old entry if this panel still owns it (avoid evicting another panel).
+            if (AgentWorkbenchWebview._panels.get(oldSessionId) === this) {
+                AgentWorkbenchWebview._panels.delete(oldSessionId);
+            }
         }
         if (newSessionId) {
-            AgentWorkbenchWebview._panels.set(newSessionId, this);
+            const existingOwner = AgentWorkbenchWebview._panels.get(newSessionId);
+            if (!existingOwner || existingOwner === this) {
+                // Only claim the session if it is unclaimed or already ours.
+                AgentWorkbenchWebview._panels.set(newSessionId, this);
+            }
             if (this._panel.active) {
                 AgentWorkbenchWebview._lastActiveSessionId = newSessionId;
             }

--- a/packages/vscode-extension/src/ui/configuration-webview.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview.ts
@@ -5,7 +5,7 @@ import type { UpsertGlobalN8nInstanceInput } from '@n8n-as-code/n8n-manager-core
 import { ConfigService, resolveInstanceIdentifier } from 'n8nac';
 import { getWorkspaceRoot } from '../utils/state-detection.js';
 import type { N8nConfigurationController, N8nConfigurationSnapshot } from '../services/n8n-configuration-controller.js';
-import { YagrProviderService, normalizeYagrProviderId } from '../services/yagr-provider-service.js';
+import { AgentProviderService, normalizeAgentProviderId } from '../services/agent-provider-service.js';
 import { getConfigurationHtml } from './configuration-webview-html.js';
 import { runWorkspaceMigrationFromVscode } from '../services/workspace-migration-runner.js';
 import { loadProjectsForConfigurationWebview } from './configuration-webview-projects.js';
@@ -104,7 +104,7 @@ export class ConfigurationWebview {
   private readonly _panel: vscode.WebviewPanel;
   private readonly _context: vscode.ExtensionContext;
   private readonly _configurationController: N8nConfigurationController;
-  private readonly _providerService: YagrProviderService;
+  private readonly _providerService: AgentProviderService;
   private readonly _disposables: vscode.Disposable[] = [];
   private _stateVersion = 0;
   private _initialTab: string | undefined;
@@ -122,7 +122,7 @@ export class ConfigurationWebview {
     this._panel = panel;
     this._context = context;
     this._configurationController = configurationController;
-    this._providerService = new YagrProviderService(context);
+    this._providerService = new AgentProviderService(context);
     this._initialTab = initialTab;
 
     this._panel.onDidDispose(() => {
@@ -573,7 +573,7 @@ export class ConfigurationWebview {
           return;
 
         case 'connectProvider': {
-          const provider = normalizeYagrProviderId(String(payload.provider || ''));
+          const provider = normalizeAgentProviderId(String(payload.provider || ''));
           if (!provider) throw new Error('Unsupported provider.');
           const configured = await this._providerService.setupProvider(provider);
           if (configured) {
@@ -586,7 +586,7 @@ export class ConfigurationWebview {
         }
 
         case 'disconnectProvider': {
-          const provider = normalizeYagrProviderId(String(payload.provider || ''));
+          const provider = normalizeAgentProviderId(String(payload.provider || ''));
           if (!provider) throw new Error('Unsupported provider.');
           await this._providerService.disconnectProvider(provider);
           await this.postInitialState();

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -214,8 +214,8 @@ test('Agent runtime: start state includes checkpointed user message', () => {
     const path = require('node:path');
     const source = fs.readFileSync(path.join(__dirname, '../../src/services/agent-runtime-controller.ts'), 'utf8');
 
-    const stateIndex = source.indexOf("await postMessage({ type: 'agent.state', state: await this.getWorkbenchState({ ...input, sessionId: activeRecord.id }) });");
-    const startIndex = source.indexOf("await postMessage({ type: 'agent.streamEvent', event: { type: 'start', sessionId: activeRecord.id, message: prompt } });");
+    const stateIndex = source.indexOf("await postMessage({ type: 'agent.state', state: await this.getWorkbenchState({ ...input, sessionId: targetSessionId }) });");
+    const startIndex = source.indexOf("await postMessage({ type: 'agent.streamEvent', event: { type: 'start', sessionId: targetSessionId, message: prompt } });");
     assert.ok(stateIndex >= 0, 'Must post the checkpointed user-message state before streaming starts');
     assert.ok(startIndex > stateIndex, 'The start event must follow the checkpointed state so rewind controls exist during a stopped run');
 });
@@ -291,3 +291,18 @@ test('Agent Workbench HTML: context usage and compaction follow agent runtime co
     assert.ok(html.includes('Context compacted with fallback'), 'Must label fallback compactions explicitly');
     assert.ok(html.includes("type: 'agent.context.compact'"), 'Must request runtime compaction from the extension host');
 });
+
+test('Agent Workbench HTML: handles panel.visibility to unload/reload iframe', () => {
+    const { buildAgentWorkbenchHtml } = require('../../src/ui/agent-workbench-html.js');
+    const html: string = buildAgentWorkbenchHtml({
+        workflowId: 'wf-1',
+        workflowName: 'Workflow 1',
+        workflowUrl: 'http://localhost:5678/workflow/wf-1',
+        providerModelLabel: 'openai / gpt-5.4',
+    });
+
+    assert.ok(html.includes("message.type === 'panel.visibility'"), 'Must handle panel.visibility messages');
+    assert.ok(html.includes("frame.src = 'about:blank'"), 'Must set frame.src to about:blank when hidden');
+    assert.ok(html.includes("frame.src = workflowUrl"), 'Must restore original workflowUrl when visible');
+});
+

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -191,6 +191,60 @@ test('Agent runtime: workbench uses the native DeepAgents v3 run stream', () => 
     }
 });
 
+test('Agent runtime: Codex v3 output adapter reads provider output items', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const source = fs.readFileSync(path.join(__dirname, '../../src/services/agent-runtime-controller.ts'), 'utf8');
+
+    assert.ok(source.includes('extractProviderOutputItemsText'), 'Must read provider-specific output metadata when native final content is empty');
+    assert.ok(source.includes('codex_output_items'), 'Must handle Codex raw Responses output stored by the local Codex provider runtime');
+    assert.ok(source.includes('rawOutputItems'), 'Must handle raw output item metadata from the Codex provider runtime');
+    assert.ok(source.includes('lastProviderTextChars'), 'Debug logs must make provider-output text extraction visible');
+    assert.ok(source.includes("type === 'output_text'"), 'Must extract text from Responses API output_text blocks');
+});
+
+test('Agent runtime: Codex stream keeps parallel tool calls separated', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const source = fs.readFileSync(path.join(__dirname, '../../src/services/agent-provider-runtime/chat-codex-oauth.ts'), 'utf8');
+
+    assert.ok(source.includes('toolCallIndexes = new Map'), 'Codex tool-call indexes must be stable per tool call id');
+    assert.ok(source.includes('index: index') || source.includes('index,'), 'Native LangChain tool-call chunks must receive distinct indexes');
+    assert.ok(source.includes('additional_kwargs'), 'Provider additional_kwargs tool calls must receive matching indexes');
+    assert.ok(source.includes('createOpenAiAccountLanguageModel'), 'The index mapping must live inside the local Codex LangChain model');
+});
+
+test('Agent runtime: agent provider runtime dependency is removed', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const controller = fs.readFileSync(path.join(__dirname, '../../src/services/agent-runtime-controller.ts'), 'utf8');
+    const providerService = fs.readFileSync(path.join(__dirname, '../../src/services/agent-provider-service.ts'), 'utf8');
+    const localFactory = fs.readFileSync(path.join(__dirname, '../../src/services/agent-provider-runtime/create-langchain-model.ts'), 'utf8');
+    const packageJson = fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf8');
+    const removedRuntimePackage = `@${String.fromCharCode(121, 97, 103, 114)}/provider-runtime`;
+    const removedServiceName = `${String.fromCharCode(121, 97, 103, 114)}-provider-service`;
+
+    assert.ok(!controller.includes(removedRuntimePackage), 'Agent runtime must not import the external agent provider runtime');
+    assert.ok(!providerService.includes(removedRuntimePackage), 'Provider service must not import the external agent provider runtime');
+    assert.ok(!packageJson.includes(removedRuntimePackage), 'Extension package must not depend on the external agent provider runtime');
+    assert.ok(!controller.includes(removedServiceName), 'Agent runtime imports must use the renamed provider service');
+    assert.ok(localFactory.includes("case 'minimax'"), 'MiniMax must be handled by the local provider factory');
+    assert.ok(localFactory.includes('ChatAnthropic'), 'MiniMax M2 Anthropic-compatible endpoint should use the standard LangChain Anthropic model');
+    assert.ok(localFactory.includes('anthropicApiUrl'), 'MiniMax must use LangChain standard Anthropic-compatible base URL support');
+    assert.ok(!packageJson.includes('@langchain/community'), 'Do not add the old ChatMinimax integration for the Anthropic-compatible MiniMax path');
+});
+
+test('Agent runtime: invalid tool-call recovery stays hidden from the Workbench', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const source = fs.readFileSync(path.join(__dirname, '../../src/services/agent-runtime-controller.ts'), 'utf8');
+
+    assert.ok(source.includes('isInternalRecoveryText'), 'Must identify internal recovery prompts');
+    assert.ok(source.includes('pendingVisibleText.startsWith(INVALID_TOOL_CALL_RECOVERY_MARKER)'), 'Event projection must suppress recovery prompts before rendering');
+    assert.ok(source.includes('pendingText.startsWith(INVALID_TOOL_CALL_RECOVERY_MARKER)'), 'Message text projection must suppress recovery prompts before rendering');
+    assert.ok(source.includes('if (this.isInternalRecoveryText(value)) return'), 'Sanitization must never return internal recovery text as an assistant answer');
+});
+
 test('Agent runtime: LangGraph checkpoints are sharded by thread', () => {
     const fs = require('node:fs');
     const path = require('node:path');

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -22,6 +22,8 @@ test('Agent Workbench HTML: forwards node detail context to the agent', () => {
     const html: string = buildAgentWorkbenchHtml({
         workflowId: 'wf-1',
         workflowName: 'Workflow 1',
+        workflowFilename: 'Workflow 1.workflow.ts',
+        workflowFilePath: '/workspace/workflows/dev3/Workflow 1.workflow.ts',
         workflowUrl: 'http://localhost:5678/workflow/wf-1',
         providerModelLabel: 'openai / gpt-5.4',
     });
@@ -50,14 +52,18 @@ test('Agent Workbench HTML: renders provider/session controls', () => {
     assert.ok(html.includes("type: 'agent.session.new'"), 'Must allow creating new persisted sessions');
     assert.ok(html.includes("type: 'agent.session.delete'"), 'Must allow deleting persisted sessions from history');
     assert.ok(html.includes("className = 'ghost session-delete'"), 'Must render a trash icon button for each persisted session');
-    assert.ok(html.includes('Delete this conversation? This cannot be undone.'), 'Must confirm before deleting a session');
+    assert.ok(!html.includes("window.confirm('Delete this conversation? This cannot be undone.')"), 'Conversation delete confirmation must be handled by the extension host');
     assert.ok(html.includes('id="new-session-menu"'), 'Must render new conversation context picker');
     assert.ok(html.includes('This workflow'), 'Must allow a new chat for the current workflow');
     assert.ok(html.includes('New workflow'), 'Must allow a new unattached workflow chat');
     assert.ok(html.includes('state.availableWorkflows'), 'Must list available workflows in the new chat picker');
+    assert.ok(html.includes('availableWorkflowCache'), 'Must keep the new conversation workflow menu stable while runtime state is lightweight');
+    assert.ok(html.includes('const menuWorkflowContext = currentWorkflowContext || openWorkflowContext'), 'Must show the currently open workflow while a run is active');
+    assert.ok(html.includes('workflowFilename'), 'Must preserve the open workflow filename in the client fallback context');
+    assert.ok(html.includes('workflowFilePath'), 'Must preserve the open workflow file path in the client fallback context');
     assert.ok(html.includes('startNewSession(null)'), 'Must request an unattached session for new workflow');
-    assert.ok(html.includes('blank.disabled = isRunning'), 'Must disable new-session options while a run is active');
-    assert.ok(html.includes('if (isRunning) return;'), 'Must guard against starting a new session while a run is active');
+    assert.ok(!html.includes('blank.disabled = isRunning'), 'Parallel chats must allow starting a new session while a run is active');
+    assert.ok(!html.includes('function startNewSession(workflow) {\n            if (isRunning) return;'), 'Parallel chats must not guard new-session creation on the current run state');
     assert.ok(html.includes('history-overlay'), 'Must render conversation history as a modal overlay');
     assert.ok(html.includes("type: 'agent.ready'"), 'Must request initial state from the extension host');
     assert.ok(html.includes('openai / gpt-5.4'), 'Must render selected provider/model label');
@@ -209,6 +215,31 @@ test('Agent Workbench state delivery: runtime states are lightweight and ordered
     assert.ok(source.includes('await this.postWorkbenchState(message.state, { enrich: false });'), 'Runtime state messages should use the lightweight path');
 });
 
+test('Agent Workbench webview: conversation deletion is confirmed and cleans panel ownership', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const source = fs.readFileSync(path.join(__dirname, '../../src/ui/agent-workbench-webview.ts'), 'utf8');
+
+    assert.ok(source.includes("payload.type === 'agent.session.delete'"), 'Must handle session deletion messages');
+    assert.ok(source.includes('vscode.window.showWarningMessage('), 'Session deletion must use a VS Code host confirmation dialog');
+    assert.ok(source.includes("confirmed !== 'Delete'"), 'Session deletion must be cancellable');
+    assert.ok(source.includes('AgentWorkbenchWebview._panels.delete(sessionId)'), 'Deleting a session must clear stale panel ownership');
+    assert.ok(source.includes('deletedPanel.dispose()'), 'Deleting a session from another panel must close that stale panel');
+});
+
+test('Agent Workbench webview: workflow menu options preserve local file paths', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const source = fs.readFileSync(path.join(__dirname, '../../src/ui/agent-workbench-webview.ts'), 'utf8');
+
+    assert.ok(source.includes('resolveWorkflow(base)'), 'Available workflows should resolve their local file targets');
+    assert.ok(source.includes('filePath: target?.workflowFilePath'), 'Available workflow options must include local file paths');
+    assert.ok(source.includes('workflowFilename: this._workflow?.filename'), 'Initial HTML must receive the current workflow filename');
+    assert.ok(source.includes('workflowFilePath: this._workflowFilePath'), 'Initial HTML must receive the current workflow file path');
+    assert.ok(source.includes("workflowFilename: workflow?.filename || ''"), 'Workflow update messages must preserve filename');
+    assert.ok(source.includes('workflowFilePath: workflowFilePath ||'), 'Workflow update messages must preserve file path');
+});
+
 test('Agent runtime: start state includes checkpointed user message', () => {
     const fs = require('node:fs');
     const path = require('node:path');
@@ -305,4 +336,3 @@ test('Agent Workbench HTML: handles panel.visibility to unload/reload iframe', (
     assert.ok(html.includes("frame.src = 'about:blank'"), 'Must set frame.src to about:blank when hidden');
     assert.ok(html.includes("frame.src = workflowUrl"), 'Must restore original workflowUrl when visible');
 });
-

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -268,6 +268,34 @@ test('Agent runtime: LangGraph checkpoints are sharded by thread', () => {
     assert.ok(!source.includes('storage: this.storage,\n                                writes: this.writes'), 'Checkpoint writes must not rewrite one global monolithic JSON file');
 });
 
+test('Agent runtime: written workflow files update the owning conversation context', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const source = fs.readFileSync(path.join(__dirname, '../../src/services/agent-runtime-controller.ts'), 'utf8');
+
+    assert.ok(source.includes('writtenWorkflowPaths'), 'Runtime must track workflow files written by the current run');
+    assert.ok(source.includes('inferWorkflowContextFromWrittenFiles'), 'Runtime must infer context from files written by this run');
+    assert.ok(source.includes('runResult.workflowContext'), 'Run result must carry the inferred workflow context back to the session');
+    assert.ok(!source.includes('runResult.workflowChanged && !promptWorkflowContext'), 'Existing context must not prevent switching to a newly written workflow');
+});
+
+test('CLI skills assets: dev resolution validates candidate assets before use', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const rootPackage = JSON.parse(fs.readFileSync(path.join(__dirname, '../../../../package.json'), 'utf8'));
+    const extensionBuildSource = fs.readFileSync(path.join(__dirname, '../../esbuild.config.js'), 'utf8');
+    const cliSource = fs.readFileSync(path.join(__dirname, '../../../cli/src/index.ts'), 'utf8');
+    const skillsCliSource = fs.readFileSync(path.join(__dirname, '../../../skills/src/cli.ts'), 'utf8');
+
+    assert.ok(rootPackage.scripts['build:extension'].includes('ensure-extension-skills-assets.cjs'), 'Extension build must verify skills assets before bundling');
+    assert.ok(extensionBuildSource.includes('hasRequiredSkillsAssets'), 'Extension bundler must reject incomplete skills asset directories');
+    assert.ok(!extensionBuildSource.includes('skills assets not found, skipping copy'), 'Extension bundler must not silently skip missing skills assets');
+    assert.ok(cliSource.includes('hasRequiredAssets'), 'CLI must verify skills asset directories before selecting them');
+    assert.ok(cliSource.includes("'vscode-extension', 'assets'"), 'CLI dev fallback should find extension-bundled assets');
+    assert.ok(skillsCliSource.includes('hasRequiredAssets'), 'Direct skills CLI must verify skills asset directories before selecting them');
+    assert.ok(skillsCliSource.includes('vscode-extension/assets'), 'Direct skills CLI dev fallback should find extension-bundled assets');
+});
+
 test('Agent Workbench state delivery: runtime states are lightweight and ordered', () => {
     const fs = require('node:fs');
     const path = require('node:path');

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -214,6 +214,17 @@ test('Agent runtime: Codex stream keeps parallel tool calls separated', () => {
     assert.ok(source.includes('createOpenAiAccountLanguageModel'), 'The index mapping must live inside the local Codex LangChain model');
 });
 
+test('Agent runtime: Codex tool schemas use LangChain JSON schema conversion', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const source = fs.readFileSync(path.join(__dirname, '../../src/services/agent-provider-runtime/chat-codex-oauth.ts'), 'utf8');
+
+    assert.ok(source.includes('langChainToJsonSchema'), 'Codex tool binding must use LangChain Core JSON schema conversion');
+    assert.ok(source.includes('normalizeJsonSchemaRoot'), 'Codex function parameters must be normalized to an object root');
+    assert.ok(!source.includes('function zodToJsonSchema'), 'Do not reintroduce the incomplete local Zod converter');
+    assert.ok(!source.includes('function serializedZodToJsonSchema'), 'Do not reintroduce the incomplete serialized Zod converter');
+});
+
 test('Agent runtime: agent provider runtime dependency is removed', () => {
     const fs = require('node:fs');
     const path = require('node:path');

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -320,6 +320,17 @@ test('Agent Workbench webview: conversation deletion is confirmed and cleans pan
     assert.ok(source.includes('deletedPanel.dispose()'), 'Deleting a session from another panel must close that stale panel');
 });
 
+test('Agent Workbench webview: active panel clears stale last-active session when it loses ownership', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const source = fs.readFileSync(path.join(__dirname, '../../src/ui/agent-workbench-webview.ts'), 'utf8');
+
+    assert.ok(source.includes('let ownsNewSession = false;'), 'Panel ownership tracking must distinguish claimed sessions from stale state');
+    assert.ok(source.includes('this._panel.active && ownsNewSession'), 'Only the active owner should publish a new last-active session');
+    assert.ok(source.includes('this._panel.active && !ownsNewSession && AgentWorkbenchWebview._lastActiveSessionId === oldSessionId'), 'Active panels that lose ownership must clear stale last-active session ids');
+    assert.ok(source.includes('AgentWorkbenchWebview._lastActiveSessionId = undefined;'), 'Stale last-active session ids must be cleared');
+});
+
 test('Agent Workbench webview: workflow menu options preserve local file paths', () => {
     const fs = require('node:fs');
     const path = require('node:path');

--- a/scripts/ensure-extension-skills-assets.cjs
+++ b/scripts/ensure-extension-skills-assets.cjs
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ROOT_DIR = path.resolve(__dirname, '..');
+const REQUIRED_ASSETS = [
+    'n8n-docs-complete.json',
+    'n8n-knowledge-index.json',
+    'n8n-nodes-technical.json',
+    'workflows-index.json',
+];
+
+const candidateDirs = [
+    path.join(ROOT_DIR, 'packages', 'skills', 'dist', 'assets'),
+    path.join(ROOT_DIR, 'packages', 'skills', 'src', 'assets'),
+    path.join(ROOT_DIR, 'packages', 'vscode-extension', 'assets'),
+];
+
+function hasRequiredAssets(dir) {
+    return REQUIRED_ASSETS.every(file => fs.existsSync(path.join(dir, file)));
+}
+
+function rel(filePath) {
+    return path.relative(ROOT_DIR, filePath) || '.';
+}
+
+const existingAssetsDir = candidateDirs.find(hasRequiredAssets);
+if (existingAssetsDir) {
+    console.log(`✅ Skills assets available at ${rel(existingAssetsDir)}`);
+    process.exit(0);
+}
+
+const nodeMajor = Number.parseInt(process.versions.node.split('.')[0] || '0', 10);
+if (nodeMajor >= 26) {
+    console.error(
+        '❌ Skills assets are missing and Node 26 cannot currently build n8n\'s isolated-vm dependency.\n' +
+        '   Use Node 22 for the first asset generation, for example:\n' +
+        '   npx -y -p node@22 -p pnpm@10.32.1 npm run build:extension',
+    );
+    process.exit(1);
+}
+
+console.log('🧱 Skills assets are missing; generating them from packages/skills...');
+const result = spawnSync(
+    process.platform === 'win32' ? 'npm.cmd' : 'npm',
+    ['run', 'build', '--workspace=packages/skills'],
+    {
+        cwd: ROOT_DIR,
+        stdio: 'inherit',
+        env: process.env,
+    },
+);
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
This PR implements parallel chat threads in the Agent Workbench, allowing concurrent execution of agent turns and multiple open tabs. It also optimizes webview performance by unloading hidden iframes to 'about:blank'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full multi-session support: per-session run control, queuing, open a specific session directly, and workspace-aware path guidance in agent prompts.
  * Snapshot operations serialized per workspace to prevent concurrent checkpoint conflicts.

* **Bug Fixes / UX**
  * Panels reveal/create matching session panels; iframe unloads when hidden and restores when shown.
  * Per-session controls: send stays enabled, stop and delete gated to that session; shared-workspace warnings and rewind gating clarified.

* **Tests**
  * Expanded tests for multi-session behavior, visibility, checkpoints, and workspace snapshot flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->