### PR TITLE
[codex] Fix promote workflow path resolution

### DIFF
--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -246,7 +246,7 @@ export class PromoteCommand {
     }
 
     private resolveSourceWorkflowPath(sourceWorkflowPath: string, sourceRoot: string): string {
-        const sourcePath = path.resolve(sourceWorkflowPath);
+        const sourcePath = path.resolve(sourceRoot, sourceWorkflowPath);
         if (!fs.existsSync(sourcePath)) {
             throw new Error(`Source workflow not found: ${sourcePath}`);
         }

--- a/packages/cli/tests/unit/promote-command.test.ts
+++ b/packages/cli/tests/unit/promote-command.test.ts
@@ -95,6 +95,57 @@ export class PromotedWorkflow {}
         }
     });
 
+    it('resolves a workflow path argument relative to the source workflowsPath', async () => {
+        const previousManagerHome = process.env.N8N_MANAGER_HOME;
+        const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-workspace-'));
+        process.env.N8N_MANAGER_HOME = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-manager-'));
+        try {
+            const globalWorkspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-global-'));
+            const globalConfigService = new ConfigService(globalWorkspaceRoot);
+            globalConfigService.saveLocalConfig({
+                host: 'https://dev.example.test',
+                instanceIdentifier: 'n8n_1111111111',
+            }, { instanceId: 'dev-instance', instanceName: 'Dev', apiKey: 'dev-key' });
+            globalConfigService.saveLocalConfig({
+                host: 'https://prod.example.test',
+                instanceIdentifier: 'n8n_2222222222',
+            }, { instanceId: 'prod-instance', instanceName: 'Prod', apiKey: 'prod-key', setActive: false });
+
+            const configService = new ConfigService(workspaceRoot);
+            const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
+            const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/prod' });
+
+            const sourceDir = configService.resolveEnvironment('Dev').workflowsPath!;
+            const targetDir = configService.resolveEnvironment('Prod').workflowsPath!;
+            mkdirSync(sourceDir, { recursive: true });
+            const sourcePath = path.join(sourceDir, 'filename-only.workflow.ts');
+            writeFileSync(sourcePath, "@workflow({ name: 'Filename Only', active: false })\nexport class FilenameOnly {}\n", 'utf8');
+
+            const result = await new PromoteCommand(configService, {
+                createClient: () => ({
+                    getAllWorkflows: async () => [],
+                    listCredentials: async () => [],
+                }),
+            }).run('filename-only.workflow.ts', {
+                from: 'Dev',
+                to: 'Prod',
+                dryRun: true,
+                promotionConfig: path.join(workspaceRoot, 'n8nac-promotion.json'),
+            });
+
+            expect(result.sourcePath).toBe(sourcePath);
+            expect(result.targetPath).toBe(path.join(targetDir, 'filename-only.workflow.ts'));
+        } finally {
+            if (previousManagerHome === undefined) {
+                delete process.env.N8N_MANAGER_HOME;
+            } else {
+                process.env.N8N_MANAGER_HOME = previousManagerHome;
+            }
+        }
+    });
+
     it('reuses an existing target workflow id without requiring overwrite', async () => {
         const previousManagerHome = process.env.N8N_MANAGER_HOME;
         const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-workspace-'));


### PR DESCRIPTION
## Summary

Fixes #481.

`n8nac promote` now resolves a workflow path argument relative to the source environment `workflowsPath`, matching the command help text. This lets calls such as:

```sh
n8nac promote --from test --to prod --dry-run "Webhook Test.workflow.ts"
```

find the workflow under the source environment workflow directory instead of incorrectly looking in the current working directory.

## Root Cause

`resolveSourceWorkflowPath()` used `path.resolve(sourceWorkflowPath)`, so relative path arguments were anchored to the process CWD.

## Changes

- Resolve provided workflow paths against the source environment workflow root.
- Add a regression test for filename-only promotion arguments.

## Validation

- `npx vitest run packages/cli/tests/unit/promote-command.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed workflow path resolution in the promote command to correctly resolve relative paths based on the source workflows directory instead of the current working directory, ensuring consistent behavior when specifying workflow filenames during promotion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->