### PR TITLE
[codex] fix docs Mermaid rendering

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -40,6 +40,7 @@ const config: Config = {
 
   onBrokenLinks: 'warn',
   markdown: {
+    mermaid: true,
     hooks: {
       onBrokenMarkdownLinks: (args) => {
         console.warn(`Broken markdown link found: ${args.url} in ${args.sourceFilePath}`);

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,9 +19,9 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "3.10.0",
-    "@docusaurus/preset-classic": "3.10.0",
-    "@docusaurus/theme-mermaid": "3.10.0",
+    "@docusaurus/core": "3.10.1",
+    "@docusaurus/preset-classic": "3.10.1",
+    "@docusaurus/theme-mermaid": "3.10.1",
     "@easyops-cn/docusaurus-search-local": "^0.55.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
@@ -33,9 +33,9 @@
     "regexpu-core": "^6.4.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.10.0",
-    "@docusaurus/tsconfig": "3.10.0",
-    "@docusaurus/types": "3.10.0",
+    "@docusaurus/module-type-aliases": "3.10.1",
+    "@docusaurus/tsconfig": "3.10.1",
+    "@docusaurus/types": "3.10.1",
     "typescript": "~5.6.2"
   },
   "browserslist": {


### PR DESCRIPTION
## Summary
- Enable Docusaurus Mermaid markdown rendering so Mermaid fenced blocks render as diagrams.
- Align Docusaurus docs packages to 3.10.1 so the Mermaid theme shares the same theme context as the site.
- Set the repository About homepage to https://n8nascode.dev/ for issue #482.

## Root cause
The docs site had @docusaurus/theme-mermaid installed and listed as a theme, but markdown.mermaid was not enabled, so Mermaid fenced blocks were emitted as regular code blocks. Enabling it also requires the Docusaurus package set to resolve consistently so the Mermaid renderer can access the color-mode theme context.

## Validation
- npm run docs:build
- npm run typecheck --workspace docs was not available, so ran npm run typecheck from docs/
- Browser verification on /docs/contribution/sync/: 2 Mermaid SVG containers, 0 Mermaid code blocks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Mermaid diagram support in documentation, allowing users to create and embed various types of diagrams directly within documentation pages.

* **Chores**
  * Updated Docusaurus and related package dependencies to version 3.10.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/485?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->