### PR TITLE
feat(workbench): add git worktree management to Agent Workbench

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1085,7 +1085,7 @@ function getSelectedAgentProviderModelLabel(): string {
 function getWorktreeService(): WorktreeService | undefined {
     const workspaceRoot = getWorkspaceRoot();
     if (!workspaceRoot) return undefined;
-    const expectedRoot = path.resolve(workspaceRoot, '.kilo', 'worktrees');
+    const expectedRoot = path.resolve(workspaceRoot, '.n8nac', 'worktrees');
     if (!worktreeService || path.resolve(worktreeService.getWorktreesRoot()) !== expectedRoot) {
         worktreeService = new WorktreeService(workspaceRoot, (message) => {
             outputChannel.appendLine(message);

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1113,12 +1113,12 @@ async function createAgentWorktree(options?: { branchName?: string }): Promise<W
     });
 }
 
-async function removeAgentWorktree(worktreePath: string): Promise<void> {
+async function removeAgentWorktree(worktreePath: string, options?: { force?: boolean }): Promise<void> {
     const workspaceRoot = getWorkspaceRoot();
     if (!workspaceRoot) throw new Error('No workspace root available.');
     const service = getWorktreeService();
     if (!service) throw new Error('Worktree service unavailable.');
-    await service.removeWorktree(workspaceRoot, worktreePath);
+    await service.removeWorktree(workspaceRoot, worktreePath, options?.force ?? false);
 }
 
 async function resolveWorkflowWebviewTarget(workflow: IWorkflowStatus): Promise<{ url: string; targetUrl: string }> {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -22,6 +22,7 @@ import { WorkflowDecorationProvider } from './ui/workflow-decoration-provider.js
 import { ProxyService } from './services/proxy-service.js';
 import { AgentRuntimeController } from './services/agent-runtime-controller.js';
 import type { AgentWorkflowContext } from './services/agent-runtime-controller.js';
+import { WorktreeService, type WorktreeInfo } from './services/worktree-service.js';
 import {
     AgentProviderService,
     AGENT_PROVIDER_DEFINITIONS,
@@ -104,6 +105,7 @@ let runtimeDisposables: vscode.Disposable[] = [];
 let configurationController: N8nConfigurationController | undefined;
 let agentRuntimeController: AgentRuntimeController | undefined;
 let agentProviderService: AgentProviderService | undefined;
+let worktreeService: WorktreeService | undefined;
 let suppressNextConfigurationReaction = false;
 let failedAutoInitRuntimeSignature: string | undefined;
 let failedAutoInitConnectionKey: string | undefined;
@@ -916,6 +918,9 @@ async function openAgentWorkbench(context: vscode.ExtensionContext, workflow?: I
                 listModelOptions: listAgentModelOptions,
                 selectProviderModel: selectAgentProviderModel,
                 selectReasoningEffort: selectInlineAgentReasoningEffort,
+                listWorktrees: listWorktreeOptions,
+                createWorktree: createAgentWorktree,
+                removeWorktree: removeAgentWorktree,
             },
             initialSessionId,
             vscode.ViewColumn.One,
@@ -1075,6 +1080,45 @@ function getSelectedAgentProviderModelLabel(): string {
     const provider = String(config.get<string>('provider') || 'openai').trim() || 'openai';
     const model = String(config.get<string>('model') || '').trim();
     return model ? `${provider} / ${model}` : provider;
+}
+
+function getWorktreeService(): WorktreeService | undefined {
+    const workspaceRoot = getWorkspaceRoot();
+    if (!workspaceRoot) return undefined;
+    const expectedRoot = path.resolve(workspaceRoot, '.kilo', 'worktrees');
+    if (!worktreeService || path.resolve(worktreeService.getWorktreesRoot()) !== expectedRoot) {
+        worktreeService = new WorktreeService(workspaceRoot, (message) => {
+            outputChannel.appendLine(message);
+        });
+    }
+    return worktreeService;
+}
+
+async function listWorktreeOptions(): Promise<WorktreeInfo[]> {
+    const workspaceRoot = getWorkspaceRoot();
+    if (!workspaceRoot) return [];
+    const service = getWorktreeService();
+    if (!service) return [];
+    return service.listWorktrees(workspaceRoot);
+}
+
+async function createAgentWorktree(options?: { branchName?: string }): Promise<WorktreeInfo | undefined> {
+    const workspaceRoot = getWorkspaceRoot();
+    if (!workspaceRoot) throw new Error('No workspace root available.');
+    const service = getWorktreeService();
+    if (!service) throw new Error('Worktree service unavailable.');
+    return service.createWorktree(workspaceRoot, {
+        branchName: options?.branchName,
+        baseBranch: 'HEAD',
+    });
+}
+
+async function removeAgentWorktree(worktreePath: string): Promise<void> {
+    const workspaceRoot = getWorkspaceRoot();
+    if (!workspaceRoot) throw new Error('No workspace root available.');
+    const service = getWorktreeService();
+    if (!service) throw new Error('Worktree service unavailable.');
+    await service.removeWorktree(workspaceRoot, worktreePath);
 }
 
 async function resolveWorkflowWebviewTarget(workflow: IWorkflowStatus): Promise<{ url: string; targetUrl: string }> {

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { randomUUID } from 'crypto';
 import { WorkspaceSnapshotService } from './workspace-snapshot-service.js';
 import { createLocalProviderLangChainModel } from './agent-provider-runtime/create-langchain-model.js';
+import type { WorktreeInfo } from './worktree-service.js';
 
 export interface AgentPromptInput {
     prompt: string;
@@ -12,6 +13,7 @@ export interface AgentPromptInput {
     workflowFilename?: string;
     workflowFilePath?: string;
     workspaceRoot?: string;
+    worktreePath?: string;
     nodeContext?: AgentNodeContext;
     nodeContexts?: AgentNodeContext[];
     sessionId?: string;
@@ -20,6 +22,7 @@ export interface AgentPromptInput {
 const ENVIRONMENT_DETAILS_BLOCK_PATTERN = /<environment_details>[\s\S]*?<\/environment_details>/gi;
 const UNATTACHED_WORKFLOW_SCOPE_KEY = '__unattached__';
 const DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000;
+const ACTIVE_WORKTREE_PATH_KEY = 'n8n.agent.activeWorktreePath';
 const INVALID_TOOL_CALL_RECOVERY_MARKER = 'N8N_INVALID_TOOL_CALL_RECOVERY';
 
 export interface AgentNodeContext {
@@ -143,6 +146,8 @@ export interface AgentWorkbenchState {
     sessions: AgentSessionSummary[];
     session: AgentSessionState;
     isRunning: boolean;
+    activeWorktree?: WorktreeInfo;
+    availableWorktrees: WorktreeInfo[];
 }
 
 export interface AgentRunResult {
@@ -820,6 +825,7 @@ export class AgentRuntimeController implements vscode.Disposable {
             sessions: await this.listSessionSummaries(scope, activeRecord.id),
             session,
             isRunning: this.activeRuns.has(activeRecord.id),
+            availableWorktrees: [],
         };
     }
 
@@ -835,6 +841,18 @@ export class AgentRuntimeController implements vscode.Disposable {
             return this.getWorkbenchState({ ...input, sessionId: record.id, nodeContext: undefined, nodeContexts: undefined });
         }
         return this.getWorkbenchState({ ...input, workflowId: undefined, workflowName: undefined, workflowFilename: undefined, workflowFilePath: undefined, nodeContext: undefined, nodeContexts: undefined, sessionId: record.id });
+    }
+
+    getActiveWorktreePath(): string | undefined {
+        return this._context.workspaceState.get<string>(ACTIVE_WORKTREE_PATH_KEY);
+    }
+
+    async setActiveWorktreePath(worktreePath: string | undefined): Promise<void> {
+        if (worktreePath) {
+            await this._context.workspaceState.update(ACTIVE_WORKTREE_PATH_KEY, worktreePath);
+        } else {
+            await this._context.workspaceState.update(ACTIVE_WORKTREE_PATH_KEY, undefined);
+        }
     }
 
     async getLatestSessionId(): Promise<string | undefined> {
@@ -1108,6 +1126,12 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     async sendPrompt(input: AgentPromptInput, postMessage: AgentWorkbenchPostMessage): Promise<AgentRunResult> {
+        const activeWorktreePath = this.getActiveWorktreePath();
+        if (activeWorktreePath) {
+            input.workspaceRoot = activeWorktreePath;
+            input.worktreePath = activeWorktreePath;
+        }
+
         const sessions = await this.getSessionRuntime();
         const scope = this.getSessionScope(input);
         const activeRecord = input.sessionId

--- a/packages/vscode-extension/src/services/worktree-service.ts
+++ b/packages/vscode-extension/src/services/worktree-service.ts
@@ -56,10 +56,10 @@ export class WorktreeService {
         } else {
             args.push('-b', branchName);
         }
+        args.push(worktreePath);
         if (options.baseBranch) {
             args.push(options.baseBranch);
         }
-        args.push(worktreePath);
 
         try {
             await execFileAsync('git', args, {

--- a/packages/vscode-extension/src/services/worktree-service.ts
+++ b/packages/vscode-extension/src/services/worktree-service.ts
@@ -1,0 +1,166 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export interface WorktreeInfo {
+    path: string;
+    head: string;
+    branch?: string;
+    bare: boolean;
+    detached: boolean;
+    locked: boolean;
+}
+
+export interface CreateWorktreeOptions {
+    branchName?: string;
+    baseBranch?: string;
+    detach?: boolean;
+}
+
+export type WorktreeLogger = (message: string) => void;
+
+export class WorktreeService {
+    private readonly worktreesRoot: string;
+
+    constructor(
+        workspaceRoot: string,
+        private readonly log: WorktreeLogger = () => {},
+    ) {
+        this.worktreesRoot = path.join(workspaceRoot, '.kilo', 'worktrees');
+    }
+
+    async listWorktrees(repoPath: string): Promise<WorktreeInfo[]> {
+        try {
+            const { stdout } = await execFileAsync('git', ['worktree', 'list', '--porcelain'], {
+                cwd: repoPath,
+                maxBuffer: 1024 * 1024,
+            });
+            return this.parseWorktreePorcelain(stdout);
+        } catch (error: any) {
+            this.log(`[n8n-worktree] List failed: ${error?.message || String(error)}`);
+            return [];
+        }
+    }
+
+    async createWorktree(repoPath: string, options: CreateWorktreeOptions = {}): Promise<WorktreeInfo> {
+        const branchName = options.branchName || `n8n-agent-${Date.now().toString(36)}`;
+        const worktreePath = path.join(this.worktreesRoot, branchName);
+        fs.mkdirSync(this.worktreesRoot, { recursive: true });
+
+        const args = ['worktree', 'add'];
+        if (options.detach) {
+            args.push('--detach');
+        } else {
+            args.push('-b', branchName);
+        }
+        if (options.baseBranch) {
+            args.push(options.baseBranch);
+        }
+        args.push(worktreePath);
+
+        try {
+            await execFileAsync('git', args, {
+                cwd: repoPath,
+                maxBuffer: 10 * 1024 * 1024,
+            });
+            this.log(`[n8n-worktree] Created worktree at ${worktreePath} branch=${branchName}`);
+        } catch (error: any) {
+            const message = error?.message || String(error);
+            this.log(`[n8n-worktree] Create failed: ${message}`);
+            throw new Error(`Failed to create worktree: ${message}`);
+        }
+
+        const worktrees = await this.listWorktrees(repoPath);
+        const created = worktrees.find((wt) => wt.path === worktreePath);
+        if (!created) {
+            throw new Error('Worktree created but not found in listing.');
+        }
+        return created;
+    }
+
+    async removeWorktree(repoPath: string, worktreePath: string, force = false): Promise<void> {
+        const args = ['worktree', 'remove'];
+        if (force) args.push('--force');
+        args.push(worktreePath);
+
+        try {
+            await execFileAsync('git', args, {
+                cwd: repoPath,
+                maxBuffer: 10 * 1024 * 1024,
+            });
+            this.log(`[n8n-worktree] Removed worktree at ${worktreePath}`);
+        } catch (error: any) {
+            const message = error?.message || String(error);
+            this.log(`[n8n-worktree] Remove failed: ${message}`);
+            throw new Error(`Failed to remove worktree: ${message}`);
+        }
+    }
+
+    getWorktreesRoot(): string {
+        return this.worktreesRoot;
+    }
+
+    private parseWorktreePorcelain(output: string): WorktreeInfo[] {
+        const lines = output.trim().split('\n');
+        const result: WorktreeInfo[] = [];
+        let current: Partial<WorktreeInfo> = {};
+
+        for (const line of lines) {
+            if (line === '') {
+                if (current.path) {
+                    result.push({
+                        path: current.path,
+                        head: current.head || '',
+                        branch: current.branch,
+                        bare: current.bare ?? false,
+                        detached: current.detached ?? false,
+                        locked: current.locked ?? false,
+                    });
+                }
+                current = {};
+                continue;
+            }
+
+            const spaceIndex = line.indexOf(' ');
+            const key = spaceIndex >= 0 ? line.slice(0, spaceIndex) : line;
+            const value = spaceIndex >= 0 ? line.slice(spaceIndex + 1) : '';
+
+            switch (key) {
+                case 'worktree':
+                    current.path = value;
+                    break;
+                case 'HEAD':
+                    current.head = value;
+                    break;
+                case 'branch':
+                    current.branch = value;
+                    break;
+                case 'bare':
+                    current.bare = true;
+                    break;
+                case 'detached':
+                    current.detached = true;
+                    break;
+                case 'locked':
+                    current.locked = true;
+                    break;
+            }
+        }
+
+        if (current.path) {
+            result.push({
+                path: current.path,
+                head: current.head || '',
+                branch: current.branch,
+                bare: current.bare ?? false,
+                detached: current.detached ?? false,
+                locked: current.locked ?? false,
+            });
+        }
+
+        return result;
+    }
+}

--- a/packages/vscode-extension/src/services/worktree-service.ts
+++ b/packages/vscode-extension/src/services/worktree-service.ts
@@ -29,7 +29,7 @@ export class WorktreeService {
         workspaceRoot: string,
         private readonly log: WorktreeLogger = () => {},
     ) {
-        this.worktreesRoot = path.join(workspaceRoot, '.kilo', 'worktrees');
+        this.worktreesRoot = path.join(workspaceRoot, '.n8nac', 'worktrees');
     }
 
     async listWorktrees(repoPath: string): Promise<WorktreeInfo[]> {

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -900,6 +900,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         }
         .worktree-warning {
             display: none;
+            padding: 4px 14px 6px;
             color: var(--warning);
             font-size: 12px;
             line-height: 1.4;
@@ -1279,7 +1280,6 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                     <div id="runtime-finalizing" class="runtime-finalizing" aria-live="polite">Finalizing context before the next run...</div>
                     <div id="mention-menu" class="mention-menu"></div>
                     <textarea id="prompt" placeholder="Ask the n8n agent what to do with this workflow..." rows="2"></textarea>
-                    <div id="worktree-warning" class="worktree-warning" aria-live="polite">Isolated worktree — n8n-as-code config changes and local workflow list from extension UI don't apply here.</div>
                     <div class="composer-toolbar">
                         <div class="composer-provider">
                             <button id="select-model" class="secondary small" type="button" title="${safeProviderModelLabel}">${safeProviderModelLabel}</button>
@@ -1296,6 +1296,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                     </div>
                 </div>
             </form>
+            <div id="worktree-warning" class="worktree-warning" aria-live="polite">Isolated worktree — n8n-as-code config changes and local workflow list from extension UI don't apply here.</div>
         </section>
         ${hasWorkflow ? `<section class="workflow" aria-label="n8n workflow">
             <div id="refresh-pill" class="refresh-pill">Refreshing n8n...</div>

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -860,7 +860,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             width: min(340px, calc(100vw - 28px));
         }
         .inline-option.worktree-item {
-            grid-template-columns: 1fr auto auto;
+            grid-template-columns: 1fr auto auto auto;
         }
         .inline-option.worktree-item .branch-name {
             color: var(--muted);
@@ -1820,6 +1820,10 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             for (const wt of worktrees) {
                 const branchDisplay = wt.branch ? wt.branch.replace('refs/heads/', '') : (wt.detached ? '(detached)' : '');
                 const isActive = activePath === wt.path;
+
+                const wrapper = document.createElement('div');
+                wrapper.style.display = 'contents';
+
                 const option = document.createElement('button');
                 option.type = 'button';
                 option.className = 'inline-option worktree-item' + (isActive ? ' active' : '');
@@ -1832,12 +1836,28 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 const mark = document.createElement('span');
                 mark.className = 'mark';
                 mark.textContent = isActive ? 'Active' : '';
-                option.append(main, sub, mark);
+
+                const removeBtn = document.createElement('button');
+                removeBtn.type = 'button';
+                removeBtn.className = 'ghost worktree-delete';
+                removeBtn.title = 'Remove worktree';
+                removeBtn.setAttribute('aria-label', 'Remove worktree ' + (branchDisplay || wt.path));
+                removeBtn.innerHTML = ${JSON.stringify(trashIcon)};
+                removeBtn.disabled = isActive;
+                removeBtn.addEventListener('click', (event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    if (removeBtn.disabled) return;
+                    vscode.postMessage({ type: 'agent.worktree.remove', path: wt.path });
+                });
+
+                option.append(main, sub, mark, removeBtn);
                 option.addEventListener('click', () => {
                     closeInlineMenus();
                     vscode.postMessage({ type: 'agent.worktree.select', path: wt.path });
                 });
-                list.appendChild(option);
+                wrapper.appendChild(option);
+                list.appendChild(wrapper);
             }
 
             worktreeMenu.appendChild(list);
@@ -1849,9 +1869,11 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             closeCheckpointPanel();
             providerMenuOpen = false;
             reasoningMenuOpen = false;
+            newSessionMenuOpen = false;
             worktreeMenuOpen = !worktreeMenuOpen;
             if (providerMenu) providerMenu.classList.remove('open');
             if (reasoningMenu) reasoningMenu.classList.remove('open');
+            if (newSessionMenu) newSessionMenu.classList.remove('open');
             vscode.postMessage({ type: 'agent.worktree.list' });
             renderWorktreeMenu();
         }

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -898,6 +898,20 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             color: var(--accent-text);
             background: var(--accent);
         }
+        .worktree-warning {
+            display: none;
+            padding: 6px 10px;
+            margin-bottom: 2px;
+            border: 1px solid color-mix(in srgb, var(--warning) 55%, var(--border));
+            border-radius: 7px;
+            background: color-mix(in srgb, var(--warning) 14%, transparent);
+            color: var(--text);
+            font-size: 12px;
+            line-height: 1.4;
+        }
+        .worktree-warning.active {
+            display: block;
+        }
         .inline-popover-head {
             display: flex;
             justify-content: space-between;
@@ -1268,6 +1282,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                     <div id="context-badges" class="context-badges"></div>
                     <div id="pending-prompt" class="pending-prompt" aria-live="polite"></div>
                     <div id="runtime-finalizing" class="runtime-finalizing" aria-live="polite">Finalizing context before the next run...</div>
+                    <div id="worktree-warning" class="worktree-warning" aria-live="polite">Isolated worktree — n8n-as-code config changes and workflow list don't apply here.</div>
                     <div id="mention-menu" class="mention-menu"></div>
                     <textarea id="prompt" placeholder="Ask the n8n agent what to do with this workflow..." rows="2"></textarea>
                     <div class="composer-toolbar">
@@ -1394,6 +1409,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const promptInput = document.getElementById('prompt');
         const pendingPromptEl = document.getElementById('pending-prompt');
         const runtimeFinalizingEl = document.getElementById('runtime-finalizing');
+        const worktreeWarningEl = document.getElementById('worktree-warning');
         const sendButton = document.getElementById('send');
         const stopButton = document.getElementById('stop');
         const selectModelButton = document.getElementById('select-model');
@@ -2138,6 +2154,9 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 selectWorktreeButton.textContent = wtLabel;
                 selectWorktreeButton.title = state.activeWorktree ? state.activeWorktree.path : 'Current workspace';
                 selectWorktreeButton.classList.toggle('worktree-active', Boolean(state.activeWorktree));
+            }
+            if (worktreeWarningEl) {
+                worktreeWarningEl.classList.toggle('active', Boolean(state.activeWorktree));
             }
             renderProviderMenu();
             renderReasoningMenu();

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -900,12 +900,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         }
         .worktree-warning {
             display: none;
-            padding: 6px 10px;
-            margin-bottom: 2px;
-            border: 1px solid color-mix(in srgb, var(--warning) 55%, var(--border));
-            border-radius: 7px;
-            background: color-mix(in srgb, var(--warning) 14%, transparent);
-            color: var(--text);
+            color: var(--warning);
             font-size: 12px;
             line-height: 1.4;
         }
@@ -1282,9 +1277,9 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                     <div id="context-badges" class="context-badges"></div>
                     <div id="pending-prompt" class="pending-prompt" aria-live="polite"></div>
                     <div id="runtime-finalizing" class="runtime-finalizing" aria-live="polite">Finalizing context before the next run...</div>
-                    <div id="worktree-warning" class="worktree-warning" aria-live="polite">Isolated worktree — n8n-as-code config changes and workflow list don't apply here.</div>
                     <div id="mention-menu" class="mention-menu"></div>
                     <textarea id="prompt" placeholder="Ask the n8n agent what to do with this workflow..." rows="2"></textarea>
+                    <div id="worktree-warning" class="worktree-warning" aria-live="polite">Isolated worktree — n8n-as-code config changes and local workflow list from extension UI don't apply here.</div>
                     <div class="composer-toolbar">
                         <div class="composer-provider">
                             <button id="select-model" class="secondary small" type="button" title="${safeProviderModelLabel}">${safeProviderModelLabel}</button>

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -854,6 +854,50 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             bottom: auto;
             width: min(340px, calc(100vw - 28px));
         }
+        .inline-popover.worktree {
+            left: auto;
+            right: 0;
+            width: min(340px, calc(100vw - 28px));
+        }
+        .inline-option.worktree-item {
+            grid-template-columns: 1fr auto auto;
+        }
+        .inline-option.worktree-item .branch-name {
+            color: var(--muted);
+            font-family: var(--vscode-editor-font-family, monospace);
+            font-size: 10px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .worktree-delete {
+            width: 22px;
+            height: 22px;
+            min-width: 22px;
+            padding: 0;
+            border-radius: 4px;
+            color: var(--muted);
+            display: inline-grid;
+            place-items: center;
+        }
+        .worktree-delete:hover {
+            color: var(--error);
+            background: color-mix(in srgb, var(--error) 12%, transparent);
+        }
+        .worktree-delete svg {
+            width: 12px;
+            height: 12px;
+        }
+        #select-worktree {
+            max-width: 120px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        #select-worktree.worktree-active {
+            color: var(--accent-text);
+            background: var(--accent);
+        }
         .inline-popover-head {
             display: flex;
             justify-content: space-between;
@@ -1230,8 +1274,10 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                         <div class="composer-provider">
                             <button id="select-model" class="secondary small" type="button" title="${safeProviderModelLabel}">${safeProviderModelLabel}</button>
                             <button id="select-reasoning" class="secondary small" type="button">Reasoning</button>
+                            <button id="select-worktree" class="secondary small" type="button" title="Worktree">Workspace</button>
                             <div id="provider-menu" class="inline-popover" role="menu"></div>
                             <div id="reasoning-menu" class="inline-popover reasoning" role="menu"></div>
+                            <div id="worktree-menu" class="inline-popover worktree" role="menu"></div>
                         </div>
                         <div class="composer-actions">
                             <button id="stop" class="ghost stop-button" type="button" title="Stop" aria-label="Stop" disabled>${stopIcon}</button>
@@ -1316,6 +1362,8 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         let modelSearchQuery = '';
         let reasoningMenuOpen = false;
         let newSessionMenuOpen = false;
+        let worktreeMenuOpen = false;
+        let activeWorktreePath = null;
         let autoScrollFeed = true;
         let pendingPrompt = null;
         let runtimeFinalizing = false;
@@ -1352,6 +1400,8 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const selectReasoningButton = document.getElementById('select-reasoning');
         const providerMenu = document.getElementById('provider-menu');
         const reasoningMenu = document.getElementById('reasoning-menu');
+        const selectWorktreeButton = document.getElementById('select-worktree');
+        const worktreeMenu = document.getElementById('worktree-menu');
         const frame = document.getElementById('workflow-frame');
         const refreshPill = document.getElementById('refresh-pill');
         const contextBadges = document.getElementById('context-badges');
@@ -1728,9 +1778,82 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             providerMenuOpen = false;
             reasoningMenuOpen = false;
             newSessionMenuOpen = false;
+            worktreeMenuOpen = false;
             if (providerMenu) providerMenu.classList.remove('open');
             if (reasoningMenu) reasoningMenu.classList.remove('open');
             if (newSessionMenu) newSessionMenu.classList.remove('open');
+            if (worktreeMenu) worktreeMenu.classList.remove('open');
+        }
+
+        function renderWorktreeMenu() {
+            if (!worktreeMenu || !state) return;
+            worktreeMenu.innerHTML = '';
+
+            const head = document.createElement('div');
+            head.className = 'inline-popover-head';
+            head.innerHTML = '<strong>Workspace</strong><span>Choose where the agent works</span>';
+            worktreeMenu.appendChild(head);
+
+            const list = document.createElement('div');
+            list.className = 'inline-popover-list';
+
+            const currentOption = inlineOption('Current workspace', 'Work in this VS Code workspace directly', state.activeWorktree ? '' : 'Active', '');
+            currentOption.addEventListener('click', () => {
+                closeInlineMenus();
+                vscode.postMessage({ type: 'agent.worktree.clear' });
+            });
+            list.appendChild(currentOption);
+
+            const divider = document.createElement('div');
+            divider.className = 'inline-divider';
+            list.appendChild(divider);
+
+            const createOption = inlineOption('+ Create new worktree', 'Isolated branch for agent changes', '', '');
+            createOption.addEventListener('click', () => {
+                closeInlineMenus();
+                vscode.postMessage({ type: 'agent.worktree.create' });
+            });
+            list.appendChild(createOption);
+
+            const worktrees = Array.isArray(state.availableWorktrees) ? state.availableWorktrees : [];
+            const activePath = state.activeWorktree ? state.activeWorktree.path : activeWorktreePath;
+            for (const wt of worktrees) {
+                const branchDisplay = wt.branch ? wt.branch.replace('refs/heads/', '') : (wt.detached ? '(detached)' : '');
+                const isActive = activePath === wt.path;
+                const option = document.createElement('button');
+                option.type = 'button';
+                option.className = 'inline-option worktree-item' + (isActive ? ' active' : '');
+                const main = document.createElement('span');
+                main.className = 'main';
+                main.textContent = branchDisplay || wt.path.split('/').pop() || 'worktree';
+                const sub = document.createElement('span');
+                sub.className = 'branch-name';
+                sub.textContent = wt.path;
+                const mark = document.createElement('span');
+                mark.className = 'mark';
+                mark.textContent = isActive ? 'Active' : '';
+                option.append(main, sub, mark);
+                option.addEventListener('click', () => {
+                    closeInlineMenus();
+                    vscode.postMessage({ type: 'agent.worktree.select', path: wt.path });
+                });
+                list.appendChild(option);
+            }
+
+            worktreeMenu.appendChild(list);
+            worktreeMenu.classList.toggle('open', worktreeMenuOpen);
+        }
+
+        function openWorktreeMenu() {
+            closeHistory();
+            closeCheckpointPanel();
+            providerMenuOpen = false;
+            reasoningMenuOpen = false;
+            worktreeMenuOpen = !worktreeMenuOpen;
+            if (providerMenu) providerMenu.classList.remove('open');
+            if (reasoningMenu) reasoningMenu.classList.remove('open');
+            vscode.postMessage({ type: 'agent.worktree.list' });
+            renderWorktreeMenu();
         }
 
         function workflowKey(workflow) {
@@ -1985,8 +2108,18 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             if (state.provider && Array.isArray(state.modelOptions)) providerModelCache[state.provider] = state.modelOptions;
             selectReasoningButton.textContent = state.reasoningEffort ? 'Reasoning ' + state.reasoningEffort : 'Reasoning';
             selectReasoningButton.style.display = state.supportsReasoningEffort ? 'inline-block' : 'none';
+            if (selectWorktreeButton) {
+                activeWorktreePath = state.activeWorktree ? state.activeWorktree.path : null;
+                const wtLabel = state.activeWorktree
+                    ? (state.activeWorktree.branch ? state.activeWorktree.branch.replace('refs/heads/', '') : 'Worktree')
+                    : 'Workspace';
+                selectWorktreeButton.textContent = wtLabel;
+                selectWorktreeButton.title = state.activeWorktree ? state.activeWorktree.path : 'Current workspace';
+                selectWorktreeButton.classList.toggle('worktree-active', Boolean(state.activeWorktree));
+            }
             renderProviderMenu();
             renderReasoningMenu();
+            renderWorktreeMenu();
             renderNewSessionMenu();
             const usage = state.session && state.session.contextUsage;
             if (!usage || usage.source !== 'api') {
@@ -2769,6 +2902,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             if (providerMenu && (providerMenu.contains(target) || selectModelButton.contains(target))) return;
             if (reasoningMenu && (reasoningMenu.contains(target) || selectReasoningButton.contains(target))) return;
             if (newSessionMenu && (newSessionMenu.contains(target) || newSessionHeaderButton.contains(target))) return;
+            if (worktreeMenu && (worktreeMenu.contains(target) || selectWorktreeButton.contains(target))) return;
             closeInlineMenus();
         }, true);
         on(promptInput, 'input', renderMentionMenu);
@@ -2808,6 +2942,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             renderProviderMenu();
             renderReasoningMenu();
         });
+        on(selectWorktreeButton, 'click', openWorktreeMenu);
         function startNewSession(workflow) {
             closeHistory();
             closeCheckpointPanel();
@@ -2936,6 +3071,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             if (message.type === 'agent.state') {
                 if (!acceptIncomingStateMessage(message)) return;
                 state = message.state || null;
+                activeWorktreePath = state && state.activeWorktree ? state.activeWorktree.path : null;
                 renderAll();
                 return;
             }
@@ -2944,6 +3080,16 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 providerModelCache[String(message.provider || '')] = Array.isArray(message.models) ? message.models : [];
                 providerMenuOpen = true;
                 renderProviderMenu();
+                return;
+            }
+
+            if (message.type === 'agent.worktrees') {
+                if (state) {
+                    state.availableWorktrees = Array.isArray(message.worktrees) ? message.worktrees : [];
+                    state.activeWorktree = state.availableWorktrees.find((wt) => wt.path === message.activePath) || null;
+                    activeWorktreePath = typeof message.activePath === 'string' && message.activePath ? message.activePath : null;
+                    renderWorktreeMenu();
+                }
                 return;
             }
 

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -1849,20 +1849,23 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 mark.className = 'mark';
                 mark.textContent = isActive ? 'Active' : '';
 
-                const removeBtn = document.createElement('button');
-                removeBtn.type = 'button';
+                const removeBtn = document.createElement('span');
                 removeBtn.className = 'ghost worktree-delete';
                 removeBtn.title = 'Remove worktree';
+                removeBtn.setAttribute('role', 'button');
+                removeBtn.setAttribute('tabindex', '0');
                 removeBtn.setAttribute('aria-label', 'Remove worktree ' + (branchDisplay || wt.path));
                 removeBtn.innerHTML = ${JSON.stringify(trashIcon)};
-                removeBtn.disabled = isActive;
-                removeBtn.addEventListener('click', (event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    if (removeBtn.disabled) return;
-                    vscode.postMessage({ type: 'agent.worktree.remove', path: wt.path });
-                });
-
+                if (!isActive) {
+                    removeBtn.addEventListener('click', (event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        vscode.postMessage({ type: 'agent.worktree.remove', path: wt.path });
+                    });
+                } else {
+                    removeBtn.style.opacity = '0.38';
+                    removeBtn.style.pointerEvents = 'none';
+                }
                 option.append(main, sub, mark, removeBtn);
                 option.addEventListener('click', () => {
                     closeInlineMenus();

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -510,6 +510,13 @@ export class AgentWorkbenchWebview {
         }
 
         if (payload.type === 'agent.worktree.remove' && typeof payload.path === 'string') {
+            const confirmed = await vscode.window.showWarningMessage(
+                'Delete this worktree? Unsaved or unpushed work may be lost.',
+                { modal: true },
+                'Delete',
+            );
+            if (confirmed !== 'Delete') return;
+
             try {
                 const allowed = await this._workflowProviders.listWorktrees();
                 const isKnown = allowed.some((wt) => wt.path === payload.path);

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -467,9 +467,19 @@ export class AgentWorkbenchWebview {
         }
 
         if (payload.type === 'agent.worktree.select' && typeof payload.path === 'string') {
-            await this._agentRuntime.setActiveWorktreePath(payload.path);
-            await this._outputChannel.appendLine(`[n8n-agent-debug] Worktree selected path=${payload.path}`);
-            await this.postWorkbenchState();
+            try {
+                const worktrees = await this._workflowProviders.listWorktrees();
+                const isKnown = worktrees.some((wt) => wt.path === payload.path);
+                if (!isKnown) {
+                    this._outputChannel.appendLine(`[n8n-agent] Worktree select refused: unknown path=${payload.path}`);
+                    return;
+                }
+                await this._agentRuntime.setActiveWorktreePath(payload.path);
+                this._outputChannel.appendLine(`[n8n-agent-debug] Worktree selected path=${payload.path}`);
+                await this.postWorkbenchState();
+            } catch (error: any) {
+                this._outputChannel.appendLine(`[n8n-agent] Worktree select error: ${error?.message || String(error)}`);
+            }
             return;
         }
 
@@ -499,6 +509,11 @@ export class AgentWorkbenchWebview {
 
         if (payload.type === 'agent.worktree.remove' && typeof payload.path === 'string') {
             try {
+                const allowed = await this._workflowProviders.listWorktrees().catch(() => []);
+                const isKnown = allowed.some((wt) => wt.path === payload.path);
+                if (!isKnown) {
+                    throw new Error('Refusing to remove unknown worktree path.');
+                }
                 await this._workflowProviders.removeWorktree(payload.path);
                 const activePath = this._agentRuntime.getActiveWorktreePath();
                 if (activePath === payload.path) {

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -661,7 +661,9 @@ export class AgentWorkbenchWebview {
         await this.reconcileWorkflowContext(nextState.workflowContext);
 
         const activeWorktreePath = this._agentRuntime.getActiveWorktreePath();
-        const availableWorktrees = await this._workflowProviders.listWorktrees().catch(() => []);
+        const allWorktrees = await this._workflowProviders.listWorktrees().catch(() => []);
+        const mainWorkspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        const availableWorktrees = allWorktrees.filter((wt) => wt.path !== mainWorkspacePath);
         const activeWorktree = activeWorktreePath
             ? availableWorktrees.find((wt) => wt.path === activeWorktreePath)
             : undefined;

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -29,7 +29,7 @@ interface AgentWorkbenchWorkflowProviders {
     selectReasoningEffort(effort: string): Promise<void>;
     listWorktrees(): Promise<WorktreeInfo[]>;
     createWorktree(options?: { branchName?: string }): Promise<WorktreeInfo | undefined>;
-    removeWorktree(worktreePath: string): Promise<void>;
+    removeWorktree(worktreePath: string, options?: { force?: boolean }): Promise<void>;
 }
 
 export class AgentWorkbenchWebview {
@@ -523,7 +523,7 @@ export class AgentWorkbenchWebview {
                 if (!isKnown) {
                     throw new Error('Refusing to remove unknown worktree path.');
                 }
-                await this._workflowProviders.removeWorktree(payload.path);
+                await this._workflowProviders.removeWorktree(payload.path, { force: true });
                 const activePath = this._agentRuntime.getActiveWorktreePath();
                 if (activePath === payload.path) {
                     await this._agentRuntime.setActiveWorktreePath(undefined);

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -453,7 +453,9 @@ export class AgentWorkbenchWebview {
 
         if (payload.type === 'agent.worktree.list') {
             try {
-                const worktrees = await this._workflowProviders.listWorktrees();
+                const allWorktrees = await this._workflowProviders.listWorktrees();
+                const mainWorkspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+                const worktrees = allWorktrees.filter((wt) => wt.path !== mainWorkspacePath);
                 const activePath = this._agentRuntime.getActiveWorktreePath();
                 await this._panel.webview.postMessage({
                     type: 'agent.worktrees',

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -4,6 +4,7 @@ import { IWorkflowStatus } from 'n8nac';
 import { AgentRuntimeController, type AgentWorkbenchMessage, type AgentWorkflowContext } from '../services/agent-runtime-controller.js';
 import { workflowWebviewRegistry } from '../services/workflow-webview-registry.js';
 import { buildAgentWorkbenchHtml } from './agent-workbench-html.js';
+import type { WorktreeInfo } from '../services/worktree-service.js';
 
 interface AgentWorkbenchNodeContext {
     name: string;
@@ -26,6 +27,9 @@ interface AgentWorkbenchWorkflowProviders {
     listModelOptions(provider: string): Promise<Array<Record<string, unknown>>>;
     selectProviderModel(provider: string, model: string): Promise<void>;
     selectReasoningEffort(effort: string): Promise<void>;
+    listWorktrees(): Promise<WorktreeInfo[]>;
+    createWorktree(options?: { branchName?: string }): Promise<WorktreeInfo | undefined>;
+    removeWorktree(worktreePath: string): Promise<void>;
 }
 
 export class AgentWorkbenchWebview {
@@ -446,6 +450,70 @@ export class AgentWorkbenchWebview {
             }
             return;
         }
+
+        if (payload.type === 'agent.worktree.list') {
+            try {
+                const worktrees = await this._workflowProviders.listWorktrees();
+                const activePath = this._agentRuntime.getActiveWorktreePath();
+                await this._panel.webview.postMessage({
+                    type: 'agent.worktrees',
+                    worktrees,
+                    activePath,
+                });
+            } catch (error: any) {
+                this._outputChannel.appendLine(`[n8n-agent] Worktree list error: ${error?.message || String(error)}`);
+            }
+            return;
+        }
+
+        if (payload.type === 'agent.worktree.select' && typeof payload.path === 'string') {
+            await this._agentRuntime.setActiveWorktreePath(payload.path);
+            await this._outputChannel.appendLine(`[n8n-agent-debug] Worktree selected path=${payload.path}`);
+            await this.postWorkbenchState();
+            return;
+        }
+
+        if (payload.type === 'agent.worktree.create') {
+            const branchName = typeof payload.branchName === 'string' && payload.branchName ? payload.branchName : undefined;
+            try {
+                const worktree = await this._workflowProviders.createWorktree({ branchName });
+                if (worktree) {
+                    await this._agentRuntime.setActiveWorktreePath(worktree.path);
+                    this._outputChannel.appendLine(`[n8n-agent-debug] Worktree created and selected path=${worktree.path}`);
+                }
+            } catch (error: any) {
+                const message = error?.message || String(error);
+                this._outputChannel.appendLine(`[n8n-agent] Worktree create error: ${message}`);
+                await this._panel.webview.postMessage({ type: 'agent.error', message: `Failed to create worktree: ${message}` });
+            }
+            await this.postWorkbenchState();
+            return;
+        }
+
+        if (payload.type === 'agent.worktree.clear') {
+            await this._agentRuntime.setActiveWorktreePath(undefined);
+            this._outputChannel.appendLine('[n8n-agent-debug] Worktree cleared, back to current workspace');
+            await this.postWorkbenchState();
+            return;
+        }
+
+        if (payload.type === 'agent.worktree.remove' && typeof payload.path === 'string') {
+            try {
+                await this._workflowProviders.removeWorktree(payload.path);
+                const activePath = this._agentRuntime.getActiveWorktreePath();
+                if (activePath === payload.path) {
+                    await this._agentRuntime.setActiveWorktreePath(undefined);
+                }
+                this._outputChannel.appendLine(`[n8n-agent-debug] Worktree removed path=${payload.path}`);
+                fs.promises.rm(payload.path, { recursive: true, force: true }).catch(() => {});
+            } catch (error: any) {
+                const message = error?.message || String(error);
+                this._outputChannel.appendLine(`[n8n-agent] Worktree remove error: ${message}`);
+                await this._panel.webview.postMessage({ type: 'agent.error', message: `Failed to remove worktree: ${message}` });
+            }
+            await this.postWorkbenchState();
+            return;
+        }
     }
 
     private sanitizeNodeContext(value: unknown): AgentWorkbenchNodeContext | undefined {
@@ -513,16 +581,19 @@ export class AgentWorkbenchWebview {
         workflowFilename?: string;
         workflowFilePath?: string;
         workspaceRoot?: string;
+        worktreePath?: string;
         nodeContext?: AgentWorkbenchNodeContext;
         nodeContexts?: AgentWorkbenchNodeContext[];
         sessionId?: string;
     } {
+        const activeWorktreePath = this._agentRuntime.getActiveWorktreePath();
         return {
             workflowId: this._workflow?.id,
             workflowName: this._workflow?.name,
             workflowFilename: this._workflow?.filename,
             workflowFilePath: this._workflowFilePath,
-            workspaceRoot: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+            workspaceRoot: activeWorktreePath || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+            worktreePath: activeWorktreePath,
             nodeContext: this._nodeContexts[0],
             nodeContexts: this._nodeContexts,
             sessionId: this._activeSessionId,
@@ -573,6 +644,13 @@ export class AgentWorkbenchWebview {
             return;
         }
         await this.reconcileWorkflowContext(nextState.workflowContext);
+
+        const activeWorktreePath = this._agentRuntime.getActiveWorktreePath();
+        const availableWorktrees = await this._workflowProviders.listWorktrees().catch(() => []);
+        const activeWorktree = activeWorktreePath
+            ? availableWorktrees.find((wt) => wt.path === activeWorktreePath)
+            : undefined;
+
         const enrichedState = {
             ...nextState,
             availableWorkflows: await this.getWorkflowOptions(),
@@ -584,6 +662,8 @@ export class AgentWorkbenchWebview {
                 label: effort,
                 selected: effort === nextState.reasoningEffort,
             })),
+            activeWorktree,
+            availableWorktrees,
         };
         await this._panel.webview.postMessage({ type: 'agent.state', state: enrichedState, stateSequence });
     }

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -509,7 +509,7 @@ export class AgentWorkbenchWebview {
 
         if (payload.type === 'agent.worktree.remove' && typeof payload.path === 'string') {
             try {
-                const allowed = await this._workflowProviders.listWorktrees().catch(() => []);
+                const allowed = await this._workflowProviders.listWorktrees();
                 const isKnown = allowed.some((wt) => wt.path === payload.path);
                 if (!isKnown) {
                     throw new Error('Refusing to remove unknown worktree path.');


### PR DESCRIPTION
## Summary
- Adds a "Workspace" button in the Agent Workbench composer toolbar (next to model/reasoning selectors) that allows users to create and switch between isolated git worktrees
- When a worktree is active, the agent's `workspaceRoot` switches to the isolated directory, scoping all file operations
- Inspired by Kilo Code's Agent Manager worktree system

## Changes
- **New:** `WorktreeService` wrapping `git worktree` CLI (list, create, remove) with porcelain output parsing
- `AgentRuntimeController` now exposes `getActiveWorktreePath()`/`setActiveWorktreePath()`, stores path in `workspaceState`, overrides `workspaceRoot` on prompt send
- `AgentWorkbenchState` enriched with `activeWorktree`/`availableWorktrees` fields
- `AgentWorkbenchWebview` handles 5 new message types: `agent.worktree.list/create/select/clear/remove`
- UI: Worktree button + popover menu in composer toolbar with current workspace, create new worktree, and existing worktree list
- `extension.ts` wires up worktree service singleton and provider functions

## How it works
1. "Workspace" button appears in the composer toolbar
2. Clicking opens a popover: "Current workspace" (default), "+ Create new worktree", and list of existing worktrees
3. Creating a worktree runs `git worktree add -b n8n-agent-<id>` under `.kilo/worktrees/`
4. When active, `workspaceRoot` switches to the worktree — all agent file operations happen in isolation
5. VS Code window stays on main workspace; only the agent operates in the worktree

## Screenshots
*(UI shows a compact "Workspace" button in composer toolbar, with a popover listing current workspace and worktree options)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage Git worktrees from the Agent Workbench: list available worktrees, create new ones (optional branch), and remove worktrees.
  * Select an active workspace/worktree that persists across sessions and is applied to agent runs.
  * New "Workspace" inline menu in the composer for switching, creating, and deleting worktrees.

* **UX**
  * Clear error reporting for worktree operations and best-effort local cleanup on removal failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->