### PR TITLE
chore(vscode): prune source maps from VSIX package

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -455,11 +455,12 @@
     "typescript": "^5.3.3"
   },
   "scripts": {
-    "vscode:prepublish": "npm run build",
+    "vscode:prepublish": "npm run build && npm run prune-package-artifacts",
     "compile": "tsc -b",
     "watch": "tsc -b -w",
     "package-bundle": "node esbuild.config.js",
     "copy-assets": "node scripts/copy-assets.mjs",
+    "prune-package-artifacts": "node scripts/prune-package-artifacts.mjs",
     "build": "npm run compile && npm run copy-assets && npm run package-bundle",
     "clean": "rm -rf out assets tsconfig.tsbuildinfo",
     "test": "npm run compile && npx tsx --test tests/unit/*.test.ts"

--- a/packages/vscode-extension/scripts/prune-package-artifacts.mjs
+++ b/packages/vscode-extension/scripts/prune-package-artifacts.mjs
@@ -1,0 +1,47 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const outDir = path.join(packageDir, 'out');
+
+function formatBytes(bytes) {
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+}
+
+function removeSourceMaps(directory) {
+  let removedFiles = 0;
+  let removedBytes = 0;
+
+  if (!fs.existsSync(directory)) {
+    return { removedFiles, removedBytes };
+  }
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      const result = removeSourceMaps(entryPath);
+      removedFiles += result.removedFiles;
+      removedBytes += result.removedBytes;
+      continue;
+    }
+
+    if (!entry.isFile() || !entry.name.endsWith('.map')) {
+      continue;
+    }
+
+    const { size } = fs.statSync(entryPath);
+    fs.rmSync(entryPath, { force: true });
+    removedFiles += 1;
+    removedBytes += size;
+  }
+
+  return { removedFiles, removedBytes };
+}
+
+const result = removeSourceMaps(outDir);
+
+console.log(
+  `Pruned ${result.removedFiles} source map files from out/ (${formatBytes(result.removedBytes)} uncompressed).`
+);


### PR DESCRIPTION
## Summary
- Prune generated source map files from `out/` during VSIX prepublish packaging.
- Keep regular builds unchanged while reducing packaged extension size.
- Preserve runtime files and assets to keep the optimization low risk.

## Validation
- `npm run test --workspace=packages/vscode-extension`
- `npx --yes @vscode/vsce package --out /var/folders/5k/6_n2hl1d0msdlkntdn45_d100000gn/T/kilo/vsix-analysis/n8n-as-code-2.10.0-pruned.vsix --no-dependencies`

## Size Impact
- VSIX: 25.66 MB -> 20.64 MB
- Unpacked: 127.91 MB -> 112.89 MB
- Files: 10,435 -> 7,240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the VS Code extension build process to remove unnecessary debugging artifacts, reducing the extension package size.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->