### PR TITLE
feat: add interactive credential mapping for promote

### DIFF
--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -540,7 +540,8 @@ export class PromoteCommand {
             node.credentials[credentialType] = { id: targetId, name: targetName };
             const sourceBindingName = sourceName || sourceId;
             if (sourceBindingName && targetName) {
-                route.bindings!.credentials![this.credentialBindingKey(sourceBindingName, credentialType)] = this.credentialBindingKey(targetName, credentialType);
+                const sourceBindingKey = this.credentialBindingKey(sourceBindingName, credentialType);
+                route.bindings!.credentials![sourceBindingKey] ??= this.credentialBindingKey(targetName, credentialType);
             }
             substitutions.push({
                 kind: 'credential',
@@ -624,8 +625,9 @@ export class PromoteCommand {
 
             const targetName = String(answer.credential.name ?? '').trim();
             const targetType = String(answer.credential.type ?? '').trim();
+            const targetId = String(answer.credential.id ?? '').trim();
             if (!targetName || targetType !== candidate.credentialType) continue;
-            route.bindings!.credentials![this.credentialBindingKey(candidate.sourceName, candidate.credentialType)] = this.credentialBindingKey(targetName, targetType);
+            route.bindings!.credentials![this.credentialBindingKey(candidate.sourceName, candidate.credentialType)] = targetId || this.credentialBindingKey(targetName, targetType);
             mapped = true;
         }
         return mapped ? 'mapped' : 'none';

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -15,6 +15,7 @@ export interface PromoteOptions {
     overwrite?: boolean;
     json?: boolean;
     promotionConfig?: string;
+    interactive?: boolean;
 }
 
 export interface PromotionSubstitution {
@@ -33,6 +34,9 @@ export interface PromotionProblem {
     message: string;
     nodeName?: string;
     ref?: string;
+    credentialType?: string;
+    sourceId?: string;
+    sourceName?: string;
 }
 
 export interface PromotionWorkflowResult {
@@ -71,9 +75,31 @@ export interface PromoteResult {
     workflows: PromotionWorkflowResult[];
 }
 
+export interface CredentialMappingCandidate {
+    credentialType: string;
+    sourceId?: string;
+    sourceName: string;
+    nodeNames: string[];
+}
+
+export interface CredentialMappingPromptContext {
+    routeKey: string;
+    targetEnvironmentName: string;
+}
+
+export type CredentialMappingPromptAnswer =
+    | { action: 'map'; credential: Record<string, unknown> }
+    | { action: 'skip' }
+    | { action: 'abort' };
+
 export interface PromotionCommandDependencies {
     createClient?: (environment: IResolvedWorkspaceEnvironment) => PromotionRuntimeClient;
     pushWorkflow?: (targetEnvironment: IResolvedWorkspaceEnvironment, targetPath: string) => Promise<string | undefined>;
+    promptCredentialMapping?: (
+        candidate: CredentialMappingCandidate,
+        targetCredentials: Array<Record<string, unknown>>,
+        context: CredentialMappingPromptContext,
+    ) => Promise<CredentialMappingPromptAnswer>;
 }
 
 export interface PromotionRuntimeClient {
@@ -82,7 +108,7 @@ export interface PromotionRuntimeClient {
 }
 
 interface PromotionConfig {
-    version: 1;
+    version: 1 | 2;
     routes: Record<string, PromotionRouteConfig>;
 }
 
@@ -177,11 +203,24 @@ export class PromoteCommand {
 
         await this.discoverTargetWorkflowIds(sources, target, route, indexes, options);
 
-        const planned = await this.planWorkflows(sources, target, route, indexes);
-        const blockingProblems = planned.flatMap((workflow) => workflow.problems);
+        let planned = await this.planWorkflows(sources, target, route, indexes);
+        let blockingProblems = planned.flatMap((workflow) => workflow.problems);
+        let hasConfirmedInteractiveMappings = false;
+        const credentialMappingStatus = await this.resolveCredentialProblemsInteractively(planned, target, route, indexes, routeKey, options);
+        if (credentialMappingStatus === 'aborted') {
+            throw new Error('Promotion aborted by user.');
+        }
+        if (credentialMappingStatus === 'mapped') {
+            hasConfirmedInteractiveMappings = true;
+            planned = await this.planWorkflows(sources, target, route, indexes);
+            blockingProblems = planned.flatMap((workflow) => workflow.problems);
+        }
         if (blockingProblems.length > 0) {
             const result = this.buildResult(source, target, routeKey, configPath, planned, options);
             this.printResult(result, options);
+            if (hasConfirmedInteractiveMappings && !options.dryRun) {
+                this.savePromotionConfig(configPath, config);
+            }
             throw new Error(`Promotion blocked by ${blockingProblems.length} problem${blockingProblems.length === 1 ? '' : 's'}.`);
         }
 
@@ -488,7 +527,10 @@ export class PromoteCommand {
                 problems.push({
                     kind: 'credential',
                     nodeName: node.name,
-                    ref: sourceId || sourceName,
+                    ref: sourceName ? this.credentialBindingKey(sourceName, credentialType) : sourceId,
+                    credentialType,
+                    sourceId: sourceId || undefined,
+                    sourceName: sourceName || undefined,
                     message: `Cannot resolve credential "${sourceName || sourceId}" of type "${credentialType}" in target environment.`,
                 });
                 continue;
@@ -496,7 +538,10 @@ export class PromoteCommand {
             const targetId = String(targetCredential.id ?? '').trim();
             const targetName = String(targetCredential.name ?? '').trim();
             node.credentials[credentialType] = { id: targetId, name: targetName };
-            if (sourceId) route.bindings!.credentials![sourceId] = targetId;
+            const sourceBindingName = sourceName || sourceId;
+            if (sourceBindingName && targetName) {
+                route.bindings!.credentials![this.credentialBindingKey(sourceBindingName, credentialType)] = this.credentialBindingKey(targetName, credentialType);
+            }
             substitutions.push({
                 kind: 'credential',
                 nodeName: node.name,
@@ -519,10 +564,16 @@ export class PromoteCommand {
         sourceName: string,
     ): Promise<Record<string, unknown> | undefined> {
         await this.ensureTargetCredentialIndexes(target, indexes);
+        const sourceBindingName = sourceName || sourceId;
+        if (sourceBindingName) {
+            const boundRef = route.bindings?.credentials?.[this.credentialBindingKey(sourceBindingName, credentialType)];
+            const boundCredential = this.resolveCredentialBindingReference(boundRef, credentialType, indexes);
+            if (boundCredential) return boundCredential;
+        }
         if (sourceId) {
             const boundId = route.bindings?.credentials?.[sourceId];
             if (boundId) {
-                return indexes.targetCredentialsById!.get(boundId);
+                return this.resolveCredentialBindingReference(boundId, credentialType, indexes);
             }
         }
 
@@ -540,6 +591,137 @@ export class PromoteCommand {
         const matches = indexes.targetCredentialsByKey!.get(`${credentialType}::${targetName}`) ?? [];
         if (matches.length === 1) return matches[0];
         return undefined;
+    }
+
+    private async resolveCredentialProblemsInteractively(
+        planned: PromotionWorkflowResult[],
+        target: IResolvedWorkspaceEnvironment,
+        route: PromotionRouteConfig,
+        indexes: PromotionIndexes,
+        routeKey: string,
+        options: PromoteOptions,
+    ): Promise<'none' | 'mapped' | 'aborted'> {
+        if (!this.shouldPromptForCredentialMappings(options)) return 'none';
+        const candidates = this.collectCredentialMappingCandidates(planned);
+        if (candidates.length === 0) return 'none';
+
+        await this.ensureTargetCredentialIndexes(target, indexes);
+        console.log(chalk.yellow('\nUnresolved credentials require target mappings.'));
+        let mapped = false;
+        let currentType: string | undefined;
+        for (const candidate of candidates) {
+            if (candidate.credentialType !== currentType) {
+                currentType = candidate.credentialType;
+                console.log(chalk.dim(`\n${candidate.credentialType}`));
+            }
+            const targetCredentials = this.getTargetCredentialsByType(indexes, candidate.credentialType);
+            const answer = await this.askCredentialMapping(candidate, targetCredentials, {
+                routeKey,
+                targetEnvironmentName: target.environmentName,
+            });
+            if (answer.action === 'abort') return 'aborted';
+            if (answer.action === 'skip') continue;
+
+            const targetName = String(answer.credential.name ?? '').trim();
+            const targetType = String(answer.credential.type ?? '').trim();
+            if (!targetName || targetType !== candidate.credentialType) continue;
+            route.bindings!.credentials![this.credentialBindingKey(candidate.sourceName, candidate.credentialType)] = this.credentialBindingKey(targetName, targetType);
+            mapped = true;
+        }
+        return mapped ? 'mapped' : 'none';
+    }
+
+    private shouldPromptForCredentialMappings(options: PromoteOptions): boolean {
+        if (options.interactive === false || options.dryRun || options.json) return false;
+        if (this.dependencies.promptCredentialMapping) return true;
+        return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+    }
+
+    private collectCredentialMappingCandidates(planned: PromotionWorkflowResult[]): CredentialMappingCandidate[] {
+        const byKey = new Map<string, CredentialMappingCandidate>();
+        for (const workflow of planned) {
+            for (const problem of workflow.problems) {
+                if (problem.kind !== 'credential' || !problem.credentialType) continue;
+                const sourceName = problem.sourceName || problem.sourceId || problem.ref;
+                if (!sourceName) continue;
+                const key = this.credentialBindingKey(sourceName, problem.credentialType);
+                const existing = byKey.get(key) ?? {
+                    credentialType: problem.credentialType,
+                    sourceId: problem.sourceId,
+                    sourceName,
+                    nodeNames: [],
+                };
+                if (problem.nodeName && !existing.nodeNames.includes(problem.nodeName)) {
+                    existing.nodeNames.push(problem.nodeName);
+                }
+                byKey.set(key, existing);
+            }
+        }
+        return Array.from(byKey.values()).sort((a, b) => {
+            const byType = a.credentialType.localeCompare(b.credentialType);
+            return byType || a.sourceName.localeCompare(b.sourceName);
+        });
+    }
+
+    private getTargetCredentialsByType(indexes: PromotionIndexes, credentialType: string): Array<Record<string, unknown>> {
+        return Array.from(indexes.targetCredentialsById?.values() ?? [])
+            .filter((credential) => String(credential.type ?? '').trim() === credentialType)
+            .sort((a, b) => String(a.name ?? '').localeCompare(String(b.name ?? '')));
+    }
+
+    private async askCredentialMapping(
+        candidate: CredentialMappingCandidate,
+        targetCredentials: Array<Record<string, unknown>>,
+        context: CredentialMappingPromptContext,
+    ): Promise<CredentialMappingPromptAnswer> {
+        if (this.dependencies.promptCredentialMapping) {
+            return this.dependencies.promptCredentialMapping(candidate, targetCredentials, context);
+        }
+
+        const { default: inquirer } = await import('inquirer');
+        const choices = targetCredentials.map((credential, index) => ({
+            name: `${String(credential.name ?? 'Unnamed credential')} (${String(credential.id ?? 'no id')})`,
+            value: `map:${index}`,
+        }));
+        choices.push(
+            { name: 'Skip this credential', value: 'skip' },
+            { name: 'Abort promotion', value: 'abort' },
+        );
+        const nodeLabel = candidate.nodeNames.length > 0 ? ` used by ${candidate.nodeNames.join(', ')}` : '';
+        const answer = await inquirer.prompt<{ selection: string }>([{
+            type: 'list',
+            name: 'selection',
+            message: `Map "${candidate.sourceName}" (${candidate.credentialType})${nodeLabel} in ${context.targetEnvironmentName}`,
+            choices,
+        }]);
+        if (answer.selection === 'abort') return { action: 'abort' };
+        if (answer.selection === 'skip') return { action: 'skip' };
+        const index = Number(answer.selection.replace(/^map:/, ''));
+        const credential = targetCredentials[index];
+        return credential ? { action: 'map', credential } : { action: 'skip' };
+    }
+
+    private resolveCredentialBindingReference(boundRef: string | undefined, credentialType: string, indexes: PromotionIndexes): Record<string, unknown> | undefined {
+        if (!boundRef) return undefined;
+        const byId = indexes.targetCredentialsById!.get(boundRef);
+        if (byId) return byId;
+
+        const parsed = this.parseCredentialBindingKey(boundRef);
+        if (!parsed || parsed.type !== credentialType) return undefined;
+        return unique(indexes.targetCredentialsByKey!.get(`${parsed.type}::${parsed.name}`));
+    }
+
+    private credentialBindingKey(name: string, credentialType: string): string {
+        return `${name}:${credentialType}`;
+    }
+
+    private parseCredentialBindingKey(value: string): { name: string; type: string } | undefined {
+        const delimiterIndex = value.lastIndexOf(':');
+        if (delimiterIndex <= 0 || delimiterIndex === value.length - 1) return undefined;
+        return {
+            name: value.slice(0, delimiterIndex),
+            type: value.slice(delimiterIndex + 1),
+        };
     }
 
     private async remapWorkflowReferences(
@@ -730,16 +912,17 @@ export class PromoteCommand {
 
     private loadPromotionConfig(configPath: string): PromotionConfig {
         if (!fs.existsSync(configPath)) {
-            return { version: 1, routes: {} };
+            return { version: 2, routes: {} };
         }
         const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as PromotionConfig;
-        if (parsed.version !== 1 || !parsed.routes || typeof parsed.routes !== 'object') {
+        if ((parsed.version !== 1 && parsed.version !== 2) || !parsed.routes || typeof parsed.routes !== 'object') {
             throw new Error(`Invalid promotion config: ${configPath}`);
         }
         return parsed;
     }
 
     private savePromotionConfig(configPath: string, config: PromotionConfig): void {
+        config.version = 2;
         fs.mkdirSync(path.dirname(configPath), { recursive: true });
         fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1215,6 +1215,7 @@ program.command('promote')
     .option('--no-push', 'Copy/adapt the workflow into the target environment without pushing')
     .option('--overwrite', 'Overwrite the target local workflow file if it already exists')
     .option('--promotion-config <path>', 'Promotion config path', 'n8nac-promotion.json')
+    .option('--no-interactive', 'Disable interactive credential mapping prompts')
     .option('--json', 'Output promotion result as JSON')
     .action(async (pathArg, options) => {
         try {
@@ -1225,6 +1226,7 @@ program.command('promote')
                 push: options.push,
                 overwrite: options.overwrite,
                 promotionConfig: options.promotionConfig,
+                interactive: options.interactive,
                 json: options.json,
             });
         } catch (error: any) {

--- a/packages/cli/tests/unit/promote-command.test.ts
+++ b/packages/cli/tests/unit/promote-command.test.ts
@@ -316,7 +316,151 @@ export class CredentialWorkflow {
             expect(promoted).toContain("id: 'target-cred'");
             expect(promoted).toContain("name: 'Shared Credential'");
             const promotionConfig = JSON.parse(readFileSync(path.join(workspaceRoot, 'n8nac-promotion.json'), 'utf8'));
-            expect(promotionConfig.routes['Dev->Prod'].bindings.credentials['source-cred']).toBe('target-cred');
+            expect(promotionConfig.routes['Dev->Prod'].bindings.credentials['Shared Credential:httpBasicAuth']).toBe('Shared Credential:httpBasicAuth');
+        } finally {
+            if (previousManagerHome === undefined) {
+                delete process.env.N8N_MANAGER_HOME;
+            } else {
+                process.env.N8N_MANAGER_HOME = previousManagerHome;
+            }
+        }
+    });
+
+    it('prompts for unresolved credential mappings and persists name-type bindings', async () => {
+        const previousManagerHome = process.env.N8N_MANAGER_HOME;
+        const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-workspace-'));
+        process.env.N8N_MANAGER_HOME = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-manager-'));
+        try {
+            const globalWorkspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-global-'));
+            const globalConfigService = new ConfigService(globalWorkspaceRoot);
+            globalConfigService.saveLocalConfig({
+                host: 'https://dev.example.test',
+                instanceIdentifier: 'n8n_1111111111',
+            }, { instanceId: 'dev-instance', instanceName: 'Dev', apiKey: 'dev-key' });
+            globalConfigService.saveLocalConfig({
+                host: 'https://prod.example.test',
+                instanceIdentifier: 'n8n_2222222222',
+            }, { instanceId: 'prod-instance', instanceName: 'Prod', apiKey: 'prod-key', setActive: false });
+
+            const configService = new ConfigService(workspaceRoot);
+            const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
+            const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/prod' });
+
+            const sourceDir = configService.resolveEnvironment('Dev').workflowsPath!;
+            const targetDir = configService.resolveEnvironment('Prod').workflowsPath!;
+            mkdirSync(sourceDir, { recursive: true });
+            const sourcePath = path.join(sourceDir, 'mapped-credential.workflow.ts');
+            writeFileSync(sourcePath, `import { workflow, node } from '@n8n-as-code/transformer';
+
+@workflow({ id: 'source-wf', name: 'Mapped Credential Workflow', active: false })
+export class MappedCredentialWorkflow {
+  @node({
+    name: 'Postgres',
+    type: 'n8n-nodes-base.postgres',
+    version: 2,
+    position: [100, 100],
+    credentials: { postgres: { id: 'source-postgres', name: 'Dev Database' } }
+  })
+  Postgres = { operation: 'executeQuery' };
+}
+`, 'utf8');
+
+            const promptCandidates: string[] = [];
+            await new PromoteCommand(configService, {
+                createClient: () => ({
+                    getAllWorkflows: async () => [],
+                    listCredentials: async () => [
+                        { id: 'target-postgres', name: 'Prod Database', type: 'postgres' },
+                        { id: 'target-http', name: 'Prod HTTP', type: 'httpBasicAuth' },
+                    ],
+                }),
+                promptCredentialMapping: async (candidate, targetCredentials) => {
+                    promptCandidates.push(`${candidate.sourceName}:${candidate.credentialType}`);
+                    expect(targetCredentials).toEqual([{ id: 'target-postgres', name: 'Prod Database', type: 'postgres' }]);
+                    return { action: 'map', credential: targetCredentials[0]! };
+                },
+            }).run(sourcePath, {
+                from: 'Dev',
+                to: 'Prod',
+                push: false,
+                promotionConfig: path.join(workspaceRoot, 'n8nac-promotion.json'),
+            });
+
+            expect(promptCandidates).toEqual(['Dev Database:postgres']);
+            const promoted = readFileSync(path.join(targetDir, 'mapped-credential.workflow.ts'), 'utf8');
+            expect(promoted).toContain("id: 'target-postgres'");
+            expect(promoted).toContain("name: 'Prod Database'");
+            const promotionConfig = JSON.parse(readFileSync(path.join(workspaceRoot, 'n8nac-promotion.json'), 'utf8'));
+            expect(promotionConfig.version).toBe(2);
+            expect(promotionConfig.routes['Dev->Prod'].bindings.credentials['Dev Database:postgres']).toBe('Prod Database:postgres');
+        } finally {
+            if (previousManagerHome === undefined) {
+                delete process.env.N8N_MANAGER_HOME;
+            } else {
+                process.env.N8N_MANAGER_HOME = previousManagerHome;
+            }
+        }
+    });
+
+    it('keeps blocking unresolved credentials when interactive prompts are disabled', async () => {
+        const previousManagerHome = process.env.N8N_MANAGER_HOME;
+        const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-workspace-'));
+        process.env.N8N_MANAGER_HOME = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-manager-'));
+        try {
+            const globalWorkspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-global-'));
+            const globalConfigService = new ConfigService(globalWorkspaceRoot);
+            globalConfigService.saveLocalConfig({
+                host: 'https://dev.example.test',
+                instanceIdentifier: 'n8n_1111111111',
+            }, { instanceId: 'dev-instance', instanceName: 'Dev', apiKey: 'dev-key' });
+            globalConfigService.saveLocalConfig({
+                host: 'https://prod.example.test',
+                instanceIdentifier: 'n8n_2222222222',
+            }, { instanceId: 'prod-instance', instanceName: 'Prod', apiKey: 'prod-key', setActive: false });
+
+            const configService = new ConfigService(workspaceRoot);
+            const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
+            const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/prod' });
+
+            const sourceDir = configService.resolveEnvironment('Dev').workflowsPath!;
+            mkdirSync(sourceDir, { recursive: true });
+            const sourcePath = path.join(sourceDir, 'blocked-credential.workflow.ts');
+            writeFileSync(sourcePath, `import { workflow, node } from '@n8n-as-code/transformer';
+
+@workflow({ id: 'source-wf', name: 'Blocked Credential Workflow', active: false })
+export class BlockedCredentialWorkflow {
+  @node({
+    name: 'Postgres',
+    type: 'n8n-nodes-base.postgres',
+    version: 2,
+    position: [100, 100],
+    credentials: { postgres: { id: 'source-postgres', name: 'Dev Database' } }
+  })
+  Postgres = { operation: 'executeQuery' };
+}
+`, 'utf8');
+
+            const promotionConfigPath = path.join(workspaceRoot, 'n8nac-promotion.json');
+            await expect(new PromoteCommand(configService, {
+                createClient: () => ({
+                    getAllWorkflows: async () => [],
+                    listCredentials: async () => [
+                        { id: 'target-postgres', name: 'Prod Database', type: 'postgres' },
+                    ],
+                }),
+                promptCredentialMapping: async () => ({ action: 'abort' }),
+            }).run(sourcePath, {
+                from: 'Dev',
+                to: 'Prod',
+                push: false,
+                interactive: false,
+                promotionConfig: promotionConfigPath,
+            })).rejects.toThrow('Promotion blocked by 1 problem.');
+            expect(existsSync(promotionConfigPath)).toBe(false);
         } finally {
             if (previousManagerHome === undefined) {
                 delete process.env.N8N_MANAGER_HOME;

--- a/packages/cli/tests/unit/promote-command.test.ts
+++ b/packages/cli/tests/unit/promote-command.test.ts
@@ -326,7 +326,7 @@ export class CredentialWorkflow {
         }
     });
 
-    it('prompts for unresolved credential mappings and persists name-type bindings', async () => {
+    it('prompts for unresolved credential mappings and persists deterministic target id bindings', async () => {
         const previousManagerHome = process.env.N8N_MANAGER_HOME;
         const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-workspace-'));
         process.env.N8N_MANAGER_HOME = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-manager-'));
@@ -394,7 +394,78 @@ export class MappedCredentialWorkflow {
             expect(promoted).toContain("name: 'Prod Database'");
             const promotionConfig = JSON.parse(readFileSync(path.join(workspaceRoot, 'n8nac-promotion.json'), 'utf8'));
             expect(promotionConfig.version).toBe(2);
-            expect(promotionConfig.routes['Dev->Prod'].bindings.credentials['Dev Database:postgres']).toBe('Prod Database:postgres');
+            expect(promotionConfig.routes['Dev->Prod'].bindings.credentials['Dev Database:postgres']).toBe('target-postgres');
+        } finally {
+            if (previousManagerHome === undefined) {
+                delete process.env.N8N_MANAGER_HOME;
+            } else {
+                process.env.N8N_MANAGER_HOME = previousManagerHome;
+            }
+        }
+    });
+
+    it('uses the selected credential id when interactive mapping target names are duplicated', async () => {
+        const previousManagerHome = process.env.N8N_MANAGER_HOME;
+        const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-workspace-'));
+        process.env.N8N_MANAGER_HOME = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-manager-'));
+        try {
+            const globalWorkspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-global-'));
+            const globalConfigService = new ConfigService(globalWorkspaceRoot);
+            globalConfigService.saveLocalConfig({
+                host: 'https://dev.example.test',
+                instanceIdentifier: 'n8n_1111111111',
+            }, { instanceId: 'dev-instance', instanceName: 'Dev', apiKey: 'dev-key' });
+            globalConfigService.saveLocalConfig({
+                host: 'https://prod.example.test',
+                instanceIdentifier: 'n8n_2222222222',
+            }, { instanceId: 'prod-instance', instanceName: 'Prod', apiKey: 'prod-key', setActive: false });
+
+            const configService = new ConfigService(workspaceRoot);
+            const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
+            const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/prod' });
+
+            const sourceDir = configService.resolveEnvironment('Dev').workflowsPath!;
+            const targetDir = configService.resolveEnvironment('Prod').workflowsPath!;
+            mkdirSync(sourceDir, { recursive: true });
+            const sourcePath = path.join(sourceDir, 'duplicate-credential.workflow.ts');
+            writeFileSync(sourcePath, `import { workflow, node } from '@n8n-as-code/transformer';
+
+@workflow({ id: 'source-wf', name: 'Duplicate Credential Workflow', active: false })
+export class DuplicateCredentialWorkflow {
+  @node({
+    name: 'Postgres',
+    type: 'n8n-nodes-base.postgres',
+    version: 2,
+    position: [100, 100],
+    credentials: { postgres: { id: 'source-postgres', name: 'Dev Database' } }
+  })
+  Postgres = { operation: 'executeQuery' };
+}
+`, 'utf8');
+
+            await new PromoteCommand(configService, {
+                createClient: () => ({
+                    getAllWorkflows: async () => [],
+                    listCredentials: async () => [
+                        { id: 'target-postgres-a', name: 'Prod Database', type: 'postgres' },
+                        { id: 'target-postgres-b', name: 'Prod Database', type: 'postgres' },
+                    ],
+                }),
+                promptCredentialMapping: async (_candidate, targetCredentials) => ({ action: 'map', credential: targetCredentials[1]! }),
+            }).run(sourcePath, {
+                from: 'Dev',
+                to: 'Prod',
+                push: false,
+                promotionConfig: path.join(workspaceRoot, 'n8nac-promotion.json'),
+            });
+
+            const promoted = readFileSync(path.join(targetDir, 'duplicate-credential.workflow.ts'), 'utf8');
+            expect(promoted).toContain("id: 'target-postgres-b'");
+            expect(promoted).toContain("name: 'Prod Database'");
+            const promotionConfig = JSON.parse(readFileSync(path.join(workspaceRoot, 'n8nac-promotion.json'), 'utf8'));
+            expect(promotionConfig.routes['Dev->Prod'].bindings.credentials['Dev Database:postgres']).toBe('target-postgres-b');
         } finally {
             if (previousManagerHome === undefined) {
                 delete process.env.N8N_MANAGER_HOME;
@@ -452,7 +523,9 @@ export class BlockedCredentialWorkflow {
                         { id: 'target-postgres', name: 'Prod Database', type: 'postgres' },
                     ],
                 }),
-                promptCredentialMapping: async () => ({ action: 'abort' }),
+                promptCredentialMapping: async () => {
+                    throw new Error('promptCredentialMapping must not be called when interactive is false');
+                },
             }).run(sourcePath, {
                 from: 'Dev',
                 to: 'Prod',


### PR DESCRIPTION
## Summary
- Add an interactive credential mapping flow for unresolved credentials during `n8nac promote`.
- Persist confirmed credential bindings as `<name>:<type>` mappings in promotion config v2 while preserving existing id-based binding resolution.
- Add `--no-interactive` and unit coverage for wizard and CI/blocking behavior.

## Tests
- `npx vitest run packages/cli/tests/unit/promote-command.test.ts`
- `npm run build --workspace=n8nac`

Closes #490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive credential remapping during promotion—prompt to map unresolved source credentials to target credentials; can be disabled with a new flag.
  * Promotion now persists credential bindings using type-aware binding keys (e.g., "name:type") for more reliable resolution.
* **Behavior Changes**
  * Promotion config is saved only when interactive mappings are confirmed; never saved during dry run. Promotion still blocks when unresolved problems remain.
* **Tests**
  * Added tests covering interactive mapping, duplicate names, and non-interactive blocking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->