### PR TITLE
fix(vscode): avoid forced worktree deletion

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1113,12 +1113,12 @@ async function createAgentWorktree(options?: { branchName?: string }): Promise<W
     });
 }
 
-async function removeAgentWorktree(worktreePath: string, options?: { force?: boolean }): Promise<void> {
+async function removeAgentWorktree(worktreePath: string): Promise<void> {
     const workspaceRoot = getWorkspaceRoot();
     if (!workspaceRoot) throw new Error('No workspace root available.');
     const service = getWorktreeService();
     if (!service) throw new Error('Worktree service unavailable.');
-    await service.removeWorktree(workspaceRoot, worktreePath, options?.force ?? false);
+    await service.removeWorktree(workspaceRoot, worktreePath);
 }
 
 async function resolveWorkflowWebviewTarget(workflow: IWorkflowStatus): Promise<{ url: string; targetUrl: string }> {

--- a/packages/vscode-extension/src/services/worktree-service.ts
+++ b/packages/vscode-extension/src/services/worktree-service.ts
@@ -81,19 +81,15 @@ export class WorktreeService {
         return created;
     }
 
-    async removeWorktree(repoPath: string, worktreePath: string, force = false): Promise<void> {
-        const args = ['worktree', 'remove'];
-        if (force) args.push('--force');
-        args.push(worktreePath);
-
+    async removeWorktree(repoPath: string, worktreePath: string): Promise<void> {
         try {
-            await execFileAsync('git', args, {
+            await execFileAsync('git', ['worktree', 'remove', worktreePath], {
                 cwd: repoPath,
                 maxBuffer: 10 * 1024 * 1024,
             });
             this.log(`[n8n-worktree] Removed worktree at ${worktreePath}`);
         } catch (error: any) {
-            const message = error?.message || String(error);
+            const message = this.formatRemoveError(error);
             this.log(`[n8n-worktree] Remove failed: ${message}`);
             throw new Error(`Failed to remove worktree: ${message}`);
         }
@@ -162,5 +158,15 @@ export class WorktreeService {
         }
 
         return result;
+    }
+
+    private formatRemoveError(error: any): string {
+        const stderr = typeof error?.stderr === 'string' ? error.stderr : '';
+        const stdout = typeof error?.stdout === 'string' ? error.stdout : '';
+        const message = [stderr, stdout, error?.message || String(error)].filter(Boolean).join('\n').trim();
+        if (/contains modified or untracked files|contains.*uncommitted|is dirty/i.test(message)) {
+            return 'Cannot remove worktree because it contains uncommitted changes. Commit, stash, or discard those changes first.';
+        }
+        return message || 'Unknown git worktree remove error.';
     }
 }

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -29,7 +29,7 @@ interface AgentWorkbenchWorkflowProviders {
     selectReasoningEffort(effort: string): Promise<void>;
     listWorktrees(): Promise<WorktreeInfo[]>;
     createWorktree(options?: { branchName?: string }): Promise<WorktreeInfo | undefined>;
-    removeWorktree(worktreePath: string, options?: { force?: boolean }): Promise<void>;
+    removeWorktree(worktreePath: string): Promise<void>;
 }
 
 export class AgentWorkbenchWebview {
@@ -511,7 +511,7 @@ export class AgentWorkbenchWebview {
 
         if (payload.type === 'agent.worktree.remove' && typeof payload.path === 'string') {
             const confirmed = await vscode.window.showWarningMessage(
-                'Delete this worktree? Unsaved or unpushed work may be lost.',
+                'Delete this worktree? This will fail if it contains uncommitted changes.',
                 { modal: true },
                 'Delete',
             );
@@ -523,7 +523,7 @@ export class AgentWorkbenchWebview {
                 if (!isKnown) {
                     throw new Error('Refusing to remove unknown worktree path.');
                 }
-                await this._workflowProviders.removeWorktree(payload.path, { force: true });
+                await this._workflowProviders.removeWorktree(payload.path);
                 const activePath = this._agentRuntime.getActiveWorktreePath();
                 if (activePath === payload.path) {
                     await this._agentRuntime.setActiveWorktreePath(undefined);


### PR DESCRIPTION
## Summary
- Remove the `--force` path from Agent Workbench worktree deletion.
- Let Git block deletion when a worktree has uncommitted changes and surface a clearer user-facing message.
- Update the delete confirmation copy to set that expectation.

## Validation
- `npm run compile --workspace=packages/vscode-extension`

## Notes
- This intentionally excludes the unrelated root `package.json` working-tree change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for failed worktree removals with clearer details when uncommitted changes prevent deletion
  * Removed forced removal capability; worktree removal now requires a clean repository state

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->