### PR TITLE
fix(vscode): harden agent worktree handling

### DIFF
--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -23,6 +23,7 @@ const ENVIRONMENT_DETAILS_BLOCK_PATTERN = /<environment_details>[\s\S]*?<\/envir
 const UNATTACHED_WORKFLOW_SCOPE_KEY = '__unattached__';
 const DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000;
 const ACTIVE_WORKTREE_PATH_KEY = 'n8n.agent.activeWorktreePath';
+const ACTIVE_WORKTREE_PATH_BY_SESSION_KEY = 'n8n.agent.activeWorktreePathBySession';
 const INVALID_TOOL_CALL_RECOVERY_MARKER = 'N8N_INVALID_TOOL_CALL_RECOVERY';
 
 export interface AgentNodeContext {
@@ -843,16 +844,36 @@ export class AgentRuntimeController implements vscode.Disposable {
         return this.getWorkbenchState({ ...input, workflowId: undefined, workflowName: undefined, workflowFilename: undefined, workflowFilePath: undefined, nodeContext: undefined, nodeContexts: undefined, sessionId: record.id });
     }
 
-    getActiveWorktreePath(): string | undefined {
+    getActiveWorktreePath(sessionId?: string): string | undefined {
+        if (sessionId) {
+            return this.readActiveWorktreePathsBySession()[sessionId];
+        }
         return this._context.workspaceState.get<string>(ACTIVE_WORKTREE_PATH_KEY);
     }
 
-    async setActiveWorktreePath(worktreePath: string | undefined): Promise<void> {
+    async setActiveWorktreePath(worktreePath: string | undefined, sessionId?: string): Promise<void> {
+        if (sessionId) {
+            const bySession = this.readActiveWorktreePathsBySession();
+            if (worktreePath) {
+                bySession[sessionId] = worktreePath;
+            } else {
+                delete bySession[sessionId];
+            }
+            await this._context.workspaceState.update(ACTIVE_WORKTREE_PATH_BY_SESSION_KEY, bySession);
+            await this._context.workspaceState.update(ACTIVE_WORKTREE_PATH_KEY, undefined);
+            return;
+        }
         if (worktreePath) {
             await this._context.workspaceState.update(ACTIVE_WORKTREE_PATH_KEY, worktreePath);
         } else {
             await this._context.workspaceState.update(ACTIVE_WORKTREE_PATH_KEY, undefined);
         }
+    }
+
+    private readActiveWorktreePathsBySession(): Record<string, string> {
+        const value = this._context.workspaceState.get<Record<string, string>>(ACTIVE_WORKTREE_PATH_BY_SESSION_KEY);
+        if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+        return Object.fromEntries(Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === 'string' && entry[1].trim().length > 0));
     }
 
     async getLatestSessionId(): Promise<string | undefined> {
@@ -926,6 +947,7 @@ export class AgentRuntimeController implements vscode.Disposable {
         const active = sessions.service.getActiveForScope(scope)?.id;
         const deletedSelectedSession = input.sessionId === sessionId;
         await sessions.service.delete(sessionId);
+        await this.setActiveWorktreePath(undefined, sessionId);
         if (active === sessionId) {
             sessions.service.getOrCreateForScope(scope, { title: this.getDefaultSessionTitle(input.workflowName) });
         }
@@ -1126,12 +1148,6 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     async sendPrompt(input: AgentPromptInput, postMessage: AgentWorkbenchPostMessage): Promise<AgentRunResult> {
-        const activeWorktreePath = this.getActiveWorktreePath();
-        if (activeWorktreePath) {
-            input.workspaceRoot = activeWorktreePath;
-            input.worktreePath = activeWorktreePath;
-        }
-
         const sessions = await this.getSessionRuntime();
         const scope = this.getSessionScope(input);
         const activeRecord = input.sessionId
@@ -1141,6 +1157,12 @@ export class AgentRuntimeController implements vscode.Disposable {
             }));
         const targetSessionId = activeRecord.id;
         input.sessionId = targetSessionId;
+
+        const activeWorktreePath = this.getActiveWorktreePath(targetSessionId);
+        if (activeWorktreePath) {
+            input.workspaceRoot = activeWorktreePath;
+            input.worktreePath = activeWorktreePath;
+        }
 
         const activeRun = this.activeRuns.get(targetSessionId);
         if (activeRun) {

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -26,6 +26,8 @@ const ACTIVE_WORKTREE_PATH_KEY = 'n8n.agent.activeWorktreePath';
 const ACTIVE_WORKTREE_PATH_BY_SESSION_KEY = 'n8n.agent.activeWorktreePathBySession';
 const INVALID_TOOL_CALL_RECOVERY_MARKER = 'N8N_INVALID_TOOL_CALL_RECOVERY';
 
+type ActiveWorktreePathsBySession = Record<string, string | null>;
+
 export interface AgentNodeContext {
     name: string;
     type?: string;
@@ -847,7 +849,9 @@ export class AgentRuntimeController implements vscode.Disposable {
     getActiveWorktreePath(sessionId?: string): string | undefined {
         const legacyPath = this._context.workspaceState.get<string>(ACTIVE_WORKTREE_PATH_KEY);
         if (sessionId) {
-            return this.readActiveWorktreePathsBySession()[sessionId] ?? legacyPath;
+            const sessionPath = this.readActiveWorktreePathsBySession()[sessionId];
+            if (sessionPath === null) return undefined;
+            return sessionPath ?? legacyPath;
         }
         return legacyPath;
     }
@@ -858,7 +862,7 @@ export class AgentRuntimeController implements vscode.Disposable {
             if (worktreePath) {
                 bySession[sessionId] = worktreePath;
             } else {
-                delete bySession[sessionId];
+                bySession[sessionId] = null;
             }
             await this._context.workspaceState.update(ACTIVE_WORKTREE_PATH_BY_SESSION_KEY, bySession);
             return;
@@ -875,7 +879,7 @@ export class AgentRuntimeController implements vscode.Disposable {
         let changed = false;
         for (const [sessionId, activeWorktreePath] of Object.entries(bySession)) {
             if (activeWorktreePath === worktreePath) {
-                delete bySession[sessionId];
+                bySession[sessionId] = null;
                 changed = true;
             }
         }
@@ -887,10 +891,17 @@ export class AgentRuntimeController implements vscode.Disposable {
         }
     }
 
-    private readActiveWorktreePathsBySession(): Record<string, string> {
-        const value = this._context.workspaceState.get<Record<string, string>>(ACTIVE_WORKTREE_PATH_BY_SESSION_KEY);
+    private async deleteActiveWorktreePathForSession(sessionId: string): Promise<void> {
+        const bySession = this.readActiveWorktreePathsBySession();
+        if (!Object.prototype.hasOwnProperty.call(bySession, sessionId)) return;
+        delete bySession[sessionId];
+        await this._context.workspaceState.update(ACTIVE_WORKTREE_PATH_BY_SESSION_KEY, bySession);
+    }
+
+    private readActiveWorktreePathsBySession(): ActiveWorktreePathsBySession {
+        const value = this._context.workspaceState.get<ActiveWorktreePathsBySession>(ACTIVE_WORKTREE_PATH_BY_SESSION_KEY);
         if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
-        return Object.fromEntries(Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === 'string' && entry[1].trim().length > 0));
+        return Object.fromEntries(Object.entries(value).filter((entry): entry is [string, string | null] => entry[1] === null || (typeof entry[1] === 'string' && entry[1].trim().length > 0)));
     }
 
     async getLatestSessionId(): Promise<string | undefined> {
@@ -964,7 +975,7 @@ export class AgentRuntimeController implements vscode.Disposable {
         const active = sessions.service.getActiveForScope(scope)?.id;
         const deletedSelectedSession = input.sessionId === sessionId;
         await sessions.service.delete(sessionId);
-        await this.setActiveWorktreePath(undefined, sessionId);
+        await this.deleteActiveWorktreePathForSession(sessionId);
         if (active === sessionId) {
             sessions.service.getOrCreateForScope(scope, { title: this.getDefaultSessionTitle(input.workflowName) });
         }

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -845,10 +845,11 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     getActiveWorktreePath(sessionId?: string): string | undefined {
+        const legacyPath = this._context.workspaceState.get<string>(ACTIVE_WORKTREE_PATH_KEY);
         if (sessionId) {
-            return this.readActiveWorktreePathsBySession()[sessionId];
+            return this.readActiveWorktreePathsBySession()[sessionId] ?? legacyPath;
         }
-        return this._context.workspaceState.get<string>(ACTIVE_WORKTREE_PATH_KEY);
+        return legacyPath;
     }
 
     async setActiveWorktreePath(worktreePath: string | undefined, sessionId?: string): Promise<void> {
@@ -860,12 +861,28 @@ export class AgentRuntimeController implements vscode.Disposable {
                 delete bySession[sessionId];
             }
             await this._context.workspaceState.update(ACTIVE_WORKTREE_PATH_BY_SESSION_KEY, bySession);
-            await this._context.workspaceState.update(ACTIVE_WORKTREE_PATH_KEY, undefined);
             return;
         }
         if (worktreePath) {
             await this._context.workspaceState.update(ACTIVE_WORKTREE_PATH_KEY, worktreePath);
         } else {
+            await this._context.workspaceState.update(ACTIVE_WORKTREE_PATH_KEY, undefined);
+        }
+    }
+
+    async clearActiveWorktreePath(worktreePath: string): Promise<void> {
+        const bySession = this.readActiveWorktreePathsBySession();
+        let changed = false;
+        for (const [sessionId, activeWorktreePath] of Object.entries(bySession)) {
+            if (activeWorktreePath === worktreePath) {
+                delete bySession[sessionId];
+                changed = true;
+            }
+        }
+        if (changed) {
+            await this._context.workspaceState.update(ACTIVE_WORKTREE_PATH_BY_SESSION_KEY, bySession);
+        }
+        if (this._context.workspaceState.get<string>(ACTIVE_WORKTREE_PATH_KEY) === worktreePath) {
             await this._context.workspaceState.update(ACTIVE_WORKTREE_PATH_KEY, undefined);
         }
     }

--- a/packages/vscode-extension/src/services/worktree-service.ts
+++ b/packages/vscode-extension/src/services/worktree-service.ts
@@ -46,7 +46,7 @@ export class WorktreeService {
     }
 
     async createWorktree(repoPath: string, options: CreateWorktreeOptions = {}): Promise<WorktreeInfo> {
-        const branchName = options.branchName || `n8n-agent-${Date.now().toString(36)}`;
+        const branchName = this.normalizeBranchName(options.branchName || `n8n-agent-${Date.now().toString(36)}`);
         const worktreePath = path.join(this.worktreesRoot, branchName);
         fs.mkdirSync(this.worktreesRoot, { recursive: true });
 
@@ -74,7 +74,7 @@ export class WorktreeService {
         }
 
         const worktrees = await this.listWorktrees(repoPath);
-        const created = worktrees.find((wt) => wt.path === worktreePath);
+        const created = await this.findWorktreeByPath(worktrees, worktreePath);
         if (!created) {
             throw new Error('Worktree created but not found in listing.');
         }
@@ -82,12 +82,22 @@ export class WorktreeService {
     }
 
     async removeWorktree(repoPath: string, worktreePath: string): Promise<void> {
+        const resolvedWorktreePath = this.resolveManagedWorktreePath(worktreePath);
+        const worktrees = await this.listWorktrees(repoPath);
+        const knownWorktree = await this.findWorktreeByPath(worktrees, resolvedWorktreePath);
+        if (!knownWorktree) {
+            throw new Error('Refusing to remove unknown worktree path.');
+        }
+        if (knownWorktree.locked) {
+            throw new Error('Cannot remove locked worktree. Unlock it with Git before deleting it.');
+        }
+
         try {
-            await execFileAsync('git', ['worktree', 'remove', worktreePath], {
+            await execFileAsync('git', ['worktree', 'remove', resolvedWorktreePath], {
                 cwd: repoPath,
                 maxBuffer: 10 * 1024 * 1024,
             });
-            this.log(`[n8n-worktree] Removed worktree at ${worktreePath}`);
+            this.log(`[n8n-worktree] Removed worktree at ${resolvedWorktreePath}`);
         } catch (error: any) {
             const message = this.formatRemoveError(error);
             this.log(`[n8n-worktree] Remove failed: ${message}`);
@@ -97,6 +107,63 @@ export class WorktreeService {
 
     getWorktreesRoot(): string {
         return this.worktreesRoot;
+    }
+
+    private normalizeBranchName(value: string): string {
+        const branchName = value.trim();
+        if (!branchName) {
+            throw new Error('Worktree branch name is required.');
+        }
+        if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/.test(branchName)) {
+            throw new Error('Worktree branch name may only contain letters, numbers, dots, underscores, and hyphens.');
+        }
+        if (branchName.endsWith('.') || branchName.includes('..') || branchName.endsWith('.lock')) {
+            throw new Error('Worktree branch name is not a safe Git branch name.');
+        }
+        return branchName;
+    }
+
+    private resolveManagedWorktreePath(worktreePath: string): string {
+        const resolvedRoot = path.resolve(this.worktreesRoot);
+        const resolvedWorktreePath = path.resolve(worktreePath);
+        if (this.isManagedChildPath(resolvedRoot, resolvedWorktreePath)) {
+            return resolvedWorktreePath;
+        }
+
+        try {
+            const realRoot = fs.realpathSync(this.worktreesRoot);
+            const realWorktreePath = fs.realpathSync(worktreePath);
+            if (this.isManagedChildPath(realRoot, realWorktreePath)) {
+                return realWorktreePath;
+            }
+        } catch {
+            // Fall through to the explicit error below.
+        }
+
+        throw new Error('Refusing to remove worktree outside the managed worktrees directory.');
+    }
+
+    private isManagedChildPath(rootPath: string, childPath: string): boolean {
+        const relativePath = path.relative(rootPath, childPath);
+        return Boolean(relativePath) && relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath);
+    }
+
+    private async findWorktreeByPath(worktrees: WorktreeInfo[], worktreePath: string): Promise<WorktreeInfo | undefined> {
+        const expectedPath = await this.canonicalPath(worktreePath);
+        for (const worktree of worktrees) {
+            if (await this.canonicalPath(worktree.path) === expectedPath) {
+                return worktree;
+            }
+        }
+        return undefined;
+    }
+
+    private async canonicalPath(value: string): Promise<string> {
+        try {
+            return await fs.promises.realpath(value);
+        } catch {
+            return path.resolve(value);
+        }
     }
 
     private parseWorktreePorcelain(output: string): WorktreeInfo[] {

--- a/packages/vscode-extension/src/services/worktree-service.ts
+++ b/packages/vscode-extension/src/services/worktree-service.ts
@@ -126,21 +126,24 @@ export class WorktreeService {
     private resolveManagedWorktreePath(worktreePath: string): string {
         const resolvedRoot = path.resolve(this.worktreesRoot);
         const resolvedWorktreePath = path.resolve(worktreePath);
-        if (this.isManagedChildPath(resolvedRoot, resolvedWorktreePath)) {
-            return resolvedWorktreePath;
-        }
 
         try {
             const realRoot = fs.realpathSync(this.worktreesRoot);
             const realWorktreePath = fs.realpathSync(worktreePath);
-            if (this.isManagedChildPath(realRoot, realWorktreePath)) {
-                return realWorktreePath;
+            if (!this.isManagedChildPath(realRoot, realWorktreePath)) {
+                throw new Error('Refusing to remove worktree outside the managed worktrees directory.');
             }
-        } catch {
-            // Fall through to the explicit error below.
+            return realWorktreePath;
+        } catch (error: any) {
+            if (error?.code !== 'ENOENT') {
+                throw error;
+            }
         }
 
-        throw new Error('Refusing to remove worktree outside the managed worktrees directory.');
+        if (!this.isManagedChildPath(resolvedRoot, resolvedWorktreePath)) {
+            throw new Error('Refusing to remove worktree outside the managed worktrees directory.');
+        }
+        return resolvedWorktreePath;
     }
 
     private isManagedChildPath(rootPath: string, childPath: string): boolean {

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -456,7 +456,7 @@ export class AgentWorkbenchWebview {
                 const allWorktrees = await this._workflowProviders.listWorktrees();
                 const mainWorkspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
                 const worktrees = allWorktrees.filter((wt) => wt.path !== mainWorkspacePath);
-                const activePath = this._agentRuntime.getActiveWorktreePath();
+                const activePath = this._agentRuntime.getActiveWorktreePath(this._activeSessionId);
                 await this._panel.webview.postMessage({
                     type: 'agent.worktrees',
                     worktrees,
@@ -476,7 +476,7 @@ export class AgentWorkbenchWebview {
                     this._outputChannel.appendLine(`[n8n-agent] Worktree select refused: unknown path=${payload.path}`);
                     return;
                 }
-                await this._agentRuntime.setActiveWorktreePath(payload.path);
+                await this._agentRuntime.setActiveWorktreePath(payload.path, this._activeSessionId);
                 this._outputChannel.appendLine(`[n8n-agent-debug] Worktree selected path=${payload.path}`);
                 await this.postWorkbenchState();
             } catch (error: any) {
@@ -490,7 +490,7 @@ export class AgentWorkbenchWebview {
             try {
                 const worktree = await this._workflowProviders.createWorktree({ branchName });
                 if (worktree) {
-                    await this._agentRuntime.setActiveWorktreePath(worktree.path);
+                    await this._agentRuntime.setActiveWorktreePath(worktree.path, this._activeSessionId);
                     this._outputChannel.appendLine(`[n8n-agent-debug] Worktree created and selected path=${worktree.path}`);
                 }
             } catch (error: any) {
@@ -503,7 +503,7 @@ export class AgentWorkbenchWebview {
         }
 
         if (payload.type === 'agent.worktree.clear') {
-            await this._agentRuntime.setActiveWorktreePath(undefined);
+            await this._agentRuntime.setActiveWorktreePath(undefined, this._activeSessionId);
             this._outputChannel.appendLine('[n8n-agent-debug] Worktree cleared, back to current workspace');
             await this.postWorkbenchState();
             return;
@@ -524,9 +524,9 @@ export class AgentWorkbenchWebview {
                     throw new Error('Refusing to remove unknown worktree path.');
                 }
                 await this._workflowProviders.removeWorktree(payload.path);
-                const activePath = this._agentRuntime.getActiveWorktreePath();
+                const activePath = this._agentRuntime.getActiveWorktreePath(this._activeSessionId);
                 if (activePath === payload.path) {
-                    await this._agentRuntime.setActiveWorktreePath(undefined);
+                    await this._agentRuntime.setActiveWorktreePath(undefined, this._activeSessionId);
                 }
                 this._outputChannel.appendLine(`[n8n-agent-debug] Worktree removed path=${payload.path}`);
             } catch (error: any) {
@@ -609,7 +609,7 @@ export class AgentWorkbenchWebview {
         nodeContexts?: AgentWorkbenchNodeContext[];
         sessionId?: string;
     } {
-        const activeWorktreePath = this._agentRuntime.getActiveWorktreePath();
+        const activeWorktreePath = this._agentRuntime.getActiveWorktreePath(this._activeSessionId);
         return {
             workflowId: this._workflow?.id,
             workflowName: this._workflow?.name,
@@ -668,7 +668,7 @@ export class AgentWorkbenchWebview {
         }
         await this.reconcileWorkflowContext(nextState.workflowContext);
 
-        const activeWorktreePath = this._agentRuntime.getActiveWorktreePath();
+        const activeWorktreePath = this._agentRuntime.getActiveWorktreePath(nextState.activeSessionId);
         const allWorktrees = await this._workflowProviders.listWorktrees().catch(() => []);
         const mainWorkspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
         const availableWorktrees = allWorktrees.filter((wt) => wt.path !== mainWorkspacePath);

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -524,10 +524,7 @@ export class AgentWorkbenchWebview {
                     throw new Error('Refusing to remove unknown worktree path.');
                 }
                 await this._workflowProviders.removeWorktree(payload.path);
-                const activePath = this._agentRuntime.getActiveWorktreePath(this._activeSessionId);
-                if (activePath === payload.path) {
-                    await this._agentRuntime.setActiveWorktreePath(undefined, this._activeSessionId);
-                }
+                await this._agentRuntime.clearActiveWorktreePath(payload.path);
                 this._outputChannel.appendLine(`[n8n-agent-debug] Worktree removed path=${payload.path}`);
             } catch (error: any) {
                 const message = error?.message || String(error);

--- a/packages/vscode-extension/tests/unit/worktree-service.test.ts
+++ b/packages/vscode-extension/tests/unit/worktree-service.test.ts
@@ -25,6 +25,14 @@ test('WorktreeService rejects unsafe branch names before creating worktrees', as
             () => service.createWorktree(root, { branchName: 'unsafe..name' }),
             /not a safe Git branch name/,
         );
+        await assert.rejects(
+            () => service.createWorktree(root, { branchName: 'unsafe.' }),
+            /not a safe Git branch name/,
+        );
+        await assert.rejects(
+            () => service.createWorktree(root, { branchName: 'unsafe.lock' }),
+            /not a safe Git branch name/,
+        );
     } finally {
         fs.rmSync(root, { recursive: true, force: true });
     }
@@ -52,6 +60,23 @@ test('WorktreeService refuses to remove unknown managed worktree paths', async (
         await assert.rejects(
             () => service.removeWorktree(root, path.join(service.getWorktreesRoot(), 'missing')),
             /unknown worktree path/,
+        );
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('WorktreeService refuses to remove locked managed worktrees', async () => {
+    const { WorktreeService } = require('../../src/services/worktree-service.js');
+    const root = await createGitRepo();
+    try {
+        const service = new WorktreeService(root);
+        const worktree = await service.createWorktree(root, { branchName: 'n8n-agent-locked' });
+        await execFileAsync('git', ['worktree', 'lock', worktree.path], { cwd: root });
+
+        await assert.rejects(
+            () => service.removeWorktree(root, worktree.path),
+            /Cannot remove locked worktree/,
         );
     } finally {
         fs.rmSync(root, { recursive: true, force: true });

--- a/packages/vscode-extension/tests/unit/worktree-service.test.ts
+++ b/packages/vscode-extension/tests/unit/worktree-service.test.ts
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+test('WorktreeService rejects unsafe branch names before creating worktrees', async () => {
+    const { WorktreeService } = require('../../src/services/worktree-service.js');
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-worktree-'));
+    try {
+        const service = new WorktreeService(root);
+        await assert.rejects(
+            () => service.createWorktree(root, { branchName: '../escape' }),
+            /may only contain letters, numbers, dots, underscores, and hyphens/,
+        );
+        await assert.rejects(
+            () => service.createWorktree(root, { branchName: 'feature/name' }),
+            /may only contain letters, numbers, dots, underscores, and hyphens/,
+        );
+        await assert.rejects(
+            () => service.createWorktree(root, { branchName: 'unsafe..name' }),
+            /not a safe Git branch name/,
+        );
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('WorktreeService refuses to remove paths outside managed worktrees', async () => {
+    const { WorktreeService } = require('../../src/services/worktree-service.js');
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-worktree-'));
+    try {
+        const service = new WorktreeService(root);
+        await assert.rejects(
+            () => service.removeWorktree(root, path.dirname(root)),
+            /outside the managed worktrees directory/,
+        );
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('WorktreeService refuses to remove unknown managed worktree paths', async () => {
+    const { WorktreeService } = require('../../src/services/worktree-service.js');
+    const root = await createGitRepo();
+    try {
+        const service = new WorktreeService(root);
+        await assert.rejects(
+            () => service.removeWorktree(root, path.join(service.getWorktreesRoot(), 'missing')),
+            /unknown worktree path/,
+        );
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('WorktreeService creates and removes known managed worktrees', async () => {
+    const { WorktreeService } = require('../../src/services/worktree-service.js');
+    const root = await createGitRepo();
+    try {
+        const service = new WorktreeService(root);
+        const worktree = await service.createWorktree(root, { branchName: 'n8n-agent-test' });
+        assert.equal(fs.realpathSync(path.dirname(worktree.path)), fs.realpathSync(service.getWorktreesRoot()));
+        assert.equal(fs.existsSync(worktree.path), true);
+
+        await service.removeWorktree(root, worktree.path);
+
+        const remaining = await service.listWorktrees(root);
+        assert.equal(remaining.some((entry: { path: string }) => entry.path === worktree.path), false);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+async function createGitRepo(): Promise<string> {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-worktree-repo-'));
+    await execFileAsync('git', ['init'], { cwd: root });
+    await execFileAsync('git', ['config', 'user.name', 'n8n Agent Workbench'], { cwd: root });
+    await execFileAsync('git', ['config', 'user.email', 'n8n-agent-workbench@localhost'], { cwd: root });
+    fs.writeFileSync(path.join(root, 'README.md'), '# test\n', 'utf8');
+    await execFileAsync('git', ['add', 'README.md'], { cwd: root });
+    await execFileAsync('git', ['commit', '-m', 'Initial commit'], { cwd: root });
+    return root;
+}


### PR DESCRIPTION
## Summary
- Validate agent worktree branch names before invoking Git.
- Refuse service-side worktree deletion for unknown, unmanaged, or locked paths.
- Scope the active agent worktree by session and clean it up when sessions are deleted.

## Tests
- npm run test --workspace=packages/vscode-extension
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-session active worktree tracking for concurrent agent sessions; prompts now use the session-scoped worktree path and sessions clear their scoped value on deletion.

* **Improvements**
  * Branch names validated/sanitized during worktree creation.
  * Safer worktree removal with canonical path checks and protections against removing unmanaged or locked worktrees.
  * Webview now resolves and sets worktree paths per session; clearing propagation improved.

* **Tests**
  * Added unit and integration tests for branch validation, managed-path safety, and removal behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->