### PR TITLE
[codex] Fix credential mapping wizard resolution

### DIFF
--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -723,27 +723,38 @@ export class PromoteCommand {
         const byId = indexes.targetCredentialsById!.get(boundRef);
         if (byId) return byId;
 
+        const byName = unique(indexes.targetCredentialsByKey!.get(`${credentialType}::${boundRef}`));
+        if (byName) return byName;
+
         const parsed = this.parseCredentialBindingKey(boundRef);
         if (parsed) {
             if (parsed.type !== credentialType) return undefined;
             return unique(indexes.targetCredentialsByKey!.get(`${parsed.type}::${parsed.name}`));
         }
-        return unique(indexes.targetCredentialsByKey!.get(`${credentialType}::${boundRef}`));
+        return undefined;
     }
 
     private resolveCredentialFromInput(reference: string, credentialType: string, targetCredentials: Array<Record<string, unknown>>): Record<string, unknown> | undefined {
         const value = String(reference ?? '').trim();
         if (!value) return undefined;
-        const parsed = this.parseCredentialBindingKey(value);
-        const targetName = parsed ? parsed.name : value;
-        const targetType = parsed?.type ?? credentialType;
-        if (targetType !== credentialType) return undefined;
 
-        const idMatch = targetCredentials.find((credential) => this.getCredentialId(credential) === value);
+        const idMatch = targetCredentials.find((credential) =>
+            this.getCredentialId(credential) === value &&
+            this.getCredentialType(credential) === credentialType
+        );
         if (idMatch) return idMatch;
 
+        const nameMatch = unique(targetCredentials.filter((credential) =>
+            this.getCredentialName(credential) === value &&
+            this.getCredentialType(credential) === credentialType
+        ));
+        if (nameMatch) return nameMatch;
+
+        const parsed = this.parseCredentialBindingKey(value);
+        if (!parsed || parsed.type !== credentialType) return undefined;
+
         return unique(targetCredentials.filter((credential) =>
-            this.getCredentialName(credential) === targetName &&
+            this.getCredentialName(credential) === parsed.name &&
             this.getCredentialType(credential) === credentialType
         ));
     }

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -148,6 +148,7 @@ interface PromotionIndexes {
     sourceByName: Map<string, PromotionSourceWorkflow[]>;
     targetWorkflowsById?: Map<string, IWorkflow>;
     targetWorkflowsByName?: Map<string, IWorkflow[]>;
+    targetCredentials?: Array<Record<string, unknown>>;
     targetCredentialsById?: Map<string, Record<string, unknown>>;
     targetCredentialsByKey?: Map<string, Array<Record<string, unknown>>>;
 }
@@ -535,8 +536,8 @@ export class PromoteCommand {
                 });
                 continue;
             }
-            const targetId = String(targetCredential.id ?? '').trim();
-            const targetName = String(targetCredential.name ?? '').trim();
+            const targetId = this.getCredentialId(targetCredential);
+            const targetName = this.getCredentialName(targetCredential);
             node.credentials[credentialType] = { id: targetId, name: targetName };
             const sourceBindingName = sourceName || sourceId;
             if (sourceBindingName && targetName) {
@@ -623,9 +624,9 @@ export class PromoteCommand {
             if (answer.action === 'abort') return 'aborted';
             if (answer.action === 'skip') continue;
 
-            const targetName = String(answer.credential.name ?? '').trim();
-            const targetType = String(answer.credential.type ?? '').trim();
-            const targetId = String(answer.credential.id ?? '').trim();
+            const targetName = this.getCredentialName(answer.credential);
+            const targetType = this.getCredentialType(answer.credential);
+            const targetId = this.getCredentialId(answer.credential);
             if (!targetName || targetType !== candidate.credentialType) continue;
             route.bindings!.credentials![this.credentialBindingKey(candidate.sourceName, candidate.credentialType)] = targetId || this.credentialBindingKey(targetName, targetType);
             mapped = true;
@@ -666,9 +667,9 @@ export class PromoteCommand {
     }
 
     private getTargetCredentialsByType(indexes: PromotionIndexes, credentialType: string): Array<Record<string, unknown>> {
-        return Array.from(indexes.targetCredentialsById?.values() ?? [])
-            .filter((credential) => String(credential.type ?? '').trim() === credentialType)
-            .sort((a, b) => String(a.name ?? '').localeCompare(String(b.name ?? '')));
+        return (indexes.targetCredentials ?? [])
+            .filter((credential) => this.getCredentialType(credential) === credentialType)
+            .sort((a, b) => this.getCredentialName(a).localeCompare(this.getCredentialName(b)));
     }
 
     private async askCredentialMapping(
@@ -682,10 +683,11 @@ export class PromoteCommand {
 
         const { default: inquirer } = await import('inquirer');
         const choices = targetCredentials.map((credential, index) => ({
-            name: `${String(credential.name ?? 'Unnamed credential')} (${String(credential.id ?? 'no id')})`,
+            name: `${this.getCredentialName(credential) || 'Unnamed credential'} (${this.getCredentialId(credential) || 'no id'})`,
             value: `map:${index}`,
         }));
         choices.push(
+            { name: 'Enter credential name or ID manually', value: 'manual' },
             { name: 'Skip this credential', value: 'skip' },
             { name: 'Abort promotion', value: 'abort' },
         );
@@ -698,6 +700,19 @@ export class PromoteCommand {
         }]);
         if (answer.selection === 'abort') return { action: 'abort' };
         if (answer.selection === 'skip') return { action: 'skip' };
+        if (answer.selection === 'manual') {
+            const manual = await inquirer.prompt<{ reference: string }>([{
+                type: 'input',
+                name: 'reference',
+                message: `Target credential name or ID for "${candidate.sourceName}" (${candidate.credentialType})`,
+            }]);
+            const credential = this.resolveCredentialFromInput(manual.reference, candidate.credentialType, targetCredentials);
+            if (!credential) {
+                console.log(chalk.yellow(`No ${candidate.credentialType} credential matched "${manual.reference}".`));
+                return { action: 'skip' };
+            }
+            return { action: 'map', credential };
+        }
         const index = Number(answer.selection.replace(/^map:/, ''));
         const credential = targetCredentials[index];
         return credential ? { action: 'map', credential } : { action: 'skip' };
@@ -709,8 +724,28 @@ export class PromoteCommand {
         if (byId) return byId;
 
         const parsed = this.parseCredentialBindingKey(boundRef);
-        if (!parsed || parsed.type !== credentialType) return undefined;
-        return unique(indexes.targetCredentialsByKey!.get(`${parsed.type}::${parsed.name}`));
+        if (parsed) {
+            if (parsed.type !== credentialType) return undefined;
+            return unique(indexes.targetCredentialsByKey!.get(`${parsed.type}::${parsed.name}`));
+        }
+        return unique(indexes.targetCredentialsByKey!.get(`${credentialType}::${boundRef}`));
+    }
+
+    private resolveCredentialFromInput(reference: string, credentialType: string, targetCredentials: Array<Record<string, unknown>>): Record<string, unknown> | undefined {
+        const value = String(reference ?? '').trim();
+        if (!value) return undefined;
+        const parsed = this.parseCredentialBindingKey(value);
+        const targetName = parsed ? parsed.name : value;
+        const targetType = parsed?.type ?? credentialType;
+        if (targetType !== credentialType) return undefined;
+
+        const idMatch = targetCredentials.find((credential) => this.getCredentialId(credential) === value);
+        if (idMatch) return idMatch;
+
+        return unique(targetCredentials.filter((credential) =>
+            this.getCredentialName(credential) === targetName &&
+            this.getCredentialType(credential) === credentialType
+        ));
     }
 
     private credentialBindingKey(name: string, credentialType: string): string {
@@ -724,6 +759,18 @@ export class PromoteCommand {
             name: value.slice(0, delimiterIndex),
             type: value.slice(delimiterIndex + 1),
         };
+    }
+
+    private getCredentialId(credential: Record<string, unknown>): string {
+        return String(credential.id ?? credential.credentialId ?? '').trim();
+    }
+
+    private getCredentialName(credential: Record<string, unknown>): string {
+        return String(credential.name ?? '').trim();
+    }
+
+    private getCredentialType(credential: Record<string, unknown>): string {
+        return String(credential.type ?? credential.credentialType ?? credential.credentialTypeName ?? '').trim();
     }
 
     private async remapWorkflowReferences(
@@ -824,11 +871,15 @@ export class PromoteCommand {
     private async ensureTargetCredentialIndexes(target: IResolvedWorkspaceEnvironment, indexes: PromotionIndexes): Promise<void> {
         if (indexes.targetCredentialsById && indexes.targetCredentialsByKey) return;
         const credentials = await this.getTargetCredentials(target);
-        indexes.targetCredentialsById = new Map(credentials.map((credential) => [String(credential.id ?? ''), credential]));
+        indexes.targetCredentials = credentials;
+        indexes.targetCredentialsById = new Map();
         indexes.targetCredentialsByKey = new Map();
         for (const credential of credentials) {
-            const type = String(credential.type ?? '').trim();
-            const name = String(credential.name ?? '').trim();
+            const id = this.getCredentialId(credential);
+            if (id) indexes.targetCredentialsById.set(id, credential);
+            const type = this.getCredentialType(credential);
+            const name = this.getCredentialName(credential);
+            if (!type || !name) continue;
             const key = `${type}::${name}`;
             const existing = indexes.targetCredentialsByKey.get(key) ?? [];
             existing.push(credential);

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -26,7 +26,7 @@ export interface PromotionSubstitution {
     fromName?: string;
     toId?: string;
     toName?: string;
-    status: 'mapped' | 'pending-create' | 'unchanged';
+    status: 'mapped' | 'pending-create' | 'unchanged' | 'omitted';
 }
 
 export interface PromotionProblem {
@@ -89,6 +89,7 @@ export interface CredentialMappingPromptContext {
 
 export type CredentialMappingPromptAnswer =
     | { action: 'map'; credential: Record<string, unknown> }
+    | { action: 'omit' }
     | { action: 'skip' }
     | { action: 'abort' };
 
@@ -151,6 +152,7 @@ interface PromotionIndexes {
     targetCredentials?: Array<Record<string, unknown>>;
     targetCredentialsById?: Map<string, Record<string, unknown>>;
     targetCredentialsByKey?: Map<string, Array<Record<string, unknown>>>;
+    omittedCredentialBindings?: Set<string>;
 }
 
 interface WorkflowTransformResult {
@@ -523,6 +525,22 @@ export class PromoteCommand {
         for (const [credentialType, credentialRef] of Object.entries(node.credentials as Record<string, any>)) {
             const sourceId = String(credentialRef?.id ?? '').trim();
             const sourceName = String(credentialRef?.name ?? '').trim();
+            const sourceBindingName = sourceName || sourceId;
+            const sourceBindingKey = sourceBindingName ? this.credentialBindingKey(sourceBindingName, credentialType) : undefined;
+            if (sourceBindingKey && indexes.omittedCredentialBindings?.has(sourceBindingKey)) {
+                delete node.credentials[credentialType];
+                if (Object.keys(node.credentials).length === 0) delete node.credentials;
+                substitutions.push({
+                    kind: 'credential',
+                    nodeName: node.name,
+                    field: credentialType,
+                    fromId: sourceId || undefined,
+                    fromName: sourceName || undefined,
+                    toName: 'omitted',
+                    status: 'omitted',
+                });
+                continue;
+            }
             const targetCredential = await this.resolveTargetCredential(target, route, indexes, credentialType, sourceId, sourceName);
             if (!targetCredential) {
                 problems.push({
@@ -539,10 +557,8 @@ export class PromoteCommand {
             const targetId = this.getCredentialId(targetCredential);
             const targetName = this.getCredentialName(targetCredential);
             node.credentials[credentialType] = { id: targetId, name: targetName };
-            const sourceBindingName = sourceName || sourceId;
             if (sourceBindingName && targetName) {
-                const sourceBindingKey = this.credentialBindingKey(sourceBindingName, credentialType);
-                route.bindings!.credentials![sourceBindingKey] ??= this.credentialBindingKey(targetName, credentialType);
+                route.bindings!.credentials![sourceBindingKey!] ??= this.credentialBindingKey(targetName, credentialType);
             }
             substitutions.push({
                 kind: 'credential',
@@ -623,6 +639,12 @@ export class PromoteCommand {
             });
             if (answer.action === 'abort') return 'aborted';
             if (answer.action === 'skip') continue;
+            if (answer.action === 'omit') {
+                indexes.omittedCredentialBindings ??= new Set();
+                indexes.omittedCredentialBindings.add(this.credentialBindingKey(candidate.sourceName, candidate.credentialType));
+                mapped = true;
+                continue;
+            }
 
             const targetName = this.getCredentialName(answer.credential);
             const targetType = this.getCredentialType(answer.credential);
@@ -688,18 +710,20 @@ export class PromoteCommand {
         }));
         choices.push(
             { name: 'Enter credential name or ID manually', value: 'manual' },
-            { name: 'Skip this credential', value: 'skip' },
+            { name: 'Promote without this credential', value: 'omit' },
+            { name: 'Skip (promotion will fail)', value: 'skip' },
             { name: 'Abort promotion', value: 'abort' },
         );
-        const nodeLabel = candidate.nodeNames.length > 0 ? ` used by ${candidate.nodeNames.join(', ')}` : '';
+        const nodeLabel = candidate.nodeNames.length > 0 ? ` used by node ${candidate.nodeNames.join(', ')}` : '';
         const answer = await inquirer.prompt<{ selection: string }>([{
-            type: 'list',
+            type: 'select',
             name: 'selection',
-            message: `Map "${candidate.sourceName}" (${candidate.credentialType})${nodeLabel} in ${context.targetEnvironmentName}`,
+            message: `Select target ${candidate.credentialType} credential for source credential "${candidate.sourceName}"${nodeLabel} in ${context.targetEnvironmentName}`,
             choices,
         }]);
         if (answer.selection === 'abort') return { action: 'abort' };
         if (answer.selection === 'skip') return { action: 'skip' };
+        if (answer.selection === 'omit') return { action: 'omit' };
         if (answer.selection === 'manual') {
             const manual = await inquirer.prompt<{ reference: string }>([{
                 type: 'input',

--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -589,6 +589,7 @@ export class N8nApiClient {
 
         const clean: Record<string, unknown> = {};
         for (const [key, value] of Object.entries(payload as Record<string, unknown>)) {
+            if (key === 'projectId' && value === 'personal') continue;
             if (allowedKeys.has(key) && value !== undefined) {
                 clean[key] = value;
             }

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -32,6 +32,8 @@ const WINDOWS_RESERVED_FILENAMES = new Set([
     'LPT9'
 ]);
 
+const EXPLICIT_WORKFLOW_ID_FIELD = '__n8nacExplicitWorkflowId';
+
 /**
  * Watcher - State Observation Component
  * 
@@ -194,12 +196,25 @@ export class WorkflowStateTracker extends EventEmitter {
             this.idToFileMap.set(id, winner);
         }
 
+        // Explicit id: undefined/null means "create a new remote workflow". Do not
+        // resurrect stale filename mappings from state for these files.
+        for (const { filename, content } of fileContents) {
+            if (!content?.[EXPLICIT_WORKFLOW_ID_FIELD] || content.id) continue;
+            const staleId = this.fileToIdMap.get(filename);
+            if (!staleId) continue;
+            this.fileToIdMap.delete(filename);
+            if (this.idToFileMap.get(staleId) === filename) {
+                this.idToFileMap.delete(staleId);
+            }
+        }
+
         // Recovery path: if a tracked file lost its decorator ID after a manual rewrite,
         // reconnect it using the last known filename hint from state.
         const claimedIds = new Set(idClaims.keys());
         const state = this.loadState();
         for (const { filename, content } of fileContents) {
             if (content?.id) continue;
+            if (content?.[EXPLICIT_WORKFLOW_ID_FIELD]) continue;
             if (this.fileToIdMap.has(filename)) continue;
 
             const matchingIds = Object.entries(state.workflows)
@@ -697,10 +712,16 @@ export class WorkflowStateTracker extends EventEmitter {
                     const decoratorContent = decoratorMatch[1];
                     const result: any = {};
 
-                    // Extract id if present
-                    const idMatch = decoratorContent.match(/id:\s*["']([^"']+)["']/);
-                    if (idMatch) {
-                        result.id = idMatch[1];
+                    // Extract id if present. `id: undefined` is meaningful: it marks
+                    // a local-only workflow that must not recover an old ID from state.
+                    const idFieldMatch = decoratorContent.match(/\bid\s*:\s*([^,\n\r}]+)/);
+                    if (idFieldMatch) {
+                        result[EXPLICIT_WORKFLOW_ID_FIELD] = true;
+                        const idValue = idFieldMatch[1].trim();
+                        const idMatch = idValue.match(/^["']([^"']+)["']$/);
+                        if (idMatch) {
+                            result.id = idMatch[1];
+                        }
                     }
 
                     // Extract name if present

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -714,7 +714,7 @@ export class WorkflowStateTracker extends EventEmitter {
 
                     // Extract id if present. `id: undefined` is meaningful: it marks
                     // a local-only workflow that must not recover an old ID from state.
-                    const idFieldMatch = decoratorContent.match(/\bid\s*:\s*([^,\n\r}]+)/);
+                    const idFieldMatch = decoratorContent.match(/(?:^|[,{])\s*id\s*:\s*([^,\n\r}]+)/);
                     if (idFieldMatch) {
                         result[EXPLICIT_WORKFLOW_ID_FIELD] = true;
                         const idValue = idFieldMatch[1].trim();

--- a/packages/cli/tests/unit/n8n-api-client.test.ts
+++ b/packages/cli/tests/unit/n8n-api-client.test.ts
@@ -377,6 +377,34 @@ describe('N8nApiClient test workflow support', () => {
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Workflow wf-created was created'));
     });
 
+    it('omits the personal project placeholder when creating a workflow', async () => {
+        const client = new N8nApiClient({ host: 'https://n8n.local', apiKey: 'secret' });
+        mockAxiosPost.mockResolvedValueOnce({
+            data: {
+                id: 'wf-created',
+                name: 'Personal Workflow',
+                nodes: [],
+                connections: {},
+                settings: { executionOrder: 'v1' },
+            },
+        });
+
+        await client.createWorkflow({
+            name: 'Personal Workflow',
+            nodes: [],
+            connections: {},
+            settings: { executionOrder: 'v1' },
+            projectId: 'personal',
+        } as any);
+
+        expect(mockAxiosPost).toHaveBeenCalledWith('/api/v1/workflows', {
+            name: 'Personal Workflow',
+            nodes: [],
+            connections: {},
+            settings: { executionOrder: 'v1' },
+        });
+    });
+
     it('normalizes webhook paths with leading slashes and special characters', () => {
         const client = new N8nApiClient({ host: 'https://n8n.local', apiKey: 'secret' });
 

--- a/packages/cli/tests/unit/promote-command.test.ts
+++ b/packages/cli/tests/unit/promote-command.test.ts
@@ -481,6 +481,48 @@ export class PostgresWorkflow {
         }
     });
 
+    it('resolves manual credential references with colons as exact names or ids before binding syntax', () => {
+        const cmd = new PromoteCommand();
+        const credentials = [
+            { credentialId: 'target:postgres', name: 'DB_PROD', credentialType: 'postgres' },
+            { credentialId: 'target-postgres-eu', name: 'Prod:EU', credentialType: 'postgres' },
+            { credentialId: 'target-postgres-fallback', name: 'Prod', credentialType: 'postgres' },
+            { credentialId: 'target-http-eu', name: 'Prod:EU', credentialType: 'httpBasicAuth' },
+        ];
+        const resolveInput = (cmd as unknown as {
+            resolveCredentialFromInput: (
+                reference: string,
+                credentialType: string,
+                targetCredentials: Array<Record<string, unknown>>,
+            ) => Record<string, unknown> | undefined;
+        }).resolveCredentialFromInput.bind(cmd);
+        const resolveBinding = (cmd as unknown as {
+            resolveCredentialBindingReference: (
+                boundRef: string | undefined,
+                credentialType: string,
+                indexes: {
+                    targetCredentialsById: Map<string, Record<string, unknown>>;
+                    targetCredentialsByKey: Map<string, Array<Record<string, unknown>>>;
+                },
+            ) => Record<string, unknown> | undefined;
+        }).resolveCredentialBindingReference.bind(cmd);
+
+        expect(resolveInput('target:postgres', 'postgres', credentials)).toBe(credentials[0]);
+        expect(resolveInput('Prod:EU', 'postgres', credentials)).toBe(credentials[1]);
+        expect(resolveInput('Prod:postgres', 'postgres', credentials)).toBe(credentials[2]);
+        expect(resolveInput('Prod:httpBasicAuth', 'postgres', credentials)).toBeUndefined();
+
+        const indexes = {
+            targetCredentialsById: new Map(credentials.map((credential) => [String(credential.credentialId), credential])),
+            targetCredentialsByKey: new Map([
+                ['postgres::Prod:EU', [credentials[1]!]],
+                ['postgres::Prod', [credentials[2]!]],
+            ]),
+        };
+        expect(resolveBinding('Prod:EU', 'postgres', indexes)).toBe(credentials[1]);
+        expect(resolveBinding('Prod:postgres', 'postgres', indexes)).toBe(credentials[2]);
+    });
+
     it('uses the selected credential id when interactive mapping target names are duplicated', async () => {
         const previousManagerHome = process.env.N8N_MANAGER_HOME;
         const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-workspace-'));

--- a/packages/cli/tests/unit/promote-command.test.ts
+++ b/packages/cli/tests/unit/promote-command.test.ts
@@ -594,6 +594,78 @@ export class DuplicateCredentialWorkflow {
         }
     });
 
+    it('can promote without an unresolved credential without persisting the omission', async () => {
+        const previousManagerHome = process.env.N8N_MANAGER_HOME;
+        const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-workspace-'));
+        process.env.N8N_MANAGER_HOME = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-manager-'));
+        try {
+            const globalWorkspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-global-'));
+            const globalConfigService = new ConfigService(globalWorkspaceRoot);
+            globalConfigService.saveLocalConfig({
+                host: 'https://dev.example.test',
+                instanceIdentifier: 'n8n_1111111111',
+            }, { instanceId: 'dev-instance', instanceName: 'Dev', apiKey: 'dev-key' });
+            globalConfigService.saveLocalConfig({
+                host: 'https://prod.example.test',
+                instanceIdentifier: 'n8n_2222222222',
+            }, { instanceId: 'prod-instance', instanceName: 'Prod', apiKey: 'prod-key', setActive: false });
+
+            const configService = new ConfigService(workspaceRoot);
+            const devTarget = configService.addInstanceTarget({ name: 'Dev Target', managedInstanceId: 'dev-instance' });
+            const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
+            configService.addEnvironment({ name: 'Dev', environmentTarget: devTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/dev' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/prod' });
+
+            const sourceDir = configService.resolveEnvironment('Dev').workflowsPath!;
+            const targetDir = configService.resolveEnvironment('Prod').workflowsPath!;
+            mkdirSync(sourceDir, { recursive: true });
+            const sourcePath = path.join(sourceDir, 'omitted-credential.workflow.ts');
+            writeFileSync(sourcePath, `import { workflow, node } from '@n8n-as-code/transformer';
+
+@workflow({ id: 'source-wf', name: 'Omitted Credential Workflow', active: false })
+export class OmittedCredentialWorkflow {
+  @node({
+    name: 'Postgres',
+    type: 'n8n-nodes-base.postgres',
+    version: 2,
+    position: [100, 100],
+    credentials: { postgres: { id: 'source-postgres', name: 'Dev Database' } }
+  })
+  Postgres = { operation: 'executeQuery' };
+}
+`, 'utf8');
+
+            const result = await new PromoteCommand(configService, {
+                createClient: () => ({
+                    getAllWorkflows: async () => [],
+                    listCredentials: async () => [],
+                }),
+                promptCredentialMapping: async () => ({ action: 'omit' }),
+            }).run(sourcePath, {
+                from: 'Dev',
+                to: 'Prod',
+                push: false,
+                promotionConfig: path.join(workspaceRoot, 'n8nac-promotion.json'),
+            });
+
+            expect(result.summary.blocked).toBe(0);
+            expect(result.workflows[0].substitutions).toEqual(expect.arrayContaining([
+                expect.objectContaining({ kind: 'credential', fromName: 'Dev Database', toName: 'omitted', status: 'omitted' }),
+            ]));
+            const promoted = readFileSync(path.join(targetDir, 'omitted-credential.workflow.ts'), 'utf8');
+            expect(promoted).not.toContain('credentials:');
+            const promotionConfig = JSON.parse(readFileSync(path.join(workspaceRoot, 'n8nac-promotion.json'), 'utf8'));
+            expect(promotionConfig.routes['Dev->Prod'].credentialPolicies).toBeUndefined();
+            expect(promotionConfig.routes['Dev->Prod'].bindings.credentials['Dev Database:postgres']).toBeUndefined();
+        } finally {
+            if (previousManagerHome === undefined) {
+                delete process.env.N8N_MANAGER_HOME;
+            } else {
+                process.env.N8N_MANAGER_HOME = previousManagerHome;
+            }
+        }
+    });
+
     it('keeps blocking unresolved credentials when interactive prompts are disabled', async () => {
         const previousManagerHome = process.env.N8N_MANAGER_HOME;
         const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-workspace-'));

--- a/packages/cli/tests/unit/promote-command.test.ts
+++ b/packages/cli/tests/unit/promote-command.test.ts
@@ -404,6 +404,83 @@ export class MappedCredentialWorkflow {
         }
     });
 
+    it('prompts with target credentials that use n8n credentialType and credentialId fields', async () => {
+        const previousManagerHome = process.env.N8N_MANAGER_HOME;
+        const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-workspace-'));
+        process.env.N8N_MANAGER_HOME = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-manager-'));
+        try {
+            const globalWorkspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-global-'));
+            const globalConfigService = new ConfigService(globalWorkspaceRoot);
+            globalConfigService.saveLocalConfig({
+                host: 'https://test.example.test',
+                instanceIdentifier: 'n8n_1111111111',
+            }, { instanceId: 'test-instance', instanceName: 'Test', apiKey: 'test-key' });
+            globalConfigService.saveLocalConfig({
+                host: 'https://prod.example.test',
+                instanceIdentifier: 'n8n_2222222222',
+            }, { instanceId: 'prod-instance', instanceName: 'Prod', apiKey: 'prod-key', setActive: false });
+
+            const configService = new ConfigService(workspaceRoot);
+            const testTarget = configService.addInstanceTarget({ name: 'Test Target', managedInstanceId: 'test-instance' });
+            const prodTarget = configService.addInstanceTarget({ name: 'Prod Target', managedInstanceId: 'prod-instance' });
+            configService.addEnvironment({ name: 'Test', environmentTarget: testTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/test' });
+            configService.addEnvironment({ name: 'Prod', environmentTarget: prodTarget.id, projectId: 'personal', projectName: 'Personal', workflowsPath: 'workflows/prod' });
+
+            const sourceDir = configService.resolveEnvironment('Test').workflowsPath!;
+            const targetDir = configService.resolveEnvironment('Prod').workflowsPath!;
+            mkdirSync(sourceDir, { recursive: true });
+            const sourcePath = path.join(sourceDir, 'postgres.workflow.ts');
+            writeFileSync(sourcePath, `import { workflow, node } from '@n8n-as-code/transformer';
+
+@workflow({ id: 'source-wf', name: 'Postgres Workflow', active: false })
+export class PostgresWorkflow {
+  @node({
+    name: 'Postgres',
+    type: 'n8n-nodes-base.postgres',
+    version: 2,
+    position: [100, 100],
+    credentials: { postgres: { id: 'source-postgres', name: 'DB_TEST' } }
+  })
+  Postgres = { operation: 'executeQuery' };
+}
+`, 'utf8');
+
+            const promptCandidates: string[] = [];
+            await new PromoteCommand(configService, {
+                createClient: () => ({
+                    getAllWorkflows: async () => [],
+                    listCredentials: async () => [
+                        { credentialId: 'target-postgres', name: 'DB_PROD', credentialType: 'postgres' },
+                        { credentialId: 'target-http', name: 'HTTP_PROD', credentialType: 'httpBasicAuth' },
+                    ],
+                }),
+                promptCredentialMapping: async (candidate, targetCredentials) => {
+                    promptCandidates.push(`${candidate.sourceName}:${candidate.credentialType}`);
+                    expect(targetCredentials).toEqual([{ credentialId: 'target-postgres', name: 'DB_PROD', credentialType: 'postgres' }]);
+                    return { action: 'map', credential: targetCredentials[0]! };
+                },
+            }).run(sourcePath, {
+                from: 'Test',
+                to: 'Prod',
+                push: false,
+                promotionConfig: path.join(workspaceRoot, 'n8nac-promotion.json'),
+            });
+
+            expect(promptCandidates).toEqual(['DB_TEST:postgres']);
+            const promoted = readFileSync(path.join(targetDir, 'postgres.workflow.ts'), 'utf8');
+            expect(promoted).toContain("id: 'target-postgres'");
+            expect(promoted).toContain("name: 'DB_PROD'");
+            const promotionConfig = JSON.parse(readFileSync(path.join(workspaceRoot, 'n8nac-promotion.json'), 'utf8'));
+            expect(promotionConfig.routes['Test->Prod'].bindings.credentials['DB_TEST:postgres']).toBe('target-postgres');
+        } finally {
+            if (previousManagerHome === undefined) {
+                delete process.env.N8N_MANAGER_HOME;
+            } else {
+                process.env.N8N_MANAGER_HOME = previousManagerHome;
+            }
+        }
+    });
+
     it('uses the selected credential id when interactive mapping target names are duplicated', async () => {
         const previousManagerHome = process.env.N8N_MANAGER_HOME;
         const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-promote-workspace-'));

--- a/packages/cli/tests/unit/workflow-state-tracker.test.ts
+++ b/packages/cli/tests/unit/workflow-state-tracker.test.ts
@@ -220,4 +220,35 @@ export class NewCopyWorkflow {
         expect(tracker.getWorkflowIdForFilename('new-copy.workflow.ts')).toBeUndefined();
         expect(tracker.getFilenameForId('stale-wf')).toBeUndefined();
     });
+
+    it('extracts the workflow id key without matching id text inside decorator string values', async () => {
+        const tracker = createTracker();
+
+        fs.writeFileSync(
+            path.join(tempDir!, 'order-id.workflow.ts'),
+            `import { workflow, node } from '@n8n-as-code/transformer';
+
+@workflow({
+  name: 'Order id: x',
+  id: 'real-id',
+  active: false
+})
+export class OrderIdWorkflow {
+  @node({
+    name: 'Webhook',
+    type: 'n8n-nodes-base.webhook',
+    version: 2.1,
+    position: [0, 0]
+  })
+  Webhook = { path: 'order-id', httpMethod: 'POST' };
+}
+`,
+            'utf-8',
+        );
+
+        await tracker.refreshLocalState();
+
+        expect(tracker.getWorkflowIdForFilename('order-id.workflow.ts')).toBe('real-id');
+        expect(tracker.getFilenameForId('real-id')).toBe('order-id.workflow.ts');
+    });
 });

--- a/packages/cli/tests/unit/workflow-state-tracker.test.ts
+++ b/packages/cli/tests/unit/workflow-state-tracker.test.ts
@@ -168,4 +168,56 @@ export class RecoveredWorkflow {
         expect(tracker.getWorkflowIdForFilename('recovered.workflow.ts')).toBe('wf-123');
         expect(tracker.getFilenameForId('wf-123')).toBe('recovered.workflow.ts');
     });
+
+    it('does not recover a persisted workflow ID when the decorator explicitly sets id undefined', async () => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-tracker-'));
+        fs.writeFileSync(
+            path.join(tempDir, 'new-copy.workflow.ts'),
+            `import { workflow, node } from '@n8n-as-code/transformer';
+
+@workflow({
+  id: undefined,
+  name: 'New Copy',
+  active: false
+})
+export class NewCopyWorkflow {
+  @node({
+    name: 'Webhook',
+    type: 'n8n-nodes-base.webhook',
+    version: 2.1,
+    position: [0, 0]
+  })
+  Webhook = { path: 'new-copy', httpMethod: 'POST' };
+}
+`,
+            'utf-8',
+        );
+        fs.writeFileSync(
+            path.join(tempDir, '.n8n-state.json'),
+            JSON.stringify({
+                workflows: {
+                    'stale-wf': {
+                        lastSyncedHash: 'abc123',
+                        lastSyncedAt: '2026-03-30T12:00:00.000Z',
+                        filename: 'new-copy.workflow.ts',
+                    },
+                },
+            }),
+            'utf-8',
+        );
+
+        const tracker = new WorkflowStateTracker({} as any, {
+            directory: tempDir,
+            syncInactive: false,
+            ignoredTags: [],
+            projectId: 'test-project',
+        });
+
+        expect(tracker.getWorkflowIdForFilename('new-copy.workflow.ts')).toBe('stale-wf');
+
+        await tracker.refreshLocalState();
+
+        expect(tracker.getWorkflowIdForFilename('new-copy.workflow.ts')).toBeUndefined();
+        expect(tracker.getFilenameForId('stale-wf')).toBeUndefined();
+    });
 });


### PR DESCRIPTION
## Summary

- Fix credential mapping wizard resolution for n8n credential inventory fields like `credentialId` and `credentialType`.
- Show same-type target credentials reliably and persist the selected target credential ID.
- Allow manual wizard input by target credential name or ID, matching the behavior requested in issue #490.

## Root Cause

Promotion assumed credential inventory objects always exposed `id` and `type`. Some n8n metadata responses use alternate field names, so the wizard could not list matching target credentials and selected mappings were ignored.

## Validation

- `npx vitest run packages/cli/tests/unit/promote-command.test.ts`
- `npx tsc -b packages/cli/tsconfig.json`

Fixes follow-up from #490.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "omit this credential" option in interactive promotion and a manual credential-entry flow.

* **Refactor**
  * Centralized normalized credential lookup and matching for consistent resolution across varied credential formats.
  * Workflow handling updated to respect explicit "create new" markers and avoid recovering stale IDs.

* **Bug Fixes**
  * Do not send the literal projectId "personal" when creating workflows.

* **Tests**
  * Added tests for interactive mapping, omission flows, colon-containing inputs, and workflow ID recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/501?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->