### PR TITLE
[codex] Fix Cursor configure command activation

### DIFF
--- a/packages/vscode-extension/esbuild.config.js
+++ b/packages/vscode-extension/esbuild.config.js
@@ -274,12 +274,28 @@ exports.activate = activate;
 exports.deactivate = deactivate;
 const path = require('node:path');
 process.env.N8N_AS_CODE_ASSETS_DIR ??= path.join(__dirname, '..', 'assets');
-const runtime = require('./extension-runtime.js');
+let runtime;
+function loadRuntime() {
+  runtime ??= require('./extension-runtime.js');
+  return runtime;
+}
 async function activate(context) {
-  return runtime.activate(context);
+  try {
+    return await loadRuntime().activate(context);
+  } catch (error) {
+    const vscode = require('vscode');
+    const message = error && (error.stack || error.message) || String(error);
+    const outputChannel = vscode.window.createOutputChannel('n8n-as-code');
+    outputChannel.appendLine('[n8n] Failed to load extension runtime: ' + message);
+    context.subscriptions.push(vscode.commands.registerCommand('n8n.configure', async () => {
+      await vscode.commands.executeCommand('workbench.action.openSettings', 'n8n');
+      vscode.window.showErrorMessage('n8n as code could not load its full runtime. See the n8n-as-code output channel for details.');
+    }));
+    vscode.window.showErrorMessage('n8n as code could not load its full runtime. See the n8n-as-code output channel for details.');
+  }
 }
 function deactivate() {
-  return typeof runtime.deactivate === 'function' ? runtime.deactivate() : undefined;
+  return runtime && typeof runtime.deactivate === 'function' ? runtime.deactivate() : undefined;
 }
 //# sourceMappingURL=extension.js.map
 `);

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -221,26 +221,12 @@ async function refreshWorkflowList(): Promise<IWorkflowStatus[]> {
 }
 
 export async function activate(context: vscode.ExtensionContext) {
-    outputChannel.show(true);
-    outputChannel.appendLine('🔌 Activation of "n8n-as-code"...');
-    telemetryClient = createTelemetryClient({
-        facade: 'vscode',
-        version: String(context.extension.packageJSON?.version ?? __N8NAC_CLI_SEMVER__ ?? ''),
-        forceDisabled: !vscode.env.isTelemetryEnabled,
-    });
-    telemetryClient.track('vscode_extension_activated', {
-        vscode_version: vscode.version,
-        extension_version: String(context.extension.packageJSON?.version ?? ''),
-        has_workspace: Boolean(vscode.workspace.workspaceFolders?.length),
-    });
-    context.subscriptions.push(vscode.env.onDidChangeTelemetryEnabled((enabled) => {
-        telemetryClient = createTelemetryClient({
-            facade: 'vscode',
-            version: String(context.extension.packageJSON?.version ?? __N8NAC_CLI_SEMVER__ ?? ''),
-            forceDisabled: !enabled,
-        });
-    }));
-
+    try {
+        outputChannel.show(true);
+        outputChannel.appendLine('🔌 Activation of "n8n-as-code"...');
+    } catch {
+        // Keep activation moving so command registration still happens in Cursor-compatible hosts.
+    }
     const registerTelemetryCommand = (command: string, callback: (...args: any[]) => any): vscode.Disposable => (
         vscode.commands.registerCommand(command, async (...args: any[]) => {
             const telemetry = telemetryClient;
@@ -258,6 +244,51 @@ export async function activate(context: vscode.ExtensionContext) {
         })
     );
 
+    context.subscriptions.push(
+        registerTelemetryCommand('n8n.configure', async () => {
+            ConfigurationWebview.createOrShow(context, getOrCreateConfigurationController());
+        }),
+    );
+
+    try {
+        const controller = getOrCreateConfigurationController();
+        context.subscriptions.push(
+            controller,
+            controller.onDidChangeSnapshot((event) => {
+                const workspaceRoot = getWorkspaceRoot();
+                if (shouldAutoEnsureAiContext({ workspaceRoot, snapshot: event.snapshot })) {
+                    scheduleEnsureAiContextFresh(context, `snapshot:${event.reason}`, event.snapshot);
+                }
+                void handleConfigurationSnapshotChanged(context, event);
+            }),
+        );
+    } catch (error: any) {
+        outputChannel.appendLine(`[n8n] Configuration controller initialization failed: ${error?.message || error}`);
+    }
+
+    try {
+        telemetryClient = createTelemetryClient({
+            facade: 'vscode',
+            version: String(context.extension.packageJSON?.version ?? __N8NAC_CLI_SEMVER__ ?? ''),
+            forceDisabled: !vscode.env.isTelemetryEnabled,
+        });
+        telemetryClient.track('vscode_extension_activated', {
+            vscode_version: vscode.version,
+            extension_version: String(context.extension.packageJSON?.version ?? ''),
+            has_workspace: Boolean(vscode.workspace.workspaceFolders?.length),
+        });
+        context.subscriptions.push(vscode.env.onDidChangeTelemetryEnabled((enabled) => {
+            telemetryClient = createTelemetryClient({
+                facade: 'vscode',
+                version: String(context.extension.packageJSON?.version ?? __N8NAC_CLI_SEMVER__ ?? ''),
+                forceDisabled: !enabled,
+            });
+        }));
+    } catch (error: any) {
+        outputChannel.appendLine(`[n8n] Telemetry initialization skipped: ${error?.message || error}`);
+    }
+
+    try {
     // Register Remote Content Provider for Diffs
     context.subscriptions.push(
         vscode.workspace.registerTextDocumentContentProvider('n8n-remote', {
@@ -282,17 +313,6 @@ export async function activate(context: vscode.ExtensionContext) {
     agentRuntimeController = new AgentRuntimeController(context, outputChannel);
     agentProviderService = new AgentProviderService(context);
     context.subscriptions.push(agentRuntimeController);
-    configurationController = new N8nConfigurationController(outputChannel);
-    context.subscriptions.push(
-        configurationController,
-        configurationController.onDidChangeSnapshot((event) => {
-            const workspaceRoot = getWorkspaceRoot();
-            if (shouldAutoEnsureAiContext({ workspaceRoot, snapshot: event.snapshot })) {
-                scheduleEnsureAiContextFresh(context, `snapshot:${event.reason}`, event.snapshot);
-            }
-            void handleConfigurationSnapshotChanged(context, event);
-        }),
-    );
 
     // ── Register Commands ──────────────────────────────────────────────────────
     // Commands are registered early so they are available during activation.
@@ -301,10 +321,6 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         registerTelemetryCommand('n8n.init', async () => {
             await handleInitializeCommand(context);
-        }),
-
-        registerTelemetryCommand('n8n.configure', async () => {
-            ConfigurationWebview.createOrShow(context, requireConfigurationController());
         }),
 
         registerTelemetryCommand('n8n.migrateWorkspaceConfiguration', async () => {
@@ -712,7 +728,7 @@ export async function activate(context: vscode.ExtensionContext) {
     );
 
     // ── Backend configuration snapshot initialization ────────────────────────
-    configurationController.start();
+    getOrCreateConfigurationController().start();
 
     // ── Settings change listener ───────────────────────────────────────────
     context.subscriptions.push(
@@ -750,6 +766,10 @@ export async function activate(context: vscode.ExtensionContext) {
             }
         })
     );
+    } catch (error: any) {
+        outputChannel.appendLine(`[n8n] Activation completed with degraded functionality: ${error?.stack || error?.message || error}`);
+        vscode.window.showErrorMessage(`n8n as code activation issue: ${error?.message || error}`);
+    }
 }
 
 function getExistingWorkflowFileUri(workflow: IWorkflowStatus): vscode.Uri | undefined {
@@ -1275,11 +1295,13 @@ function updateContextKeys() {
     vscode.commands.executeCommand('setContext', 'n8n.initialized', state === ExtensionState.INITIALIZED);
 }
 
-function requireConfigurationController(): N8nConfigurationController {
-    if (!configurationController) {
-        throw new Error('n8n configuration controller is not initialized.');
-    }
+function getOrCreateConfigurationController(): N8nConfigurationController {
+    configurationController ??= new N8nConfigurationController(outputChannel);
     return configurationController;
+}
+
+function requireConfigurationController(): N8nConfigurationController {
+    return getOrCreateConfigurationController();
 }
 
 async function migrateWorkspaceConfiguration(context: vscode.ExtensionContext): Promise<void> {

--- a/packages/vscode-extension/tests/unit/activation-policy.test.ts
+++ b/packages/vscode-extension/tests/unit/activation-policy.test.ts
@@ -9,12 +9,25 @@ import { shouldAutoEnsureAiContext } from '../../src/utils/ai-context-policy.js'
 const extensionPackage = JSON.parse(
     fs.readFileSync(path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../package.json'), 'utf8'),
 ) as { activationEvents?: string[] };
+const extensionSource = fs.readFileSync(
+    path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../src/extension.ts'),
+    'utf8',
+);
 
 test('extension does not activate on every VS Code startup', () => {
     assert.ok(Array.isArray(extensionPackage.activationEvents));
     assert.ok(!extensionPackage.activationEvents?.includes('onStartupFinished'));
     assert.ok(extensionPackage.activationEvents?.includes('onView:n8n-explorer.workflows'));
     assert.ok(extensionPackage.activationEvents?.includes('workspaceContains:n8nac-config.json'));
+});
+
+test('configure command is registered before activation can initialize optional services', () => {
+    const configureRegistration = extensionSource.indexOf("registerTelemetryCommand('n8n.configure'");
+    const treeViewInitialization = extensionSource.indexOf('vscode.window.createTreeView');
+
+    assert.ok(configureRegistration >= 0);
+    assert.ok(treeViewInitialization >= 0);
+    assert.ok(configureRegistration < treeViewInitialization);
 });
 
 test('AI context auto-refresh requires explicit workspace configuration', () => {


### PR DESCRIPTION
## Summary
- register `n8n.configure` before optional activation services so Cursor can always bind the contributed command
- keep activation moving in degraded mode when Cursor-compatible hosts fail during telemetry, view, or service initialization
- make the generated extension wrapper load the runtime lazily and register a fallback configure command if runtime loading fails

## Root cause
The command was contributed in `package.json`, but its handler was registered only after several activation-time services were initialized. If Cursor failed before that point, the extension had a contributed command with no registered handler, producing `command n8n.configure not found`.

## Validation
- `npm run test --workspace=packages/vscode-extension` (98/98 tests passing)
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `n8n.configure` command to open n8n settings from VS Code.

* **Improvements**
  * Enhanced error handling during extension activation with improved logging to a dedicated output channel.
  * Extension now gracefully handles initialization failures, allowing continued functionality with reduced features.

* **Tests**
  * Added validation for extension component initialization order.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtienneLescot/n8n-as-code/pull/507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->