### PR TITLE
[codex] fix non-final assistant phase loop

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -476,6 +476,7 @@
     "test": "npm run compile && npx tsx --test tests/unit/*.test.ts",
     "test:integration:providers": "node scripts/run-provider-stream-v3-integrations.mjs",
     "test:integration:providers:single": "npx tsx --test tests/integration/provider-stream-v3.integration.test.ts",
-    "test:integration:tool-usage": "npx tsx --test tests/integration/tool-usage-workflow-authoring.integration.test.ts"
+    "test:integration:tool-usage": "npx tsx --test tests/integration/tool-usage-workflow-authoring.integration.test.ts",
+    "test:integration:workbench-runtime": "npx tsx --test tests/integration/workbench-runtime-authoring.integration.test.ts"
   }
 }

--- a/packages/vscode-extension/src/services/agent-provider-runtime/chat-codex-oauth.ts
+++ b/packages/vscode-extension/src/services/agent-provider-runtime/chat-codex-oauth.ts
@@ -321,13 +321,36 @@ export class ChatCodexOAuth extends BaseChatModel<ChatCodexOAuthCallOptions> {
           });
           return;
         } else if (part.type === 'error') {
-          throw new Error(`Codex stream error: ${part.error}`);
+          throw new Error(formatCodexStreamError(part.error));
         }
       }
     } finally {
       reader.releaseLock();
     }
   }
+}
+
+function formatCodexStreamError(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return `Codex stream error: ${error.message.trim()}`;
+  }
+  if (typeof error === 'string' && error.trim()) {
+    return `Codex stream error: ${error.trim()}`;
+  }
+  if (error && typeof error === 'object') {
+    const record = error as Record<string, unknown>;
+    for (const key of ['message', 'detail', 'code', 'type']) {
+      if (typeof record[key] === 'string' && record[key].trim()) {
+        return `Codex stream error: ${record[key].trim()}`;
+      }
+    }
+    try {
+      return `Codex stream error: ${JSON.stringify(record)}`;
+    } catch {
+      return 'Codex stream error.';
+    }
+  }
+  return 'Codex stream error.';
 }
 
 function buildIncrementalPrompt(

--- a/packages/vscode-extension/src/services/agent-provider-runtime/openai-account.ts
+++ b/packages/vscode-extension/src/services/agent-provider-runtime/openai-account.ts
@@ -875,6 +875,8 @@ export function createOpenAiAccountLanguageModel(
       let outputTokens = 0;
       let finishReason: 'stop' | 'error' | 'tool-calls' | 'length' | 'content-filter' | 'other' | 'unknown' = 'unknown';
       const toolCalls = new Map<string, LanguageModelV1FunctionToolCall>();
+      const toolCallAliases = new Map<string, string>();
+      const streamedToolCallArgs = new Map<string, string>();
       let responseId: string | undefined;
       let assistantPhase: string | undefined;
       let rawOutputItems: Array<Record<string, unknown>> | undefined;
@@ -895,13 +897,29 @@ export function createOpenAiAccountLanguageModel(
               const toolCall = extractCodexToolCallFromItem(item, toolCalls.size);
               if (toolCall) {
                 toolCalls.set(toolCall.toolCallId, toolCall);
-                controller.enqueue({
-                  type: 'tool-call-delta',
-                  toolCallType: 'function',
-                  toolCallId: toolCall.toolCallId,
-                  toolName: toolCall.toolName,
-                  argsTextDelta: toolCall.args,
-                });
+                rememberCodexToolCallAliases(item, toolCall.toolCallId, toolCallAliases);
+                if (type === 'response.output_item.added') {
+                  controller.enqueue({
+                    type: 'tool-call-delta',
+                    toolCallType: 'function',
+                    toolCallId: toolCall.toolCallId,
+                    toolName: toolCall.toolName,
+                    argsTextDelta: '',
+                  });
+                } else {
+                  const streamed = streamedToolCallArgs.get(toolCall.toolCallId) ?? '';
+                  const missingArgs = getUnstreamedCodexToolArgs(toolCall.args, streamed);
+                  if (missingArgs) {
+                    streamedToolCallArgs.set(toolCall.toolCallId, `${streamed}${missingArgs}`);
+                    controller.enqueue({
+                      type: 'tool-call-delta',
+                      toolCallType: 'function',
+                      toolCallId: toolCall.toolCallId,
+                      toolName: toolCall.toolName,
+                      argsTextDelta: missingArgs,
+                    });
+                  }
+                }
               }
               if (item && typeof item === 'object' && (item as { type?: unknown }).type === 'message') {
                 const phase = readOptionalString((item as { phase?: unknown }).phase);
@@ -910,13 +928,14 @@ export function createOpenAiAccountLanguageModel(
                 }
               }
             } else if (type === 'response.function_call_arguments.delta') {
-              const itemId = readOptionalString(event.item_id) || readOptionalString(event.call_id);
+              const itemId = resolveCodexToolCallEventId(event, toolCallAliases);
               if (!itemId) continue;
               const existing = toolCalls.get(itemId);
               if (!existing || typeof event.delta !== 'string') continue;
               const delta = event.delta;
               const newArgs = `${existing.args}${delta}`;
               toolCalls.set(itemId, { ...existing, args: newArgs });
+              streamedToolCallArgs.set(itemId, `${streamedToolCallArgs.get(itemId) ?? ''}${delta}`);
               controller.enqueue({
                 type: 'tool-call-delta',
                 toolCallType: 'function',
@@ -925,12 +944,24 @@ export function createOpenAiAccountLanguageModel(
                 argsTextDelta: delta,
               });
             } else if (type === 'response.function_call_arguments.done') {
-              const itemId = readOptionalString(event.item_id) || readOptionalString(event.call_id);
+              const itemId = resolveCodexToolCallEventId(event, toolCallAliases);
               if (!itemId) continue;
               const existing = toolCalls.get(itemId);
               if (!existing) continue;
               const finalArgs = readOptionalString(event.arguments) ?? existing.args;
               toolCalls.set(itemId, { ...existing, args: finalArgs });
+              const streamed = streamedToolCallArgs.get(itemId) ?? '';
+              const missingArgs = getUnstreamedCodexToolArgs(finalArgs, streamed);
+              if (missingArgs) {
+                streamedToolCallArgs.set(itemId, `${streamed}${missingArgs}`);
+                controller.enqueue({
+                  type: 'tool-call-delta',
+                  toolCallType: 'function',
+                  toolCallId: itemId,
+                  toolName: existing.toolName,
+                  argsTextDelta: missingArgs,
+                });
+              }
             } else if (type === 'response.completed') {
               const resp = event.response as {
                 id?: string;
@@ -950,11 +981,9 @@ export function createOpenAiAccountLanguageModel(
               completed = true;
               break;
             } else if (type === 'response.failed') {
-              const resp = event.response as { error?: { message?: string } } | undefined;
-              throw new Error(resp?.error?.message || 'Codex response failed.');
+              throw new Error(extractCodexSseErrorMessage(event) || 'Codex response failed.');
             } else if (type === 'error') {
-              const msg = typeof event.message === 'string' ? event.message : '';
-              throw new Error(msg || 'Codex stream error.');
+              throw new Error(extractCodexSseErrorMessage(event) || 'Codex stream error.');
             }
           }
 
@@ -1069,6 +1098,7 @@ async function runOpenAiAccountCompletion(
   let inputTokens = 0;
   let outputTokens = 0;
   const toolCalls = new Map<string, LanguageModelV1FunctionToolCall>();
+  const toolCallAliases = new Map<string, string>();
   let responseId: string | undefined;
   let assistantPhase: string | undefined;
   let rawOutputItems: Array<Record<string, unknown>> | undefined;
@@ -1086,6 +1116,7 @@ async function runOpenAiAccountCompletion(
       const toolCall = extractCodexToolCallFromItem(item, toolCalls.size);
       if (toolCall) {
         toolCalls.set(toolCall.toolCallId, toolCall);
+        rememberCodexToolCallAliases(item, toolCall.toolCallId, toolCallAliases);
       }
       if (item && typeof item === 'object' && (item as { type?: unknown }).type === 'message') {
         const phase = readOptionalString((item as { phase?: unknown }).phase);
@@ -1094,7 +1125,7 @@ async function runOpenAiAccountCompletion(
         }
       }
     } else if (type === 'response.function_call_arguments.delta') {
-      const itemId = readOptionalString(event.item_id) || readOptionalString(event.call_id);
+      const itemId = resolveCodexToolCallEventId(event, toolCallAliases);
       if (!itemId) {
         continue;
       }
@@ -1107,7 +1138,7 @@ async function runOpenAiAccountCompletion(
         args: `${existing.args}${event.delta}`,
       });
     } else if (type === 'response.function_call_arguments.done') {
-      const itemId = readOptionalString(event.item_id) || readOptionalString(event.call_id);
+      const itemId = resolveCodexToolCallEventId(event, toolCallAliases);
       if (!itemId) {
         continue;
       }
@@ -1141,11 +1172,9 @@ async function runOpenAiAccountCompletion(
         }
       }
     } else if (type === 'response.failed') {
-      const resp = event.response as { error?: { message?: string } } | undefined;
-      throw new Error(resp?.error?.message || 'Codex response failed.');
+      throw new Error(extractCodexSseErrorMessage(event) || 'Codex response failed.');
     } else if (type === 'error') {
-      const msg = typeof event.message === 'string' ? event.message : '';
-      throw new Error(msg || 'Codex stream error.');
+      throw new Error(extractCodexSseErrorMessage(event) || 'Codex stream error.');
     }
   }
 
@@ -1442,6 +1471,85 @@ function extractCodexToolCallFromItem(item: unknown, index: number): LanguageMod
     toolName,
     args,
   };
+}
+
+function rememberCodexToolCallAliases(item: unknown, toolCallId: string, aliases: Map<string, string>): void {
+  if (!item || typeof item !== 'object') {
+    return;
+  }
+  const record = item as Record<string, unknown>;
+  for (const candidate of [record.call_id, record.id]) {
+    const alias = readOptionalString(candidate);
+    if (alias) {
+      aliases.set(alias, toolCallId);
+    }
+  }
+}
+
+function resolveCodexToolCallEventId(event: Record<string, unknown>, aliases: Map<string, string>): string | undefined {
+  const callId = readOptionalString(event.call_id);
+  if (callId) {
+    return aliases.get(callId) ?? callId;
+  }
+  const itemId = readOptionalString(event.item_id);
+  return itemId ? aliases.get(itemId) ?? itemId : undefined;
+}
+
+function getUnstreamedCodexToolArgs(finalArgs: string, streamedArgs: string): string {
+  if (!finalArgs) {
+    return '';
+  }
+  if (!streamedArgs) {
+    return finalArgs;
+  }
+  if (finalArgs.startsWith(streamedArgs)) {
+    return finalArgs.slice(streamedArgs.length);
+  }
+  return '';
+}
+
+function extractCodexSseErrorMessage(event: Record<string, unknown>): string | undefined {
+  const direct = readOptionalString(event.message)
+    || readOptionalString(event.detail)
+    || readOptionalString(event.code);
+  if (direct) {
+    return direct;
+  }
+  const nestedError = event.error;
+  if (typeof nestedError === 'string') {
+    return nestedError.trim() || undefined;
+  }
+  if (nestedError && typeof nestedError === 'object') {
+    const errorRecord = nestedError as Record<string, unknown>;
+    const nested = readOptionalString(errorRecord.message)
+      || readOptionalString(errorRecord.detail)
+      || readOptionalString(errorRecord.code)
+      || readOptionalString(errorRecord.type);
+    if (nested) {
+      return nested;
+    }
+  }
+  const response = event.response;
+  if (response && typeof response === 'object') {
+    const responseRecord = response as Record<string, unknown>;
+    const responseError = responseRecord.error;
+    if (responseError && typeof responseError === 'object') {
+      const errorRecord = responseError as Record<string, unknown>;
+      const responseMessage = readOptionalString(errorRecord.message)
+        || readOptionalString(errorRecord.detail)
+        || readOptionalString(errorRecord.code)
+        || readOptionalString(errorRecord.type);
+      if (responseMessage) {
+        return responseMessage;
+      }
+    }
+  }
+  try {
+    const serialized = JSON.stringify(event);
+    return serialized && serialized !== '{}' ? serialized : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function stringifyToolResult(value: unknown): string {

--- a/packages/vscode-extension/src/services/agent-provider-settings.ts
+++ b/packages/vscode-extension/src/services/agent-provider-settings.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode';
+import type * as vscode from 'vscode';
 
 export type AgentProviderId =
     | 'anthropic'
@@ -41,8 +41,16 @@ export interface AgentProviderSettings {
     reasoningEffort?: AgentProviderReasoningEffortSetting;
 }
 
+type LegacyConfiguration = {
+    get<T>(key: string): T | undefined;
+};
+
+const EMPTY_LEGACY_CONFIGURATION: LegacyConfiguration = {
+    get: () => undefined,
+};
+
 export function readAgentProviderSettings(state: vscode.Memento): AgentProviderSettings {
-    const legacyConfig = vscode.workspace.getConfiguration('n8n.agent');
+    const legacyConfig = getLegacyAgentConfiguration();
     const legacyProvider = readOptionalString(legacyConfig.get<string>('provider'));
     const useManagedSettings = state.get<boolean>(MANAGED_SETTINGS_STATE_KEY) === true || !legacyProvider;
     const provider = normalizeAgentProviderId(useManagedSettings
@@ -61,6 +69,17 @@ export function readAgentProviderSettings(state: vscode.Memento): AgentProviderS
         ? reasoningValue as AgentProviderReasoningEffortSetting
         : undefined;
     return { provider, model, baseUrl, reasoningEffort };
+}
+
+function getLegacyAgentConfiguration(): LegacyConfiguration {
+    const runtimeRequire = typeof require === 'function' ? require : undefined;
+    if (!runtimeRequire) return EMPTY_LEGACY_CONFIGURATION;
+    try {
+        const vscodeModule = runtimeRequire('vscode') as { workspace?: { getConfiguration(section: string): LegacyConfiguration } };
+        return vscodeModule.workspace?.getConfiguration('n8n.agent') || EMPTY_LEGACY_CONFIGURATION;
+    } catch {
+        return EMPTY_LEGACY_CONFIGURATION;
+    }
 }
 
 function normalizeAgentProviderId(provider?: string): AgentProviderId | undefined {

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -28,6 +28,7 @@ const ACTIVE_WORKTREE_PATH_KEY = 'n8n.agent.activeWorktreePath';
 const ACTIVE_WORKTREE_PATH_BY_SESSION_KEY = 'n8n.agent.activeWorktreePathBySession';
 const INVALID_TOOL_CALL_RECOVERY_MARKER = 'N8N_INVALID_TOOL_CALL_RECOVERY';
 const NON_FINAL_ASSISTANT_PHASE_RECOVERY_MARKER = 'N8N_NON_FINAL_ASSISTANT_PHASE_RECOVERY';
+const NON_FINAL_ASSISTANT_PHASE_MAX_RECOVERY_ATTEMPTS = 12;
 
 type ActiveWorktreePathsBySession = Record<string, string | null>;
 
@@ -2159,6 +2160,7 @@ export class AgentRuntimeController implements vscode.Disposable {
         const checkpointer = await this.createPersistentCheckpointer();
         const backend = await deepagents.LocalShellBackend.create({
             rootDir,
+            virtualMode: true,
             inheritEnv: false,
             env: this.buildAgentBackendEnv(),
         });
@@ -2243,8 +2245,8 @@ export class AgentRuntimeController implements vscode.Disposable {
                     const lastMessage = messages[messages.length - 1];
                     if (!this.isNonFinalAssistantPhaseMessage(lastMessage, state)) return undefined;
                     const recoveryAttempts = this.countRecentRecoveryAttempts(messages, NON_FINAL_ASSISTANT_PHASE_RECOVERY_MARKER);
-                    if (recoveryAttempts >= 2) {
-                        this.outputChannel.appendLine('[n8n-agent] Stopping non-final assistant phase recovery after two attempts.');
+                    if (recoveryAttempts >= NON_FINAL_ASSISTANT_PHASE_MAX_RECOVERY_ATTEMPTS) {
+                        this.outputChannel.appendLine(`[n8n-agent] Stopping non-final assistant phase recovery after ${NON_FINAL_ASSISTANT_PHASE_MAX_RECOVERY_ATTEMPTS} attempts.`);
                         const lastMessageId = this.getMessageId(lastMessage);
                         return {
                             messages: [
@@ -2483,8 +2485,9 @@ export class AgentRuntimeController implements vscode.Disposable {
             text ? `Removed assistant text: ${text}` : undefined,
             '',
             'Continue the same user task now.',
-            hasIncompleteTodos ? 'The todo list shows unfinished work; continue with the next required tool call or update the todo list before finalizing.' : undefined,
-            'If work remains, emit the next required tool call or another non-terminal assistant phase followed by a tool call.',
+            hasIncompleteTodos ? 'The todo list shows unfinished work. Your next response must include a valid tool call; do not emit another text-only progress update.' : undefined,
+            hasIncompleteTodos ? 'Call the next concrete tool now, for example read_file, execute, write_file, or write_todos.' : undefined,
+            'If work remains, emit the next required tool call or another non-terminal assistant phase paired with a tool call.',
             'Only emit a final answer when the requested work is actually complete or blocked.',
         ].filter(Boolean).join('\n');
     }
@@ -2493,15 +2496,16 @@ export class AgentRuntimeController implements vscode.Disposable {
         return [
             'You are the embedded n8n-as-code VS Code agent.',
             'You help users design, inspect, validate, and operate n8n workflows from the current workspace.',
-            'Your DeepAgents backend working directory is the VS Code workspace root. Use real workspace paths: either relative paths like workflows/dev/example.workflow.ts or absolute paths under the workspace root. Do not use pseudo-root paths like /workflows/... unless the workspace root itself is /.',
+            'Your DeepAgents filesystem tools are scoped to the VS Code workspace root. Prefer relative paths like workflows/dev/example.workflow.ts. Absolute filesystem tool paths are virtual paths rooted at the workspace, so /workflows/dev/example.workflow.ts maps to the workspace workflows/dev/example.workflow.ts file, not the host root.',
             'Use tools only when useful. For workflow-specific questions, use the inline workflow and node context supplied with each user turn as authoritative.',
             'Assistant phases are part of the runtime contract: non-terminal phases such as commentary or analysis are interim only. A run may end without tool calls only when the assistant response is in a terminal final phase and the work is complete or genuinely blocked.',
             'When creating or editing n8n-as-code workflows, write TypeScript source files (.ts) using @workflow, @node, and @links decorators. Do not create raw n8n workflow JSON unless the user explicitly asks for JSON export.',
             'Do not invent workflow helper APIs such as createWorkflow. The canonical TypeScript shape is: import { workflow, node, links } from "@n8n-as-code/transformer"; then @workflow({...}) export class MyWorkflow { @node({...}) ManualTrigger = {}; @links() defineRouting() {} }.',
             'Do not claim to push workflows, provision credentials, or change n8n runtime state unless a tool explicitly performs that action successfully.',
             'When using the execute tool, pass exactly one argument object with a command string: {"command":"..."}. Never pass a separate path field, and never concatenate multiple JSON objects.',
+            'Do not end a run with plain progress text while work remains. If todos are pending or in progress, continue with the next tool call such as read_file, execute, write_file, or write_todos. Only final answers may end without tool calls.',
             workspaceRoot ? `Workspace root: ${workspaceRoot}` : undefined,
-            workspaceRoot ? `Example absolute workflow path: ${path.join(workspaceRoot, 'workflows/dev/example.workflow.ts')}` : undefined,
+            'Example workflow file path for tools: workflows/dev/example.workflow.ts',
         ].filter(Boolean).join('\n');
     }
 

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -27,6 +27,7 @@ const DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000;
 const ACTIVE_WORKTREE_PATH_KEY = 'n8n.agent.activeWorktreePath';
 const ACTIVE_WORKTREE_PATH_BY_SESSION_KEY = 'n8n.agent.activeWorktreePathBySession';
 const INVALID_TOOL_CALL_RECOVERY_MARKER = 'N8N_INVALID_TOOL_CALL_RECOVERY';
+const NON_FINAL_ASSISTANT_PHASE_RECOVERY_MARKER = 'N8N_NON_FINAL_ASSISTANT_PHASE_RECOVERY';
 
 type ActiveWorktreePathsBySession = Record<string, string | null>;
 
@@ -2170,6 +2171,7 @@ export class AgentRuntimeController implements vscode.Disposable {
             middleware: [
                 this.createProviderMessageCompatibilityMiddleware(langchain, messagesModule),
                 this.createInvalidToolCallRecoveryMiddleware(langchain, messagesModule),
+                this.createNonFinalAssistantPhaseRecoveryMiddleware(langchain, messagesModule),
             ].filter(Boolean),
             systemPrompt: this.buildStaticSystemPrompt(input.workspaceRoot),
         });
@@ -2216,6 +2218,41 @@ export class AgentRuntimeController implements vscode.Disposable {
                         messages: [
                             ...(lastMessageId ? [new RemoveMessage({ id: lastMessageId })] : []),
                             repairMessage,
+                        ],
+                        jumpTo: 'model',
+                    };
+                },
+            },
+        });
+    }
+
+    private createNonFinalAssistantPhaseRecoveryMiddleware(langchain: any, messagesModule: any): unknown {
+        const createMiddleware = langchain?.createMiddleware;
+        const HumanMessage = messagesModule?.HumanMessage;
+        const RemoveMessage = messagesModule?.RemoveMessage;
+        if (typeof createMiddleware !== 'function' || typeof HumanMessage !== 'function' || typeof RemoveMessage !== 'function') {
+            return undefined;
+        }
+        return createMiddleware({
+            name: 'N8nNonFinalAssistantPhaseRecovery',
+            afterModel: {
+                canJumpTo: ['model'],
+                hook: (state: any) => {
+                    const messages = Array.isArray(state?.messages) ? state.messages : [];
+                    const lastMessage = messages[messages.length - 1];
+                    if (!this.isNonFinalAssistantPhaseMessage(lastMessage)) return undefined;
+                    const recoveryAttempts = this.countRecentRecoveryAttempts(messages, NON_FINAL_ASSISTANT_PHASE_RECOVERY_MARKER);
+                    if (recoveryAttempts >= 2) {
+                        this.outputChannel.appendLine('[n8n-agent] Stopping non-final assistant phase recovery after two attempts.');
+                        return undefined;
+                    }
+                    const phase = this.getAssistantPhase(lastMessage) || 'unknown';
+                    this.outputChannel.appendLine(`[n8n-agent-debug] recovering non-final assistant phase=${phase} attempt=${recoveryAttempts + 1}`);
+                    const lastMessageId = this.getMessageId(lastMessage);
+                    return {
+                        messages: [
+                            ...(lastMessageId ? [new RemoveMessage({ id: lastMessageId })] : []),
+                            new HumanMessage({ content: this.buildNonFinalAssistantPhaseRecoveryPrompt(lastMessage) }),
                         ],
                         jumpTo: 'model',
                     };
@@ -2368,12 +2405,16 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     private countRecentInvalidToolCallRecoveryAttempts(messages: unknown[]): number {
+        return this.countRecentRecoveryAttempts(messages, INVALID_TOOL_CALL_RECOVERY_MARKER);
+    }
+
+    private countRecentRecoveryAttempts(messages: unknown[], marker: string): number {
         let attempts = 0;
         for (let idx = messages.length - 1; idx >= 0; idx -= 1) {
             const message = messages[idx];
             if (!this.isRecord(message)) continue;
             const text = this.extractMessageTextContent(message.content);
-            if (text.includes('N8N_INVALID_TOOL_CALL_RECOVERY')) {
+            if (text.includes(marker)) {
                 attempts += 1;
                 continue;
             }
@@ -2415,12 +2456,27 @@ export class AgentRuntimeController implements vscode.Disposable {
         ].filter(Boolean).join('\n');
     }
 
+    private buildNonFinalAssistantPhaseRecoveryPrompt(message: unknown): string {
+        const phase = this.getAssistantPhase(message) || 'unknown';
+        const text = this.extractAssistantMessageText(message).replace(/\s+/g, ' ').trim();
+        return [
+            NON_FINAL_ASSISTANT_PHASE_RECOVERY_MARKER,
+            `Your previous assistant message had non-terminal assistant phase "${phase}" and was removed before ending the run.`,
+            text ? `Removed assistant text: ${text}` : undefined,
+            '',
+            'Continue the same user task now.',
+            'If work remains, emit the next required tool call or another non-terminal assistant phase followed by a tool call.',
+            'Only emit a final answer when the requested work is actually complete or blocked.',
+        ].filter(Boolean).join('\n');
+    }
+
     private buildStaticSystemPrompt(workspaceRoot?: string): string {
         return [
             'You are the embedded n8n-as-code VS Code agent.',
             'You help users design, inspect, validate, and operate n8n workflows from the current workspace.',
             'Your DeepAgents backend working directory is the VS Code workspace root. Use real workspace paths: either relative paths like workflows/dev/example.workflow.ts or absolute paths under the workspace root. Do not use pseudo-root paths like /workflows/... unless the workspace root itself is /.',
             'Use tools only when useful. For workflow-specific questions, use the inline workflow and node context supplied with each user turn as authoritative.',
+            'Assistant phases are part of the runtime contract: non-terminal phases such as commentary or analysis are interim only. A run may end without tool calls only when the assistant response is in a terminal final phase and the work is complete or genuinely blocked.',
             'When creating or editing n8n-as-code workflows, write TypeScript source files (.ts) using @workflow, @node, and @links decorators. Do not create raw n8n workflow JSON unless the user explicitly asks for JSON export.',
             'Do not invent workflow helper APIs such as createWorkflow. The canonical TypeScript shape is: import { workflow, node, links } from "@n8n-as-code/transformer"; then @workflow({...}) export class MyWorkflow { @node({...}) ManualTrigger = {}; @links() defineRouting() {} }.',
             'Do not claim to push workflows, provision credentials, or change n8n runtime state unless a tool explicitly performs that action successfully.',
@@ -2735,7 +2791,9 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     private isInternalRecoveryText(value: string): boolean {
-        return value.trimStart().startsWith(INVALID_TOOL_CALL_RECOVERY_MARKER);
+        const trimmed = value.trimStart();
+        return trimmed.startsWith(INVALID_TOOL_CALL_RECOVERY_MARKER)
+            || trimmed.startsWith(NON_FINAL_ASSISTANT_PHASE_RECOVERY_MARKER);
     }
 
     private extractProviderOutputItemsText(message: Record<string, unknown>): string {
@@ -2847,6 +2905,36 @@ export class AgentRuntimeController implements vscode.Disposable {
         if (messageType === 'tool' || messageType === 'human' || messageType === 'system') return false;
         if (messageType === 'ai' || messageType === 'assistant') return true;
         return false;
+    }
+
+    private isNonFinalAssistantPhaseMessage(message: unknown): boolean {
+        if (!this.isAssistantMessage(message)) return false;
+        if (this.messageHasToolCalls(message)) return false;
+        const phase = this.getAssistantPhase(message);
+        if (!phase) return false;
+        return !this.isTerminalAssistantPhase(phase);
+    }
+
+    private isTerminalAssistantPhase(phase: string): boolean {
+        const normalized = phase.toLowerCase().replace(/[-\s]/g, '_').trim();
+        return normalized === 'final' || normalized === 'final_answer';
+    }
+
+    private getAssistantPhase(message: unknown): string | undefined {
+        if (!this.isRecord(message)) return undefined;
+        const read = (value: unknown): string | undefined => {
+            if (!this.isRecord(value)) return undefined;
+            const direct = value.phase;
+            if (typeof direct === 'string' && direct.trim()) return direct.trim();
+            return undefined;
+        };
+        return read(message)
+            || read(message.additional_kwargs)
+            || read(message.response_metadata)
+            || read(message.kwargs)
+            || read(message.lc_kwargs)
+            || (this.isRecord(message.kwargs) ? read(message.kwargs.additional_kwargs) || read(message.kwargs.response_metadata) : undefined)
+            || (this.isRecord(message.lc_kwargs) ? read(message.lc_kwargs.additional_kwargs) || read(message.lc_kwargs.response_metadata) : undefined);
     }
 
     private getMessageType(value: Record<string, unknown>): string | undefined {

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -1712,11 +1712,11 @@ export class AgentRuntimeController implements vscode.Disposable {
             if (!delta || isInternalRecoveryMessage) return;
             if (!textVisibilityResolved) {
                 pendingVisibleText += delta;
-                if (INVALID_TOOL_CALL_RECOVERY_MARKER.startsWith(pendingVisibleText) && pendingVisibleText.length < INVALID_TOOL_CALL_RECOVERY_MARKER.length) {
+                if (this.isInternalRecoveryPrefix(pendingVisibleText) && !this.isInternalRecoveryText(pendingVisibleText)) {
                     return;
                 }
                 textVisibilityResolved = true;
-                if (pendingVisibleText.startsWith(INVALID_TOOL_CALL_RECOVERY_MARKER)) {
+                if (this.isInternalRecoveryText(pendingVisibleText)) {
                     isInternalRecoveryMessage = true;
                     pendingVisibleText = '';
                     blockText.clear();
@@ -1883,11 +1883,11 @@ export class AgentRuntimeController implements vscode.Disposable {
                 }
                 if (!textVisibilityResolved) {
                     pendingText += delta;
-                    if (INVALID_TOOL_CALL_RECOVERY_MARKER.startsWith(pendingText) && pendingText.length < INVALID_TOOL_CALL_RECOVERY_MARKER.length) {
+                    if (this.isInternalRecoveryPrefix(pendingText) && !this.isInternalRecoveryText(pendingText)) {
                         continue;
                     }
                     textVisibilityResolved = true;
-                    if (pendingText.startsWith(INVALID_TOOL_CALL_RECOVERY_MARKER)) {
+                    if (this.isInternalRecoveryText(pendingText)) {
                         isInternalRecoveryMessage = true;
                         pendingText = '';
                         continue;
@@ -2228,15 +2228,16 @@ export class AgentRuntimeController implements vscode.Disposable {
 
     private createNonFinalAssistantPhaseRecoveryMiddleware(langchain: any, messagesModule: any): unknown {
         const createMiddleware = langchain?.createMiddleware;
+        const AIMessage = messagesModule?.AIMessage;
         const HumanMessage = messagesModule?.HumanMessage;
         const RemoveMessage = messagesModule?.RemoveMessage;
-        if (typeof createMiddleware !== 'function' || typeof HumanMessage !== 'function' || typeof RemoveMessage !== 'function') {
+        if (typeof createMiddleware !== 'function' || typeof AIMessage !== 'function' || typeof HumanMessage !== 'function' || typeof RemoveMessage !== 'function') {
             return undefined;
         }
         return createMiddleware({
             name: 'N8nNonFinalAssistantPhaseRecovery',
             afterModel: {
-                canJumpTo: ['model'],
+                canJumpTo: ['model', 'end'],
                 hook: (state: any) => {
                     const messages = Array.isArray(state?.messages) ? state.messages : [];
                     const lastMessage = messages[messages.length - 1];
@@ -2244,7 +2245,18 @@ export class AgentRuntimeController implements vscode.Disposable {
                     const recoveryAttempts = this.countRecentRecoveryAttempts(messages, NON_FINAL_ASSISTANT_PHASE_RECOVERY_MARKER);
                     if (recoveryAttempts >= 2) {
                         this.outputChannel.appendLine('[n8n-agent] Stopping non-final assistant phase recovery after two attempts.');
-                        return undefined;
+                        const lastMessageId = this.getMessageId(lastMessage);
+                        return {
+                            messages: [
+                                ...(lastMessageId ? [new RemoveMessage({ id: lastMessageId })] : []),
+                                new AIMessage({
+                                    content: 'I could not complete the task after repeated non-final assistant phases. Please try again or rephrase the request.',
+                                    additional_kwargs: { phase: 'final' },
+                                    response_metadata: { phase: 'final' },
+                                }),
+                            ],
+                            jumpTo: 'end',
+                        };
                     }
                     const phase = this.getAssistantPhase(lastMessage) || 'unknown';
                     this.outputChannel.appendLine(`[n8n-agent-debug] recovering non-final assistant phase=${phase} attempt=${recoveryAttempts + 1}`);
@@ -2794,6 +2806,12 @@ export class AgentRuntimeController implements vscode.Disposable {
         const trimmed = value.trimStart();
         return trimmed.startsWith(INVALID_TOOL_CALL_RECOVERY_MARKER)
             || trimmed.startsWith(NON_FINAL_ASSISTANT_PHASE_RECOVERY_MARKER);
+    }
+
+    private isInternalRecoveryPrefix(value: string): boolean {
+        const trimmed = value.trimStart();
+        return INVALID_TOOL_CALL_RECOVERY_MARKER.startsWith(trimmed)
+            || NON_FINAL_ASSISTANT_PHASE_RECOVERY_MARKER.startsWith(trimmed);
     }
 
     private extractProviderOutputItemsText(message: Record<string, unknown>): string {

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode';
+import type * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
@@ -2241,7 +2241,7 @@ export class AgentRuntimeController implements vscode.Disposable {
                 hook: (state: any) => {
                     const messages = Array.isArray(state?.messages) ? state.messages : [];
                     const lastMessage = messages[messages.length - 1];
-                    if (!this.isNonFinalAssistantPhaseMessage(lastMessage)) return undefined;
+                    if (!this.isNonFinalAssistantPhaseMessage(lastMessage, state)) return undefined;
                     const recoveryAttempts = this.countRecentRecoveryAttempts(messages, NON_FINAL_ASSISTANT_PHASE_RECOVERY_MARKER);
                     if (recoveryAttempts >= 2) {
                         this.outputChannel.appendLine('[n8n-agent] Stopping non-final assistant phase recovery after two attempts.');
@@ -2264,7 +2264,7 @@ export class AgentRuntimeController implements vscode.Disposable {
                     return {
                         messages: [
                             ...(lastMessageId ? [new RemoveMessage({ id: lastMessageId })] : []),
-                            new HumanMessage({ content: this.buildNonFinalAssistantPhaseRecoveryPrompt(lastMessage) }),
+                            new HumanMessage({ content: this.buildNonFinalAssistantPhaseRecoveryPrompt(lastMessage, state) }),
                         ],
                         jumpTo: 'model',
                     };
@@ -2468,15 +2468,22 @@ export class AgentRuntimeController implements vscode.Disposable {
         ].filter(Boolean).join('\n');
     }
 
-    private buildNonFinalAssistantPhaseRecoveryPrompt(message: unknown): string {
+    private buildNonFinalAssistantPhaseRecoveryPrompt(message: unknown, state?: unknown): string {
         const phase = this.getAssistantPhase(message) || 'unknown';
         const text = this.extractAssistantMessageText(message).replace(/\s+/g, ' ').trim();
+        const hasIncompleteTodos = this.hasIncompleteAgentTodos(state);
+        const reason = phase === 'unknown' && hasIncompleteTodos
+            ? 'Your previous assistant message had no terminal assistant phase or tool call, and the todo list still has pending or in-progress work, so it was removed before ending the run.'
+            : phase === 'unknown' && !text
+            ? 'Your previous assistant message had no terminal assistant phase, no tool call, and no visible text, so it was removed before ending the run.'
+            : `Your previous assistant message had non-terminal assistant phase "${phase}" and was removed before ending the run.`;
         return [
             NON_FINAL_ASSISTANT_PHASE_RECOVERY_MARKER,
-            `Your previous assistant message had non-terminal assistant phase "${phase}" and was removed before ending the run.`,
+            reason,
             text ? `Removed assistant text: ${text}` : undefined,
             '',
             'Continue the same user task now.',
+            hasIncompleteTodos ? 'The todo list shows unfinished work; continue with the next required tool call or update the todo list before finalizing.' : undefined,
             'If work remains, emit the next required tool call or another non-terminal assistant phase followed by a tool call.',
             'Only emit a final answer when the requested work is actually complete or blocked.',
         ].filter(Boolean).join('\n');
@@ -2925,12 +2932,19 @@ export class AgentRuntimeController implements vscode.Disposable {
         return false;
     }
 
-    private isNonFinalAssistantPhaseMessage(message: unknown): boolean {
+    private isNonFinalAssistantPhaseMessage(message: unknown, state?: unknown): boolean {
         if (!this.isAssistantMessage(message)) return false;
         if (this.messageHasToolCalls(message)) return false;
         const phase = this.getAssistantPhase(message);
-        if (!phase) return false;
+        if (!phase) return !this.extractAssistantMessageText(message).trim() || this.hasIncompleteAgentTodos(state);
         return !this.isTerminalAssistantPhase(phase);
+    }
+
+    private hasIncompleteAgentTodos(state: unknown): boolean {
+        return this.extractTodosFromPayload(state).some((todo) => {
+            const status = String(todo.status || 'pending').toLowerCase().replace(/[-\s]/g, '_').trim();
+            return status === 'pending' || status === 'in_progress';
+        });
     }
 
     private isTerminalAssistantPhase(phase: string): boolean {
@@ -4318,21 +4332,29 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     private extractTodosFromPayload(value: unknown): Array<{ content?: unknown; status?: unknown }> {
+        const todoLists = this.extractTodoListsFromPayload(value);
+        return todoLists[todoLists.length - 1] || [];
+    }
+
+    private extractTodoListsFromPayload(value: unknown): Array<Array<{ content?: unknown; status?: unknown }>> {
         const visited = new Set<unknown>();
-        const visit = (candidate: unknown): Array<{ content?: unknown; status?: unknown }> => {
+        const visit = (candidate: unknown): Array<Array<{ content?: unknown; status?: unknown }>> => {
             if (candidate === undefined || candidate === null || visited.has(candidate)) return [];
             if (typeof candidate === 'string') {
                 const trimmed = candidate.trim();
-                if (!trimmed || (!trimmed.startsWith('{') && !trimmed.startsWith('['))) return [];
+                if (!trimmed) return [];
+                const embeddedTodoList = /^Updated todo list to (\[[\s\S]*\])$/i.exec(trimmed)?.[1];
+                const jsonCandidate = embeddedTodoList || trimmed;
+                if (!jsonCandidate.startsWith('{') && !jsonCandidate.startsWith('[')) return [];
                 try {
-                    return visit(JSON.parse(trimmed));
+                    return visit(JSON.parse(jsonCandidate));
                 } catch {
                     return [];
                 }
             }
             if (Array.isArray(candidate)) {
                 if (candidate.every((item) => item && typeof item === 'object' && 'content' in item)) {
-                    return candidate as Array<{ content?: unknown; status?: unknown }>;
+                    return [candidate as Array<{ content?: unknown; status?: unknown }>];
                 }
                 return candidate.flatMap((item) => visit(item));
             }
@@ -4340,10 +4362,12 @@ export class AgentRuntimeController implements vscode.Disposable {
                 visited.add(candidate);
                 const record = candidate as Record<string, unknown>;
                 if (Array.isArray(record.todos)) return visit(record.todos);
-                for (const key of ['update', 'input', 'args', 'kwargs']) {
+                const todoLists: Array<Array<{ content?: unknown; status?: unknown }>> = [];
+                for (const key of ['messages', 'tool_calls', 'toolCalls', 'additional_kwargs', 'response_metadata', 'lc_kwargs', 'kwargs', 'content', 'update', 'input', 'args']) {
                     const todos = visit(record[key]);
-                    if (todos.length) return todos;
+                    if (todos.length) todoLists.push(...todos);
                 }
+                return todoLists;
             }
             return [];
         };

--- a/packages/vscode-extension/tests/integration/workbench-runtime-authoring.integration.test.ts
+++ b/packages/vscode-extension/tests/integration/workbench-runtime-authoring.integration.test.ts
@@ -460,6 +460,12 @@ function readFirstEnv(keys: string[]): string | undefined {
 }
 
 function findAuthoredWorkflowPath(workspaceRoot: string, result: unknown): string | undefined {
+  const resolvedWorkspaceRoot = path.resolve(workspaceRoot);
+  const isWithinWorkspace = (candidatePath: string): boolean => {
+    const relative = path.relative(resolvedWorkspaceRoot, candidatePath);
+    return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+  };
+
   const resultPath = result && typeof result === 'object' && typeof (result as { workflowContext?: { filePath?: unknown } }).workflowContext?.filePath === 'string'
     ? (result as { workflowContext: { filePath: string } }).workflowContext.filePath
     : undefined;
@@ -469,8 +475,8 @@ function findAuthoredWorkflowPath(workspaceRoot: string, result: unknown): strin
     ...listWorkflowFiles(path.join(workspaceRoot, 'workflows')).filter((filePath) => !filePath.endsWith('recherche-annonces-leboncoin.workflow.ts')),
   ].filter((candidate): candidate is string => Boolean(candidate));
   return candidates.find((candidate) => {
-    const resolved = path.isAbsolute(candidate) ? candidate : path.join(workspaceRoot, candidate);
-    return fs.existsSync(resolved) && resolved.endsWith('.workflow.ts') ? resolved : undefined;
+    const resolved = path.resolve(path.isAbsolute(candidate) ? candidate : path.join(workspaceRoot, candidate));
+    return fs.existsSync(resolved) && resolved.endsWith('.workflow.ts') && isWithinWorkspace(resolved) ? resolved : undefined;
   });
 }
 
@@ -560,7 +566,7 @@ function liveDiagnostics(result: unknown, messages: AgentWorkbenchMessage[], out
     issues,
     workflowPath,
     workflowExists: Boolean(workflowPath && fs.existsSync(workflowPath)),
-    workflowExcerpt: workflowContent?.slice(0, 4000),
+    workflowContentLength: workflowContent?.length ?? 0,
     operationEvents,
     lastStreamEvent: streamEvents[streamEvents.length - 1],
     lastMessage: messages[messages.length - 1],

--- a/packages/vscode-extension/tests/integration/workbench-runtime-authoring.integration.test.ts
+++ b/packages/vscode-extension/tests/integration/workbench-runtime-authoring.integration.test.ts
@@ -1,0 +1,441 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import dotenv from 'dotenv';
+import { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { AIMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import type { ChatResult } from '@langchain/core/outputs';
+import { AgentRuntimeController, getAgentProviderSecretKey, type AgentWorkbenchMessage } from '../../src/services/agent-runtime-controller.js';
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../../..');
+dotenv.config({ path: path.join(repoRoot, '.env.test'), quiet: true });
+
+const TARGET_WORKFLOW = 'workflows/dev/recherche-annonces-multi-plateformes.workflow.ts';
+const EXACT_AUTHORING_PROMPT = `Crée un workflow TypeScript n8n-as-code similaire à \`recherche-annonces-leboncoin\`: un moteur interactif de recherche d’annonces pertinentes multi-plateformes.
+
+Objectif:
+Permettre à un utilisateur de décrire librement une recherche d’annonce, puis:
+1. transformer la demande en critères structurés;
+2. générer plusieurs requêtes de recherche multi-plateformes;
+3. récupérer des résultats via Leboncoin, Bing RSS ou sources équivalentes;
+4. extraire et dédupliquer des annonces candidates;
+5. faire sélectionner et scorer les meilleures annonces par un LLM;
+6. afficher une page HTML de résultats;
+7. permettre à l’utilisateur d’ajouter des ajustements et de relancer la recherche.
+
+Contraintes:
+- Utilise \`@n8n-as-code/transformer\` avec \`@workflow\`, \`@node\` et \`@links\`.
+- Ajoute un bloc \`<workflow-map>\` en haut du fichier.
+- Vérifie les schémas n8n réels avant de choisir les types, versions et paramètres de nœuds.
+- Ne hardcode aucun secret ni credential ID.
+- Les sous-nœuds AI doivent être connectés avec \`.uses()\`.
+- Les sorties LLM importantes doivent passer par des parsers structurés.
+- Le workflow doit être lisible, validable et maintenable.
+
+Architecture attendue:
+- Un \`Form Trigger\` demandant:
+  - critères libres de recherche;
+  - nombre maximum de résultats.
+- Un agent LLM d’extraction qui convertit la demande en critères:
+  - requête principale;
+  - localisation;
+  - prix min/max;
+  - mots obligatoires;
+  - mots exclus;
+  - critères qualitatifs;
+  - plateformes cibles;
+  - requêtes d’exploration;
+  - nombre de résultats max.
+- Un nœud Code qui construit plusieurs recherches:
+  - requête large;
+  - synonymes;
+  - variantes de mots-clés;
+  - plateformes comme Leboncoin, eBay, ParuVendu ou autres selon le contexte;
+  - URLs Bing RSS ou URLs lisibles via Jina Reader pour Leboncoin.
+- Une boucle qui exécute les recherches HTTP.
+- Une agrégation des réponses.
+- Un nœud Code qui extrait des annonces candidates:
+  - titre;
+  - prix;
+  - localisation;
+  - catégorie;
+  - URL;
+  - plateforme;
+  - extrait;
+  - score de tri préliminaire.
+- Un agent LLM de sélection qui évalue uniquement les annonces candidates, sans inventer de nouvelles annonces.
+- Un outil HTTP optionnel de recherche Bing RSS utilisable par l’agent au maximum une fois pour clarifier un point important.
+- Un nœud Code qui génère une page HTML responsive avec:
+  - critères interprétés;
+  - synthèse;
+  - résultats scorés;
+  - raisons de sélection;
+  - points d’attention;
+  - liens vers les annonces.
+- Un formulaire de “steering” permettant:
+  - de terminer;
+  - ou de relancer avec des ajustements.
+- Un agent LLM qui fusionne les critères actuels avec les ajustements utilisateur, puis reboucle sur la construction des recherches.
+
+Critères d’acceptation:
+- Recherche itérative fonctionnelle.
+- Résultats affichés dans une page HTML claire.
+- Parsers structurés pour les critères et les annonces sélectionnées.
+- Gestion des résultats pauvres, bloqués ou incomplets.
+- Pas d’annonces inventées par le LLM.
+- Pas de secrets hardcodés.`;
+
+test('workbench runtime authoring continues past non-final progress text', { timeout: 120_000 }, async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-workbench-runtime-'));
+  const storageDir = path.join(tempDir, '.storage');
+  const workspaceRoot = path.join(tempDir, 'workspace');
+  const outputLines: string[] = [];
+  const postedMessages: AgentWorkbenchMessage[] = [];
+  const scriptedModel = new ScriptedWorkbenchModel(createScriptedResponses(TARGET_WORKFLOW));
+
+  try {
+    createWorkbenchWorkspace(workspaceRoot);
+    const controller = new AgentRuntimeController(createExtensionContext(storageDir), {
+      appendLine: (line: string) => outputLines.push(line),
+    } as any);
+    (controller as any).getProviderRuntimeConfig = async () => ({
+      ready: true,
+      provider: 'openai-compatible',
+      model: 'scripted-workbench',
+      temperature: 0,
+    });
+    (controller as any).createLangChainModel = async () => scriptedModel;
+    (controller as any).resolveContextWindow = async () => 200_000;
+
+    const result = await controller.sendPrompt({
+      prompt: EXACT_AUTHORING_PROMPT,
+      workspaceRoot,
+    }, async (message) => {
+      postedMessages.push(message);
+      return true;
+    });
+
+    const workflowPath = path.join(workspaceRoot, TARGET_WORKFLOW);
+    const workflowContent = fs.existsSync(workflowPath) ? fs.readFileSync(workflowPath, 'utf8') : '';
+    const streamEvents = postedMessages.filter((message): message is Extract<AgentWorkbenchMessage, { type: 'agent.streamEvent' }> => message.type === 'agent.streamEvent').map((message) => message.event);
+    const operationEvents = streamEvents.filter((event) => event.type === 'operation');
+    const toolLabels = operationEvents.map((event) => `${event.label}:${event.status}`);
+    const toolEvents = operationEvents.map((event) => `${event.operationId.split(':')[0]}:${event.status}:${event.category}`);
+    const finalIndex = streamEvents.findIndex((event) => event.type === 'final');
+    const writeDoneIndex = streamEvents.findIndex((event) => event.type === 'operation' && event.label === 'Write File' && event.status === 'done');
+    const diagnostics = () => JSON.stringify({
+      result,
+      toolLabels,
+      toolEvents,
+      finalIndex,
+      writeDoneIndex,
+      modelCalls: scriptedModel.callLog,
+      outputLines,
+      lastMessage: postedMessages[postedMessages.length - 1],
+    }, null, 2);
+
+    assert.equal(postedMessages.some((message) => message.type === 'agent.error'), false, diagnostics());
+    assert.ok(toolLabels.includes('Write Todos:done'), diagnostics());
+    assert.ok(toolLabels.includes('Read File:done'), diagnostics());
+    assert.ok(operationEvents.filter((event) => event.label === 'Tool' && event.status === 'done').length >= 2, diagnostics());
+    assert.ok(scriptedModel.callLog.some((entry) => entry.includes('workflows/dev/recherche-annonces-leboncoin.workflow.ts')), diagnostics());
+    assert.ok(toolLabels.includes('Execute:done'), diagnostics());
+    assert.ok(writeDoneIndex >= 0, diagnostics());
+    assert.ok(finalIndex > writeDoneIndex, diagnostics());
+    assert.ok(fs.existsSync(workflowPath), diagnostics());
+    assert.equal(result.workflowChanged, true, diagnostics());
+    assert.match(workflowContent, /<workflow-map>/, diagnostics());
+    assert.match(workflowContent, /@workflow\s*\(/, diagnostics());
+    assert.match(workflowContent, /@node\s*\(/, diagnostics());
+    assert.match(workflowContent, /@links\s*\(/, diagnostics());
+    assert.match(workflowContent, /Form Trigger/, diagnostics());
+    assert.match(workflowContent, /structured parser|parser structuré|Structured Output Parser/i, diagnostics());
+    assert.ok(scriptedModel.callLog.some((entry) => entry.includes('N8N_NON_FINAL_ASSISTANT_PHASE_RECOVERY')), diagnostics());
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('workbench runtime live authoring prompt', {
+  skip: process.env.N8N_AGENT_WORKBENCH_LIVE_PROMPT !== '1',
+  timeout: 600_000,
+}, async (t) => {
+  const provider = (process.env.N8N_AGENT_WORKBENCH_LIVE_PROVIDER || 'openai').trim();
+  const apiKey = readFirstEnv(liveProviderEnvKeys(provider));
+  if (!apiKey) {
+    t.skip(`Missing API key for live provider ${provider}`);
+    return;
+  }
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-workbench-live-'));
+  const storageDir = path.join(tempDir, '.storage');
+  const workspaceRoot = path.join(tempDir, 'workspace');
+  const outputLines: string[] = [];
+  const postedMessages: AgentWorkbenchMessage[] = [];
+  try {
+    createWorkbenchWorkspace(workspaceRoot);
+    const context = createExtensionContext(storageDir, {
+      globalState: {
+        'n8n.agent.settingsManaged': true,
+        'n8n.agent.provider': provider,
+        'n8n.agent.model': process.env.N8N_AGENT_WORKBENCH_LIVE_MODEL || undefined,
+        'n8n.agent.baseUrl': process.env.N8N_AGENT_WORKBENCH_LIVE_BASE_URL || undefined,
+      },
+      secrets: {
+        [getAgentProviderSecretKey(provider)]: apiKey,
+      },
+    });
+    const controller = new AgentRuntimeController(context, {
+      appendLine: (line: string) => outputLines.push(line),
+    } as any);
+
+    const result = await controller.sendPrompt({ prompt: EXACT_AUTHORING_PROMPT, workspaceRoot }, async (message) => {
+      postedMessages.push(message);
+      return true;
+    });
+    const workflowPath = path.join(workspaceRoot, TARGET_WORKFLOW);
+    assert.equal(postedMessages.some((message) => message.type === 'agent.error'), false, liveDiagnostics(result, postedMessages, outputLines, workflowPath));
+    assert.ok(fs.existsSync(workflowPath), liveDiagnostics(result, postedMessages, outputLines, workflowPath));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+class ScriptedWorkbenchModel extends BaseChatModel {
+  private readonly responses: AIMessage[];
+  readonly callLog: string[] = [];
+  boundTools: string[] = [];
+
+  constructor(responses: AIMessage[]) {
+    super({});
+    this.responses = [...responses];
+  }
+
+  _llmType(): string {
+    return 'scripted-workbench';
+  }
+
+  bindTools(tools: Array<{ name?: string }>): this {
+    this.boundTools = tools.map((tool) => String(tool.name || 'unknown'));
+    return this;
+  }
+
+  async _generate(messages: BaseMessage[], _options: this['ParsedCallOptions'], _runManager?: CallbackManagerForLLMRun): Promise<ChatResult> {
+    this.callLog.push(messages.map((message) => extractMessageText(message)).join('\n---\n').slice(-2500));
+    const message = this.responses.shift() || new AIMessage({
+      content: 'Scripted model exhausted before the workbench run completed.',
+      additional_kwargs: { phase: 'final' },
+      response_metadata: { phase: 'final' },
+    });
+    return {
+      generations: [{ message, text: extractMessageText(message) }],
+      llmOutput: {},
+    };
+  }
+}
+
+function createScriptedResponses(targetWorkflow: string): AIMessage[] {
+  return [
+    toolMessage('scripted-write-todos', 'write_todos', {
+      todos: [
+        { content: 'Charger les consignes n8n-as-code', status: 'completed' },
+        { content: 'Inspecter le workflow de référence', status: 'in_progress' },
+        { content: 'Vérifier les schémas n8n réels', status: 'pending' },
+        { content: 'Créer et valider le workflow multi-plateformes', status: 'pending' },
+      ],
+    }),
+    toolMessage('scripted-read-skill', 'read_file', { file_path: '.agents/skills/n8n-architect/SKILL.md', limit: 100 }),
+    toolMessage('scripted-ls', 'ls', { path: '.' }),
+    toolMessage('scripted-glob', 'glob', { pattern: 'workflows/**/*.workflow.ts', path: '.' }),
+    new AIMessage({
+      content: 'J’ai chargé les consignes n8n-as-code et identifié le workflow de référence. Je vais maintenant vérifier les schémas avant de générer le workflow demandé.',
+    }),
+    toolMessage('scripted-schema-form', 'execute', { command: 'node -e "console.log(\'n8n-nodes-base.formTrigger v2 schema ok\')"' }),
+    toolMessage('scripted-schema-http', 'execute', { command: 'node -e "console.log(\'n8n-nodes-base.httpRequest v4.2 schema ok\')"' }),
+    toolMessage('scripted-write-workflow', 'write_file', { file_path: targetWorkflow, content: workflowSource() }),
+    toolMessage('scripted-validate', 'execute', { command: 'node -e "console.log(\'validation ok\')"' }),
+    new AIMessage({
+      content: `Le workflow TypeScript multi-plateformes a été créé et validé dans ${targetWorkflow}.`,
+      additional_kwargs: { phase: 'final' },
+      response_metadata: { phase: 'final' },
+    }),
+  ];
+}
+
+function toolMessage(id: string, name: string, args: Record<string, unknown>): AIMessage {
+  return new AIMessage({
+    content: '',
+    tool_calls: [{ id, name, args, type: 'tool_call' }],
+  });
+}
+
+function workflowSource(): string {
+  return `/*
+<workflow-map>
+Form Trigger -> Criteria Extraction Agent -> Structured Criteria Parser -> Build Searches Code -> HTTP Search Loop -> Aggregate Responses -> Extract Candidates Code -> Selection Agent -> Structured Selection Parser -> Results HTML Code -> Steering Form -> Merge Adjustments Agent -> Build Searches Code
+</workflow-map>
+*/
+import { workflow, node, links } from '@n8n-as-code/transformer';
+
+@workflow({
+  name: 'Recherche Annonces Multi-Plateformes',
+  active: false,
+})
+export class RechercheAnnoncesMultiPlateformesWorkflow {
+  @node({
+    name: 'Form Trigger',
+    type: 'n8n-nodes-base.formTrigger',
+    version: 2,
+    parameters: {
+      formTitle: 'Recherche interactive d’annonces',
+      formFields: {
+        values: [
+          { fieldLabel: 'Critères libres de recherche', fieldType: 'textarea', requiredField: true },
+          { fieldLabel: 'Nombre maximum de résultats', fieldType: 'number', requiredField: true },
+        ],
+      },
+    },
+  })
+  FormTrigger = {};
+
+  @node({ name: 'Extraction Criteria Agent', type: '@n8n/n8n-nodes-langchain.agent', version: 2, parameters: { promptType: 'define', text: 'Convertis la demande en critères structurés sans inventer de données.' } })
+  ExtractionCriteriaAgent = {};
+
+  @node({ name: 'Criteria Structured Output Parser', type: '@n8n/n8n-nodes-langchain.outputParserStructured', version: 1.3, parameters: { schemaType: 'manual', inputSchema: '{"type":"object","properties":{"query":{"type":"string"},"location":{"type":"string"},"priceMin":{"type":"number"},"priceMax":{"type":"number"},"requiredKeywords":{"type":"array","items":{"type":"string"}},"excludedKeywords":{"type":"array","items":{"type":"string"}},"qualityCriteria":{"type":"array","items":{"type":"string"}},"platforms":{"type":"array","items":{"type":"string"}},"explorationQueries":{"type":"array","items":{"type":"string"}},"maxResults":{"type":"number"}},"required":["query","platforms","explorationQueries","maxResults"]}' } })
+  CriteriaParser = {};
+
+  @node({ name: 'Build Multi Platform Searches', type: 'n8n-nodes-base.code', version: 2, parameters: { jsCode: 'return [{ json: { platform: "Leboncoin", url: "https://r.jina.ai/http://www.bing.com/search?q=site:leboncoin.fr+annonce" } }, { json: { platform: "eBay", url: "https://www.bing.com/search?format=rss&q=site:ebay.fr+annonce" } }, { json: { platform: "ParuVendu", url: "https://www.bing.com/search?format=rss&q=site:paruvendu.fr+annonce" } }];' } })
+  BuildSearches = {};
+
+  @node({ name: 'HTTP Search Loop', type: 'n8n-nodes-base.httpRequest', version: 4.2, parameters: { method: 'GET', url: '={{$json.url}}', options: { timeout: 15000 } } })
+  HttpSearchLoop = {};
+
+  @node({ name: 'Aggregate Responses', type: 'n8n-nodes-base.aggregate', version: 1, parameters: { aggregate: 'aggregateAllItemData', destinationFieldName: 'responses' } })
+  AggregateResponses = {};
+
+  @node({ name: 'Extract Candidate Ads', type: 'n8n-nodes-base.code', version: 2, parameters: { jsCode: 'const seen = new Set(); return ($json.responses || []).flatMap((response) => { const text = JSON.stringify(response); return [{ title: "Annonce candidate", price: null, location: null, category: null, url: response.url, platform: response.platform, excerpt: text.slice(0, 300), preliminaryScore: 0.5 }]; }).filter((ad) => ad.url && !seen.has(ad.url) && seen.add(ad.url)).map((ad) => ({ json: ad }));' } })
+  ExtractCandidateAds = {};
+
+  @node({ name: 'Selection Agent', type: '@n8n/n8n-nodes-langchain.agent', version: 2, parameters: { promptType: 'define', text: 'Évalue uniquement les annonces candidates fournies. N’invente jamais de nouvelles annonces.' } })
+  SelectionAgent = {};
+
+  @node({ name: 'Bing RSS Clarification Tool', type: '@n8n/n8n-nodes-langchain.toolHttpRequest', version: 1.1, parameters: { name: 'bing_rss_clarification_once', url: 'https://www.bing.com/search?format=rss&q={{$fromAI("query")}}' } })
+  BingRssClarificationTool = {};
+
+  @node({ name: 'Selection Structured Output Parser', type: '@n8n/n8n-nodes-langchain.outputParserStructured', version: 1.3, parameters: { schemaType: 'manual', inputSchema: '{"type":"object","properties":{"summary":{"type":"string"},"results":{"type":"array","items":{"type":"object","properties":{"title":{"type":"string"},"url":{"type":"string"},"score":{"type":"number"},"reasons":{"type":"array","items":{"type":"string"}},"warnings":{"type":"array","items":{"type":"string"}}},"required":["title","url","score","reasons"]}}},"required":["summary","results"]}' } })
+  SelectionParser = {};
+
+  @node({ name: 'Generate Responsive HTML Results', type: 'n8n-nodes-base.code', version: 2, parameters: { jsCode: 'const results = $json.results || []; const cards = results.map((ad) => "<article><h2>" + ad.title + "</h2><p>Score: " + ad.score + "</p><a href=\"" + ad.url + "\">Voir l’annonce</a></article>").join(""); return [{ json: { html: "<!doctype html><html><body><main><h1>Résultats scorés</h1>" + cards + "<form><textarea name=\"adjustments\"></textarea><button>Relancer</button></form></main></body></html>" } } }];' } })
+  GenerateHtmlResults = {};
+
+  @node({ name: 'Steering Form', type: 'n8n-nodes-base.form', version: 1, parameters: { formTitle: 'Ajuster ou terminer', formFields: { values: [{ fieldLabel: 'Action', fieldType: 'dropdown', fieldOptions: { values: [{ option: 'Terminer' }, { option: 'Relancer avec ajustements' }] } }, { fieldLabel: 'Ajustements utilisateur', fieldType: 'textarea' }] } } })
+  SteeringForm = {};
+
+  @node({ name: 'Merge Adjustments Agent', type: '@n8n/n8n-nodes-langchain.agent', version: 2, parameters: { promptType: 'define', text: 'Fusionne les critères actuels avec les ajustements utilisateur puis renvoie des critères structurés.' } })
+  MergeAdjustmentsAgent = {};
+
+  @links()
+  defineRouting() {
+    this.ExtractionCriteriaAgent.uses(this.CriteriaParser);
+    this.SelectionAgent.uses(this.BingRssClarificationTool);
+    this.SelectionAgent.uses(this.SelectionParser);
+    this.MergeAdjustmentsAgent.uses(this.CriteriaParser);
+  }
+}
+`;
+}
+
+function createWorkbenchWorkspace(rootDir: string): void {
+  fs.mkdirSync(path.join(rootDir, '.agents', 'skills', 'n8n-architect'), { recursive: true });
+  fs.mkdirSync(path.join(rootDir, 'workflows', 'dev'), { recursive: true });
+  fs.writeFileSync(path.join(rootDir, 'AGENTS.md'), [
+    '# n8n-as-code workspace',
+    'Use n8n-as-code TypeScript workflows with @workflow, @node, and @links.',
+    'Before workflow commands, run n8nac workspace migrate --json then workspace status --json.',
+  ].join('\n'));
+  fs.writeFileSync(path.join(rootDir, '.agents', 'skills', 'n8n-architect', 'SKILL.md'), [
+    '# n8n Architect',
+    'Create maintainable n8n-as-code workflows and verify node schemas before choosing versions.',
+    'Connect LangChain sub-nodes with .uses() and use structured parsers for important LLM outputs.',
+  ].join('\n'));
+  fs.writeFileSync(path.join(rootDir, 'workflows', 'dev', 'recherche-annonces-leboncoin.workflow.ts'), `import { workflow, node, links } from '@n8n-as-code/transformer';
+
+@workflow({ name: 'Recherche Annonces Leboncoin', active: false })
+export class RechercheAnnoncesLeboncoinWorkflow {
+  @node({ name: 'Form Trigger', type: 'n8n-nodes-base.formTrigger', version: 2 })
+  FormTrigger = {};
+
+  @links()
+  defineRouting() {}
+}
+`);
+  fs.writeFileSync(path.join(rootDir, 'n8nac-config.json'), JSON.stringify({ version: 1, environments: {} }, null, 2));
+}
+
+function createExtensionContext(storageDir: string, seed: { globalState?: Record<string, unknown>; workspaceState?: Record<string, unknown>; secrets?: Record<string, string> } = {}): any {
+  fs.mkdirSync(storageDir, { recursive: true });
+  return {
+    globalStorageUri: { fsPath: storageDir },
+    globalState: createMemento(seed.globalState),
+    workspaceState: createMemento(seed.workspaceState),
+    secrets: {
+      get: async (key: string) => seed.secrets?.[key],
+      store: async (key: string, value: string) => { seed.secrets = { ...(seed.secrets || {}), [key]: value }; },
+      delete: async (key: string) => { if (seed.secrets) delete seed.secrets[key]; },
+    },
+  };
+}
+
+function createMemento(seed: Record<string, unknown> = {}): any {
+  const values = new Map(Object.entries(seed));
+  return {
+    get: <T>(key: string, defaultValue?: T) => values.has(key) ? values.get(key) as T : defaultValue,
+    update: async (key: string, value: unknown) => {
+      if (value === undefined) values.delete(key);
+      else values.set(key, value);
+    },
+  };
+}
+
+function extractMessageText(message: unknown): string {
+  if (!message || typeof message !== 'object') return '';
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content.map((part) => typeof part === 'string' ? part : typeof part?.text === 'string' ? part.text : '').join('');
+}
+
+function liveProviderEnvKeys(provider: string): string[] {
+  switch (provider) {
+    case 'anthropic': return ['ANTHROPIC_API_KEY', 'ANTHROPIC_LLM_API_KEY', 'CLAUDE_API_KEY'];
+    case 'mistral': return ['MISTRAL_API_KEY', 'MISTRAL_LLM_API_KEY'];
+    case 'google': return ['GOOGLE_GENERATIVE_AI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY'];
+    case 'openrouter': return ['OPENROUTER_API_KEY', 'OPENROUTER_LLM_API_KEY'];
+    case 'openai-compatible': return ['OPENAI_COMPATIBLE_API_KEY', 'OPENAI_API_KEY'];
+    default: return ['OPENAI_API_KEY', 'OPENAI_LLM_API_KEY', 'OPENAI_KEY'];
+  }
+}
+
+function readFirstEnv(keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = process.env[key]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function liveDiagnostics(result: unknown, messages: AgentWorkbenchMessage[], outputLines: string[], workflowPath: string): string {
+  const streamEvents = messages.filter((message): message is Extract<AgentWorkbenchMessage, { type: 'agent.streamEvent' }> => message.type === 'agent.streamEvent').map((message) => message.event);
+  return JSON.stringify({
+    result,
+    workflowPath,
+    workflowExists: fs.existsSync(workflowPath),
+    lastStreamEvent: streamEvents[streamEvents.length - 1],
+    lastMessage: messages[messages.length - 1],
+    outputLines,
+  }, null, 2);
+}

--- a/packages/vscode-extension/tests/integration/workbench-runtime-authoring.integration.test.ts
+++ b/packages/vscode-extension/tests/integration/workbench-runtime-authoring.integration.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import dotenv from 'dotenv';
 import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { AIMessage } from '@langchain/core/messages';
@@ -11,7 +12,7 @@ import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager
 import type { ChatResult } from '@langchain/core/outputs';
 import { AgentRuntimeController, getAgentProviderSecretKey, type AgentWorkbenchMessage } from '../../src/services/agent-runtime-controller.js';
 
-const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../../..');
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
 dotenv.config({ path: path.join(repoRoot, '.env.test'), quiet: true });
 
 const TARGET_WORKFLOW = 'workflows/dev/recherche-annonces-multi-plateformes.workflow.ts';

--- a/packages/vscode-extension/tests/integration/workbench-runtime-authoring.integration.test.ts
+++ b/packages/vscode-extension/tests/integration/workbench-runtime-authoring.integration.test.ts
@@ -160,11 +160,11 @@ test('workbench runtime authoring continues past non-final progress text', { tim
   }
 });
 
-test('workbench runtime live authoring prompt', {
+test('workbench runtime live provider generates a validated workflow', {
   skip: process.env.N8N_AGENT_WORKBENCH_LIVE_PROMPT !== '1',
   timeout: 600_000,
 }, async (t) => {
-  const provider = (process.env.N8N_AGENT_WORKBENCH_LIVE_PROVIDER || 'openai').trim();
+  const provider = chooseLiveProvider();
   const apiKey = readFirstEnv(liveProviderEnvKeys(provider));
   if (!apiKey) {
     t.skip(`Missing API key for live provider ${provider}`);
@@ -193,13 +193,32 @@ test('workbench runtime live authoring prompt', {
       appendLine: (line: string) => outputLines.push(line),
     } as any);
 
-    const result = await controller.sendPrompt({ prompt: EXACT_AUTHORING_PROMPT, workspaceRoot }, async (message) => {
+    let result = await controller.sendPrompt({ prompt: EXACT_AUTHORING_PROMPT, workspaceRoot }, async (message) => {
       postedMessages.push(message);
       return true;
     });
-    const workflowPath = path.join(workspaceRoot, TARGET_WORKFLOW);
-    assert.equal(postedMessages.some((message) => message.type === 'agent.error'), false, liveDiagnostics(result, postedMessages, outputLines, workflowPath));
-    assert.ok(fs.existsSync(workflowPath), liveDiagnostics(result, postedMessages, outputLines, workflowPath));
+    let workflowPath = findAuthoredWorkflowPath(workspaceRoot, result);
+    let workflowContent = workflowPath && fs.existsSync(workflowPath) ? fs.readFileSync(workflowPath, 'utf8') : '';
+    let issues = validateProviderGeneratedWorkflow(workflowContent, collectOperationEvents(postedMessages));
+    for (let repairAttempt = 1; issues.length && repairAttempt <= 3; repairAttempt += 1) {
+      const sessionId = latestSessionId(postedMessages);
+      assert.ok(sessionId, liveDiagnostics(result, postedMessages, outputLines, workflowPath, workflowContent, issues));
+      result = await controller.sendPrompt({
+        prompt: buildLiveRepairPrompt(issues, workflowPath || path.join(workspaceRoot, TARGET_WORKFLOW), workflowContent),
+        workspaceRoot,
+        sessionId,
+      }, async (message) => {
+        postedMessages.push(message);
+        return true;
+      });
+      workflowPath = findAuthoredWorkflowPath(workspaceRoot, result) || workflowPath;
+      workflowContent = workflowPath && fs.existsSync(workflowPath) ? fs.readFileSync(workflowPath, 'utf8') : '';
+      issues = validateProviderGeneratedWorkflow(workflowContent, collectOperationEvents(postedMessages));
+    }
+
+    assert.equal(postedMessages.some((message) => message.type === 'agent.error'), false, liveDiagnostics(result, postedMessages, outputLines, workflowPath, workflowContent, issues));
+    assert.ok(workflowPath && fs.existsSync(workflowPath), liveDiagnostics(result, postedMessages, outputLines, workflowPath, workflowContent, issues));
+    assert.deepEqual(issues, [], liveDiagnostics(result, postedMessages, outputLines, workflowPath, workflowContent, issues));
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
@@ -355,9 +374,14 @@ function createWorkbenchWorkspace(rootDir: string): void {
   fs.writeFileSync(path.join(rootDir, 'AGENTS.md'), [
     '# n8n-as-code workspace',
     'Use n8n-as-code TypeScript workflows with @workflow, @node, and @links.',
+    `When creating the multi-platform annonces workflow, write it to ${TARGET_WORKFLOW}.`,
     'Before workflow commands, run n8nac workspace migrate --json then workspace status --json.',
   ].join('\n'));
   fs.writeFileSync(path.join(rootDir, '.agents', 'skills', 'n8n-architect', 'SKILL.md'), [
+    '---',
+    'name: n8n-architect',
+    'description: Create and validate n8n-as-code TypeScript workflows.',
+    '---',
     '# n8n Architect',
     'Create maintainable n8n-as-code workflows and verify node schemas before choosing versions.',
     'Connect LangChain sub-nodes with .uses() and use structured parsers for important LLM outputs.',
@@ -420,6 +444,13 @@ function liveProviderEnvKeys(provider: string): string[] {
   }
 }
 
+function chooseLiveProvider(): string {
+  const configured = process.env.N8N_AGENT_WORKBENCH_LIVE_PROVIDER?.trim();
+  if (configured) return configured;
+  const candidates = ['google', 'openai', 'anthropic', 'mistral', 'openrouter', 'openai-compatible'];
+  return candidates.find((provider) => Boolean(readFirstEnv(liveProviderEnvKeys(provider)))) || 'openai';
+}
+
 function readFirstEnv(keys: string[]): string | undefined {
   for (const key of keys) {
     const value = process.env[key]?.trim();
@@ -428,12 +459,109 @@ function readFirstEnv(keys: string[]): string | undefined {
   return undefined;
 }
 
-function liveDiagnostics(result: unknown, messages: AgentWorkbenchMessage[], outputLines: string[], workflowPath: string): string {
+function findAuthoredWorkflowPath(workspaceRoot: string, result: unknown): string | undefined {
+  const resultPath = result && typeof result === 'object' && typeof (result as { workflowContext?: { filePath?: unknown } }).workflowContext?.filePath === 'string'
+    ? (result as { workflowContext: { filePath: string } }).workflowContext.filePath
+    : undefined;
+  const candidates = [
+    resultPath,
+    path.join(workspaceRoot, TARGET_WORKFLOW),
+    ...listWorkflowFiles(path.join(workspaceRoot, 'workflows')).filter((filePath) => !filePath.endsWith('recherche-annonces-leboncoin.workflow.ts')),
+  ].filter((candidate): candidate is string => Boolean(candidate));
+  return candidates.find((candidate) => {
+    const resolved = path.isAbsolute(candidate) ? candidate : path.join(workspaceRoot, candidate);
+    return fs.existsSync(resolved) && resolved.endsWith('.workflow.ts') ? resolved : undefined;
+  });
+}
+
+function listWorkflowFiles(directory: string): string[] {
+  if (!fs.existsSync(directory)) return [];
+  const entries = fs.readdirSync(directory, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) return listWorkflowFiles(entryPath);
+    return entry.isFile() && entry.name.endsWith('.workflow.ts') ? [entryPath] : [];
+  });
+}
+
+function assertProviderGeneratedWorkflow(content: string, diagnostics: string): void {
+  assert.deepEqual(validateProviderGeneratedWorkflow(content, []), [], diagnostics);
+}
+
+function validateProviderGeneratedWorkflow(content: string, operationEvents: Array<Extract<AgentWorkbenchMessage, { type: 'agent.streamEvent' }>['event']>): string[] {
+  const issues: string[] = [];
+  if (!content.trim()) issues.push('workflow file was not created or is empty');
+  if (content.trim() === workflowSource().trim()) issues.push('workflow must be generated by the provider, not the deterministic fixture');
+  if (!/<workflow-map>/.test(content)) issues.push('missing <workflow-map> block');
+  if (!/@workflow\s*\(/.test(content)) issues.push('missing @workflow decorator');
+  if (!/@node\s*\(/.test(content)) issues.push('missing @node decorators');
+  if (!/@links\s*\(/.test(content)) issues.push('missing @links decorator');
+  if ((content.match(/@node\s*\(/g) || []).length < 8) issues.push('expected at least 8 @node decorators for the requested architecture');
+  if (!/Form Trigger|formTrigger/i.test(content)) issues.push('missing Form Trigger node');
+  if (!/agent|langchain/i.test(content)) issues.push('missing AI agent nodes');
+  if (!/outputParserStructured|structured output|parser structuré|structured parser/i.test(content)) issues.push('missing structured parser nodes for LLM outputs');
+  if (!/httpRequest|Bing|RSS|Jina|Leboncoin/i.test(content)) issues.push('missing HTTP/search platform retrieval nodes');
+  if (!/steering|ajustement|relancer|Form/i.test(content)) issues.push('missing steering/adjustment loop');
+  if (!/\.uses\s*\(/.test(content)) issues.push('missing .uses() connections for AI sub-nodes');
+  if (/@workflow\s*\(\s*\{[\s\S]{0,1000}\bnodes\s*:/.test(content)) issues.push('@workflow must not contain raw n8n nodes object; use @node-decorated class properties');
+  if (/"""/.test(content)) issues.push('workflow contains Python-style triple quotes, which is invalid TypeScript');
+  if (/credentialId|credentials\s*:\s*\{[^}]*id/i.test(content)) issues.push('workflow must not hardcode credential IDs or placeholders');
+  if (/(?:api[_-]?key|secret|token)\s*[:=]\s*['"][^'"]+['"]/i.test(content)) issues.push('workflow must not hardcode secrets');
+  if (!operationEvents.some((event) => event.type === 'operation' && event.label === 'Write File' && event.status === 'done')) issues.push('provider did not complete a write_file operation');
+  if (!operationEvents.some((event) => event.type === 'operation' && event.label === 'Execute' && event.status === 'done')) issues.push('provider did not complete an execute operation to check schemas or validate');
+  return issues;
+}
+
+function buildLiveRepairPrompt(issues: string[], workflowPath: string, currentContent: string): string {
+  return [
+    'The workflow you generated is not acceptable yet. Continue the same task and repair the workflow now.',
+    `Target file: ${workflowPath}`,
+    '',
+    'Validation issues:',
+    ...issues.map((issue) => `- ${issue}`),
+    '',
+    'Mandatory repair steps:',
+    '1. Use execute to check at least the Form Trigger, HTTP Request, LangChain Agent, and Structured Output Parser schemas or to run a local validation command.',
+    '2. Replace the workflow file with complete decorator-based TypeScript using @workflow, @node, and @links class members.',
+    '3. Do not use raw @workflow({ nodes: ... }) JSON-style definitions.',
+    '4. Do not include credentials, credential IDs, API keys, tokens, or placeholders like CHANGE_ME.',
+    '5. Connect AI sub-nodes with .uses().',
+    '6. Use structured parser nodes for criteria extraction and selected-annonce output.',
+    '7. Include the iterative steering loop.',
+    '8. End only after writing the corrected file and validating it.',
+    '',
+    'Current file content:',
+    '```ts',
+    currentContent.slice(0, 12000),
+    '```',
+  ].join('\n');
+}
+
+function latestSessionId(messages: AgentWorkbenchMessage[]): string | undefined {
+  for (let idx = messages.length - 1; idx >= 0; idx -= 1) {
+    const message = messages[idx];
+    if (message.type === 'agent.state') return message.state.activeSessionId;
+  }
+  return undefined;
+}
+
+function collectOperationEvents(messages: AgentWorkbenchMessage[]): Array<Extract<AgentWorkbenchMessage, { type: 'agent.streamEvent' }>['event']> {
+  return messages
+    .filter((message): message is Extract<AgentWorkbenchMessage, { type: 'agent.streamEvent' }> => message.type === 'agent.streamEvent')
+    .map((message) => message.event)
+    .filter((event) => event.type === 'operation');
+}
+
+function liveDiagnostics(result: unknown, messages: AgentWorkbenchMessage[], outputLines: string[], workflowPath?: string, workflowContent?: string, issues: string[] = []): string {
   const streamEvents = messages.filter((message): message is Extract<AgentWorkbenchMessage, { type: 'agent.streamEvent' }> => message.type === 'agent.streamEvent').map((message) => message.event);
+  const operationEvents = streamEvents.filter((event) => event.type === 'operation').map((event) => `${event.label}:${event.status}:${event.summary || ''}`);
   return JSON.stringify({
     result,
+    issues,
     workflowPath,
-    workflowExists: fs.existsSync(workflowPath),
+    workflowExists: Boolean(workflowPath && fs.existsSync(workflowPath)),
+    workflowExcerpt: workflowContent?.slice(0, 4000),
+    operationEvents,
     lastStreamEvent: streamEvents[streamEvents.length - 1],
     lastMessage: messages[messages.length - 1],
     outputLines,

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -277,14 +277,14 @@ test('Agent runtime: provider middleware flattens unsupported complex content bl
     assert.ok(source.includes("block.type !== 'text' && block.type !== 'image_url'"), 'Only text and image_url complex blocks can pass through to strict adapters such as Mistral');
 });
 
-test('Agent runtime: filesystem backend tells models to use real workspace paths', () => {
+test('Agent runtime: filesystem backend confines tools to the workspace root', () => {
     const fs = require('node:fs');
     const path = require('node:path');
     const source = fs.readFileSync(path.join(__dirname, '../../src/services/agent-runtime-controller.ts'), 'utf8');
 
-    assert.ok(!source.includes('virtualMode: true'), 'VS Code agent must keep real workspace absolute paths usable');
-    assert.ok(source.includes('Use real workspace paths'), 'System prompt must tell models to use real workspace paths');
-    assert.ok(source.includes('Do not use pseudo-root paths like /workflows/'), 'System prompt must prevent pseudo-root paths from escaping the workspace');
+    assert.ok(source.includes('virtualMode: true'), 'VS Code agent filesystem tools must not let absolute paths escape the workspace root');
+    assert.ok(source.includes('Absolute filesystem tool paths are virtual paths rooted at the workspace'), 'System prompt must explain workspace-virtual absolute paths');
+    assert.ok(source.includes('Prefer relative paths'), 'System prompt must guide models toward relative workspace paths');
     assert.ok(source.includes('Do not create raw n8n workflow JSON'), 'System prompt must prevent weak models from authoring JSON workflows by default');
 });
 

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -230,6 +230,28 @@ test('Agent runtime: v3 tool message projections are not duplicated as assistant
     assert.ok(source.includes("normalized.startsWith('tools:')"), 'Tool namespace segments must be recognized');
 });
 
+test('Agent runtime: non-final assistant phases do not end workbench runs', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const source = fs.readFileSync(path.join(__dirname, '../../src/services/agent-runtime-controller.ts'), 'utf8');
+
+    assert.ok(source.includes('createNonFinalAssistantPhaseRecoveryMiddleware'), 'Runtime must install a DeepAgents middleware for non-final assistant phases');
+    assert.ok(source.includes('afterModel'), 'Recovery must use the LangChain afterModel hook');
+    assert.ok(source.includes("canJumpTo: ['model']"), 'Recovery must declare the LangChain model jump target');
+    assert.ok(source.includes("jumpTo: 'model'"), 'Recovery must continue the same turn through the LangChain router');
+    assert.ok(source.includes('new RemoveMessage'), 'Recovery must remove the terminal-looking assistant message before routing');
+    assert.ok(source.includes('N8N_NON_FINAL_ASSISTANT_PHASE_RECOVERY'), 'Recovery prompt must be marked so repeated attempts can be bounded');
+    assert.ok(source.includes('isNonFinalAssistantPhaseMessage'), 'Runtime must classify assistant messages by protocol phase');
+    assert.ok(source.includes('getAssistantPhase'), 'Runtime must read provider assistant phase metadata');
+    assert.ok(source.includes('isTerminalAssistantPhase'), 'Runtime must distinguish terminal and non-terminal assistant phases');
+    assert.ok(source.includes("normalized === 'final' || normalized === 'final_answer'"), 'Only final phases should be accepted as terminal no-tool responses');
+    assert.ok(source.includes('Assistant phases are part of the runtime contract'), 'System prompt must describe the phase contract');
+    assert.ok(!source.includes('createPrematureProgressRecoveryMiddleware'), 'Runtime must not use progress-text recovery middleware');
+    assert.ok(!source.includes('N8N_PREMATURE_PROGRESS_RECOVERY'), 'Runtime must not use heuristic progress recovery markers');
+    assert.ok(!source.includes('isPrematureProgressMessage'), 'Runtime must not classify progress text heuristically');
+    assert.ok(!source.includes('Je poursuis'), 'Runtime must not special-case the observed French text');
+});
+
 test('Agent runtime: provider raw tool calls are preserved for Gemini 3 tool loops', () => {
     const fs = require('node:fs');
     const path = require('node:path');

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -247,6 +247,9 @@ test('Agent runtime: non-final assistant phases do not end workbench runs', () =
     assert.ok(source.includes('getAssistantPhase'), 'Runtime must read provider assistant phase metadata');
     assert.ok(source.includes('isTerminalAssistantPhase'), 'Runtime must distinguish terminal and non-terminal assistant phases');
     assert.ok(source.includes("normalized === 'final' || normalized === 'final_answer'"), 'Only final phases should be accepted as terminal no-tool responses');
+    assert.ok(source.includes('if (!phase) return !this.extractAssistantMessageText(message).trim() || this.hasIncompleteAgentTodos(state);'), 'No-tool assistant messages without terminal phase must not silently end while todos are incomplete');
+    assert.ok(source.includes('private hasIncompleteAgentTodos'), 'Runtime must use DeepAgents todo state as a non-terminal completion signal');
+    assert.ok(source.includes('The todo list shows unfinished work'), 'Recovery prompt must explain unfinished todo-driven continuation');
     assert.ok(source.includes('Assistant phases are part of the runtime contract'), 'System prompt must describe the phase contract');
     assert.ok(!source.includes('createPrematureProgressRecoveryMiddleware'), 'Runtime must not use progress-text recovery middleware');
     assert.ok(!source.includes('N8N_PREMATURE_PROGRESS_RECOVERY'), 'Runtime must not use heuristic progress recovery markers');
@@ -306,6 +309,20 @@ test('Agent runtime: Codex stream keeps parallel tool calls separated', () => {
     assert.ok(source.includes('index: index') || source.includes('index,'), 'Native LangChain tool-call chunks must receive distinct indexes');
     assert.ok(source.includes('additional_kwargs'), 'Provider additional_kwargs tool calls must receive matching indexes');
     assert.ok(source.includes('createOpenAiAccountLanguageModel'), 'The index mapping must live inside the local Codex LangChain model');
+});
+
+test('Agent runtime: Codex continuations keep tool call ids stable', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const source = fs.readFileSync(path.join(__dirname, '../../src/services/agent-provider-runtime/openai-account.ts'), 'utf8');
+    const adapter = fs.readFileSync(path.join(__dirname, '../../src/services/agent-provider-runtime/chat-codex-oauth.ts'), 'utf8');
+
+    assert.ok(source.includes('rememberCodexToolCallAliases'), 'Codex stream must remember item_id to call_id aliases');
+    assert.ok(source.includes('const callId = readOptionalString(event.call_id);'), 'Codex argument events must prefer stable call_id over item_id');
+    assert.ok(source.includes('resolveCodexToolCallEventId(event, toolCallAliases)'), 'Codex argument events must resolve aliases before updating tool calls');
+    assert.ok(source.includes('getUnstreamedCodexToolArgs'), 'Codex stream must avoid replaying already-streamed tool arguments');
+    assert.ok(source.includes('extractCodexSseErrorMessage(event)'), 'Codex SSE errors must preserve backend details');
+    assert.ok(adapter.includes('formatCodexStreamError(part.error)'), 'Codex LangChain adapter must format object stream errors safely');
 });
 
 test('Agent runtime: Codex tool schemas use LangChain JSON schema conversion', () => {

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -237,10 +237,12 @@ test('Agent runtime: non-final assistant phases do not end workbench runs', () =
 
     assert.ok(source.includes('createNonFinalAssistantPhaseRecoveryMiddleware'), 'Runtime must install a DeepAgents middleware for non-final assistant phases');
     assert.ok(source.includes('afterModel'), 'Recovery must use the LangChain afterModel hook');
-    assert.ok(source.includes("canJumpTo: ['model']"), 'Recovery must declare the LangChain model jump target');
+    assert.ok(source.includes("canJumpTo: ['model', 'end']"), 'Recovery must declare the LangChain model and exhaustion jump targets');
     assert.ok(source.includes("jumpTo: 'model'"), 'Recovery must continue the same turn through the LangChain router');
+    assert.ok(source.includes("jumpTo: 'end'"), 'Recovery exhaustion must end with a controlled terminal assistant message');
     assert.ok(source.includes('new RemoveMessage'), 'Recovery must remove the terminal-looking assistant message before routing');
     assert.ok(source.includes('N8N_NON_FINAL_ASSISTANT_PHASE_RECOVERY'), 'Recovery prompt must be marked so repeated attempts can be bounded');
+    assert.ok(source.includes('isInternalRecoveryPrefix'), 'Streaming gates must hide partial internal recovery markers');
     assert.ok(source.includes('isNonFinalAssistantPhaseMessage'), 'Runtime must classify assistant messages by protocol phase');
     assert.ok(source.includes('getAssistantPhase'), 'Runtime must read provider assistant phase metadata');
     assert.ok(source.includes('isTerminalAssistantPhase'), 'Runtime must distinguish terminal and non-terminal assistant phases');
@@ -343,8 +345,9 @@ test('Agent runtime: invalid tool-call recovery stays hidden from the Workbench'
     const source = fs.readFileSync(path.join(__dirname, '../../src/services/agent-runtime-controller.ts'), 'utf8');
 
     assert.ok(source.includes('isInternalRecoveryText'), 'Must identify internal recovery prompts');
-    assert.ok(source.includes('pendingVisibleText.startsWith(INVALID_TOOL_CALL_RECOVERY_MARKER)'), 'Event projection must suppress recovery prompts before rendering');
-    assert.ok(source.includes('pendingText.startsWith(INVALID_TOOL_CALL_RECOVERY_MARKER)'), 'Message text projection must suppress recovery prompts before rendering');
+    assert.ok(source.includes('isInternalRecoveryPrefix(pendingVisibleText)'), 'Event projection must suppress recovery prompts before rendering');
+    assert.ok(source.includes('isInternalRecoveryPrefix(pendingText)'), 'Message text projection must suppress recovery prompts before rendering');
+    assert.ok(source.includes('NON_FINAL_ASSISTANT_PHASE_RECOVERY_MARKER.startsWith(trimmed)'), 'Recovery prefix checks must include non-final assistant phase prompts');
     assert.ok(source.includes('if (this.isInternalRecoveryText(value)) return'), 'Sanitization must never return internal recovery text as an assistant answer');
 });
 


### PR DESCRIPTION
## What changed

- Added a DeepAgents/LangChain `afterModel` middleware that handles assistant messages carrying non-terminal phase metadata without tool calls.
- The middleware removes the terminal-looking assistant message, inserts an internal recovery prompt, and routes the graph back to `model` using the supported `jumpTo` mechanism.
- Added a regression test that verifies the runtime relies on assistant phase metadata rather than text heuristics.

## Why

Workbench runs could stop after an interim assistant phase such as commentary even though no human decision was needed and the task was not complete. LangChain's router exits when the last message is an `AIMessage` without tool calls, so the runtime needs to intercept non-terminal phases before they are treated as final.

## Validation

- `npm run test --workspace=packages/vscode-extension`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Improvements**
  * Robust recovery when the assistant emits interim (non-final) progress; runs retry and produce final responses while suppressing internal recovery text from the UI.
  * Better correlation of streamed and non-streamed tool-call arguments and richer, normalized stream error messages.
  * Filesystem-backed tools now operate in a workspace-constrained virtual mode.

* **Tests**
  * New unit and integration tests covering non-final-phase recovery, streaming sanitization, tool-call stability, runtime authoring, and virtual filesystem behavior.

* **Chores**
  * Added an integration test script for workbench runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->