### PR TITLE
[codex] Support webview popup handoff

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -8,7 +8,8 @@ declare const __N8NAC_VERSION__: string;
 declare const __N8NAC_CLI_SEMVER__: string;
 import {
     SyncManager, CliApi, N8nApiClient, IN8nCredentials, WorkflowSyncStatus, ConfigService,
-    resolveInstanceIdentifier, isCanonicalUserInstanceIdentifier, SYNC_EVENT_JOURNAL_FILENAME, type SyncEvent
+    resolveInstanceIdentifier, isCanonicalUserInstanceIdentifier, SYNC_EVENT_JOURNAL_FILENAME, type SyncEvent,
+    type ITestPlan, type IWorkflowStatus,
 } from 'n8nac';
 import { AiContextGenerator, getN8nacDevConfigFilenames } from '@n8n-as-code/skills';
 
@@ -50,7 +51,7 @@ import { buildWorkflowQuickPickItems } from './utils/workflow-finder.js';
 import { isClipboardBridgeRequired } from './utils/clipboard-utils.js';
 import { getCanonicalProjectName, getProjectDetail, getProjectDisplayLabel } from './utils/project-display.js';
 import { shouldAutoEnsureAiContext } from './utils/ai-context-policy.js';
-import { IWorkflowStatus } from 'n8nac';
+import { createWorkflowWebviewContext, type WorkflowWebviewContext } from './services/workflow-webview-context.js';
 
 import {
     store,
@@ -881,11 +882,45 @@ async function openWorkflowBoard(workflow: IWorkflowStatus, viewColumn?: vscode.
     }
 
     try {
-        const openTarget = await resolveWorkflowWebviewTarget(workflow);
-        WorkflowWebview.createOrShow(workflow, openTarget.url, viewColumn);
+        const webviewContext = await resolveWorkflowWebviewContext(workflow);
+        if (!webviewContext.workflowUrl) throw new Error(`Workflow "${workflow.name}" does not have a webview URL.`);
+        WorkflowWebview.createOrShow(webviewContext.workflow, webviewContext.workflowUrl, viewColumn, webviewContext.endpoints);
         registerClipboardHandler();
     } catch (e: any) {
         vscode.window.showErrorMessage(`Failed to open n8n workflow: ${e.message}`);
+    }
+}
+
+async function resolveWorkflowWebviewContext(workflow: IWorkflowStatus, workflowFilePath?: string): Promise<WorkflowWebviewContext> {
+    const [openTarget, testPlan] = await Promise.all([
+        resolveWorkflowWebviewTarget(workflow),
+        resolveWorkflowTestPlan(workflow),
+    ]);
+    return createWorkflowWebviewContext({
+        workflow,
+        workflowFilePath,
+        workflowUrl: openTarget.url,
+        workflowReloadUrl: openTarget.targetUrl,
+        testPlan,
+    });
+}
+
+async function resolveWorkflowTestPlan(workflow: IWorkflowStatus): Promise<ITestPlan | undefined> {
+    if (!workflow.id) return undefined;
+    const credentials = getN8nConfig();
+    if (!credentials.host || !credentials.apiKey) return undefined;
+
+    try {
+        const client = new N8nApiClient(credentials);
+        const plan = await client.getTestPlan(workflow.id);
+        const triggerType = plan.triggerInfo?.type || 'unknown';
+        if (plan.endpoints.testUrl) {
+            outputChannel.appendLine(`[n8n] ${triggerType} trigger test URL prepared for workflow ${workflow.id}.`);
+        }
+        return plan;
+    } catch (error: any) {
+        outputChannel.appendLine(`[n8n] Could not resolve trigger test plan for workflow ${workflow.id}: ${error?.message || error}`);
+        return undefined;
     }
 }
 
@@ -925,15 +960,16 @@ async function resolveWorkflowForSplitView(arg: any): Promise<IWorkflowStatus | 
 
 async function openAgentWorkbench(context: vscode.ExtensionContext, workflow?: IWorkflowStatus, initialSessionId?: string): Promise<void> {
     try {
-        const openTarget = workflow?.id ? await resolveWorkflowWebviewTarget(workflow) : undefined;
         const workflowFilePath = workflow ? getExistingWorkflowFileUri(workflow)?.fsPath : undefined;
+        const webviewContext = workflow?.id ? await resolveWorkflowWebviewContext(workflow, workflowFilePath) : undefined;
         const providerModelLabel = getSelectedAgentProviderModelLabel();
         AgentWorkbenchWebview.createOrShow(
             context,
-            workflow,
-            workflowFilePath,
-            openTarget?.url,
-            openTarget?.targetUrl,
+            webviewContext?.workflow || workflow,
+            webviewContext?.workflowFilePath || workflowFilePath,
+            webviewContext?.workflowUrl,
+            webviewContext?.workflowReloadUrl,
+            webviewContext?.endpoints,
             providerModelLabel,
             requireAgentRuntimeController(),
             outputChannel,
@@ -952,7 +988,7 @@ async function openAgentWorkbench(context: vscode.ExtensionContext, workflow?: I
             initialSessionId,
             vscode.ViewColumn.One,
         );
-        if (openTarget?.url) {
+        if (webviewContext?.workflowUrl) {
             registerClipboardHandler();
         }
     } catch (e: any) {
@@ -998,7 +1034,7 @@ async function listAgentWorkflowOptions(): Promise<IWorkflowStatus[]> {
     return selectAllWorkflows(store.getState());
 }
 
-async function resolveAgentWorkflowTarget(workflowContext: AgentWorkflowContext): Promise<{ workflow?: IWorkflowStatus; workflowFilePath?: string; workflowUrl?: string; workflowReloadUrl?: string }> {
+async function resolveAgentWorkflowTarget(workflowContext: AgentWorkflowContext): Promise<{ workflow?: IWorkflowStatus; workflowFilePath?: string; workflowUrl?: string; workflowReloadUrl?: string; workflowEndpoints?: WorkflowWebviewContext['endpoints'] }> {
     const workflows = await listAgentWorkflowOptions();
     const workflow = workflows.find((candidate) => (
         Boolean(workflowContext.id && candidate.id === workflowContext.id)
@@ -1015,12 +1051,13 @@ async function resolveAgentWorkflowTarget(workflowContext: AgentWorkflowContext)
         return { workflow: effectiveWorkflow, workflowFilePath };
     }
     try {
-        const openTarget = await resolveWorkflowWebviewTarget(effectiveWorkflow);
+        const webviewContext = await resolveWorkflowWebviewContext(effectiveWorkflow, workflowFilePath);
         return {
-            workflow: effectiveWorkflow,
-            workflowFilePath,
-            workflowUrl: openTarget.url,
-            workflowReloadUrl: openTarget.targetUrl,
+            workflow: webviewContext.workflow,
+            workflowFilePath: webviewContext.workflowFilePath,
+            workflowUrl: webviewContext.workflowUrl,
+            workflowReloadUrl: webviewContext.workflowReloadUrl,
+            workflowEndpoints: webviewContext.endpoints,
         };
     } catch {
         return { workflow: effectiveWorkflow, workflowFilePath };

--- a/packages/vscode-extension/src/services/proxy-service.ts
+++ b/packages/vscode-extension/src/services/proxy-service.ts
@@ -777,6 +777,7 @@ export class ProxyService {
   var _lastCanvasNode = null;
   var _uiMutationTimer = null;
   var _uiMutationCount = 0;
+  var _popupBridgeInstalled = false;
 
   function postBridgeReady() {
     window.parent.postMessage({ type: "n8n-bridge-ready", build: N8NAC_BRIDGE_BUILD, pageKind: N8NAC_BRIDGE_PAGE_KIND, href: window.location.href }, "*");
@@ -801,6 +802,18 @@ export class ProxyService {
     return normalized === "_blank" || normalized === "_new";
   }
 
+  function isFormTestUrl(url) {
+    if (url === undefined || url === null) return false;
+    url = String(url);
+    if (!url) return false;
+    try {
+      var absoluteUrl = new URL(url, window.location.href);
+      return absoluteUrl.pathname === "/form-test" || absoluteUrl.pathname.indexOf("/form-test/") !== -1;
+    } catch (e) {
+      return false;
+    }
+  }
+
   function postOpenExternal(url, target) {
     if (url === undefined || url === null) return false;
     url = String(url);
@@ -820,24 +833,82 @@ export class ProxyService {
     }
   }
 
+  function createPopupBridgeWindow(target) {
+    var locationProxy = {
+      assign: function(nextUrl) { postOpenExternal(nextUrl, target); },
+      replace: function(nextUrl) { postOpenExternal(nextUrl, target); },
+      toString: function() { return ""; }
+    };
+    var popup = {
+      closed: false,
+      close: function() { this.closed = true; },
+      focus: function() {},
+      blur: function() {}
+    };
+
+    Object.defineProperty(locationProxy, "href", {
+      get: function() { return ""; },
+      set: function(nextUrl) { postOpenExternal(nextUrl, target); }
+    });
+    Object.defineProperty(popup, "location", {
+      get: function() { return locationProxy; },
+      set: function(nextUrl) { postOpenExternal(nextUrl, target); }
+    });
+
+    return popup;
+  }
+
   function installPopupBridge() {
+    if (_popupBridgeInstalled) return;
+    _popupBridgeInstalled = true;
     var originalWindowOpen = window.open;
     window.open = function(url, target, features) {
-      if (isPopupTarget(target) && postOpenExternal(url, target)) return null;
+      if (isPopupTarget(target)) {
+        var popup = createPopupBridgeWindow(target);
+        if (url === undefined || url === null || !String(url)) return popup;
+        if (postOpenExternal(url, target)) return popup;
+      }
       return originalWindowOpen.apply(window, arguments);
     };
+
+    if (window.HTMLAnchorElement && window.HTMLAnchorElement.prototype) {
+      var originalAnchorClick = window.HTMLAnchorElement.prototype.click;
+      window.HTMLAnchorElement.prototype.click = function() {
+        var href = this && this.getAttribute ? this.getAttribute("href") || "" : "";
+        var target = this && this.getAttribute ? this.getAttribute("target") || "" : "";
+        if ((isAnchorPopupTarget(target) || isFormTestUrl(href)) && postOpenExternal(href, target)) return;
+        return originalAnchorClick.apply(this, arguments);
+      };
+    }
 
     document.addEventListener("click", function(e) {
       var target = e.target;
       var anchor = target && target.closest ? target.closest("a[href]") : null;
-      if (!anchor || !isAnchorPopupTarget(anchor.getAttribute("target") || "")) return;
+      if (!anchor) return;
+      var href = anchor.getAttribute("href") || "";
+      var anchorTarget = anchor.getAttribute("target") || "";
+      if (!isAnchorPopupTarget(anchorTarget) && !isFormTestUrl(href)) return;
       if (anchor.hasAttribute("download")) return;
-      if (!postOpenExternal(anchor.getAttribute("href") || "", anchor.getAttribute("target") || "")) return;
+      if (!postOpenExternal(href, anchorTarget)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+    }, true);
+
+    document.addEventListener("submit", function(e) {
+      var form = e.target;
+      if (!form || !form.getAttribute) return;
+      var action = form.getAttribute("action") || window.location.href;
+      var target = form.getAttribute("target") || "";
+      if (!isAnchorPopupTarget(target) && !isFormTestUrl(action)) return;
+      if (!postOpenExternal(action, target)) return;
       e.preventDefault();
       e.stopPropagation();
       e.stopImmediatePropagation();
     }, true);
   }
+
+  installPopupBridge();
 
   function coerceNode(value) {
     var record = asRecord(value);

--- a/packages/vscode-extension/src/services/proxy-service.ts
+++ b/packages/vscode-extension/src/services/proxy-service.ts
@@ -6,6 +6,7 @@ import type * as vscode from 'vscode';
 import { AddressInfo } from 'net';
 import { randomUUID } from 'crypto';
 import { WebSocket, WebSocketServer } from 'ws';
+import { openExternalNavigation } from '../utils/external-navigation.js';
 
 type ExternalAuthRequest = {
     token: string;
@@ -139,12 +140,11 @@ export class ProxyService {
     }
 
     private async openExternalUrl(url: string): Promise<void> {
-        try {
-            const vscodeRuntime = await import('vscode');
-            await vscodeRuntime.env.openExternal(vscodeRuntime.Uri.parse(url));
-        } catch (error: any) {
-            this.log(`[Proxy] Unable to open external authentication URL: ${error?.message || String(error)}`);
-        }
+        await openExternalNavigation({
+            url,
+            reason: 'oauth',
+            source: { panelKind: 'proxy' },
+        }, { outputChannel: this.outputChannel, logPrefix: '[Proxy]' });
     }
 
     private getStorageKey(): string {
@@ -778,6 +778,8 @@ export class ProxyService {
   var _uiMutationTimer = null;
   var _uiMutationCount = 0;
   var _popupBridgeInstalled = false;
+  var _lastFormTestReadyAt = 0;
+  var _formTestReadyVisible = false;
 
   function postBridgeReady() {
     window.parent.postMessage({ type: "n8n-bridge-ready", build: N8NAC_BRIDGE_BUILD, pageKind: N8NAC_BRIDGE_PAGE_KIND, href: window.location.href }, "*");
@@ -802,30 +804,63 @@ export class ProxyService {
     return normalized === "_blank" || normalized === "_new";
   }
 
-  function isFormTestUrl(url) {
+  function classifyExternalNavigation(url, target, fallbackReason) {
     if (url === undefined || url === null) return false;
     url = String(url);
     if (!url) return false;
     try {
       var absoluteUrl = new URL(url, window.location.href);
-      return absoluteUrl.pathname === "/form-test" || absoluteUrl.pathname.indexOf("/form-test/") !== -1;
+      var normalizedTarget = cleanText(target || "").toLowerCase();
+      var reason = fallbackReason || "unknown";
+      var isEndpoint = false;
+      if (absoluteUrl.pathname === "/form-test" || absoluteUrl.pathname.indexOf("/form-test/") === 0
+          || absoluteUrl.pathname === "/form" || absoluteUrl.pathname.indexOf("/form/") === 0) {
+        reason = "form-trigger";
+        isEndpoint = true;
+      } else if (absoluteUrl.pathname === "/webhook-test" || absoluteUrl.pathname.indexOf("/webhook-test/") === 0
+          || absoluteUrl.pathname === "/webhook" || absoluteUrl.pathname.indexOf("/webhook/") === 0) {
+        reason = "webhook";
+        isEndpoint = true;
+      }
+      return {
+        url: absoluteUrl,
+        reason: reason,
+        externalOrigin: absoluteUrl.origin !== window.location.origin,
+        endpoint: isEndpoint,
+        popupTarget: isPopupTarget(normalizedTarget),
+        anchorPopupTarget: isAnchorPopupTarget(normalizedTarget),
+        topTarget: normalizedTarget === "_top" || normalizedTarget === "_parent"
+      };
     } catch (e) {
       return false;
     }
   }
 
-  function postOpenExternal(url, target) {
-    if (url === undefined || url === null) return false;
-    url = String(url);
-    if (!url) return false;
+  function shouldExternalizeNavigation(url, target, fallbackReason) {
+    var classified = classifyExternalNavigation(url, target, fallbackReason);
+    if (!classified) return false;
+    return classified.externalOrigin || classified.endpoint || classified.anchorPopupTarget || classified.topTarget ? classified : false;
+  }
+
+  function postOpenExternal(url, target, reason, features, sourceKind) {
     try {
-      var absoluteUrl = new URL(url, window.location.href);
+      var classified = classifyExternalNavigation(url, target, reason || "popup");
+      if (!classified) return false;
+      var absoluteUrl = classified.url;
       if (absoluteUrl.protocol !== "http:" && absoluteUrl.protocol !== "https:") return false;
       window.parent.postMessage({
-        type: "n8n-open-external",
+        type: "n8n-external-navigation",
         build: N8NAC_BRIDGE_BUILD,
         url: absoluteUrl.toString(),
-        target: typeof target === "string" ? target : ""
+        reason: classified.reason,
+        target: typeof target === "string" ? target : "",
+        features: typeof features === "string" ? features : "",
+        source: {
+          opener: sourceKind || "unknown",
+          iframeHref: window.location.href,
+          pageKind: N8NAC_BRIDGE_PAGE_KIND,
+          bridgeBuild: N8NAC_BRIDGE_BUILD
+        }
       }, "*");
       return true;
     } catch (e) {
@@ -835,8 +870,8 @@ export class ProxyService {
 
   function createPopupBridgeWindow(target) {
     var locationProxy = {
-      assign: function(nextUrl) { postOpenExternal(nextUrl, target); },
-      replace: function(nextUrl) { postOpenExternal(nextUrl, target); },
+      assign: function(nextUrl) { postOpenExternal(nextUrl, target, "delayed-popup", "", "popup.location.assign"); },
+      replace: function(nextUrl) { postOpenExternal(nextUrl, target, "delayed-popup", "", "popup.location.replace"); },
       toString: function() { return ""; }
     };
     var popup = {
@@ -848,11 +883,11 @@ export class ProxyService {
 
     Object.defineProperty(locationProxy, "href", {
       get: function() { return ""; },
-      set: function(nextUrl) { postOpenExternal(nextUrl, target); }
+      set: function(nextUrl) { postOpenExternal(nextUrl, target, "delayed-popup", "", "popup.location.href"); }
     });
     Object.defineProperty(popup, "location", {
       get: function() { return locationProxy; },
-      set: function(nextUrl) { postOpenExternal(nextUrl, target); }
+      set: function(nextUrl) { postOpenExternal(nextUrl, target, "delayed-popup", "", "popup.location"); }
     });
 
     return popup;
@@ -863,10 +898,11 @@ export class ProxyService {
     _popupBridgeInstalled = true;
     var originalWindowOpen = window.open;
     window.open = function(url, target, features) {
-      if (isPopupTarget(target)) {
+      var classified = url === undefined || url === null || !String(url) ? false : shouldExternalizeNavigation(url, target, "popup");
+      if (isPopupTarget(target) || classified) {
         var popup = createPopupBridgeWindow(target);
         if (url === undefined || url === null || !String(url)) return popup;
-        if (postOpenExternal(url, target)) return popup;
+        if (postOpenExternal(url, target, classified ? classified.reason : "popup", features, "window.open")) return popup;
       }
       return originalWindowOpen.apply(window, arguments);
     };
@@ -876,10 +912,49 @@ export class ProxyService {
       window.HTMLAnchorElement.prototype.click = function() {
         var href = this && this.getAttribute ? this.getAttribute("href") || "" : "";
         var target = this && this.getAttribute ? this.getAttribute("target") || "" : "";
-        if ((isAnchorPopupTarget(target) || isFormTestUrl(href)) && postOpenExternal(href, target)) return;
+        var classified = shouldExternalizeNavigation(href, target, "popup");
+        if (classified && postOpenExternal(href, target, classified.reason, "", "anchor.click")) return;
         return originalAnchorClick.apply(this, arguments);
       };
     }
+
+    try {
+      if (window.Location && window.Location.prototype) {
+        var originalLocationAssign = window.Location.prototype.assign;
+        var originalLocationReplace = window.Location.prototype.replace;
+        window.Location.prototype.assign = function(nextUrl) {
+          var classified = shouldExternalizeNavigation(nextUrl, "_self", "unknown");
+          if (classified && postOpenExternal(nextUrl, "_self", classified.reason, "", "location.assign")) return;
+          return originalLocationAssign.apply(this, arguments);
+        };
+        window.Location.prototype.replace = function(nextUrl) {
+          var classified = shouldExternalizeNavigation(nextUrl, "_self", "unknown");
+          if (classified && postOpenExternal(nextUrl, "_self", classified.reason, "", "location.replace")) return;
+          return originalLocationReplace.apply(this, arguments);
+        };
+      }
+    } catch (e) {}
+
+    try {
+      var originalPushState = history.pushState;
+      var originalReplaceState = history.replaceState;
+      history.pushState = function(state, title, url) {
+        var result = originalPushState.apply(this, arguments);
+        if (url !== undefined && url !== null) {
+          var classified = shouldExternalizeNavigation(url, "_self", "unknown");
+          if (classified) postOpenExternal(url, "_self", classified.reason, "", "history.pushState");
+        }
+        return result;
+      };
+      history.replaceState = function(state, title, url) {
+        var result = originalReplaceState.apply(this, arguments);
+        if (url !== undefined && url !== null) {
+          var classified = shouldExternalizeNavigation(url, "_self", "unknown");
+          if (classified) postOpenExternal(url, "_self", classified.reason, "", "history.replaceState");
+        }
+        return result;
+      };
+    } catch (e) {}
 
     document.addEventListener("click", function(e) {
       var target = e.target;
@@ -887,9 +962,10 @@ export class ProxyService {
       if (!anchor) return;
       var href = anchor.getAttribute("href") || "";
       var anchorTarget = anchor.getAttribute("target") || "";
-      if (!isAnchorPopupTarget(anchorTarget) && !isFormTestUrl(href)) return;
+      var classified = shouldExternalizeNavigation(href, anchorTarget, "popup");
+      if (!classified) return;
       if (anchor.hasAttribute("download")) return;
-      if (!postOpenExternal(href, anchorTarget)) return;
+      if (!postOpenExternal(href, anchorTarget, classified.reason, "", "anchor.click-event")) return;
       e.preventDefault();
       e.stopPropagation();
       e.stopImmediatePropagation();
@@ -898,10 +974,12 @@ export class ProxyService {
     document.addEventListener("submit", function(e) {
       var form = e.target;
       if (!form || !form.getAttribute) return;
-      var action = form.getAttribute("action") || window.location.href;
-      var target = form.getAttribute("target") || "";
-      if (!isAnchorPopupTarget(target) && !isFormTestUrl(action)) return;
-      if (!postOpenExternal(action, target)) return;
+      var submitter = e.submitter && e.submitter.getAttribute ? e.submitter : null;
+      var action = (submitter && submitter.getAttribute("formaction")) || form.getAttribute("action") || window.location.href;
+      var target = (submitter && submitter.getAttribute("formtarget")) || form.getAttribute("target") || "";
+      var classified = shouldExternalizeNavigation(action, target, "popup");
+      if (!classified) return;
+      if (!postOpenExternal(action, target, classified.reason, "", "form.submit")) return;
       e.preventDefault();
       e.stopPropagation();
       e.stopImmediatePropagation();
@@ -958,12 +1036,43 @@ export class ProxyService {
     if (_uiMutationTimer) return;
     _uiMutationTimer = window.setTimeout(function() {
       _uiMutationTimer = null;
+      detectFormTestReady();
       window.parent.postMessage({
         type: "n8n-ui-change",
         build: N8NAC_BRIDGE_BUILD,
         count: _uiMutationCount
       }, "*");
     }, 250);
+  }
+
+  function detectFormTestReady() {
+    var text = cleanText((document.body && document.body.textContent) || "");
+    if (!text) {
+      _formTestReadyVisible = false;
+      return;
+    }
+    var looksReady = /Waiting for you to submit the form/i.test(text)
+      || /En attente de l'envoi du formulaire/i.test(text)
+      || /soumettre le formulaire/i.test(text);
+    if (!looksReady) {
+      _formTestReadyVisible = false;
+      return;
+    }
+    if (_formTestReadyVisible) return;
+    var now = Date.now();
+    if (now - _lastFormTestReadyAt < 1200) return;
+    _formTestReadyVisible = true;
+    _lastFormTestReadyAt = now;
+    window.parent.postMessage({
+      type: "n8n-form-test-ready",
+      build: N8NAC_BRIDGE_BUILD,
+      source: {
+        opener: "semantic.form-trigger-ready",
+        iframeHref: window.location.href,
+        pageKind: N8NAC_BRIDGE_PAGE_KIND,
+        bridgeBuild: N8NAC_BRIDGE_BUILD
+      }
+    }, "*");
   }
 
   function firstUsefulText(root) {
@@ -1282,6 +1391,7 @@ export class ProxyService {
       var observer = new MutationObserver(function() { postUiChangedSoon(); });
       observer.observe(document.body || document.documentElement, { childList: true, subtree: true, attributes: true });
     } catch (e) {}
+    detectFormTestReady();
     window.setInterval(postBridgeReady, 5000);
   }
 

--- a/packages/vscode-extension/src/services/workflow-webview-context.ts
+++ b/packages/vscode-extension/src/services/workflow-webview-context.ts
@@ -1,0 +1,82 @@
+import type { ITestPlan, ITriggerInfo, IWorkflowStatus, TriggerType } from 'n8nac';
+import { classifyExternalNavigationUrl } from '../utils/external-navigation.js';
+
+export interface WorkflowWebviewEndpoints {
+    triggerType?: TriggerType;
+    testUrl?: string;
+    productionUrl?: string;
+    formTestUrl?: string;
+    webhookTestUrl?: string;
+    chatTestUrl?: string;
+}
+
+export interface WorkflowWebviewContext {
+    workflow: IWorkflowStatus;
+    workflowFilePath?: string;
+    workflowUrl?: string;
+    workflowReloadUrl?: string;
+    endpoints: WorkflowWebviewEndpoints;
+    triggerInfo?: ITriggerInfo;
+}
+
+export interface CreateWorkflowWebviewContextInput {
+    workflow: IWorkflowStatus;
+    workflowFilePath?: string;
+    workflowUrl?: string;
+    workflowReloadUrl?: string;
+    testPlan?: ITestPlan;
+}
+
+export function createWorkflowWebviewContext(input: CreateWorkflowWebviewContextInput): WorkflowWebviewContext {
+    return {
+        workflow: input.workflow,
+        workflowFilePath: input.workflowFilePath,
+        workflowUrl: input.workflowUrl,
+        workflowReloadUrl: input.workflowReloadUrl,
+        endpoints: buildWorkflowWebviewEndpoints(input.testPlan),
+        triggerInfo: input.testPlan?.triggerInfo || undefined,
+    };
+}
+
+export function buildWorkflowWebviewEndpoints(testPlan?: ITestPlan): WorkflowWebviewEndpoints {
+    const triggerType = testPlan?.triggerInfo?.type;
+    const testUrl = safeBrowserUrl(testPlan?.endpoints.testUrl);
+    const productionUrl = safeBrowserUrl(testPlan?.endpoints.productionUrl);
+    const endpoints: WorkflowWebviewEndpoints = {
+        triggerType,
+        testUrl,
+        productionUrl,
+    };
+
+    if (triggerType === 'form') endpoints.formTestUrl = testUrl;
+    if (triggerType === 'webhook') endpoints.webhookTestUrl = testUrl;
+    if (triggerType === 'chat') endpoints.chatTestUrl = testUrl;
+
+    return compactEndpoints(endpoints);
+}
+
+export function normalizeWorkflowWebviewEndpoints(input?: WorkflowWebviewEndpoints | string): WorkflowWebviewEndpoints {
+    if (!input) return {};
+    if (typeof input === 'string') {
+        const formTestUrl = safeBrowserUrl(input);
+        return formTestUrl ? { triggerType: 'form', testUrl: formTestUrl, formTestUrl } : {};
+    }
+    return compactEndpoints({
+        ...input,
+        testUrl: safeBrowserUrl(input.testUrl),
+        productionUrl: safeBrowserUrl(input.productionUrl),
+        formTestUrl: safeBrowserUrl(input.formTestUrl),
+        webhookTestUrl: safeBrowserUrl(input.webhookTestUrl),
+        chatTestUrl: safeBrowserUrl(input.chatTestUrl),
+    });
+}
+
+function safeBrowserUrl(url?: string): string | undefined {
+    if (!url) return undefined;
+    const decision = classifyExternalNavigationUrl(url);
+    return decision.allowed ? decision.normalizedUrl : undefined;
+}
+
+function compactEndpoints(endpoints: WorkflowWebviewEndpoints): WorkflowWebviewEndpoints {
+    return Object.fromEntries(Object.entries(endpoints).filter(([, value]) => value !== undefined && value !== '')) as WorkflowWebviewEndpoints;
+}

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -1,3 +1,7 @@
+import { buildN8nIframeAllowPolicy, getN8nIframePermissionOrigin, N8N_IFRAME_SANDBOX } from './n8n-iframe-policy.js';
+import { buildN8nExternalNavigationClientScript } from './n8n-iframe-parent-bridge.js';
+import { normalizeWorkflowWebviewEndpoints, type WorkflowWebviewEndpoints } from '../services/workflow-webview-context.js';
+
 export interface AgentWorkbenchHtmlInput {
     workflowId: string;
     workflowName: string;
@@ -6,6 +10,8 @@ export interface AgentWorkbenchHtmlInput {
     workflowAttached?: boolean;
     workflowUrl?: string;
     workflowReloadUrl?: string;
+    workflowEndpoints?: WorkflowWebviewEndpoints;
+    workflowFormTestUrl?: string;
     providerModelLabel: string;
 }
 
@@ -57,14 +63,20 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
     const workflowFilePathJs = JSON.stringify(input.workflowFilePath || '');
     const workflowUrlJs = JSON.stringify(input.workflowUrl || '');
     const workflowReloadUrlJs = JSON.stringify(input.workflowReloadUrl || input.workflowUrl || '');
+    const workflowEndpoints = normalizeWorkflowWebviewEndpoints(input.workflowEndpoints || input.workflowFormTestUrl || undefined);
+    const workflowEndpointsJs = JSON.stringify(workflowEndpoints);
+    const workflowFormTestUrlJs = JSON.stringify(workflowEndpoints.formTestUrl || '');
 
-    let iframePermissionOrigin = 'src';
-    try {
-        iframePermissionOrigin = input.workflowUrl ? new URL(input.workflowUrl).origin : 'src';
-    } catch {
-        // Fallback to iframe's own source origin behavior if URL parsing fails.
-    }
-    const iframeAllowPolicy = `clipboard-read ${iframePermissionOrigin}; clipboard-write ${iframePermissionOrigin}; geolocation ${iframePermissionOrigin}; microphone ${iframePermissionOrigin}; camera ${iframePermissionOrigin}`;
+    const iframePermissionOrigin = getN8nIframePermissionOrigin(input.workflowUrl);
+    const iframeAllowPolicy = buildN8nIframeAllowPolicy(input.workflowUrl);
+    const externalNavigationScript = buildN8nExternalNavigationClientScript({
+        panelKind: 'agent-workbench',
+        workflowIdExpression: 'workflowId',
+        workflowNameExpression: 'workflowName',
+        sessionIdExpression: 'state && state.activeSessionId',
+        iframeHrefExpression: 'frame && frame.src',
+        endpointsExpression: 'workflowEndpoints',
+    });
     const lucideIcon = (paths: string) => `<svg viewBox="0 0 24 24" aria-hidden="true">${paths}</svg>`;
     const newConversationIcon = lucideIcon('<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/><path d="M12 7v6"/><path d="M9 10h6"/>');
     const historyIcon = lucideIcon('<path d="M3 12a9 9 0 1 0 9-9 9.8 9.8 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M12 7v5l4 2"/>');
@@ -1361,7 +1373,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             ${hasWorkflowUi ? `<iframe
                 id="workflow-frame"
                 src="${safeWorkflowUrl}"
-                sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals allow-downloads allow-top-navigation allow-top-navigation-by-user-activation"
+                sandbox="${N8N_IFRAME_SANDBOX}"
                 allow="${iframeAllowPolicy}">
             </iframe>` : `<div class="empty-workflow"><div><strong>Workflow UI unavailable</strong><br>Push this workflow to n8n to preview and interact with its UI here.</div></div>`}
         </section>` : ''}
@@ -1410,12 +1422,17 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         let workflowFilePath = ${workflowFilePathJs};
         let workflowUrl = ${workflowUrlJs};
         let workflowReloadUrl = ${workflowReloadUrlJs};
+        let workflowEndpoints = ${workflowEndpointsJs};
+        let workflowFormTestUrl = ${workflowFormTestUrlJs};
+        let lastWorkflowFormTestOpenUrl = '';
+        let lastWorkflowFormTestOpenAt = 0;
         let openWorkflowContext = workflowId || workflowFilename || workflowFilePath
             ? { id: workflowId || undefined, name: workflowName, filename: workflowFilename || undefined, filePath: workflowFilePath || undefined }
             : null;
         let iframeOrigin = ${JSON.stringify(iframePermissionOrigin)};
         const PASTE_RATE_LIMIT_MS = 1000;
         const GRANT_TTL_MS = 5000;
+        const FORM_TEST_OPEN_COOLDOWN_MS = 1500;
         let lastPasteMs = 0;
         const pendingGrants = new Map();
         let isRunning = false;
@@ -1746,6 +1763,17 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             if (!frame || event.source !== frame.contentWindow) return false;
             return event.origin === iframeOrigin;
         }
+
+        function claimWorkflowFormTestOpen(url) {
+            if (!url) return false;
+            const now = Date.now();
+            if (lastWorkflowFormTestOpenUrl === url && now - lastWorkflowFormTestOpenAt < FORM_TEST_OPEN_COOLDOWN_MS) return false;
+            lastWorkflowFormTestOpenUrl = url;
+            lastWorkflowFormTestOpenAt = now;
+            return true;
+        }
+
+        ${externalNavigationScript}
 
         function reloadWorkflowFrame() {
             if (!frame || !refreshPill) return;
@@ -3206,14 +3234,34 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                     : null;
                 workflowUrl = nextWorkflowUrl;
                 workflowReloadUrl = typeof message.reloadUrl === 'string' && message.reloadUrl ? message.reloadUrl : workflowUrl;
+                workflowEndpoints = message.endpoints && typeof message.endpoints === 'object' ? message.endpoints : {};
+                const nextWorkflowFormTestUrl = typeof message.formTestUrl === 'string' ? message.formTestUrl : (workflowEndpoints.formTestUrl || '');
+                if (nextWorkflowFormTestUrl !== workflowFormTestUrl) {
+                    workflowFormTestUrl = nextWorkflowFormTestUrl;
+                    lastWorkflowFormTestOpenUrl = '';
+                    lastWorkflowFormTestOpenAt = 0;
+                }
                 try { iframeOrigin = new URL(workflowUrl).origin; } catch (e) { iframeOrigin = 'src'; }
                 if (frame && shouldUpdateFrame) frame.src = workflowUrl;
                 return;
             }
 
+            if (message.type === 'n8n-external-navigation' && typeof message.url === 'string') {
+                if (!isWorkflowFrameEvent(event)) return;
+                postN8nExternalNavigation(message.url, message.reason || inferN8nExternalNavigationReason(message.url, 'popup'), message);
+                return;
+            }
+
             if (message.type === 'n8n-open-external' && typeof message.url === 'string') {
                 if (!isWorkflowFrameEvent(event)) return;
-                vscode.postMessage({ type: 'open-external', url: message.url });
+                postN8nExternalNavigation(message.url, 'popup', message);
+                return;
+            }
+
+            if (message.type === 'n8n-form-test-ready') {
+                if (!isWorkflowFrameEvent(event)) return;
+                if (!claimWorkflowFormTestOpen(workflowFormTestUrl)) return;
+                postN8nExternalNavigation(workflowFormTestUrl, 'form-trigger', message);
                 return;
             }
 

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -7,6 +7,8 @@ import { buildAgentWorkbenchHtml } from './agent-workbench-html.js';
 import { readAgentProviderSettings } from '../services/agent-provider-settings.js';
 import { getReasoningOptions } from '../services/agent-provider-capabilities.js';
 import type { WorktreeInfo } from '../services/worktree-service.js';
+import { openExternalNavigation } from '../utils/external-navigation.js';
+import type { WorkflowWebviewEndpoints } from '../services/workflow-webview-context.js';
 
 interface AgentWorkbenchNodeContext {
     name: string;
@@ -19,6 +21,7 @@ interface AgentWorkflowTarget {
     workflowFilePath?: string;
     workflowUrl?: string;
     workflowReloadUrl?: string;
+    workflowEndpoints?: WorkflowWebviewEndpoints;
 }
 
 interface AgentWorkbenchWorkflowProviders {
@@ -49,6 +52,7 @@ export class AgentWorkbenchWebview {
     private _workflowFilePath: string | undefined;
     private _workflowUrl: string | undefined;
     private _workflowReloadUrl: string | undefined;
+    private _workflowEndpoints: WorkflowWebviewEndpoints | undefined;
     private _providerModelLabel: string;
     private _nodeContexts: AgentWorkbenchNodeContext[] = [];
     private _workflowProviders: AgentWorkbenchWorkflowProviders;
@@ -62,6 +66,7 @@ export class AgentWorkbenchWebview {
         workflowFilePath: string | undefined,
         workflowUrl: string | undefined,
         workflowReloadUrl: string | undefined,
+        workflowEndpoints: WorkflowWebviewEndpoints | undefined,
         providerModelLabel: string,
         agentRuntime: AgentRuntimeController,
         outputChannel: vscode.OutputChannel,
@@ -74,6 +79,7 @@ export class AgentWorkbenchWebview {
         this._workflowFilePath = workflowFilePath;
         this._workflowUrl = workflowUrl;
         this._workflowReloadUrl = workflowReloadUrl;
+        this._workflowEndpoints = workflowEndpoints;
         this._providerModelLabel = providerModelLabel;
         this._agentRuntime = agentRuntime;
         this._outputChannel = outputChannel;
@@ -111,6 +117,7 @@ export class AgentWorkbenchWebview {
         workflowFilePath: string | undefined,
         workflowUrl: string | undefined,
         workflowReloadUrl: string | undefined,
+        workflowEndpoints: WorkflowWebviewEndpoints | undefined,
         providerModelLabel: string,
         agentRuntime: AgentRuntimeController,
         outputChannel: vscode.OutputChannel,
@@ -125,7 +132,7 @@ export class AgentWorkbenchWebview {
             if (existingPanel) {
                 existingPanel._panel.reveal(column);
                 existingPanel._workflowProviders = workflowProviders;
-                existingPanel.update(workflow, workflowFilePath, workflowUrl, workflowReloadUrl, providerModelLabel);
+                existingPanel.update(workflow, workflowFilePath, workflowUrl, workflowReloadUrl, workflowEndpoints, providerModelLabel);
                 return;
             }
         }
@@ -141,7 +148,7 @@ export class AgentWorkbenchWebview {
             },
         );
 
-        const workbench = new AgentWorkbenchWebview(panel, context, workflow, workflowFilePath, workflowUrl, workflowReloadUrl, providerModelLabel, agentRuntime, outputChannel, workflowProviders, initialSessionId);
+        const workbench = new AgentWorkbenchWebview(panel, context, workflow, workflowFilePath, workflowUrl, workflowReloadUrl, workflowEndpoints, providerModelLabel, agentRuntime, outputChannel, workflowProviders, initialSessionId);
         if (initialSessionId) {
             AgentWorkbenchWebview._panels.set(initialSessionId, workbench);
             AgentWorkbenchWebview._lastActiveSessionId = initialSessionId;
@@ -156,7 +163,7 @@ export class AgentWorkbenchWebview {
         return AgentWorkbenchWebview._lastActiveSessionId;
     }
 
-    public update(workflow: IWorkflowStatus | undefined, workflowFilePath: string | undefined, workflowUrl: string | undefined, workflowReloadUrl: string | undefined, providerModelLabel: string, postState = true): void {
+    public update(workflow: IWorkflowStatus | undefined, workflowFilePath: string | undefined, workflowUrl: string | undefined, workflowReloadUrl: string | undefined, workflowEndpoints: WorkflowWebviewEndpoints | undefined, providerModelLabel: string, postState = true): void {
         const hadWorkflowFrame = Boolean(this._workflow);
         const hasWorkflowFrame = Boolean(workflow);
         const hadWorkflowUi = Boolean(this._workflowUrl);
@@ -165,6 +172,7 @@ export class AgentWorkbenchWebview {
         this._workflowFilePath = workflowFilePath;
         this._workflowUrl = workflowUrl;
         this._workflowReloadUrl = workflowReloadUrl;
+        this._workflowEndpoints = workflowEndpoints;
         this._providerModelLabel = providerModelLabel;
         this.updateRegistryRegistration();
         this._panel.title = `n8n Agent: ${workflow?.name || 'New workflow'}`;
@@ -182,6 +190,8 @@ export class AgentWorkbenchWebview {
             workflowFilePath: workflowFilePath || '',
             url: workflowUrl,
             reloadUrl: workflowReloadUrl,
+            endpoints: workflowEndpoints || {},
+            formTestUrl: workflowEndpoints?.formTestUrl,
         });
         if (postState) void this.postWorkbenchState();
     }
@@ -238,7 +248,19 @@ export class AgentWorkbenchWebview {
         }
 
         if (payload.type === 'open-external' && typeof payload.url === 'string') {
-            await this.openExternalUrl(payload.url);
+            await openExternalNavigation({
+                url: payload.url,
+                reason: typeof payload.reason === 'string' ? payload.reason : 'unknown',
+                source: {
+                    ...(payload.source && typeof payload.source === 'object' ? payload.source : {}),
+                    panelKind: 'agent-workbench',
+                    workflowId: this._workflow?.id,
+                    workflowName: this._workflow?.name,
+                    sessionId: this._activeSessionId,
+                },
+                target: typeof payload.target === 'string' ? payload.target : undefined,
+                features: typeof payload.features === 'string' ? payload.features : undefined,
+            }, { outputChannel: this._outputChannel });
             return;
         }
 
@@ -703,7 +725,7 @@ export class AgentWorkbenchWebview {
     private async reconcileWorkflowContext(workflowContext: AgentWorkflowContext | undefined): Promise<void> {
         if (!workflowContext) {
             if (this._workflow || this._workflowUrl || this._workflowFilePath) {
-                this.update(undefined, undefined, undefined, undefined, this._providerModelLabel, false);
+                this.update(undefined, undefined, undefined, undefined, undefined, this._providerModelLabel, false);
             }
             return;
         }
@@ -718,7 +740,7 @@ export class AgentWorkbenchWebview {
             name: workflowContext.name,
             filename: workflowContext.filename || '',
         } as IWorkflowStatus);
-        this.update(workflow, target.workflowFilePath || workflowContext.filePath, target.workflowUrl, target.workflowReloadUrl, this._providerModelLabel, false);
+        this.update(workflow, target.workflowFilePath || workflowContext.filePath, target.workflowUrl, target.workflowReloadUrl, target.workflowEndpoints, this._providerModelLabel, false);
     }
 
     private async getWorkflowOptions(): Promise<AgentWorkflowContext[]> {
@@ -810,25 +832,8 @@ export class AgentWorkbenchWebview {
             workflowAttached: Boolean(this._workflow),
             workflowUrl: this._workflowUrl,
             workflowReloadUrl: this._workflowReloadUrl,
+            workflowEndpoints: this._workflowEndpoints,
             providerModelLabel: this._providerModelLabel,
         });
-    }
-
-    private async openExternalUrl(url: string): Promise<void> {
-        let uri: vscode.Uri;
-        try {
-            uri = vscode.Uri.parse(url);
-        } catch {
-            return;
-        }
-        const scheme = uri.scheme.toLowerCase();
-        if (scheme !== 'http' && scheme !== 'https') {
-            return;
-        }
-        try {
-            await vscode.env.openExternal(uri);
-        } catch (error) {
-            console.error('[AgentWorkbench] Open external URL error', error);
-        }
     }
 }

--- a/packages/vscode-extension/src/ui/n8n-iframe-parent-bridge.ts
+++ b/packages/vscode-extension/src/ui/n8n-iframe-parent-bridge.ts
@@ -1,0 +1,72 @@
+export interface N8nExternalNavigationClientScriptOptions {
+    panelKind: 'workflow-board' | 'agent-workbench';
+    workflowIdExpression: string;
+    workflowNameExpression?: string;
+    sessionIdExpression?: string;
+    iframeHrefExpression: string;
+    endpointsExpression: string;
+}
+
+export function buildN8nExternalNavigationClientScript(options: N8nExternalNavigationClientScriptOptions): string {
+    const panelKind = JSON.stringify(options.panelKind);
+    const workflowNameExpression = options.workflowNameExpression || "''";
+    const sessionIdExpression = options.sessionIdExpression || "''";
+
+    return `
+        function resolveN8nExternalNavigationUrl(url) {
+            if (!url || typeof url !== 'string') return '';
+            try {
+                return new URL(url, ${options.iframeHrefExpression} || window.location.href).toString();
+            } catch (e) {
+                return '';
+            }
+        }
+
+        function inferN8nExternalNavigationReason(url, fallback) {
+            var normalizedUrl = resolveN8nExternalNavigationUrl(url);
+            if (!normalizedUrl) return fallback || 'unknown';
+            try {
+                var parsed = new URL(normalizedUrl);
+                if (parsed.pathname === '/form-test' || parsed.pathname.indexOf('/form-test/') === 0
+                        || parsed.pathname === '/form' || parsed.pathname.indexOf('/form/') === 0) return 'form-trigger';
+                if (parsed.pathname === '/webhook-test' || parsed.pathname.indexOf('/webhook-test/') === 0
+                        || parsed.pathname === '/webhook' || parsed.pathname.indexOf('/webhook/') === 0) return 'webhook';
+            } catch (e) {}
+            return fallback || 'unknown';
+        }
+
+        function readN8nEndpointUrl(reason) {
+            var endpoints = ${options.endpointsExpression} || {};
+            if (reason === 'form-trigger') return endpoints.formTestUrl || endpoints.testUrl || '';
+            if (reason === 'webhook') return endpoints.webhookTestUrl || endpoints.testUrl || '';
+            if (reason === 'chat-trigger') return endpoints.chatTestUrl || endpoints.testUrl || '';
+            return '';
+        }
+
+        function buildN8nExternalNavigationSource(message) {
+            var source = message && typeof message.source === 'object' && message.source ? message.source : {};
+            return Object.assign({}, source, {
+                panelKind: ${panelKind},
+                workflowId: String(${options.workflowIdExpression} || ''),
+                workflowName: String(${workflowNameExpression} || ''),
+                sessionId: String(${sessionIdExpression} || ''),
+                iframeHref: String(${options.iframeHrefExpression} || ''),
+                bridgeBuild: message && message.build ? String(message.build) : source.bridgeBuild
+            });
+        }
+
+        function postN8nExternalNavigation(url, reason, message) {
+            var normalizedUrl = resolveN8nExternalNavigationUrl(url);
+            if (!normalizedUrl) return false;
+            vscode.postMessage({
+                type: 'open-external',
+                url: normalizedUrl,
+                reason: reason || inferN8nExternalNavigationReason(normalizedUrl, 'unknown'),
+                source: buildN8nExternalNavigationSource(message),
+                target: message && typeof message.target === 'string' ? message.target : undefined,
+                features: message && typeof message.features === 'string' ? message.features : undefined
+            });
+            return true;
+        }
+    `;
+}

--- a/packages/vscode-extension/src/ui/n8n-iframe-policy.ts
+++ b/packages/vscode-extension/src/ui/n8n-iframe-policy.ts
@@ -1,0 +1,23 @@
+export const N8N_IFRAME_SANDBOX = [
+    'allow-same-origin',
+    'allow-scripts',
+    'allow-forms',
+    'allow-popups',
+    'allow-popups-to-escape-sandbox',
+    'allow-modals',
+    'allow-downloads',
+    'allow-top-navigation-by-user-activation',
+].join(' ');
+
+export function getN8nIframePermissionOrigin(url?: string): string {
+    try {
+        return url ? new URL(url).origin : 'src';
+    } catch {
+        return 'src';
+    }
+}
+
+export function buildN8nIframeAllowPolicy(url?: string): string {
+    const origin = getN8nIframePermissionOrigin(url);
+    return `clipboard-read ${origin}; clipboard-write ${origin}; geolocation ${origin}; microphone ${origin}; camera ${origin}`;
+}

--- a/packages/vscode-extension/src/ui/webview-html.ts
+++ b/packages/vscode-extension/src/ui/webview-html.ts
@@ -12,23 +12,34 @@
  *     are all enforced in the parent-webview JavaScript (this file), which is
  *     extension-controlled and inaccessible to iframe code.
  */
+import { buildN8nIframeAllowPolicy, getN8nIframePermissionOrigin, N8N_IFRAME_SANDBOX } from './n8n-iframe-policy.js';
+import { buildN8nExternalNavigationClientScript } from './n8n-iframe-parent-bridge.js';
+import { normalizeWorkflowWebviewEndpoints, type WorkflowWebviewEndpoints } from '../services/workflow-webview-context.js';
+
 export const WORKFLOW_WEBVIEW_RELOAD_MESSAGE = 'n8nac.workflow.reload';
 
-export function buildWebviewHtml(workflowId: string, url: string): string {
+export function buildWebviewHtml(workflowId: string, url: string, endpointsOrFormTest?: WorkflowWebviewEndpoints | string): string {
     // Escape workflowId for safe interpolation in HTML and JS contexts
     const htmlSafe = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
     const safeWorkflowIdHtml = htmlSafe(workflowId);
     const safeWorkflowIdJs = JSON.stringify(workflowId);
     const reloadMessageTypeJs = JSON.stringify(WORKFLOW_WEBVIEW_RELOAD_MESSAGE);
+    const workflowEndpoints = normalizeWorkflowWebviewEndpoints(endpointsOrFormTest);
+    const workflowEndpointsJs = JSON.stringify(workflowEndpoints);
+    const formTestUrlJs = JSON.stringify(workflowEndpoints.formTestUrl || '');
 
     // url is the proxy URL pointing to the n8n workflow
-    let iframePermissionOrigin = 'src';
-    try {
-        iframePermissionOrigin = new URL(url).origin;
-    } catch {
-        // Fallback to iframe's own source origin behavior if URL parsing fails
-    }
-    const iframeAllowPolicy = `clipboard-read ${iframePermissionOrigin}; clipboard-write ${iframePermissionOrigin}; geolocation ${iframePermissionOrigin}; microphone ${iframePermissionOrigin}; camera ${iframePermissionOrigin}`;
+    const iframePermissionOrigin = getN8nIframePermissionOrigin(url);
+    const iframeAllowPolicy = buildN8nIframeAllowPolicy(url);
+    const safeWorkflowUrlHtml = htmlSafe(url);
+    const safeIframeAllowPolicyHtml = htmlSafe(iframeAllowPolicy);
+    const externalNavigationScript = buildN8nExternalNavigationClientScript({
+        panelKind: 'workflow-board',
+        workflowIdExpression: 'workflowId',
+        workflowNameExpression: 'workflowId',
+        iframeHrefExpression: 'activeFrame && activeFrame.src',
+        endpointsExpression: 'workflowEndpoints',
+    });
 
     return `<!DOCTYPE html>
         <html lang="en">
@@ -96,15 +107,15 @@ export function buildWebviewHtml(workflowId: string, url: string): string {
             <div class="iframe-container">
                 <iframe 
                     id="frame-1"
-                    src="${url}" 
-                    sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals allow-downloads allow-top-navigation allow-top-navigation-by-user-activation"
-                    allow="${iframeAllowPolicy}">
+                    src="${safeWorkflowUrlHtml}" 
+                    sandbox="${N8N_IFRAME_SANDBOX}"
+                    allow="${safeIframeAllowPolicyHtml}">
                 </iframe>
                 <iframe 
                     id="frame-2"
                     class="hidden"
-                    sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals allow-downloads allow-top-navigation allow-top-navigation-by-user-activation"
-                    allow="${iframeAllowPolicy}">
+                    sandbox="${N8N_IFRAME_SANDBOX}"
+                    allow="${safeIframeAllowPolicyHtml}">
                 </iframe>
             </div>
 
@@ -115,6 +126,8 @@ export function buildWebviewHtml(workflowId: string, url: string): string {
                 const loadingOverlay = document.getElementById('loading-overlay');
                 const initialLoading = document.getElementById('initial-loading');
                 const workflowId = ${safeWorkflowIdJs};
+                const workflowEndpoints = ${workflowEndpointsJs};
+                const formTestUrl = ${formTestUrlJs};
                 
                 function focusActiveFrame() {
                     try {
@@ -199,6 +212,9 @@ export function buildWebviewHtml(workflowId: string, url: string): string {
                 var _lastPasteMs = 0;
                 var _pendingGrants = new Map();
                 var GRANT_TTL_MS = 5000;
+                var FORM_TEST_OPEN_COOLDOWN_MS = 1500;
+                var _lastFormTestOpenUrl = '';
+                var _lastFormTestOpenAt = 0;
 
                 function issuePasteGrant() {
                     var token = crypto.randomUUID();
@@ -220,6 +236,17 @@ export function buildWebviewHtml(workflowId: string, url: string): string {
                     return event.origin === iframeOrigin && event.source === activeFrame.contentWindow;
                 }
 
+                function claimFormTestOpen(url) {
+                    if (!url) return false;
+                    var now = Date.now();
+                    if (_lastFormTestOpenUrl === url && now - _lastFormTestOpenAt < FORM_TEST_OPEN_COOLDOWN_MS) return false;
+                    _lastFormTestOpenUrl = url;
+                    _lastFormTestOpenAt = now;
+                    return true;
+                }
+
+                ${externalNavigationScript}
+
                 window.addEventListener('message', (event) => {
                     const message = event.data;
                     if (!message || typeof message !== 'object') return;
@@ -232,10 +259,26 @@ export function buildWebviewHtml(workflowId: string, url: string): string {
                         return;
                     }
 
-                    // Popup bridge: iframe requests an external browser window.
+                    // External navigation bridge: iframe requests an external browser window.
+                    if (message.type === 'n8n-external-navigation' && typeof message.url === 'string') {
+                        if (!isActiveFrameEvent(event)) return;
+                        postN8nExternalNavigation(message.url, message.reason || inferN8nExternalNavigationReason(message.url, 'popup'), message);
+                        return;
+                    }
+
+                    // Legacy popup bridge: iframe requests an external browser window.
                     if (message.type === 'n8n-open-external' && typeof message.url === 'string') {
                         if (!isActiveFrameEvent(event)) return;
-                        vscode.postMessage({ type: 'open-external', url: message.url });
+                        postN8nExternalNavigation(message.url, 'popup', message);
+                        return;
+                    }
+
+                    // Form Trigger bridge: n8n may only show a waiting hint instead of
+                    // issuing a popup request inside VS Code's webview iframe.
+                    if (message.type === 'n8n-form-test-ready') {
+                        if (!isActiveFrameEvent(event)) return;
+                        if (!claimFormTestOpen(formTestUrl)) return;
+                        postN8nExternalNavigation(formTestUrl, 'form-trigger', message);
                         return;
                     }
 

--- a/packages/vscode-extension/src/ui/workflow-webview.ts
+++ b/packages/vscode-extension/src/ui/workflow-webview.ts
@@ -2,26 +2,30 @@ import * as vscode from 'vscode';
 import { IWorkflowStatus } from 'n8nac';
 import { buildWebviewHtml, WORKFLOW_WEBVIEW_RELOAD_MESSAGE } from './webview-html.js';
 import { workflowWebviewRegistry } from '../services/workflow-webview-registry.js';
+import { openExternalNavigation } from '../utils/external-navigation.js';
+import type { WorkflowWebviewEndpoints } from '../services/workflow-webview-context.js';
 export { buildWebviewHtml } from './webview-html.js';
 
 export class WorkflowWebview {
     public static currentPanel: WorkflowWebview | undefined;
     private readonly _panel: vscode.WebviewPanel;
     private _workflowId: string;
+    private _workflowName: string;
     private _disposables: vscode.Disposable[] = [];
     private _registryDisposable: { dispose(): void } | undefined;
 
     private _onClipboardPasteRequest: ((panel: vscode.WebviewPanel, grantToken: string) => Promise<void>) | undefined;
 
-    private constructor(panel: vscode.WebviewPanel, workflowId: string, url: string) {
+    private constructor(panel: vscode.WebviewPanel, workflow: IWorkflowStatus, url: string, endpoints?: WorkflowWebviewEndpoints) {
         this._panel = panel;
-        this._workflowId = workflowId;
+        this._workflowId = workflow.id;
+        this._workflowName = workflow.name || workflow.id;
         this._registryDisposable = workflowWebviewRegistry.register({
             getWorkflowId: () => this._workflowId,
             reloadWorkflow: () => this._panel.webview.postMessage({ type: WORKFLOW_WEBVIEW_RELOAD_MESSAGE }),
         });
         this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
-        this._panel.webview.html = this.getHtmlForWebview(workflowId, url);
+        this._panel.webview.html = this.getHtmlForWebview(this._workflowId, url, endpoints);
 
         // Handle messages from the webview (clipboard bridge on macOS)
         this._panel.webview.onDidReceiveMessage(async (message) => {
@@ -39,7 +43,18 @@ export class WorkflowWebview {
                     ?.catch(e => console.error('[Webview] Clipboard paste handler error', e));
             }
             if (message.type === 'open-external' && typeof message.url === 'string') {
-                await this.openExternalUrl(message.url);
+                await openExternalNavigation({
+                    url: message.url,
+                    reason: typeof message.reason === 'string' ? message.reason : 'unknown',
+                    source: {
+                        ...(message.source && typeof message.source === 'object' ? message.source : {}),
+                        panelKind: 'workflow-board',
+                        workflowId: this._workflowId,
+                        workflowName: this._workflowName,
+                    },
+                    target: typeof message.target === 'string' ? message.target : undefined,
+                    features: typeof message.features === 'string' ? message.features : undefined,
+                });
             }
         }, null, this._disposables);
     }
@@ -55,7 +70,7 @@ export class WorkflowWebview {
         }
     }
 
-    public static createOrShow(workflow: IWorkflowStatus, url: string, viewColumn?: vscode.ViewColumn) {
+    public static createOrShow(workflow: IWorkflowStatus, url: string, viewColumn?: vscode.ViewColumn, endpoints?: WorkflowWebviewEndpoints) {
         const column = viewColumn || (vscode.window.activeTextEditor
             ? vscode.window.activeTextEditor.viewColumn
             : undefined);
@@ -64,7 +79,7 @@ export class WorkflowWebview {
         // parent-webview script reflects the new URL/origin for origin validation.
         if (WorkflowWebview.currentPanel) {
             WorkflowWebview.currentPanel._panel.reveal(column);
-            WorkflowWebview.currentPanel.update(workflow.id, url);
+            WorkflowWebview.currentPanel.update(workflow, url, endpoints);
             return;
         }
 
@@ -79,7 +94,7 @@ export class WorkflowWebview {
             }
         );
 
-        WorkflowWebview.currentPanel = new WorkflowWebview(panel, workflow.id, url);
+        WorkflowWebview.currentPanel = new WorkflowWebview(panel, workflow, url, endpoints);
     }
 
     /**
@@ -89,10 +104,11 @@ export class WorkflowWebview {
         return workflowWebviewRegistry.reloadIfMatching(workflowId);
     }
 
-    public update(workflowId: string, url: string) {
-        this._workflowId = workflowId;
-        this._panel.title = `n8n: ${workflowId}`;
-        this._panel.webview.html = this.getHtmlForWebview(workflowId, url);
+    public update(workflow: IWorkflowStatus, url: string, endpoints?: WorkflowWebviewEndpoints) {
+        this._workflowId = workflow.id;
+        this._workflowName = workflow.name || workflow.id;
+        this._panel.title = `n8n: ${workflow.name || workflow.id}`;
+        this._panel.webview.html = this.getHtmlForWebview(workflow.id, url, endpoints);
     }
 
     public dispose() {
@@ -108,25 +124,7 @@ export class WorkflowWebview {
         }
     }
 
-    private getHtmlForWebview(workflowId: string, url: string) {
-        return buildWebviewHtml(workflowId, url);
-    }
-
-    private async openExternalUrl(url: string): Promise<void> {
-        let uri: vscode.Uri;
-        try {
-            uri = vscode.Uri.parse(url);
-        } catch {
-            return;
-        }
-        const scheme = uri.scheme.toLowerCase();
-        if (scheme !== 'http' && scheme !== 'https') {
-            return;
-        }
-        try {
-            await vscode.env.openExternal(uri);
-        } catch (error) {
-            console.error('[Webview] Open external URL error', error);
-        }
+    private getHtmlForWebview(workflowId: string, url: string, endpoints?: WorkflowWebviewEndpoints) {
+        return buildWebviewHtml(workflowId, url, endpoints);
     }
 }

--- a/packages/vscode-extension/src/utils/external-navigation.ts
+++ b/packages/vscode-extension/src/utils/external-navigation.ts
@@ -1,0 +1,155 @@
+import type * as vscode from 'vscode';
+
+export type ExternalNavigationReason =
+    | 'popup'
+    | 'delayed-popup'
+    | 'form-trigger'
+    | 'webhook'
+    | 'chat-trigger'
+    | 'oauth'
+    | 'download'
+    | 'docs'
+    | 'top-navigation'
+    | 'custom-protocol'
+    | 'unknown';
+
+export interface ExternalNavigationSource {
+    panelKind?: 'workflow-board' | 'agent-workbench' | 'proxy' | 'unknown';
+    workflowId?: string;
+    workflowName?: string;
+    sessionId?: string;
+    nodeId?: string;
+    nodeName?: string;
+    iframeHref?: string;
+    bridgeBuild?: string;
+    opener?: string;
+    pageKind?: string;
+}
+
+export interface ExternalNavigationRequest {
+    url: string;
+    reason?: ExternalNavigationReason | string;
+    source?: ExternalNavigationSource;
+    target?: string;
+    features?: string;
+}
+
+export interface ExternalNavigationDecision {
+    allowed: boolean;
+    normalizedUrl?: string;
+    scheme?: string;
+    reason: ExternalNavigationReason;
+    blockedReason?: string;
+}
+
+export interface OpenExternalNavigationOptions {
+    outputChannel?: vscode.OutputChannel;
+    logPrefix?: string;
+    dedupeMs?: number;
+    opener?: (url: string) => Promise<boolean> | boolean;
+}
+
+const BROWSER_SCHEMES = new Set(['http:', 'https:']);
+const RECENT_OPEN_WINDOW_MS = 1200;
+const recentExternalOpens = new Map<string, number>();
+
+export function isN8nPublicEndpointPath(pathname: string): boolean {
+    return isPathOrChild(pathname, '/form-test')
+        || isPathOrChild(pathname, '/form')
+        || isPathOrChild(pathname, '/webhook-test')
+        || isPathOrChild(pathname, '/webhook');
+}
+
+export function inferExternalNavigationReason(url: string, fallback: ExternalNavigationReason = 'unknown'): ExternalNavigationReason {
+    try {
+        const parsed = new URL(url);
+        if (isPathOrChild(parsed.pathname, '/form-test') || isPathOrChild(parsed.pathname, '/form')) return 'form-trigger';
+        if (isPathOrChild(parsed.pathname, '/webhook-test') || isPathOrChild(parsed.pathname, '/webhook')) return 'webhook';
+    } catch {
+        // Keep the caller-provided reason for non-absolute or invalid URLs.
+    }
+    return fallback;
+}
+
+export function classifyExternalNavigationUrl(url: string, reason: ExternalNavigationReason | string = 'unknown'): ExternalNavigationDecision {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return { allowed: false, reason: normalizeExternalNavigationReason(reason), blockedReason: 'invalid-url' };
+    }
+
+    const normalizedReason = inferExternalNavigationReason(parsed.toString(), normalizeExternalNavigationReason(reason));
+    if (!BROWSER_SCHEMES.has(parsed.protocol)) {
+        return {
+            allowed: false,
+            scheme: parsed.protocol,
+            reason: normalizedReason,
+            blockedReason: `blocked-scheme:${parsed.protocol}`,
+        };
+    }
+
+    return {
+        allowed: true,
+        normalizedUrl: parsed.toString(),
+        scheme: parsed.protocol,
+        reason: normalizedReason,
+    };
+}
+
+export async function openExternalNavigation(request: ExternalNavigationRequest, options: OpenExternalNavigationOptions = {}): Promise<boolean> {
+    const decision = classifyExternalNavigationUrl(request.url, request.reason);
+    const prefix = options.logPrefix || '[n8n-nav]';
+    if (!decision.allowed || !decision.normalizedUrl) {
+        options.outputChannel?.appendLine(`${prefix} blocked reason=${decision.reason} detail=${decision.blockedReason || 'unknown'} url=${request.url}`);
+        return false;
+    }
+
+    const dedupeMs = options.dedupeMs ?? RECENT_OPEN_WINDOW_MS;
+    const source = request.source || {};
+    const dedupeKey = [decision.normalizedUrl, decision.reason, source.panelKind || '', source.workflowId || '', source.sessionId || ''].join('|');
+    const now = Date.now();
+    const lastOpenAt = recentExternalOpens.get(dedupeKey) || 0;
+    if (dedupeMs > 0 && now - lastOpenAt < dedupeMs) {
+        options.outputChannel?.appendLine(`${prefix} deduped reason=${decision.reason} panel=${source.panelKind || 'unknown'} workflow=${source.workflowId || 'none'} url=${decision.normalizedUrl}`);
+        return false;
+    }
+    recentExternalOpens.set(dedupeKey, now);
+
+    options.outputChannel?.appendLine(`${prefix} openExternal reason=${decision.reason} panel=${source.panelKind || 'unknown'} workflow=${source.workflowId || 'none'} node=${source.nodeName || source.nodeId || 'none'} url=${decision.normalizedUrl}`);
+
+    if (options.opener) {
+        return Boolean(await options.opener(decision.normalizedUrl));
+    }
+
+    try {
+        const vscodeRuntime = await import('vscode');
+        await vscodeRuntime.env.openExternal(vscodeRuntime.Uri.parse(decision.normalizedUrl));
+        return true;
+    } catch (error: any) {
+        options.outputChannel?.appendLine(`${prefix} failed reason=${decision.reason} detail=${error?.message || String(error)} url=${decision.normalizedUrl}`);
+        return false;
+    }
+}
+
+export function normalizeExternalNavigationReason(reason: ExternalNavigationReason | string | undefined): ExternalNavigationReason {
+    switch (reason) {
+        case 'popup':
+        case 'delayed-popup':
+        case 'form-trigger':
+        case 'webhook':
+        case 'chat-trigger':
+        case 'oauth':
+        case 'download':
+        case 'docs':
+        case 'top-navigation':
+        case 'custom-protocol':
+            return reason;
+        default:
+            return 'unknown';
+    }
+}
+
+function isPathOrChild(pathname: string, prefix: string): boolean {
+    return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -27,9 +27,33 @@ test('Agent Workbench HTML: relays workflow iframe popup requests', () => {
         providerModelLabel: 'openai / gpt-5.4',
     });
 
-    assert.ok(html.includes("message.type === 'n8n-open-external'"), 'Must listen for popup bridge messages');
+    assert.ok(html.includes("message.type === 'n8n-external-navigation'"), 'Must listen for source-rich navigation bridge messages');
+    assert.ok(html.includes("message.type === 'n8n-open-external'"), 'Must keep legacy popup bridge compatibility');
     assert.ok(html.includes('isWorkflowFrameEvent(event)'), 'Must validate workflow iframe origin before relaying');
-    assert.ok(html.includes("vscode.postMessage({ type: 'open-external', url: message.url });"), 'Must ask extension host to open popup URLs externally');
+    assert.ok(html.includes('postN8nExternalNavigation(message.url'), 'Must ask extension host to open popup URLs externally through the shared bridge');
+    assert.ok(html.includes("type: 'open-external'"), 'Must use the host open-external message contract');
+});
+
+test('Agent Workbench HTML: opens prepared Form Trigger test URL from workflow iframe readiness', () => {
+    const { buildAgentWorkbenchHtml } = require('../../src/ui/agent-workbench-html.js');
+    const html: string = buildAgentWorkbenchHtml({
+        workflowId: 'wf-1',
+        workflowName: 'Workflow 1',
+        workflowUrl: 'http://localhost:5678/workflow/wf-1',
+        workflowReloadUrl: 'http://localhost:5678/workflow/wf-1',
+        workflowFormTestUrl: 'http://localhost:5678/form-test/form-path',
+        providerModelLabel: 'openai / gpt-5.4',
+    });
+
+    assert.ok(html.includes('let workflowFormTestUrl ='), 'Must track the prepared form test URL');
+    assert.ok(html.includes("message.type === 'n8n-form-test-ready'"), 'Must listen for Form Trigger readiness messages');
+    assert.ok(html.includes('FORM_TEST_OPEN_COOLDOWN_MS'), 'Must use bounded duplicate suppression for form test openings');
+    assert.ok(html.includes('function claimWorkflowFormTestOpen(url)'), 'Must allow later form test openings after the cooldown');
+    assert.ok(!html.includes('workflowFormTestOpened'), 'Must not permanently suppress subsequent form test openings');
+    assert.ok(html.includes('http://localhost:5678/form-test/form-path'), 'Must embed the prepared form test URL');
+    assert.ok(html.includes("postN8nExternalNavigation(workflowFormTestUrl, 'form-trigger', message);"), 'Must ask VS Code to open the form externally through the shared bridge');
+    assert.ok(html.includes('message.formTestUrl'), 'Must update the form test URL when workflow context changes');
+    assert.ok(html.includes('workflowEndpoints'), 'Must track endpoint metadata, not only a single form URL');
 });
 
 test('Agent Workbench HTML: split view has a persistent resizable divider', () => {
@@ -207,12 +231,15 @@ test('Workflow webviews: extension host opens relayed popup URLs externally', ()
     const path = require('node:path');
     const workflowWebview = fs.readFileSync(path.join(__dirname, '../../src/ui/workflow-webview.ts'), 'utf8');
     const agentWorkbenchWebview = fs.readFileSync(path.join(__dirname, '../../src/ui/agent-workbench-webview.ts'), 'utf8');
+    const externalNavigation = fs.readFileSync(path.join(__dirname, '../../src/utils/external-navigation.ts'), 'utf8');
 
     for (const source of [workflowWebview, agentWorkbenchWebview]) {
         assert.ok(source.includes("payload.type === 'open-external'") || source.includes("message.type === 'open-external'"), 'Must handle open-external host messages');
-        assert.ok(source.includes("scheme !== 'http' && scheme !== 'https'"), 'Must reject non-browser URL schemes');
-        assert.ok(source.includes('vscode.env.openExternal(uri)'), 'Must open relayed popup URLs via VS Code');
+        assert.ok(source.includes('openExternalNavigation({'), 'Must route relayed popup URLs through the shared navigation broker');
     }
+    assert.ok(externalNavigation.includes("'http:'") && externalNavigation.includes("'https:'"), 'Broker must allow browser URL schemes');
+    assert.ok(externalNavigation.includes('blocked-scheme'), 'Broker must reject non-browser URL schemes');
+    assert.ok(externalNavigation.includes('vscodeRuntime.env.openExternal'), 'Broker must open relayed popup URLs via VS Code');
 });
 
 test('Agent runtime: workbench uses the native DeepAgents v3 run stream', () => {

--- a/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
+++ b/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
@@ -79,17 +79,29 @@ test('Bridge script: relays popup openings to the parent webview', () => {
     const { ProxyService } = require('../../src/services/proxy-service.js');
     const script: string = ProxyService.buildBridgeScript();
 
-    assert.ok(script.includes('"n8n-open-external"'), 'Must publish popup-open requests');
+    assert.ok(script.includes('"n8n-external-navigation"'), 'Must publish source-rich external navigation requests');
+    assert.ok(!script.includes('N8N_LEGACY_OPEN_EXTERNAL_TYPE'), 'Must not keep an unused legacy popup-open marker in the iframe bridge');
     assert.ok(script.includes('window.open = function(url, target, features)'), 'Must intercept window.open calls');
     assert.ok(script.includes('target.closest("a[href]")'), 'Must intercept target=_blank anchor clicks');
     assert.ok(script.includes('if (_popupBridgeInstalled) return;'), 'Must install popup bridge idempotently');
     assert.ok(script.includes('installPopupBridge();'), 'Must install popup bridge before n8n can cache window.open');
     assert.ok(script.includes('window.HTMLAnchorElement.prototype.click'), 'Must intercept programmatic anchor clicks');
     assert.ok(script.includes('document.addEventListener("submit"'), 'Must intercept popup form submissions');
-    assert.ok(script.includes('isFormTestUrl'), 'Must detect n8n form-test routes');
+    assert.ok(script.includes('classifyExternalNavigation'), 'Must classify external navigation routes in the iframe');
+    assert.ok(script.includes('shouldExternalizeNavigation'), 'Must centralize bridge-side externalization checks');
+    assert.ok(script.includes('Location.prototype.assign'), 'Must intercept location.assign when possible');
+    assert.ok(script.includes('history.pushState'), 'Must observe SPA route pushes for public endpoints');
+    assert.ok(script.includes('formaction'), 'Must respect submitter formaction overrides');
+    assert.ok(script.includes('formtarget'), 'Must respect submitter formtarget overrides');
+    assert.ok(script.includes('detectFormTestReady'), 'Must detect n8n Form Trigger waiting state');
+    assert.ok(script.includes('_formTestReadyVisible'), 'Must emit Form Trigger readiness once per visible ready-state transition');
+    assert.ok(script.includes('"n8n-form-test-ready"'), 'Must notify the parent webview when a Form Trigger is waiting');
+    assert.ok(script.includes('Waiting for you to submit the form'), 'Must detect the English Form Trigger waiting hint');
+    assert.ok(script.includes('soumettre le formulaire'), 'Must detect localized Form Trigger waiting hints');
     assert.ok(script.includes('absoluteUrl.pathname === "/form-test"'), 'Must identify the root form-test route');
-    assert.ok(script.includes('absoluteUrl.pathname.indexOf("/form-test/") !== -1'), 'Must identify nested form-test routes');
-    assert.ok(script.includes('!isAnchorPopupTarget(anchorTarget) && !isFormTestUrl(href)'), 'Must not intercept ordinary same-frame anchor clicks');
+    assert.ok(script.includes('absoluteUrl.pathname.indexOf("/form-test/") === 0'), 'Must identify nested form-test routes');
+    assert.ok(script.includes('absoluteUrl.pathname === "/webhook-test"'), 'Must identify the root webhook-test route');
+    assert.ok(script.includes('!classified) return'), 'Must not intercept ordinary same-frame anchor clicks');
     assert.ok(script.includes('new URL(url, window.location.href)'), 'Must resolve relative popup URLs against the proxied page');
     assert.ok(script.includes('absoluteUrl.protocol !== "http:" && absoluteUrl.protocol !== "https:"'), 'Must only relay browser-safe URL schemes');
     assert.ok(script.includes('createPopupBridgeWindow'), 'Must return a synthetic popup handle for delayed popup navigation');
@@ -392,11 +404,40 @@ test('Parent webview HTML: relays iframe popup requests after origin validation'
     const html: string = buildWebviewHtml('wf-1', 'http://localhost:5678/workflow/wf-1');
 
     assert.ok(html.includes("message.type === 'n8n-open-external'"), 'Must handle popup bridge messages');
+    assert.ok(html.includes("message.type === 'n8n-external-navigation'"), 'Must handle source-rich navigation bridge messages');
     assert.ok(html.includes('function isActiveFrameEvent(event)'), 'Must centralize active iframe validation for popup relays');
     assert.ok(html.includes('event.origin === iframeOrigin'), 'Must validate iframe origin before relaying popup URLs');
     assert.ok(html.includes('event.source === activeFrame.contentWindow'), 'Must reject popup requests from stale hidden iframes');
     assert.ok(html.includes("if (!isActiveFrameEvent(event)) return;"), 'Must require an active iframe event before relaying popup URLs');
-    assert.ok(html.includes("vscode.postMessage({ type: 'open-external', url: message.url });"), 'Must relay popup URL to the extension host');
+    assert.ok(html.includes('postN8nExternalNavigation(message.url'), 'Must relay popup URL to the extension host through the shared bridge');
+    assert.ok(html.includes('resolveN8nExternalNavigationUrl'), 'Must normalize relative iframe URLs before host relay');
+    assert.ok(html.includes('url: normalizedUrl'), 'Must relay the normalized absolute URL to the extension host');
+    assert.ok(html.includes("type: 'open-external'"), 'Must use the host open-external message contract');
+});
+
+test('Parent webview HTML: escapes iframe URL attributes', () => {
+    const { buildWebviewHtml } = require('../../src/ui/webview-html.js');
+    const html: string = buildWebviewHtml('wf-1', 'http://localhost:5678/workflow/wf-1" onload="alert(1)&x=<tag>');
+
+    assert.ok(!html.includes('src="http://localhost:5678/workflow/wf-1" onload='), 'Iframe src must not allow attribute breakout');
+    assert.ok(html.includes('&quot; onload=&quot;alert(1)&amp;x=&lt;tag&gt;'), 'Iframe src must be HTML-escaped');
+});
+
+test('Parent webview HTML: opens prepared Form Trigger test URL when n8n waits for form submission', () => {
+    const { buildWebviewHtml } = require('../../src/ui/webview-html.js');
+    const html: string = buildWebviewHtml(
+        'wf-1',
+        'http://localhost:5678/workflow/wf-1',
+        'http://localhost:5678/form-test/form-path',
+    );
+
+    assert.ok(html.includes("message.type === 'n8n-form-test-ready'"), 'Must listen for Form Trigger readiness messages');
+    assert.ok(html.includes('FORM_TEST_OPEN_COOLDOWN_MS'), 'Must use bounded duplicate suppression for form test openings');
+    assert.ok(html.includes('function claimFormTestOpen(url)'), 'Must allow later form test openings after the cooldown');
+    assert.ok(!html.includes('_formTestOpened'), 'Must not permanently suppress subsequent form test openings');
+    assert.ok(html.includes('http://localhost:5678/form-test/form-path'), 'Must embed the prepared form test URL');
+    assert.ok(html.includes("postN8nExternalNavigation(formTestUrl, 'form-trigger', message);"), 'Must ask the extension host to open the form externally');
+    assert.ok(html.includes('workflowEndpoints'), 'Must embed endpoint metadata for generalized trigger handling');
 });
 
 test('Parent webview HTML: does not embed a static NONCE', () => {

--- a/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
+++ b/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
@@ -82,9 +82,22 @@ test('Bridge script: relays popup openings to the parent webview', () => {
     assert.ok(script.includes('"n8n-open-external"'), 'Must publish popup-open requests');
     assert.ok(script.includes('window.open = function(url, target, features)'), 'Must intercept window.open calls');
     assert.ok(script.includes('target.closest("a[href]")'), 'Must intercept target=_blank anchor clicks');
-    assert.ok(script.includes('isAnchorPopupTarget(anchor.getAttribute("target") || "")'), 'Must not intercept ordinary same-frame anchor clicks');
+    assert.ok(script.includes('if (_popupBridgeInstalled) return;'), 'Must install popup bridge idempotently');
+    assert.ok(script.includes('installPopupBridge();'), 'Must install popup bridge before n8n can cache window.open');
+    assert.ok(script.includes('window.HTMLAnchorElement.prototype.click'), 'Must intercept programmatic anchor clicks');
+    assert.ok(script.includes('document.addEventListener("submit"'), 'Must intercept popup form submissions');
+    assert.ok(script.includes('isFormTestUrl'), 'Must detect n8n form-test routes');
+    assert.ok(script.includes('absoluteUrl.pathname === "/form-test"'), 'Must identify the root form-test route');
+    assert.ok(script.includes('absoluteUrl.pathname.indexOf("/form-test/") !== -1'), 'Must identify nested form-test routes');
+    assert.ok(script.includes('!isAnchorPopupTarget(anchorTarget) && !isFormTestUrl(href)'), 'Must not intercept ordinary same-frame anchor clicks');
     assert.ok(script.includes('new URL(url, window.location.href)'), 'Must resolve relative popup URLs against the proxied page');
     assert.ok(script.includes('absoluteUrl.protocol !== "http:" && absoluteUrl.protocol !== "https:"'), 'Must only relay browser-safe URL schemes');
+    assert.ok(script.includes('createPopupBridgeWindow'), 'Must return a synthetic popup handle for delayed popup navigation');
+    assert.ok(script.includes('Object.defineProperty(popup, "location"'), 'Must intercept popup.location assignment');
+    assert.ok(script.includes('Object.defineProperty(locationProxy, "href"'), 'Must intercept popup.location.href assignment');
+    assert.ok(script.includes('assign: function(nextUrl)'), 'Must intercept popup.location.assign');
+    assert.ok(script.includes('replace: function(nextUrl)'), 'Must intercept popup.location.replace');
+    assert.ok(script.includes('return popup'), 'window.open popup targets must return a popup-like handle');
 });
 
 test('Bridge script: does not validate nonce on incoming paste message', () => {

--- a/packages/vscode-extension/tests/unit/external-navigation.test.ts
+++ b/packages/vscode-extension/tests/unit/external-navigation.test.ts
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+test('External navigation: classifies n8n public endpoint routes', () => {
+    const { classifyExternalNavigationUrl, isN8nPublicEndpointPath } = require('../../src/utils/external-navigation.js');
+
+    assert.equal(isN8nPublicEndpointPath('/form-test/abc'), true);
+    assert.equal(isN8nPublicEndpointPath('/webhook-test/abc'), true);
+    assert.equal(isN8nPublicEndpointPath('/workflow/abc'), false);
+    assert.equal(classifyExternalNavigationUrl('http://localhost:5678/form-test/abc').reason, 'form-trigger');
+    assert.equal(classifyExternalNavigationUrl('http://localhost:5678/webhook-test/abc').reason, 'webhook');
+});
+
+test('External navigation: blocks non-browser URL schemes', () => {
+    const { classifyExternalNavigationUrl } = require('../../src/utils/external-navigation.js');
+
+    assert.equal(classifyExternalNavigationUrl('javascript:alert(1)').allowed, false);
+    assert.equal(classifyExternalNavigationUrl('data:text/plain,hello').allowed, false);
+    assert.equal(classifyExternalNavigationUrl('file:///tmp/secret').allowed, false);
+    assert.equal(classifyExternalNavigationUrl('http://localhost:5678/workflow/abc').allowed, true);
+});


### PR DESCRIPTION
## What changed

- Intercepts n8n iframe popup attempts from the injected bridge, including `window.open(...)` and explicit `_blank` / `_new` links.
- Relays validated popup requests from both workflow board webviews and agent split/workbench webviews to the VS Code extension host.
- Opens relayed popup URLs via `vscode.env.openExternal`, limited to `http` and `https` schemes.
- Adds a draggable and keyboard-accessible divider in the agent split view so users can adjust chat vs workflow width.
- Persists the split ratio across workbench reloads while enforcing minimum chat/workflow widths.
- Adds unit coverage for the popup bridge, origin-validated parent relay, extension host URL handling, and split view resizing markers.

## Why

VS Code webviews block normal browser popup behavior inside embedded n8n iframes. Workflows that open a form trigger URL in a new browser window could not be tested from the board or split webview. This change hands those popup requests off to the user’s external browser while preserving the proxied URL context.

The split workbench also used a fixed width distribution, which made it harder to give more space to either the workflow canvas or the agent chat while testing and iterating.

## Validation

- `npm test --workspace packages/vscode-extension`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webview iframes now reliably relay external-link requests (including form/webhook triggers) to the host with richer context and permission handling.
  * Automatic detection and external opening of prepared form-test flows with cooldown/duplicate suppression.
  * Improved iframe sandbox/permission handling for clipboard, camera, mic, and geolocation.

* **Bug Fixes**
  * More robust interception of popups, anchor clicks, and form submissions; only http(s) targets are allowed.

* **Tests**
  * Expanded unit tests covering popup relay, form-test readiness, and URL classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->