### PR TITLE
Improve webview popup handoff

### DIFF
--- a/packages/vscode-extension/src/services/proxy-service.ts
+++ b/packages/vscode-extension/src/services/proxy-service.ts
@@ -791,6 +791,54 @@ export class ProxyService {
     return value.replace(/\\s+/g, " ").trim();
   }
 
+  function isPopupTarget(target) {
+    var normalized = cleanText(target || "_blank").toLowerCase();
+    return !normalized || normalized === "_blank" || normalized === "_new";
+  }
+
+  function isAnchorPopupTarget(target) {
+    var normalized = cleanText(target).toLowerCase();
+    return normalized === "_blank" || normalized === "_new";
+  }
+
+  function postOpenExternal(url, target) {
+    if (url === undefined || url === null) return false;
+    url = String(url);
+    if (!url) return false;
+    try {
+      var absoluteUrl = new URL(url, window.location.href);
+      if (absoluteUrl.protocol !== "http:" && absoluteUrl.protocol !== "https:") return false;
+      window.parent.postMessage({
+        type: "n8n-open-external",
+        build: N8NAC_BRIDGE_BUILD,
+        url: absoluteUrl.toString(),
+        target: typeof target === "string" ? target : ""
+      }, "*");
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function installPopupBridge() {
+    var originalWindowOpen = window.open;
+    window.open = function(url, target, features) {
+      if (isPopupTarget(target) && postOpenExternal(url, target)) return null;
+      return originalWindowOpen.apply(window, arguments);
+    };
+
+    document.addEventListener("click", function(e) {
+      var target = e.target;
+      var anchor = target && target.closest ? target.closest("a[href]") : null;
+      if (!anchor || !isAnchorPopupTarget(anchor.getAttribute("target") || "")) return;
+      if (anchor.hasAttribute("download")) return;
+      if (!postOpenExternal(anchor.getAttribute("href") || "", anchor.getAttribute("target") || "")) return;
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+    }, true);
+  }
+
   function coerceNode(value) {
     var record = asRecord(value);
     if (!record) return null;
@@ -1142,6 +1190,7 @@ export class ProxyService {
 
   function installNodeDetailObserver() {
     postBridgeReady();
+    installPopupBridge();
     if (!NODE_BRIDGE_ENABLED) return;
     document.addEventListener("pointerdown", function(e) {
       var node = readNodeFromElement(e.target);

--- a/packages/vscode-extension/src/services/proxy-service.ts
+++ b/packages/vscode-extension/src/services/proxy-service.ts
@@ -462,7 +462,7 @@ export class ProxyService {
                             'content-type': 'text/html; charset=utf-8',
                             'cache-control': 'no-store',
                         });
-                        httpRes.end(handoff.html);
+                        httpRes.end(this.injectClipboardBridge(handoff.html, false, false, 'auth-route'));
                         return;
                     }
                 }
@@ -791,14 +791,18 @@ export class ProxyService {
     return value.replace(/\\s+/g, " ").trim();
   }
 
+  function isSameFrameTarget(normalized) {
+    return normalized === "_self" || normalized === "_parent" || normalized === "_top";
+  }
+
   function isPopupTarget(target) {
     var normalized = cleanText(target || "_blank").toLowerCase();
-    return !normalized || normalized === "_blank" || normalized === "_new";
+    return !normalized || !isSameFrameTarget(normalized);
   }
 
   function isAnchorPopupTarget(target) {
     var normalized = cleanText(target).toLowerCase();
-    return normalized === "_blank" || normalized === "_new";
+    return !!normalized && !isSameFrameTarget(normalized);
   }
 
   function postOpenExternal(url, target) {

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -3043,6 +3043,12 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 return;
             }
 
+            if (message.type === 'n8n-open-external' && typeof message.url === 'string') {
+                if (!isWorkflowFrameEvent(event)) return;
+                vscode.postMessage({ type: 'open-external', url: message.url });
+                return;
+            }
+
             if (message.type === 'n8n-paste-request') {
                 if (!isWorkflowFrameEvent(event)) return;
                 const now = Date.now();

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -111,11 +111,15 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         button, input, select, textarea { font: inherit; }
         .workbench {
             display: grid;
-            grid-template-columns: ${hasWorkflow ? 'minmax(360px, .95fr) minmax(420px, 1.05fr)' : 'minmax(420px, 1fr)'};
+            grid-template-columns: ${hasWorkflow ? 'minmax(360px, var(--agent-chat-width, .95fr)) 7px minmax(420px, 1fr)' : 'minmax(420px, 1fr)'};
             height: 100vh;
             width: 100vw;
             min-width: 0;
             min-height: 0;
+        }
+        .workbench.resizing {
+            cursor: col-resize;
+            user-select: none;
         }
         .chat {
             min-width: 0;
@@ -132,6 +136,40 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             min-width: 0;
             min-height: 0;
             background: var(--bg);
+        }
+        .split-resizer {
+            position: relative;
+            z-index: 3;
+            min-width: 7px;
+            min-height: 0;
+            cursor: col-resize;
+            background: var(--panel);
+            border-left: 1px solid var(--border);
+            border-right: 1px solid var(--border);
+            touch-action: none;
+        }
+        .split-resizer::before {
+            content: "";
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 3px;
+            height: 44px;
+            border-radius: 999px;
+            transform: translate(-50%, -50%);
+            background: color-mix(in srgb, var(--muted) 55%, transparent);
+        }
+        .split-resizer:hover::before,
+        .split-resizer:focus-visible::before,
+        .workbench.resizing .split-resizer::before {
+            background: var(--accent);
+        }
+        .split-resizer:focus-visible {
+            outline: 1px solid var(--vscode-focusBorder, var(--accent));
+            outline-offset: -1px;
+        }
+        .workbench.resizing .workflow iframe {
+            pointer-events: none;
         }
         .chat-head {
             padding: 12px 14px;
@@ -1221,6 +1259,9 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 grid-template-columns: 1fr;
                 grid-template-rows: ${hasWorkflow ? 'minmax(360px, 48%) 1fr' : '1fr'};
             }
+            .split-resizer {
+                display: none;
+            }
             .chat {
                 border-right: 0;
             }
@@ -1233,6 +1274,9 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             .workbench {
                 grid-template-columns: 1fr;
                 grid-template-rows: auto ${hasWorkflow ? 'minmax(280px, 42%)' : ''};
+            }
+            .split-resizer {
+                display: none;
             }
             .chat {
                 border-right: 0;
@@ -1298,7 +1342,8 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             </form>
             <div id="worktree-warning" class="worktree-warning" aria-live="polite">Isolated worktree — n8n-as-code config changes and local workflow list from extension UI don't apply here.</div>
         </section>
-        ${hasWorkflow ? `<section class="workflow" aria-label="n8n workflow">
+        ${hasWorkflow ? `<div id="split-resizer" class="split-resizer" role="separator" aria-label="Resize chat and workflow panels" aria-orientation="vertical" aria-valuemin="360" aria-valuemax="1200" aria-valuenow="0" tabindex="0"></div>
+        <section class="workflow" aria-label="n8n workflow">
             <div id="refresh-pill" class="refresh-pill">Refreshing n8n...</div>
             ${hasWorkflowUi ? `<iframe
                 id="workflow-frame"
@@ -1381,6 +1426,12 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         let lastStateSequence = 0;
         const rewoundMessageIds = new Set();
         const expandedDetailKeys = new Set();
+        const SPLIT_RESIZER_STORAGE_KEY = 'n8n.agentWorkbench.chatSplitRatio';
+        const DEFAULT_CHAT_SPLIT_RATIO = 0.475;
+        const MIN_CHAT_PANEL_WIDTH = 360;
+        const MIN_WORKFLOW_PANEL_WIDTH = 420;
+        let currentChatSplitRatio = DEFAULT_CHAT_SPLIT_RATIO;
+        let activeSplitResize = false;
 
         const OP_ICONS = {
             'file-read': ${JSON.stringify(readOpIcon)},
@@ -1414,6 +1465,8 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         const reasoningMenu = document.getElementById('reasoning-menu');
         const selectWorktreeButton = document.getElementById('select-worktree');
         const worktreeMenu = document.getElementById('worktree-menu');
+        const workbench = document.getElementById('workbench');
+        const splitResizer = document.getElementById('split-resizer');
         const frame = document.getElementById('workflow-frame');
         const refreshPill = document.getElementById('refresh-pill');
         const contextBadges = document.getElementById('context-badges');
@@ -1440,6 +1493,105 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
 
         function on(element, eventName, handler) {
             if (element) element.addEventListener(eventName, handler);
+        }
+
+        function clamp(value, min, max) {
+            return Math.min(Math.max(value, min), max);
+        }
+
+        function getSplitMetrics() {
+            if (!workbench || !splitResizer) return null;
+            const rect = workbench.getBoundingClientRect();
+            const resizerWidth = splitResizer.offsetWidth || 7;
+            const availableWidth = Math.max(0, rect.width - resizerWidth);
+            const maxChatWidth = Math.max(MIN_CHAT_PANEL_WIDTH, availableWidth - MIN_WORKFLOW_PANEL_WIDTH);
+            const minRatio = availableWidth > 0 ? MIN_CHAT_PANEL_WIDTH / availableWidth : DEFAULT_CHAT_SPLIT_RATIO;
+            const maxRatio = availableWidth > 0 ? maxChatWidth / availableWidth : DEFAULT_CHAT_SPLIT_RATIO;
+            return { rect, availableWidth, maxChatWidth, minRatio, maxRatio };
+        }
+
+        function readStoredChatSplitRatio() {
+            try {
+                const raw = localStorage.getItem(SPLIT_RESIZER_STORAGE_KEY);
+                if (!raw) return DEFAULT_CHAT_SPLIT_RATIO;
+                const parsed = Number(raw);
+                return Number.isFinite(parsed) ? parsed : DEFAULT_CHAT_SPLIT_RATIO;
+            } catch (e) {
+                return DEFAULT_CHAT_SPLIT_RATIO;
+            }
+        }
+
+        function persistChatSplitRatio(ratio) {
+            try {
+                localStorage.setItem(SPLIT_RESIZER_STORAGE_KEY, String(ratio));
+            } catch (e) {}
+        }
+
+        function applyChatSplitRatio(ratio, persist) {
+            const metrics = getSplitMetrics();
+            if (!metrics || !metrics.availableWidth) return;
+            const boundedRatio = clamp(ratio, metrics.minRatio, metrics.maxRatio);
+            const chatWidth = Math.round(metrics.availableWidth * boundedRatio);
+            currentChatSplitRatio = boundedRatio;
+            workbench.style.setProperty('--agent-chat-width', chatWidth + 'px');
+            splitResizer.setAttribute('aria-valuemin', String(MIN_CHAT_PANEL_WIDTH));
+            splitResizer.setAttribute('aria-valuemax', String(Math.round(metrics.maxChatWidth)));
+            splitResizer.setAttribute('aria-valuenow', String(chatWidth));
+            if (persist) persistChatSplitRatio(boundedRatio);
+        }
+
+        function setChatSplitFromClientX(clientX, persist) {
+            const metrics = getSplitMetrics();
+            if (!metrics || !metrics.availableWidth) return;
+            const chatWidth = clamp(clientX - metrics.rect.left, MIN_CHAT_PANEL_WIDTH, metrics.maxChatWidth);
+            applyChatSplitRatio(chatWidth / metrics.availableWidth, persist);
+        }
+
+        function setSplitResizing(active) {
+            activeSplitResize = active;
+            if (workbench) workbench.classList.toggle('resizing', active);
+        }
+
+        function initializeSplitResizer() {
+            if (!splitResizer || !workbench) return;
+            applyChatSplitRatio(readStoredChatSplitRatio(), false);
+
+            splitResizer.addEventListener('pointerdown', (event) => {
+                event.preventDefault();
+                splitResizer.setPointerCapture?.(event.pointerId);
+                setSplitResizing(true);
+                setChatSplitFromClientX(event.clientX, true);
+            });
+            splitResizer.addEventListener('pointermove', (event) => {
+                if (!activeSplitResize) return;
+                setChatSplitFromClientX(event.clientX, true);
+            });
+            splitResizer.addEventListener('pointerup', (event) => {
+                splitResizer.releasePointerCapture?.(event.pointerId);
+                setSplitResizing(false);
+            });
+            splitResizer.addEventListener('pointercancel', (event) => {
+                splitResizer.releasePointerCapture?.(event.pointerId);
+                setSplitResizing(false);
+            });
+            splitResizer.addEventListener('keydown', (event) => {
+                const metrics = getSplitMetrics();
+                if (!metrics) return;
+                if (event.key === 'ArrowLeft') {
+                    event.preventDefault();
+                    applyChatSplitRatio(currentChatSplitRatio - 0.03, true);
+                } else if (event.key === 'ArrowRight') {
+                    event.preventDefault();
+                    applyChatSplitRatio(currentChatSplitRatio + 0.03, true);
+                } else if (event.key === 'Home') {
+                    event.preventDefault();
+                    applyChatSplitRatio(metrics.minRatio, true);
+                } else if (event.key === 'End') {
+                    event.preventDefault();
+                    applyChatSplitRatio(metrics.maxRatio, true);
+                }
+            });
+            window.addEventListener('resize', () => applyChatSplitRatio(currentChatSplitRatio, false));
         }
 
         function isFeedNearBottom() {
@@ -3145,6 +3297,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             }
         });
 
+        initializeSplitResizer();
         vscode.postMessage({ type: 'agent.ready' });
     </script>
 </body>

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -1501,6 +1501,8 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
 
         function getSplitMetrics() {
             if (!workbench || !splitResizer) return null;
+            const resizerStyle = window.getComputedStyle(splitResizer);
+            if (resizerStyle.display === 'none') return null;
             const rect = workbench.getBoundingClientRect();
             const resizerWidth = splitResizer.offsetWidth || 7;
             const availableWidth = Math.max(0, rect.width - resizerWidth);
@@ -1554,7 +1556,8 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
 
         function initializeSplitResizer() {
             if (!splitResizer || !workbench) return;
-            applyChatSplitRatio(readStoredChatSplitRatio(), false);
+            currentChatSplitRatio = readStoredChatSplitRatio();
+            applyChatSplitRatio(currentChatSplitRatio, false);
 
             splitResizer.addEventListener('pointerdown', (event) => {
                 event.preventDefault();
@@ -1728,7 +1731,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
 
         function isWorkflowFrameEvent(event) {
             if (!frame || event.source !== frame.contentWindow) return false;
-            return event.origin === iframeOrigin || event.origin === 'null';
+            return event.origin === iframeOrigin;
         }
 
         function reloadWorkflowFrame() {

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -237,6 +237,11 @@ export class AgentWorkbenchWebview {
             return;
         }
 
+        if (payload.type === 'open-external' && typeof payload.url === 'string') {
+            await this.openExternalUrl(payload.url);
+            return;
+        }
+
         if (payload.type === 'agent.send' || payload.type === 'agent.queue' || payload.type === 'agent.steer') {
             const nodeContexts = this.sanitizeNodeContexts(payload.nodeContexts) || this.sanitizeNodeContexts(payload.nodeContext) || this._nodeContexts;
             this._outputChannel.appendLine(`[n8n-agent-debug] ${payload.type} workflowId=${this._workflow?.id || 'none'} workflowFilePath=${this._workflowFilePath || 'none'} sessionId=${typeof payload.sessionId === 'string' ? payload.sessionId : 'none'}`);
@@ -807,5 +812,23 @@ export class AgentWorkbenchWebview {
             workflowReloadUrl: this._workflowReloadUrl,
             providerModelLabel: this._providerModelLabel,
         });
+    }
+
+    private async openExternalUrl(url: string): Promise<void> {
+        let uri: vscode.Uri;
+        try {
+            uri = vscode.Uri.parse(url);
+        } catch {
+            return;
+        }
+        const scheme = uri.scheme.toLowerCase();
+        if (scheme !== 'http' && scheme !== 'https') {
+            return;
+        }
+        try {
+            await vscode.env.openExternal(uri);
+        } catch (error) {
+            console.error('[AgentWorkbench] Open external URL error', error);
+        }
     }
 }

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -826,7 +826,10 @@ export class AgentWorkbenchWebview {
             return;
         }
         try {
-            await vscode.env.openExternal(uri);
+            const opened = await vscode.env.openExternal(uri);
+            if (!opened) {
+                console.error('[AgentWorkbench] VS Code declined to open external URL', url);
+            }
         } catch (error) {
             console.error('[AgentWorkbench] Open external URL error', error);
         }

--- a/packages/vscode-extension/src/ui/webview-html.ts
+++ b/packages/vscode-extension/src/ui/webview-html.ts
@@ -216,6 +216,10 @@ export function buildWebviewHtml(workflowId: string, url: string): string {
                     return true;
                 }
 
+                function isActiveFrameEvent(event) {
+                    return event.origin === iframeOrigin && event.source === activeFrame.contentWindow;
+                }
+
                 window.addEventListener('message', (event) => {
                     const message = event.data;
                     if (!message || typeof message !== 'object') return;
@@ -230,7 +234,7 @@ export function buildWebviewHtml(workflowId: string, url: string): string {
 
                     // Popup bridge: iframe requests an external browser window.
                     if (message.type === 'n8n-open-external' && typeof message.url === 'string') {
-                        if (event.origin !== iframeOrigin) return;
+                        if (!isActiveFrameEvent(event)) return;
                         vscode.postMessage({ type: 'open-external', url: message.url });
                         return;
                     }

--- a/packages/vscode-extension/src/ui/webview-html.ts
+++ b/packages/vscode-extension/src/ui/webview-html.ts
@@ -228,6 +228,13 @@ export function buildWebviewHtml(workflowId: string, url: string): string {
                         return;
                     }
 
+                    // Popup bridge: iframe requests an external browser window.
+                    if (message.type === 'n8n-open-external' && typeof message.url === 'string') {
+                        if (event.origin !== iframeOrigin) return;
+                        vscode.postMessage({ type: 'open-external', url: message.url });
+                        return;
+                    }
+
                     // Clipboard bridge: iframe requests paste data -> forward to extension host
                     // Validate origin, apply rate limit, issue a one-time grant token.
                     if (message.type === 'n8n-paste-request') {

--- a/packages/vscode-extension/src/ui/webview-html.ts
+++ b/packages/vscode-extension/src/ui/webview-html.ts
@@ -242,7 +242,7 @@ export function buildWebviewHtml(workflowId: string, url: string): string {
                     // Clipboard bridge: iframe requests paste data -> forward to extension host
                     // Validate origin, apply rate limit, issue a one-time grant token.
                     if (message.type === 'n8n-paste-request') {
-                        if (event.origin !== iframeOrigin) return;
+                        if (!isActiveFrameEvent(event)) return;
                         var now = Date.now();
                         if (now - _lastPasteMs < PASTE_RATE_LIMIT_MS) return;
                         _lastPasteMs = now;
@@ -253,7 +253,7 @@ export function buildWebviewHtml(workflowId: string, url: string): string {
 
                     // Clipboard bridge: iframe sends copied text -> write to system clipboard
                     if (message.type === 'n8n-clipboard-write' && typeof message.text === 'string') {
-                        if (event.origin !== iframeOrigin) return;
+                        if (!isActiveFrameEvent(event)) return;
                         vscode.postMessage({ type: 'clipboard-write', text: message.text });
                         return;
                     }

--- a/packages/vscode-extension/src/ui/workflow-webview.ts
+++ b/packages/vscode-extension/src/ui/workflow-webview.ts
@@ -38,6 +38,9 @@ export class WorkflowWebview {
                 void this._onClipboardPasteRequest?.(this._panel, message.grantToken)
                     ?.catch(e => console.error('[Webview] Clipboard paste handler error', e));
             }
+            if (message.type === 'open-external' && typeof message.url === 'string') {
+                await this.openExternalUrl(message.url);
+            }
         }, null, this._disposables);
     }
 
@@ -107,5 +110,23 @@ export class WorkflowWebview {
 
     private getHtmlForWebview(workflowId: string, url: string) {
         return buildWebviewHtml(workflowId, url);
+    }
+
+    private async openExternalUrl(url: string): Promise<void> {
+        let uri: vscode.Uri;
+        try {
+            uri = vscode.Uri.parse(url);
+        } catch {
+            return;
+        }
+        const scheme = uri.scheme.toLowerCase();
+        if (scheme !== 'http' && scheme !== 'https') {
+            return;
+        }
+        try {
+            await vscode.env.openExternal(uri);
+        } catch (error) {
+            console.error('[Webview] Open external URL error', error);
+        }
     }
 }

--- a/packages/vscode-extension/src/ui/workflow-webview.ts
+++ b/packages/vscode-extension/src/ui/workflow-webview.ts
@@ -124,7 +124,10 @@ export class WorkflowWebview {
             return;
         }
         try {
-            await vscode.env.openExternal(uri);
+            const opened = await vscode.env.openExternal(uri);
+            if (!opened) {
+                console.error('[Webview] VS Code declined to open external URL', url);
+            }
         } catch (error) {
             console.error('[Webview] Open external URL error', error);
         }

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -32,6 +32,28 @@ test('Agent Workbench HTML: relays workflow iframe popup requests', () => {
     assert.ok(html.includes("vscode.postMessage({ type: 'open-external', url: message.url });"), 'Must ask extension host to open popup URLs externally');
 });
 
+test('Agent Workbench HTML: split view has a persistent resizable divider', () => {
+    const { buildAgentWorkbenchHtml } = require('../../src/ui/agent-workbench-html.js');
+    const html: string = buildAgentWorkbenchHtml({
+        workflowId: 'wf-1',
+        workflowName: 'Workflow 1',
+        workflowUrl: 'http://localhost:5678/workflow/wf-1',
+        providerModelLabel: 'openai / gpt-5.4',
+    });
+
+    assert.ok(html.includes('id="split-resizer"'), 'Must render a divider between chat and workflow');
+    assert.ok(html.includes('role="separator"'), 'Divider must expose separator semantics');
+    assert.ok(html.includes('aria-orientation="vertical"'), 'Divider must describe horizontal resizing');
+    assert.ok(html.includes('var(--agent-chat-width, .95fr)'), 'Grid must use a CSS variable for the chat column width');
+    assert.ok(html.includes('n8n.agentWorkbench.chatSplitRatio'), 'Split ratio must persist across workbench reloads');
+    assert.ok(html.includes("splitResizer.addEventListener('pointerdown'"), 'Divider must support pointer resizing');
+    assert.ok(html.includes("splitResizer.addEventListener('keydown'"), 'Divider must support keyboard resizing');
+    assert.ok(html.includes("event.key === 'ArrowLeft'"), 'Keyboard resizing must shrink the chat panel');
+    assert.ok(html.includes("event.key === 'ArrowRight'"), 'Keyboard resizing must expand the chat panel');
+    assert.ok(html.includes("workbench.classList.toggle('resizing', active)"), 'Resizing must set a state class that protects iframe interactions');
+    assert.ok(html.includes('initializeSplitResizer();'), 'Workbench must initialize split sizing on load');
+});
+
 test('Agent Workbench HTML: forwards node detail context to the agent', () => {
     const { buildAgentWorkbenchHtml } = require('../../src/ui/agent-workbench-html.js');
     const html: string = buildAgentWorkbenchHtml({

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -17,6 +17,21 @@ test('Agent Workbench HTML: workflow reload forces iframe navigation', () => {
     assert.ok(html.includes('frame.src = reloadUrl.toString()'), 'Reload must assign a fresh iframe URL');
 });
 
+test('Agent Workbench HTML: relays workflow iframe popup requests', () => {
+    const { buildAgentWorkbenchHtml } = require('../../src/ui/agent-workbench-html.js');
+    const html: string = buildAgentWorkbenchHtml({
+        workflowId: 'wf-1',
+        workflowName: 'Workflow 1',
+        workflowUrl: 'http://localhost:5678/__n8n-manager/open-workflow/wf-1',
+        workflowReloadUrl: 'http://localhost:5678/workflow/wf-1',
+        providerModelLabel: 'openai / gpt-5.4',
+    });
+
+    assert.ok(html.includes("message.type === 'n8n-open-external'"), 'Must listen for popup bridge messages');
+    assert.ok(html.includes('isWorkflowFrameEvent(event)'), 'Must validate workflow iframe origin before relaying');
+    assert.ok(html.includes("vscode.postMessage({ type: 'open-external', url: message.url });"), 'Must ask extension host to open popup URLs externally');
+});
+
 test('Agent Workbench HTML: forwards node detail context to the agent', () => {
     const { buildAgentWorkbenchHtml } = require('../../src/ui/agent-workbench-html.js');
     const html: string = buildAgentWorkbenchHtml({
@@ -160,6 +175,19 @@ test('Agent runtime: final response does not wait for post-run checkpoint work',
     assert.ok(source.includes("await postMessage({ type: 'agent.status', status: 'idle' });\n                postedIdle = true;"), 'Must post idle before slower state refresh work on normal completion');
     assert.ok(source.includes('saveAutoCheckpointAfterFileModificationInBackground'), 'Must keep auto-checkpoints off the response critical path');
     assert.ok(!source.includes('await this.saveAutoCheckpointAfterFileModification(service, input, entries);'), 'Must not await auto-checkpoint after emitting the final response');
+});
+
+test('Workflow webviews: extension host opens relayed popup URLs externally', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const workflowWebview = fs.readFileSync(path.join(__dirname, '../../src/ui/workflow-webview.ts'), 'utf8');
+    const agentWorkbenchWebview = fs.readFileSync(path.join(__dirname, '../../src/ui/agent-workbench-webview.ts'), 'utf8');
+
+    for (const source of [workflowWebview, agentWorkbenchWebview]) {
+        assert.ok(source.includes("payload.type === 'open-external'") || source.includes("message.type === 'open-external'"), 'Must handle open-external host messages');
+        assert.ok(source.includes("scheme !== 'http' && scheme !== 'https'"), 'Must reject non-browser URL schemes');
+        assert.ok(source.includes('vscode.env.openExternal(uri)'), 'Must open relayed popup URLs via VS Code');
+    }
 });
 
 test('Agent runtime: workbench uses the native DeepAgents v3 run stream', () => {

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -43,9 +43,11 @@ test('Agent Workbench HTML: split view has a persistent resizable divider', () =
 
     assert.ok(html.includes('id="split-resizer"'), 'Must render a divider between chat and workflow');
     assert.ok(html.includes('role="separator"'), 'Divider must expose separator semantics');
-    assert.ok(html.includes('aria-orientation="vertical"'), 'Divider must describe horizontal resizing');
+    assert.ok(html.includes('aria-orientation="vertical"'), 'Divider must be oriented vertically for left-right panel resizing');
     assert.ok(html.includes('var(--agent-chat-width, .95fr)'), 'Grid must use a CSS variable for the chat column width');
     assert.ok(html.includes('n8n.agentWorkbench.chatSplitRatio'), 'Split ratio must persist across workbench reloads');
+    assert.ok(html.includes("resizerStyle.display === 'none'"), 'Hidden responsive divider must not overwrite the active split ratio');
+    assert.ok(html.includes('currentChatSplitRatio = readStoredChatSplitRatio();'), 'Stored split ratio must survive reloads that start in stacked layout');
     assert.ok(html.includes("splitResizer.addEventListener('pointerdown'"), 'Divider must support pointer resizing');
     assert.ok(html.includes("splitResizer.addEventListener('keydown'"), 'Divider must support keyboard resizing');
     assert.ok(html.includes("event.key === 'ArrowLeft'"), 'Keyboard resizing must shrink the chat panel');
@@ -71,6 +73,7 @@ test('Agent Workbench HTML: forwards node detail context to the agent', () => {
     assert.ok(html.includes("message.type === 'n8n-node-detail-opened'"), 'Must handle node detail messages from iframe');
     assert.ok(html.includes("type: 'agent.nodeDetailChanged'"), 'Must forward node context to extension host');
     assert.ok(html.includes('nodeContexts: currentNodeContexts'), 'Must include node contexts when sending prompts');
+    assert.ok(!html.includes("event.origin === 'null'"), 'Workflow iframe messages must not trust null origins');
 });
 
 test('Agent Workbench HTML: context badge removal subtracts persisted context', () => {

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -211,7 +211,8 @@ test('Workflow webviews: extension host opens relayed popup URLs externally', ()
     for (const source of [workflowWebview, agentWorkbenchWebview]) {
         assert.ok(source.includes("payload.type === 'open-external'") || source.includes("message.type === 'open-external'"), 'Must handle open-external host messages');
         assert.ok(source.includes("scheme !== 'http' && scheme !== 'https'"), 'Must reject non-browser URL schemes');
-        assert.ok(source.includes('vscode.env.openExternal(uri)'), 'Must open relayed popup URLs via VS Code');
+        assert.ok(source.includes('const opened = await vscode.env.openExternal(uri)'), 'Must open relayed popup URLs via VS Code');
+        assert.ok(source.includes('if (!opened)'), 'Must handle VS Code declining to open the external URL');
     }
 });
 

--- a/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
+++ b/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
@@ -379,8 +379,11 @@ test('Parent webview HTML: relays iframe popup requests after origin validation'
     const html: string = buildWebviewHtml('wf-1', 'http://localhost:5678/workflow/wf-1');
 
     assert.ok(html.includes("message.type === 'n8n-open-external'"), 'Must handle popup bridge messages');
+    assert.ok(html.includes('function isActiveFrameEvent(event)'), 'Must centralize active iframe validation for popup relays');
+    assert.ok(html.includes('event.origin === iframeOrigin'), 'Must validate iframe origin before relaying popup URLs');
+    assert.ok(html.includes('event.source === activeFrame.contentWindow'), 'Must reject popup requests from stale hidden iframes');
+    assert.ok(html.includes("if (!isActiveFrameEvent(event)) return;"), 'Must require an active iframe event before relaying popup URLs');
     assert.ok(html.includes("vscode.postMessage({ type: 'open-external', url: message.url });"), 'Must relay popup URL to the extension host');
-    assert.ok(html.includes("if (event.origin !== iframeOrigin) return;\n                        vscode.postMessage({ type: 'open-external', url: message.url });"), 'Must validate iframe origin before relaying popup URLs');
 });
 
 test('Parent webview HTML: does not embed a static NONCE', () => {

--- a/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
+++ b/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
@@ -75,6 +75,18 @@ test('Bridge script: sends node detail opened messages', () => {
     assert.ok(script.includes('readNodeFromElement'), 'Must extract node context from canvas elements');
 });
 
+test('Bridge script: relays popup openings to the parent webview', () => {
+    const { ProxyService } = require('../../src/services/proxy-service.js');
+    const script: string = ProxyService.buildBridgeScript();
+
+    assert.ok(script.includes('"n8n-open-external"'), 'Must publish popup-open requests');
+    assert.ok(script.includes('window.open = function(url, target, features)'), 'Must intercept window.open calls');
+    assert.ok(script.includes('target.closest("a[href]")'), 'Must intercept target=_blank anchor clicks');
+    assert.ok(script.includes('isAnchorPopupTarget(anchor.getAttribute("target") || "")'), 'Must not intercept ordinary same-frame anchor clicks');
+    assert.ok(script.includes('new URL(url, window.location.href)'), 'Must resolve relative popup URLs against the proxied page');
+    assert.ok(script.includes('absoluteUrl.protocol !== "http:" && absoluteUrl.protocol !== "https:"'), 'Must only relay browser-safe URL schemes');
+});
+
 test('Bridge script: does not validate nonce on incoming paste message', () => {
     // The n8n-clipboard-paste handler in the iframe should accept the message
     // without a nonce check — security is enforced in the parent webview layer.
@@ -360,6 +372,15 @@ test('Parent webview HTML: validates event.origin against iframeOrigin', () => {
 
     assert.ok(html.includes('iframeOrigin'), 'Must declare iframeOrigin');
     assert.ok(html.includes('event.origin !== iframeOrigin'), 'Must reject messages from unknown origins');
+});
+
+test('Parent webview HTML: relays iframe popup requests after origin validation', () => {
+    const { buildWebviewHtml } = require('../../src/ui/webview-html.js');
+    const html: string = buildWebviewHtml('wf-1', 'http://localhost:5678/workflow/wf-1');
+
+    assert.ok(html.includes("message.type === 'n8n-open-external'"), 'Must handle popup bridge messages');
+    assert.ok(html.includes("vscode.postMessage({ type: 'open-external', url: message.url });"), 'Must relay popup URL to the extension host');
+    assert.ok(html.includes("if (event.origin !== iframeOrigin) return;\n                        vscode.postMessage({ type: 'open-external', url: message.url });"), 'Must validate iframe origin before relaying popup URLs');
 });
 
 test('Parent webview HTML: does not embed a static NONCE', () => {

--- a/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
+++ b/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
@@ -83,6 +83,8 @@ test('Bridge script: relays popup openings to the parent webview', () => {
     assert.ok(script.includes('window.open = function(url, target, features)'), 'Must intercept window.open calls');
     assert.ok(script.includes('target.closest("a[href]")'), 'Must intercept target=_blank anchor clicks');
     assert.ok(script.includes('isAnchorPopupTarget(anchor.getAttribute("target") || "")'), 'Must not intercept ordinary same-frame anchor clicks');
+    assert.ok(script.includes('!isSameFrameTarget(normalized)'), 'Must treat named browsing targets as external popups');
+    assert.ok(script.includes('normalized === "_self" || normalized === "_parent" || normalized === "_top"'), 'Must preserve same-frame target semantics');
     assert.ok(script.includes('new URL(url, window.location.href)'), 'Must resolve relative popup URLs against the proxied page');
     assert.ok(script.includes('absoluteUrl.protocol !== "http:" && absoluteUrl.protocol !== "https:"'), 'Must only relay browser-safe URL schemes');
 });
@@ -236,6 +238,17 @@ test('ProxyService: external n8n redirects create browser auth handoff URLs', ()
     assert.ok(handoff.html.includes('Continue n8n sign-in in your browser'), 'Handoff page should explain the browser sign-in step');
 });
 
+test('ProxyService: external auth handoff page receives popup bridge injection', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const source = fs.readFileSync(path.join(__dirname, '../../src/services/proxy-service.ts'), 'utf8');
+
+    assert.ok(
+        source.includes("httpRes.end(this.injectClipboardBridge(handoff.html, false, false, 'auth-route'))"),
+        'External auth fallback HTML must include the popup bridge for manual browser sign-in links',
+    );
+});
+
 test('ProxyService: external auth redirects remain proxied until n8n callback returns', () => {
     const { ProxyService } = require('../../src/services/proxy-service.js');
     const service = new ProxyService();
@@ -366,12 +379,13 @@ test('Parent webview HTML: includes paste rate limiting', () => {
     assert.ok(html.includes('_lastPasteMs'), 'Must track last paste timestamp');
 });
 
-test('Parent webview HTML: validates event.origin against iframeOrigin', () => {
+test('Parent webview HTML: validates iframe messages against the active frame', () => {
     const { buildWebviewHtml } = require('../../src/ui/webview-html.js');
     const html: string = buildWebviewHtml('wf-1', 'http://localhost:5678/workflow/wf-1');
 
     assert.ok(html.includes('iframeOrigin'), 'Must declare iframeOrigin');
-    assert.ok(html.includes('event.origin !== iframeOrigin'), 'Must reject messages from unknown origins');
+    assert.ok(html.includes('event.origin === iframeOrigin'), 'Must reject messages from unknown origins');
+    assert.ok(html.includes('event.source === activeFrame.contentWindow'), 'Must reject messages from stale same-origin iframes');
 });
 
 test('Parent webview HTML: relays iframe popup requests after origin validation', () => {
@@ -384,6 +398,20 @@ test('Parent webview HTML: relays iframe popup requests after origin validation'
     assert.ok(html.includes('event.source === activeFrame.contentWindow'), 'Must reject popup requests from stale hidden iframes');
     assert.ok(html.includes("if (!isActiveFrameEvent(event)) return;"), 'Must require an active iframe event before relaying popup URLs');
     assert.ok(html.includes("vscode.postMessage({ type: 'open-external', url: message.url });"), 'Must relay popup URL to the extension host');
+});
+
+test('Parent webview HTML: validates active iframe before clipboard operations', () => {
+    const { buildWebviewHtml } = require('../../src/ui/webview-html.js');
+    const html: string = buildWebviewHtml('wf-1', 'http://localhost:5678/workflow/wf-1');
+
+    assert.ok(
+        html.includes("if (message.type === 'n8n-paste-request') {\n                        if (!isActiveFrameEvent(event)) return;"),
+        'Paste requests must come from the active iframe, not a stale same-origin frame',
+    );
+    assert.ok(
+        html.includes("if (message.type === 'n8n-clipboard-write' && typeof message.text === 'string') {\n                        if (!isActiveFrameEvent(event)) return;"),
+        'Clipboard writes must come from the active iframe, not a stale same-origin frame',
+    );
 });
 
 test('Parent webview HTML: does not embed a static NONCE', () => {


### PR DESCRIPTION
## Summary
- Add webview popup handoff support through the VS Code proxy service and webview bridge.
- Add a resizable agent split view for popup-style workflow interactions.
- Cover the popup bridge and agent workbench behavior with unit tests.

## Tests
- Not run in this session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resizable split pane between chat and workflow panels with persisted width and keyboard support (arrow/home/end).
  * Safer external-link handling: in-page popup interception and forwarding of approved http/https URLs to VS Code; active-frame origin checks to ensure only the current workflow frame can request external openings.
  * Clipboard/clipboard-bridge injection now included in external auth handoffs.

* **Tests**
  * Added unit tests for split-pane behavior, popup relay flow, origin/active-frame validation, and external-open handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->