### PR TITLE
Support folder-aware workflow sync

### DIFF
--- a/docs/docs/usage/folder-sync.md
+++ b/docs/docs/usage/folder-sync.md
@@ -1,0 +1,88 @@
+---
+title: Folder Sync
+---
+
+# Folder Sync
+
+`folderSync` mirrors your local directory structure onto n8n: a workflow stored at
+`Reports/Weekly/summary.workflow.ts` is created — or moved — into the `Reports/Weekly`
+folder on the instance, creating the folders if they do not exist yet.
+
+It is **push-only**, and that is a property of n8n's public API rather than a choice
+we made. Read the section below before enabling it, because it determines what you
+can expect from `pull`.
+
+## What works, and what cannot
+
+| Operation | Supported | Since |
+| --- | --- | --- |
+| List a project's folders | Yes | n8n 2.19 |
+| Create a folder | Yes | n8n 2.19 |
+| Create a workflow inside a folder | Yes | n8n 2.32 |
+| Move a workflow between folders, or back to the root | Yes | n8n 2.32 |
+| Read which folder a workflow is in | **No** | — |
+
+The last row is the one that shapes everything else. In n8n's public API,
+`parentFolderId` is declared `writeOnly`: the workflow read endpoints never load the
+folder relation, and no endpoint maps workflows to folders. This is true on every
+edition, self-hosted and Cloud, **including Enterprise** — it is a missing endpoint,
+not a licence gate.
+
+Consequences:
+
+- **Push** carries your folder layout to n8n. This direction is complete.
+- **Pull** cannot restore it. A workflow created in the n8n UI inside a folder is
+  pulled to the root of your workflows directory. Move it where you want it once,
+  and the next push pins that placement on n8n.
+- Workflows already tracked in `.n8n-state.json` keep their local path across pulls,
+  so an existing nested layout is never flattened.
+- `n8nac status` cannot report "someone moved this workflow in the UI". Drift in that
+  direction is invisible until the next push overwrites it.
+
+## Requirements
+
+- **n8n 2.32 or newer** to place workflows in folders. On older versions the push
+  still succeeds: n8n rejects the field, n8nac retries without it, and the workflow
+  lands at the project root with a warning.
+- **Folders enabled on the instance.** Folders are unlocked by registering the
+  Community edition (free, email registration) and are present on all paid plans. On
+  an unregistered instance the folder endpoints answer `403` and n8nac degrades to a
+  flat push with a warning.
+- **An API key only.** No session login is required. The project id is read from a
+  workflow's `shared[]` payload, so the Enterprise-gated `GET /api/v1/projects`
+  endpoint is never called.
+
+## Configuration
+
+Both flags live on the workspace environment in `n8nac-config.json`:
+
+```json
+{
+  "environments": [
+    {
+      "name": "prod",
+      "folderSync": true,
+      "folderSyncMoveToRoot": false
+    }
+  ]
+}
+```
+
+`folderSync` (default `false`)
+: Mirror local folders onto n8n when pushing.
+
+`folderSyncMoveToRoot` (default `false`)
+: Also move a workflow **out** of its remote folder when its local file sits at the
+root of the workflows directory (sends `parentFolderId: null`).
+
+Leave `folderSyncMoveToRoot` off unless the repository is the sole source of truth
+for organisation. With it off, a push only ever places workflows the repository has
+an opinion about, and never undoes a folder someone created in the n8n UI. With it
+on, the repository layout wins outright: local root means project root.
+
+## Naming
+
+Folder names are sanitised into path segments: filesystem-unsafe characters are
+replaced, Windows reserved names are escaped, and two sibling folders whose names
+collide case-insensitively are disambiguated with a short id suffix. The mapping is
+deterministic, so the same remote tree always produces the same local paths.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -65,6 +65,11 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'doc',
+          id: 'usage/folder-sync',
+          label: 'Folder Sync',
+        },
+        {
+          type: 'doc',
           id: 'usage/claude-plugin-privacy',
           label: 'Claude Plugin Privacy',
         },

--- a/packages/cli/src/commands/base.ts
+++ b/packages/cli/src/commands/base.ts
@@ -108,6 +108,8 @@ export class BaseCommand {
         let apiKey: string;
         let directory: string;
         let folderSync: boolean;
+        let folderSyncMoveToRoot: boolean;
+
         // If --env <name> was passed as a global option, resolve that workspace
         // environment; otherwise use the V4 active environment.
         const requestedEnvironment = process.env.N8NAC_ENVIRONMENT?.trim() || undefined;
@@ -135,6 +137,7 @@ export class BaseCommand {
         }
         directory = resolvedEnvironment.workflowsPath;
         folderSync = resolvedEnvironment.folderSync ?? false;
+        folderSyncMoveToRoot = resolvedEnvironment.folderSyncMoveToRoot ?? false;
         this.instanceIdentifier = resolvedEnvironment.instanceIdentifier || null;
         this.instanceUserIdentifier = resolvedEnvironment.instanceUserIdentifier || null;
 
@@ -146,6 +149,7 @@ export class BaseCommand {
             host,
             apiKeyConfigured: Boolean(apiKey),
             folderSync,
+            folderSyncMoveToRoot,
         };
         this.runtimePrepared = false;
 
@@ -233,6 +237,7 @@ export class BaseCommand {
             projectId: localConfig.projectId,
             projectName: localConfig.projectName,
             folderSync: localConfig.folderSync ?? false,
+            folderSyncMoveToRoot: localConfig.folderSyncMoveToRoot ?? false,
             environmentId: this.activeEnvironment?.environmentId,
             environmentName: this.activeEnvironment?.environmentName,
             environmentTargetId: this.activeEnvironment?.environmentTargetId,
@@ -269,6 +274,7 @@ export class BaseCommand {
                 host: context.host,
                 apiKeyConfigured: true,
                 folderSync: context.folderSync ?? false,
+                folderSyncMoveToRoot: (context as any).folderSyncMoveToRoot ?? false,
             };
             this.runtimePrepared = true;
         } catch (error) {

--- a/packages/cli/src/core/index.ts
+++ b/packages/cli/src/core/index.ts
@@ -13,5 +13,6 @@ export * from './services/workflow-dir-name.js';
 export * from './services/instance-identifier.js';
 export * from './services/tls-certificates.js';
 export * from './services/workspace-setup-service.js';
+export * from './services/workflow-path-utils.js';
+export * from './services/folder-path-resolver.js';
 export * from './helpers/index.js';
-

--- a/packages/cli/src/core/index.ts
+++ b/packages/cli/src/core/index.ts
@@ -12,5 +12,6 @@ export * from './services/directory-utils.js';
 export * from './services/workflow-dir-name.js';
 export * from './services/instance-identifier.js';
 export * from './services/workspace-setup-service.js';
+export * from './services/workflow-path-utils.js';
+export * from './services/folder-path-resolver.js';
 export * from './helpers/index.js';
-

--- a/packages/cli/src/core/services/folder-path-resolver.ts
+++ b/packages/cli/src/core/services/folder-path-resolver.ts
@@ -1,0 +1,95 @@
+import { IFolder, IWorkflow } from '../types.js';
+
+const WINDOWS_RESERVED_FILENAMES = new Set([
+    'CON', 'PRN', 'AUX', 'NUL',
+    'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
+    'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9',
+]);
+
+export function sanitizePathSegment(name: string): string {
+    let safeName = (name || '')
+        .replace(/[\u0000-\u001f\u007f<>:"/\\|?*]/g, '_')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .replace(/[. ]+$/g, '');
+
+    if (!safeName || safeName === '.' || safeName === '..') safeName = 'folder';
+
+    const firstDotIndex = safeName.indexOf('.');
+    const baseName = firstDotIndex === -1 ? safeName : safeName.slice(0, firstDotIndex);
+    const rest = firstDotIndex === -1 ? '' : safeName.slice(firstDotIndex);
+    if (WINDOWS_RESERVED_FILENAMES.has(baseName.toUpperCase())) {
+        safeName = `${baseName}_${rest}`;
+    }
+
+    return safeName.replace(/[. ]+$/g, '') || 'folder';
+}
+
+export class FolderPathResolver {
+    private foldersById = new Map<string, IFolder>();
+    private memo = new Map<string, string[]>();
+    private siblingSegmentById = new Map<string, string>();
+
+    constructor(folders: IFolder[]) {
+        for (const folder of folders) {
+            if (folder?.id) this.foldersById.set(folder.id, folder);
+        }
+        this.buildSiblingSegments(folders);
+    }
+
+    getPathForWorkflow(workflow: IWorkflow): string[] {
+        const folderId = workflow.parentFolderId ?? workflow.parentFolder?.id ?? null;
+        if (!folderId) return [];
+        return this.getPathForFolderId(folderId);
+    }
+
+    getPathForFolderId(folderId: string): string[] {
+        return this.resolve(folderId, new Set());
+    }
+
+    private buildSiblingSegments(folders: IFolder[]): void {
+        const siblings = new Map<string, IFolder[]>();
+        for (const folder of folders) {
+            const parentKey = folder.parentFolderId ?? '';
+            const current = siblings.get(parentKey) ?? [];
+            current.push(folder);
+            siblings.set(parentKey, current);
+        }
+
+        for (const group of siblings.values()) {
+            const used = new Map<string, string>();
+            for (const folder of group.sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id))) {
+                const base = sanitizePathSegment(folder.name);
+                let segment = base;
+                const existingId = used.get(segment.toLowerCase());
+                if (existingId && existingId !== folder.id) {
+                    segment = `${base}_${folder.id.slice(0, 8)}`;
+                }
+                used.set(segment.toLowerCase(), folder.id);
+                this.siblingSegmentById.set(folder.id, segment);
+            }
+        }
+    }
+
+    private resolve(folderId: string, seen: Set<string>): string[] {
+        const cached = this.memo.get(folderId);
+        if (cached) return cached;
+
+        const folder = this.foldersById.get(folderId);
+        if (!folder || seen.has(folderId)) {
+            const fallback = ['_Unresolved Folder', sanitizePathSegment(folderId)];
+            this.memo.set(folderId, fallback);
+            return fallback;
+        }
+
+        seen.add(folderId);
+        const parentSegments = folder.parentFolderId
+            ? this.resolve(folder.parentFolderId, seen)
+            : [];
+        const segment = this.siblingSegmentById.get(folderId) ?? sanitizePathSegment(folder.name);
+        const segments = [...parentSegments, segment];
+        this.memo.set(folderId, segments);
+        seen.delete(folderId);
+        return segments;
+    }
+}

--- a/packages/cli/src/core/services/folder-path-resolver.ts
+++ b/packages/cli/src/core/services/folder-path-resolver.ts
@@ -6,6 +6,14 @@ const WINDOWS_RESERVED_FILENAMES = new Set([
     'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9',
 ]);
 
+/**
+ * Turns an n8n folder name into a path segment that is safe on every platform.
+ *
+ * Replaces filesystem-reserved characters, collapses whitespace, strips trailing
+ * dots and spaces (which Windows silently drops), and escapes reserved device
+ * names such as `CON` or `LPT1`. Never returns an empty string — unusable names
+ * fall back to `folder`.
+ */
 export function sanitizePathSegment(name: string): string {
     let safeName = (name || '')
         .replace(/[\u0000-\u001f\u007f<>:"/\\|?*]/g, '_')
@@ -25,6 +33,17 @@ export function sanitizePathSegment(name: string): string {
     return safeName.replace(/[. ]+$/g, '') || 'folder';
 }
 
+/**
+ * Turns a flat list of n8n folders into local path segments.
+ *
+ * Resolution is deterministic: the same remote tree always yields the same local
+ * layout. Two siblings whose sanitised names collide case-insensitively (which
+ * would be the same directory on Windows and macOS) are disambiguated with a
+ * short id suffix, and results are memoised per folder id.
+ *
+ * Only useful once n8n reports a workflow's folder — see the note on
+ * WorkflowStateTracker.createFolderResolver.
+ */
 export class FolderPathResolver {
     private foldersById = new Map<string, IFolder>();
     private memo = new Map<string, string[]>();
@@ -37,16 +56,28 @@ export class FolderPathResolver {
         this.buildSiblingSegments(folders);
     }
 
+    /**
+     * Path segments for the folder a workflow lives in.
+     *
+     * @returns Segments from the project root down, or an empty array when the
+     * workflow sits at the root or carries no folder information.
+     */
     getPathForWorkflow(workflow: IWorkflow): string[] {
         const folderId = workflow.parentFolderId ?? workflow.parentFolder?.id ?? null;
         if (!folderId) return [];
         return this.getPathForFolderId(folderId);
     }
 
+    /** Path segments for a folder id, root first. */
     getPathForFolderId(folderId: string): string[] {
         return this.resolve(folderId, new Set());
     }
 
+    /**
+     * Precomputes one segment per folder, disambiguating case-insensitive
+     * collisions between siblings. Sorted by name then id so the folder that
+     * keeps the plain name is stable across runs.
+     */
     private buildSiblingSegments(folders: IFolder[]): void {
         const siblings = new Map<string, IFolder[]>();
         for (const folder of folders) {
@@ -71,6 +102,13 @@ export class FolderPathResolver {
         }
     }
 
+    /**
+     * Walks a folder up to the root, memoising each result.
+     *
+     * `seen` guards against a cycle in the remote data: a folder that cannot be
+     * resolved — unknown id or a loop — lands under `_Unresolved Folder` rather
+     * than recursing forever.
+     */
     private resolve(folderId: string, seen: Set<string>): string[] {
         const cached = this.memo.get(folderId);
         if (cached) return cached;

--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -4,7 +4,7 @@ import * as http from 'http';
 import * as https from 'https';
 import * as tls from 'tls';
 import { resolveExtraCaCertificates, shouldVerifyServerCertificate } from './tls-certificates.js';
-import { IN8nCredentials, IWorkflow, IProject, ITag, ITriggerInfo, ITestPlan, ITestResult, TriggerType, IInferredPayload, IInferredPayloadField, IExecutionDetails, IExecutionList, IExecutionSummary, ExecutionStatus, IFolder, IFolderCapability } from '../types.js';
+import { IN8nCredentials, IWorkflow, IProject, ITag, ITriggerInfo, ITestPlan, ITestResult, TriggerType, IInferredPayload, IInferredPayloadField, IExecutionDetails, IExecutionList, IExecutionSummary, ExecutionStatus, IFolder } from '../types.js';
 
 type AgentLookup = NonNullable<http.AgentOptions['lookup']>;
 
@@ -57,6 +57,8 @@ export class N8nApiClient {
     private projectsCache: Map<string, IProject> | null = null;
     private projectsCachePromise: Promise<Map<string, IProject>> | null = null;
     private static readonly PERSONAL_PROJECT_PLACEHOLDER_ID = 'personal';
+    /** Memoized result of resolveFolderProjectId(); `null` means "resolved to nothing". */
+    private folderProjectIdPromise: Promise<string | null> | null = null;
     /** Shared agents keep DNS/TLS behavior consistent for API, health, and webhook calls. */
     private httpAgent: http.Agent;
     private httpsAgent: https.Agent;
@@ -320,7 +322,13 @@ export class N8nApiClient {
                 take: String(take),
             };
             if (useSelect) {
-                params.select = JSON.stringify(['id', 'name', 'parentFolderId', 'path', 'createdAt', 'updatedAt']);
+                // Field names come from n8n's ListFolderQueryDto allow-list
+                // (id, name, createdAt, updatedAt, project, tags, parentFolder,
+                // workflowCount, subFolderCount, path). `parentFolderId` is NOT
+                // a valid select field — asking for it makes n8n reject the whole
+                // query with a 400, which used to send every call through the
+                // no-select fallback below.
+                params.select = JSON.stringify(['id', 'name', 'parentFolder', 'path', 'createdAt', 'updatedAt']);
             }
 
             let res: any;
@@ -373,28 +381,39 @@ export class N8nApiClient {
         };
     }
 
-    async getFolderCapability(projectId: string): Promise<IFolderCapability> {
-        let folders = false;
-        try {
-            await this.client.get(`/api/v1/projects/${encodeURIComponent(projectId)}/folders`, {
-                params: { take: '1' },
-            });
-            folders = true;
-        } catch (error: any) {
-            if (![403, 404].includes(error?.response?.status)) throw error;
+    /**
+     * Resolves a project id usable with the folder endpoints.
+     *
+     * `GET /api/v1/projects` is gated behind `feat:projectRole:admin` (Business /
+     * Enterprise), and `GET /projects/:id/folders` does not accept the `personal`
+     * alias that `POST` does — so on a Community instance we have no direct way to
+     * name our own project. Workflow payloads carry it though: the public API loads
+     * the `shared` relation, and `shared[0].projectId` is the owning project.
+     *
+     * Returns null when nothing could be resolved (e.g. no workflows exist yet), in
+     * which case callers should skip folder assignment rather than fail the sync.
+     */
+    async resolveFolderProjectId(preferredProjectId?: string): Promise<string | null> {
+        if (preferredProjectId && !this.isPlaceholderPersonalProjectId(preferredProjectId)) {
+            return preferredProjectId;
         }
 
-        let workflowFolderFields = false;
-        try {
-            const res = await this.client.get('/api/v1/workflows', { params: { limit: 1 } });
-            const data = res.data && res.data.data ? res.data.data : (Array.isArray(res.data) ? res.data : []);
-            const workflow = Array.isArray(data) ? data[0] : undefined;
-            workflowFolderFields = !!(workflow && ('parentFolderId' in workflow || 'parentFolder' in workflow));
-        } catch {
-            workflowFolderFields = false;
-        }
+        this.folderProjectIdPromise ??= (async () => {
+            try {
+                const res = await this.client.get('/api/v1/workflows', { params: { limit: 1 } });
+                const data = res.data?.data ?? (Array.isArray(res.data) ? res.data : []);
+                const workflow = Array.isArray(data) ? data[0] : undefined;
+                const shared = Array.isArray(workflow?.shared) ? workflow.shared[0] : undefined;
+                return shared?.projectId ?? shared?.project?.id ?? null;
+            } catch (error: any) {
+                if (process.env.DEBUG) {
+                    console.debug(`[N8nApiClient] Could not resolve project id from workflows: ${error?.message || error}`);
+                }
+                return null;
+            }
+        })();
 
-        return { folders, workflowFolderFields };
+        return await this.folderProjectIdPromise;
     }
 
     /**

--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -309,6 +309,16 @@ export class N8nApiClient {
         }
     }
 
+    /**
+     * Lists every folder in a project, following n8n's skip/take pagination.
+     *
+     * Requires an instance where folders are licensed (`feat:folders`, unlocked by
+     * the free Community registration) and n8n 2.19+; callers are expected to
+     * handle 403/404 by falling back to a flat layout.
+     *
+     * @param projectId Real project id — the endpoint does not accept the
+     * `personal` alias that folder creation does. See resolveFolderProjectId().
+     */
     async getFolders(projectId: string): Promise<IFolder[]> {
         const folders: IFolder[] = [];
         const seen = new Set<string>();
@@ -367,6 +377,14 @@ export class N8nApiClient {
         return folders;
     }
 
+    /**
+     * Creates a folder in a project.
+     *
+     * @param projectId Project id, or `personal` to target the calling user's own
+     * project (n8n 2.32+).
+     * @param input `parentFolderId` nests the new folder; omit it for a
+     * project-root folder.
+     */
     async createFolder(projectId: string, input: { name: string; parentFolderId?: string | null }): Promise<IFolder> {
         const payload: Record<string, unknown> = { name: input.name };
         if (input.parentFolderId) payload.parentFolderId = input.parentFolderId;

--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -4,7 +4,7 @@ import * as http from 'http';
 import * as https from 'https';
 import * as tls from 'tls';
 import { resolveExtraCaCertificates, shouldVerifyServerCertificate } from './tls-certificates.js';
-import { IN8nCredentials, IWorkflow, IProject, ITag, ITriggerInfo, ITestPlan, ITestResult, TriggerType, IInferredPayload, IInferredPayloadField, IExecutionDetails, IExecutionList, IExecutionSummary, ExecutionStatus } from '../types.js';
+import { IN8nCredentials, IWorkflow, IProject, ITag, ITriggerInfo, ITestPlan, ITestResult, TriggerType, IInferredPayload, IInferredPayloadField, IExecutionDetails, IExecutionList, IExecutionSummary, ExecutionStatus, IFolder, IFolderCapability } from '../types.js';
 
 type AgentLookup = NonNullable<http.AgentOptions['lookup']>;
 
@@ -307,6 +307,96 @@ export class N8nApiClient {
         }
     }
 
+    async getFolders(projectId: string): Promise<IFolder[]> {
+        const folders: IFolder[] = [];
+        const seen = new Set<string>();
+        let skip = 0;
+        const take = 100;
+        let useSelect = true;
+
+        while (true) {
+            const params: Record<string, string> = {
+                skip: String(skip),
+                take: String(take),
+            };
+            if (useSelect) {
+                params.select = JSON.stringify(['id', 'name', 'parentFolderId', 'path', 'createdAt', 'updatedAt']);
+            }
+
+            let res: any;
+            try {
+                res = await this.client.get(`/api/v1/projects/${encodeURIComponent(projectId)}/folders`, { params });
+            } catch (error: any) {
+                if (useSelect && error?.response?.status === 400) {
+                    useSelect = false;
+                    continue;
+                }
+                throw error;
+            }
+
+            const data = Array.isArray(res.data?.data) ? res.data.data : (Array.isArray(res.data) ? res.data : []);
+            const beforeCount = folders.length;
+            for (const folder of data) {
+                if (!folder?.id || seen.has(folder.id)) continue;
+                seen.add(folder.id);
+                folders.push({
+                    id: folder.id,
+                    name: folder.name ?? 'Folder',
+                    parentFolderId: folder.parentFolderId ?? folder.parentFolder?.id ?? null,
+                    path: folder.path,
+                    createdAt: folder.createdAt,
+                    updatedAt: folder.updatedAt,
+                });
+            }
+
+            const count = typeof res.data?.count === 'number' ? res.data.count : undefined;
+            if (count !== undefined && folders.length >= count) break;
+            if (folders.length === beforeCount) break;
+            if (data.length === 0 || (count === undefined && data.length < take)) break;
+            skip += take;
+        }
+
+        return folders;
+    }
+
+    async createFolder(projectId: string, input: { name: string; parentFolderId?: string | null }): Promise<IFolder> {
+        const payload: Record<string, unknown> = { name: input.name };
+        if (input.parentFolderId) payload.parentFolderId = input.parentFolderId;
+        const res = await this.client.post(`/api/v1/projects/${encodeURIComponent(projectId)}/folders`, payload);
+        return {
+            id: res.data.id,
+            name: res.data.name,
+            parentFolderId: res.data.parentFolderId ?? res.data.parentFolder?.id ?? null,
+            path: res.data.path,
+            createdAt: res.data.createdAt,
+            updatedAt: res.data.updatedAt,
+        };
+    }
+
+    async getFolderCapability(projectId: string): Promise<IFolderCapability> {
+        let folders = false;
+        try {
+            await this.client.get(`/api/v1/projects/${encodeURIComponent(projectId)}/folders`, {
+                params: { take: '1' },
+            });
+            folders = true;
+        } catch (error: any) {
+            if (![403, 404].includes(error?.response?.status)) throw error;
+        }
+
+        let workflowFolderFields = false;
+        try {
+            const res = await this.client.get('/api/v1/workflows', { params: { limit: 1 } });
+            const data = res.data && res.data.data ? res.data.data : (Array.isArray(res.data) ? res.data : []);
+            const workflow = Array.isArray(data) ? data[0] : undefined;
+            workflowFolderFields = !!(workflow && ('parentFolderId' in workflow || 'parentFolder' in workflow));
+        } catch {
+            workflowFolderFields = false;
+        }
+
+        return { folders, workflowFolderFields };
+    }
+
     /**
      * Fetches all projects from n8n and caches them.
      * Returns a Map of projectId -> IProject for quick lookups.
@@ -584,6 +674,23 @@ export class N8nApiClient {
         if (workflow.isArchived !== undefined) {
             enriched.isArchived = workflow.isArchived;
         }
+
+        if ('parentFolderId' in workflow) {
+            enriched.parentFolderId = workflow.parentFolderId ?? null;
+        } else if (workflow.parentFolder?.id) {
+            enriched.parentFolderId = workflow.parentFolder.id;
+        }
+
+        if ('parentFolder' in workflow) {
+            enriched.parentFolder = workflow.parentFolder ?? null;
+        }
+        if (workflow.folderPath && Array.isArray(workflow.folderPath)) {
+            enriched.folderPath = workflow.folderPath;
+            enriched.folderPathString = workflow.folderPath.join('/');
+        } else if (typeof workflow.folderPathString === 'string') {
+            enriched.folderPathString = workflow.folderPathString;
+            enriched.folderPath = workflow.folderPathString.split('/').filter(Boolean);
+        }
         
         return enriched;
     }
@@ -624,6 +731,7 @@ export class N8nApiClient {
             'settings',
             'staticData',
             'projectId',
+            'parentFolderId',
         ]);
 
         const clean: Record<string, unknown> = {};

--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -847,6 +847,10 @@ export class N8nApiClient {
             'settings',
             'staticData',
             'pinData',
+            // parentFolderId is forwarded on update so a folderSync push of an
+            // already-tracked workflow moves it to the inferred folder on n8n.
+            // The create path was already wired up; the update path was missing.
+            'parentFolderId',
         ]);
 
         const clean: Record<string, unknown> = {};

--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance } from 'axios';
 import * as dns from 'dns';
 import * as http from 'http';
 import * as https from 'https';
-import { IN8nCredentials, IWorkflow, IProject, ITag, ITriggerInfo, ITestPlan, ITestResult, TriggerType, IInferredPayload, IInferredPayloadField, IExecutionDetails, IExecutionList, IExecutionSummary, ExecutionStatus } from '../types.js';
+import { IN8nCredentials, IWorkflow, IProject, ITag, ITriggerInfo, ITestPlan, ITestResult, TriggerType, IInferredPayload, IInferredPayloadField, IExecutionDetails, IExecutionList, IExecutionSummary, ExecutionStatus, IFolder, IFolderCapability } from '../types.js';
 
 type AgentLookup = NonNullable<http.AgentOptions['lookup']>;
 
@@ -266,6 +266,96 @@ export class N8nApiClient {
             console.error(`[N8nApiClient] Failed to fetch projects: ${error.message}`);
             return [];
         }
+    }
+
+    async getFolders(projectId: string): Promise<IFolder[]> {
+        const folders: IFolder[] = [];
+        const seen = new Set<string>();
+        let skip = 0;
+        const take = 100;
+        let useSelect = true;
+
+        while (true) {
+            const params: Record<string, string> = {
+                skip: String(skip),
+                take: String(take),
+            };
+            if (useSelect) {
+                params.select = JSON.stringify(['id', 'name', 'parentFolderId', 'path', 'createdAt', 'updatedAt']);
+            }
+
+            let res: any;
+            try {
+                res = await this.client.get(`/api/v1/projects/${encodeURIComponent(projectId)}/folders`, { params });
+            } catch (error: any) {
+                if (useSelect && error?.response?.status === 400) {
+                    useSelect = false;
+                    continue;
+                }
+                throw error;
+            }
+
+            const data = Array.isArray(res.data?.data) ? res.data.data : (Array.isArray(res.data) ? res.data : []);
+            const beforeCount = folders.length;
+            for (const folder of data) {
+                if (!folder?.id || seen.has(folder.id)) continue;
+                seen.add(folder.id);
+                folders.push({
+                    id: folder.id,
+                    name: folder.name ?? 'Folder',
+                    parentFolderId: folder.parentFolderId ?? folder.parentFolder?.id ?? null,
+                    path: folder.path,
+                    createdAt: folder.createdAt,
+                    updatedAt: folder.updatedAt,
+                });
+            }
+
+            const count = typeof res.data?.count === 'number' ? res.data.count : undefined;
+            if (count !== undefined && folders.length >= count) break;
+            if (folders.length === beforeCount) break;
+            if (data.length === 0 || (count === undefined && data.length < take)) break;
+            skip += take;
+        }
+
+        return folders;
+    }
+
+    async createFolder(projectId: string, input: { name: string; parentFolderId?: string | null }): Promise<IFolder> {
+        const payload: Record<string, unknown> = { name: input.name };
+        if (input.parentFolderId) payload.parentFolderId = input.parentFolderId;
+        const res = await this.client.post(`/api/v1/projects/${encodeURIComponent(projectId)}/folders`, payload);
+        return {
+            id: res.data.id,
+            name: res.data.name,
+            parentFolderId: res.data.parentFolderId ?? res.data.parentFolder?.id ?? null,
+            path: res.data.path,
+            createdAt: res.data.createdAt,
+            updatedAt: res.data.updatedAt,
+        };
+    }
+
+    async getFolderCapability(projectId: string): Promise<IFolderCapability> {
+        let folders = false;
+        try {
+            await this.client.get(`/api/v1/projects/${encodeURIComponent(projectId)}/folders`, {
+                params: { take: '1' },
+            });
+            folders = true;
+        } catch (error: any) {
+            if (![403, 404].includes(error?.response?.status)) throw error;
+        }
+
+        let workflowFolderFields = false;
+        try {
+            const res = await this.client.get('/api/v1/workflows', { params: { limit: 1 } });
+            const data = res.data && res.data.data ? res.data.data : (Array.isArray(res.data) ? res.data : []);
+            const workflow = Array.isArray(data) ? data[0] : undefined;
+            workflowFolderFields = !!(workflow && ('parentFolderId' in workflow || 'parentFolder' in workflow));
+        } catch {
+            workflowFolderFields = false;
+        }
+
+        return { folders, workflowFolderFields };
     }
 
     /**
@@ -545,6 +635,23 @@ export class N8nApiClient {
         if (workflow.isArchived !== undefined) {
             enriched.isArchived = workflow.isArchived;
         }
+
+        if ('parentFolderId' in workflow) {
+            enriched.parentFolderId = workflow.parentFolderId ?? null;
+        } else if (workflow.parentFolder?.id) {
+            enriched.parentFolderId = workflow.parentFolder.id;
+        }
+
+        if ('parentFolder' in workflow) {
+            enriched.parentFolder = workflow.parentFolder ?? null;
+        }
+        if (workflow.folderPath && Array.isArray(workflow.folderPath)) {
+            enriched.folderPath = workflow.folderPath;
+            enriched.folderPathString = workflow.folderPath.join('/');
+        } else if (typeof workflow.folderPathString === 'string') {
+            enriched.folderPathString = workflow.folderPathString;
+            enriched.folderPath = workflow.folderPathString.split('/').filter(Boolean);
+        }
         
         return enriched;
     }
@@ -585,6 +692,7 @@ export class N8nApiClient {
             'settings',
             'staticData',
             'projectId',
+            'parentFolderId',
         ]);
 
         const clean: Record<string, unknown> = {};

--- a/packages/cli/src/core/services/resolution-manager.ts
+++ b/packages/cli/src/core/services/resolution-manager.ts
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import path from 'path';
 import { SyncEngine } from './sync-engine.js';
 import { WorkflowStateTracker } from './workflow-state-tracker.js';
 import { WorkflowSanitizer } from './workflow-sanitizer.js';
@@ -7,6 +6,7 @@ import { HashUtils } from './hash-utils.js';
 import { WorkflowTransformerAdapter } from './workflow-transformer-adapter.js';
 import { WorkflowSyncStatus } from '../types.js';
 import { N8nApiClient } from './n8n-api-client.js';
+import { workflowRelativePathToAbsolute } from './workflow-path-utils.js';
 
 /**
  * Resolution & Validation Manager
@@ -67,7 +67,7 @@ export class ResolutionManager {
         remoteHash: string;
     }> {
         // Get local content
-        const filePath = path.join(this.directory, filename);
+        const filePath = workflowRelativePathToAbsolute(this.directory, filename);
         const localContent = this.readJsonFile(filePath);
         
         // Get remote content
@@ -147,7 +147,7 @@ export class ResolutionManager {
     }> {
         // Recompute local hash from disk — do NOT use the in-memory cache which may be
         // stale in VSCode mode (change events are suppressed by the file system watcher).
-        const filePath = path.join(this.directory, filename);
+        const filePath = workflowRelativePathToAbsolute(this.directory, filename);
         let localHash: string | undefined;
         if (fs.existsSync(filePath)) {
             try {
@@ -168,7 +168,7 @@ export class ResolutionManager {
 
         return {
             status,
-            localExists: !!localHash || fs.existsSync(path.join(this.directory, filename)),
+            localExists: !!localHash || fs.existsSync(workflowRelativePathToAbsolute(this.directory, filename)),
             remoteExists: !!remoteHash || (this.watcher as any).remoteIds?.has(workflowId),
             lastSyncedHash,
             localHash,

--- a/packages/cli/src/core/services/state-manager.ts
+++ b/packages/cli/src/core/services/state-manager.ts
@@ -5,7 +5,7 @@ import { IWorkflow } from '../types.js';
 export interface IWorkflowState {
     lastSyncedHash: string;
     lastSyncedAt: string;
-    /** Recovery hint: last known local filename for this workflow ID. */
+    /** Recovery hint: sync-root-relative local workflow path for this workflow ID. */
     filename?: string;
 }
 

--- a/packages/cli/src/core/services/sync-engine.ts
+++ b/packages/cli/src/core/services/sync-engine.ts
@@ -5,7 +5,7 @@ import { WorkflowTransformerAdapter } from './workflow-transformer-adapter.js';
 import { HashUtils } from './hash-utils.js';
 import { WorkflowStateTracker } from './workflow-state-tracker.js';
 import { SyncEventJournal } from './sync-event-journal.js';
-import { WorkflowSyncStatus, IWorkflow } from '../types.js';
+import { WorkflowSyncStatus, IWorkflow, IFolder } from '../types.js';
 import { ensureParentDirectory, normalizeWorkflowRelativePath, workflowRelativePathToAbsolute } from './workflow-path-utils.js';
 
 /**
@@ -25,6 +25,17 @@ export class SyncEngine {
     private projectId: string;
     private syncEventJournal: SyncEventJournal | undefined;
     private folderSync: boolean;
+    /**
+     * In-flight `createFolder` requests, keyed by
+     * `${projectId}::${parentFolderId ?? ''}::${name}`.
+     *
+     * Multiple concurrent `push()` calls that need the same parent folder
+     * (e.g. `AI Chat/x.workflow.ts` and `AI Chat/y.workflow.ts`) deduplicate
+     * their `createFolder` round-trips through this map so we never POST
+     * twice for the same folder — even if two invocations interleave after
+     * `getFolders` returns an empty array.
+     */
+    private inFlightFolderCreates: Map<string, Promise<IFolder>> = new Map();
 
     constructor(
         client: N8nApiClient,
@@ -304,7 +315,8 @@ export class SyncEngine {
         } catch (error: any) {
             if (!localWf.parentFolderId || !this.isUnsupportedParentFolderError(error)) throw error;
             console.warn(`[SyncEngine] n8n rejected parentFolderId while creating "${filename}"; retrying without folder assignment.`);
-            delete (localWf as any).parentFolderId;
+            // parentFolderId is a known IWorkflow field; strip it without an `any` cast.
+            delete localWf.parentFolderId;
             newWf = await this.client.createWorkflow(localWf);
         }
         if (!newWf || !newWf.id) {
@@ -328,34 +340,87 @@ export class SyncEngine {
         const normalized = normalizeWorkflowRelativePath(filename);
         const segments = normalized.split('/');
         if (segments.length <= 1) return undefined;
-        const folderSegments = segments.slice(0, -1);
-        const getFolders = (this.client as any).getFolders;
-        const createFolder = (this.client as any).createFolder;
-        if (typeof getFolders !== 'function' || typeof createFolder !== 'function') return undefined;
 
-        const folders = await getFolders.call(this.client, this.projectId);
+        // Soft capability check: N8nApiClient exposes both methods, but mocks in
+        // unit tests may not. Skip folder inference gracefully rather than throw.
+        if (typeof this.client.getFolders !== 'function' || typeof this.client.createFolder !== 'function') {
+            return undefined;
+        }
+
+        const folderSegments = segments.slice(0, -1);
+        const folders = await this.client.getFolders(this.projectId);
         let parentFolderId: string | null = null;
         for (const segment of folderSegments) {
-            let folder = folders.find((candidate: any) =>
-                candidate.name === segment && (candidate.parentFolderId ?? null) === parentFolderId,
-            );
-            if (!folder) {
-                folder = await createFolder.call(this.client, this.projectId, {
-                    name: segment,
-                    parentFolderId,
-                });
-                folders.push(folder);
-            }
+            const folder = await this.ensureFolder(folders, this.projectId, segment, parentFolderId);
             parentFolderId = folder.id;
         }
 
         return parentFolderId ?? undefined;
     }
 
+    /**
+     * Returns the folder named `name` under `parentFolderId`, creating it if
+     * missing. Concurrent calls for the same `(projectId, parentFolderId, name)`
+     * triple share a single in-flight `createFolder` promise so we never POST
+     * twice for the same folder.
+     */
+    private async ensureFolder(
+        folders: IFolder[],
+        projectId: string,
+        name: string,
+        parentFolderId: string | null,
+    ): Promise<IFolder> {
+        const existing = folders.find(
+            (candidate) => candidate.name === name && (candidate.parentFolderId ?? null) === parentFolderId,
+        );
+        if (existing) return existing;
+
+        const key = `${projectId}::${parentFolderId ?? ''}::${name}`;
+        const inFlight = this.inFlightFolderCreates.get(key);
+        if (inFlight) return inFlight;
+
+        const promise = this.client
+            .createFolder(projectId, { name, parentFolderId })
+            .then((created) => {
+                folders.push(created);
+                return created;
+            })
+            .finally(() => {
+                this.inFlightFolderCreates.delete(key);
+            });
+        this.inFlightFolderCreates.set(key, promise);
+        return promise;
+    }
+
+    /**
+     * Returns true when n8n rejected the create call specifically because it
+     * does not understand the `parentFolderId` field — in which case we retry
+     * without it so the sync still completes against older n8n instances.
+     *
+     * Tightened from the original `'folder'` substring match (which would have
+     * silently swallowed unrelated 400/404 errors) to require either a
+     * structured `parentFolderId` / `parentFolder` field in the response body,
+     * or a message that explicitly mentions one of those tokens.
+     */
     private isUnsupportedParentFolderError(error: any): boolean {
         const status = error?.response?.status;
-        const message = String(error?.response?.data?.message ?? error?.message ?? '').toLowerCase();
-        return [400, 404, 422].includes(status) && (message.includes('parentfolder') || message.includes('folder'));
+        if (![400, 404, 422].includes(status)) return false;
+
+        const PARENT_FOLDER_PATTERN = /(parentfolderid|parent folder id|parentfolder)/i;
+        const PARENT_FOLDER_KEYS = new Set(['parentfolderid', 'parentfolder']);
+
+        const data = error?.response?.data;
+        if (data && typeof data === 'object' && !Array.isArray(data)) {
+            for (const key of Object.keys(data)) {
+                if (PARENT_FOLDER_KEYS.has(key.toLowerCase())) return true;
+            }
+            const dataMessage = String(data.message ?? '').toLowerCase();
+            if (PARENT_FOLDER_PATTERN.test(dataMessage)) return true;
+            return false;
+        }
+
+        const errorMessage = String(error?.message ?? '').toLowerCase();
+        return PARENT_FOLDER_PATTERN.test(errorMessage);
     }
 
     private readTypeScriptFile(filePath: string): string | null {

--- a/packages/cli/src/core/services/sync-engine.ts
+++ b/packages/cli/src/core/services/sync-engine.ts
@@ -481,6 +481,17 @@ export class SyncEngine {
 
         const PARENT_FOLDER_PATTERN = /(parentfolderid|parent folder id|parentfolder)/i;
         const PARENT_FOLDER_KEYS = new Set(['parentfolderid', 'parentfolder']);
+        // n8n 2.19-2.31 licenses folders but its workflow schema has no `parentFolderId`
+        // yet, and AJV's `additionalProperties: false` rejects it *without naming the
+        // field*: `request/body must NOT have additional properties`. The patterns above
+        // never match that, so the push aborted instead of degrading, leaving an orphaned
+        // folder behind. Reported with live captures on #527 by @Happily-Coding.
+        //
+        // Safe to treat as an unsupported-`parentFolderId` signal: this matcher is only
+        // consulted when we just added `parentFolderId` to an otherwise-valid payload, and
+        // the retry strips only that field. If some *other* unknown property were the real
+        // cause, the retry fails again and the error surfaces as before -- nothing is hidden.
+        const GENERIC_ADDITIONAL_PROPERTY_PATTERN = /must not have additional properties/i;
 
         const data = error?.response?.data;
         if (data && typeof data === 'object' && !Array.isArray(data)) {
@@ -489,11 +500,13 @@ export class SyncEngine {
             }
             const dataMessage = String(data.message ?? '').toLowerCase();
             if (PARENT_FOLDER_PATTERN.test(dataMessage)) return true;
+            if (GENERIC_ADDITIONAL_PROPERTY_PATTERN.test(dataMessage)) return true;
             return false;
         }
 
         const errorMessage = String(error?.message ?? '').toLowerCase();
-        return PARENT_FOLDER_PATTERN.test(errorMessage);
+        return PARENT_FOLDER_PATTERN.test(errorMessage)
+            || GENERIC_ADDITIONAL_PROPERTY_PATTERN.test(errorMessage);
     }
 
     private readTypeScriptFile(filePath: string): string | null {

--- a/packages/cli/src/core/services/sync-engine.ts
+++ b/packages/cli/src/core/services/sync-engine.ts
@@ -228,7 +228,28 @@ export class SyncEngine {
             );
         }
 
-        const updatedWf = await this.client.updateWorkflow(workflowId, localWf);
+        // Folder-aware move: when folderSync is enabled and `filename` lives under a
+        // nested folder path, mirror the create-path logic and forward parentFolderId
+        // to n8n so the existing workflow actually moves to that folder on update.
+        // Mirrors inferParentFolderIdFromFilename() usage in executeCreate().
+        const inferredParentFolderId = await this.inferParentFolderIdFromFilename(filename);
+        if (inferredParentFolderId) {
+            localWf.parentFolderId = inferredParentFolderId;
+        }
+
+        let updatedWf: IWorkflow;
+        try {
+            updatedWf = await this.client.updateWorkflow(workflowId, localWf);
+        } catch (error: any) {
+            // Retry without parentFolderId when n8n rejects it as an unknown field
+            // (older n8n instances that don't support folder assignment on update).
+            // Same fallback used by executeCreate().
+            if (!localWf.parentFolderId || !this.isUnsupportedParentFolderError(error)) throw error;
+            console.warn(`[SyncEngine] n8n rejected parentFolderId while updating "${filename}"; retrying without folder assignment.`);
+            // parentFolderId is a known IWorkflow field; strip it without an `any` cast.
+            delete localWf.parentFolderId;
+            updatedWf = await this.client.updateWorkflow(workflowId, localWf);
+        }
 
         if (!updatedWf?.id || updatedWf.id !== workflowId || !Array.isArray(updatedWf.nodes)) {
             throw new Error('Failed to update remote workflow: n8n did not return an updated workflow payload');

--- a/packages/cli/src/core/services/sync-engine.ts
+++ b/packages/cli/src/core/services/sync-engine.ts
@@ -36,6 +36,9 @@ export class SyncEngine {
      * `getFolders` returns an empty array.
      */
     private inFlightFolderCreates: Map<string, Promise<IFolder>> = new Map();
+    private folderSyncMoveToRoot: boolean;
+    /** Guards the "folders unavailable" warning so a bulk push logs it once. */
+    private folderUnavailableWarned = false;
 
     constructor(
         client: N8nApiClient,
@@ -43,7 +46,7 @@ export class SyncEngine {
         directory: string,
         projectId: string,
         syncEventJournal?: SyncEventJournal,
-        options?: { folderSync?: boolean },
+        options?: { folderSync?: boolean; folderSyncMoveToRoot?: boolean },
     ) {
         this.client = client;
         this.watcher = watcher;
@@ -51,6 +54,7 @@ export class SyncEngine {
         this.projectId = projectId;
         this.syncEventJournal = syncEventJournal;
         this.folderSync = options?.folderSync ?? false;
+        this.folderSyncMoveToRoot = options?.folderSyncMoveToRoot ?? false;
     }
 
     /**
@@ -233,7 +237,8 @@ export class SyncEngine {
         // to n8n so the existing workflow actually moves to that folder on update.
         // Mirrors inferParentFolderIdFromFilename() usage in executeCreate().
         const inferredParentFolderId = await this.inferParentFolderIdFromFilename(filename);
-        if (inferredParentFolderId) {
+        // `null` is meaningful here (move to project root), so only skip on undefined.
+        if (inferredParentFolderId !== undefined) {
             localWf.parentFolderId = inferredParentFolderId;
         }
 
@@ -241,11 +246,11 @@ export class SyncEngine {
         try {
             updatedWf = await this.client.updateWorkflow(workflowId, localWf);
         } catch (error: any) {
-            // Retry without parentFolderId when n8n rejects it as an unknown field
-            // (older n8n instances that don't support folder assignment on update).
-            // Same fallback used by executeCreate().
-            if (!localWf.parentFolderId || !this.isUnsupportedParentFolderError(error)) throw error;
-            console.warn(`[SyncEngine] n8n rejected parentFolderId while updating "${filename}"; retrying without folder assignment.`);
+            // Retry without parentFolderId when n8n rejects it as an unknown field.
+            // Workflow placement via the public API only exists from n8n 2.32; older
+            // instances 400 on the field. Same fallback used by executeCreate().
+            if (localWf.parentFolderId === undefined || !this.isUnsupportedParentFolderError(error)) throw error;
+            console.warn(`[SyncEngine] n8n rejected parentFolderId while updating "${filename}" (folder placement needs n8n 2.32+); retrying without folder assignment.`);
             // parentFolderId is a known IWorkflow field; strip it without an `any` cast.
             delete localWf.parentFolderId;
             updatedWf = await this.client.updateWorkflow(workflowId, localWf);
@@ -326,7 +331,8 @@ export class SyncEngine {
         }
 
         const inferredParentFolderId = await this.inferParentFolderIdFromFilename(filename);
-        if (inferredParentFolderId) {
+        // `null` is meaningful here (create at project root), so only skip on undefined.
+        if (inferredParentFolderId !== undefined) {
             localWf.parentFolderId = inferredParentFolderId;
         }
 
@@ -334,8 +340,8 @@ export class SyncEngine {
         try {
             newWf = await this.client.createWorkflow(localWf);
         } catch (error: any) {
-            if (!localWf.parentFolderId || !this.isUnsupportedParentFolderError(error)) throw error;
-            console.warn(`[SyncEngine] n8n rejected parentFolderId while creating "${filename}"; retrying without folder assignment.`);
+            if (localWf.parentFolderId === undefined || !this.isUnsupportedParentFolderError(error)) throw error;
+            console.warn(`[SyncEngine] n8n rejected parentFolderId while creating "${filename}" (folder placement needs n8n 2.32+); retrying without folder assignment.`);
             // parentFolderId is a known IWorkflow field; strip it without an `any` cast.
             delete localWf.parentFolderId;
             newWf = await this.client.createWorkflow(localWf);
@@ -356,27 +362,73 @@ export class SyncEngine {
         return { id: newWf.id, updatedAt: newWf.updatedAt };
     }
 
-    private async inferParentFolderIdFromFilename(filename: string): Promise<string | undefined> {
-        if (!this.folderSync || !this.projectId || this.projectId === 'personal') return undefined;
+    /**
+     * Maps a workflow-relative filename to the n8n folder it should live in.
+     *
+     * Three distinct outcomes, matching n8n's own `parentFolderId` semantics:
+     * - `string`   — put the workflow in that folder (creating folders as needed)
+     * - `null`     — move it to the project root (only when folderSyncMoveToRoot is on)
+     * - `undefined` — say nothing, leave the workflow where n8n has it
+     */
+    private async inferParentFolderIdFromFilename(filename: string): Promise<string | null | undefined> {
+        if (!this.folderSync) return undefined;
         const normalized = normalizeWorkflowRelativePath(filename);
         const segments = normalized.split('/');
-        if (segments.length <= 1) return undefined;
+        if (segments.length <= 1) {
+            // Flat local path. Only claim the project root when the repository is
+            // configured as the source of truth, otherwise a push would silently
+            // undo folders someone created in the n8n UI.
+            return this.folderSyncMoveToRoot ? null : undefined;
+        }
 
-        // Soft capability check: N8nApiClient exposes both methods, but mocks in
+        // Soft capability check: N8nApiClient exposes these methods, but mocks in
         // unit tests may not. Skip folder inference gracefully rather than throw.
         if (typeof this.client.getFolders !== 'function' || typeof this.client.createFolder !== 'function') {
             return undefined;
         }
 
+        // `GET /projects/:id/folders` needs a real project id: it does not accept the
+        // `personal` alias that folder creation does, and `GET /api/v1/projects` is
+        // Enterprise-gated. resolveFolderProjectId() reads it off a workflow instead.
+        const projectId = typeof this.client.resolveFolderProjectId === 'function'
+            ? await this.client.resolveFolderProjectId(this.projectId)
+            : (this.projectId && this.projectId !== 'personal' ? this.projectId : null);
+        if (!projectId) {
+            this.warnFoldersUnavailable('could not determine which n8n project this instance syncs to');
+            return undefined;
+        }
+
         const folderSegments = segments.slice(0, -1);
-        const folders = await this.client.getFolders(this.projectId);
+        let folders: IFolder[];
+        try {
+            folders = await this.client.getFolders(projectId);
+        } catch (error: any) {
+            // 403 = the instance has no `feat:folders` licence (an unregistered
+            // Community instance); 404 = n8n predates the folder endpoints.
+            // Neither is a reason to fail the push — place the workflow flat.
+            if (![403, 404].includes(error?.response?.status)) throw error;
+            this.warnFoldersUnavailable(
+                error?.response?.status === 403
+                    ? 'the n8n instance reports no folder support (register the Community instance to unlock folders)'
+                    : 'this n8n version has no folder API (needs n8n 2.19+, and 2.32+ to place workflows)'
+            );
+            return undefined;
+        }
+
         let parentFolderId: string | null = null;
         for (const segment of folderSegments) {
-            const folder = await this.ensureFolder(folders, this.projectId, segment, parentFolderId);
+            const folder = await this.ensureFolder(folders, projectId, segment, parentFolderId);
             parentFolderId = folder.id;
         }
 
         return parentFolderId ?? undefined;
+    }
+
+    /** Logs the "folderSync is on but unusable" warning at most once per engine. */
+    private warnFoldersUnavailable(reason: string): void {
+        if (this.folderUnavailableWarned) return;
+        this.folderUnavailableWarned = true;
+        console.warn(`[SyncEngine] folderSync is enabled but ${reason}. Workflows will be pushed without folder assignment.`);
     }
 
     /**

--- a/packages/cli/src/core/services/sync-engine.ts
+++ b/packages/cli/src/core/services/sync-engine.ts
@@ -6,6 +6,7 @@ import { HashUtils } from './hash-utils.js';
 import { WorkflowStateTracker } from './workflow-state-tracker.js';
 import { SyncEventJournal } from './sync-event-journal.js';
 import { WorkflowSyncStatus, IWorkflow } from '../types.js';
+import { ensureParentDirectory, normalizeWorkflowRelativePath, workflowRelativePathToAbsolute } from './workflow-path-utils.js';
 
 /**
  * Sync Engine - State Mutation Component
@@ -23,6 +24,7 @@ export class SyncEngine {
     private directory: string;
     private projectId: string;
     private syncEventJournal: SyncEventJournal | undefined;
+    private folderSync: boolean;
 
     constructor(
         client: N8nApiClient,
@@ -30,12 +32,14 @@ export class SyncEngine {
         directory: string,
         projectId: string,
         syncEventJournal?: SyncEventJournal,
+        options?: { folderSync?: boolean },
     ) {
         this.client = client;
         this.watcher = watcher;
         this.directory = directory;
         this.projectId = projectId;
         this.syncEventJournal = syncEventJournal;
+        this.folderSync = options?.folderSync ?? false;
     }
 
     /**
@@ -164,7 +168,8 @@ export class SyncEngine {
             commentStyle: 'verbose'
         });
         
-        const filePath = path.join(this.directory, filename);
+        const filePath = workflowRelativePathToAbsolute(this.directory, filename);
+        ensureParentDirectory(filePath);
         fs.writeFileSync(filePath, tsCode, 'utf-8');
 
         // Update Watcher's remote hash cache since we just fetched the workflow
@@ -177,7 +182,7 @@ export class SyncEngine {
     }
 
     private async executeUpdate(workflowId: string, filename: string, skipOcc = false): Promise<string | undefined> {
-        const filePath = path.join(this.directory, filename);
+        const filePath = workflowRelativePathToAbsolute(this.directory, filename);
         const tsContent = this.readTypeScriptFile(filePath);
         if (!tsContent) {
             throw new Error('Local file not found during push');
@@ -235,6 +240,7 @@ export class SyncEngine {
             format: true,
             commentStyle: 'verbose'
         });
+        ensureParentDirectory(filePath);
         fs.writeFileSync(filePath, tsCode, 'utf-8');
 
         // Update Watcher's remote hash cache with the updated workflow
@@ -260,7 +266,7 @@ export class SyncEngine {
     }
 
     private async executeCreate(filename: string): Promise<{ id: string, updatedAt?: string }> {
-        const filePath = path.join(this.directory, filename);
+        const filePath = workflowRelativePathToAbsolute(this.directory, filename);
         const tsContent = this.readTypeScriptFile(filePath);
         if (!tsContent) {
             throw new Error('Local file not found during creation');
@@ -287,7 +293,20 @@ export class SyncEngine {
             localWf.projectId = this.projectId;
         }
 
-        const newWf = await this.client.createWorkflow(localWf);
+        const inferredParentFolderId = await this.inferParentFolderIdFromFilename(filename);
+        if (inferredParentFolderId) {
+            localWf.parentFolderId = inferredParentFolderId;
+        }
+
+        let newWf: IWorkflow;
+        try {
+            newWf = await this.client.createWorkflow(localWf);
+        } catch (error: any) {
+            if (!localWf.parentFolderId || !this.isUnsupportedParentFolderError(error)) throw error;
+            console.warn(`[SyncEngine] n8n rejected parentFolderId while creating "${filename}"; retrying without folder assignment.`);
+            delete (localWf as any).parentFolderId;
+            newWf = await this.client.createWorkflow(localWf);
+        }
         if (!newWf || !newWf.id) {
             throw new Error('Failed to create remote workflow');
         }
@@ -298,9 +317,45 @@ export class SyncEngine {
             format: true,
             commentStyle: 'verbose'
         });
+        ensureParentDirectory(filePath);
         fs.writeFileSync(filePath, tsCode, 'utf-8');
 
         return { id: newWf.id, updatedAt: newWf.updatedAt };
+    }
+
+    private async inferParentFolderIdFromFilename(filename: string): Promise<string | undefined> {
+        if (!this.folderSync || !this.projectId || this.projectId === 'personal') return undefined;
+        const normalized = normalizeWorkflowRelativePath(filename);
+        const segments = normalized.split('/');
+        if (segments.length <= 1) return undefined;
+        const folderSegments = segments.slice(0, -1);
+        const getFolders = (this.client as any).getFolders;
+        const createFolder = (this.client as any).createFolder;
+        if (typeof getFolders !== 'function' || typeof createFolder !== 'function') return undefined;
+
+        const folders = await getFolders.call(this.client, this.projectId);
+        let parentFolderId: string | null = null;
+        for (const segment of folderSegments) {
+            let folder = folders.find((candidate: any) =>
+                candidate.name === segment && (candidate.parentFolderId ?? null) === parentFolderId,
+            );
+            if (!folder) {
+                folder = await createFolder.call(this.client, this.projectId, {
+                    name: segment,
+                    parentFolderId,
+                });
+                folders.push(folder);
+            }
+            parentFolderId = folder.id;
+        }
+
+        return parentFolderId ?? undefined;
+    }
+
+    private isUnsupportedParentFolderError(error: any): boolean {
+        const status = error?.response?.status;
+        const message = String(error?.response?.data?.message ?? error?.message ?? '').toLowerCase();
+        return [400, 404, 422].includes(status) && (message.includes('parentfolder') || message.includes('folder'));
     }
 
     private readTypeScriptFile(filePath: string): string | null {

--- a/packages/cli/src/core/services/sync-manager.ts
+++ b/packages/cli/src/core/services/sync-manager.ts
@@ -71,6 +71,7 @@ export class SyncManager extends EventEmitter {
         this.syncEventJournal = new SyncEventJournal(instanceDir);
         this.syncEngine = new SyncEngine(this.client, this.watcher, instanceDir, this.config.projectId, this.syncEventJournal, {
             folderSync: this.config.folderSync ?? false,
+            folderSyncMoveToRoot: this.config.folderSyncMoveToRoot ?? false,
         });
         this.resolutionManager = new ResolutionManager(this.syncEngine, this.watcher, this.client);
 

--- a/packages/cli/src/core/services/sync-manager.ts
+++ b/packages/cli/src/core/services/sync-manager.ts
@@ -10,6 +10,7 @@ import { ResolutionManager } from './resolution-manager.js';
 import { ISyncConfig, IWorkflow, WorkflowSyncStatus, IWorkflowStatus } from '../types.js';
 import { createProjectSlug } from './directory-utils.js';
 import { WorkspaceSetupService } from './workspace-setup-service.js';
+import { normalizeWorkflowRelativePath, relativePathFromAbsolute, workflowRelativePathToAbsolute } from './workflow-path-utils.js';
 
 export class SyncManager extends EventEmitter {
     private client: N8nApiClient;
@@ -63,11 +64,14 @@ export class SyncManager extends EventEmitter {
             directory: instanceDir,
             syncInactive: true,
             ignoredTags: [],
-            projectId: this.config.projectId
+            projectId: this.config.projectId,
+            folderSync: this.config.folderSync ?? false,
         });
 
         this.syncEventJournal = new SyncEventJournal(instanceDir);
-        this.syncEngine = new SyncEngine(this.client, this.watcher, instanceDir, this.config.projectId, this.syncEventJournal);
+        this.syncEngine = new SyncEngine(this.client, this.watcher, instanceDir, this.config.projectId, this.syncEventJournal, {
+            folderSync: this.config.folderSync ?? false,
+        });
         this.resolutionManager = new ResolutionManager(this.syncEngine, this.watcher, this.client);
 
         this.watcher.on('statusChange', (data) => {
@@ -413,16 +417,11 @@ export class SyncManager extends EventEmitter {
             );
         }
 
-        if (relativePath.includes(path.sep)) {
-            throw new Error(
-                `Cannot push "${trimmed}": nested workflow paths inside the sync scope are not supported.\n` +
-                `Expected a workflow file at the scope root, for example ${this.quoteShellArg(path.join(normalizedScopeDir, path.basename(normalizedAbsolutePath)))}`
-            );
-        }
+        const workflowRelativePath = normalizeWorkflowRelativePath(relativePathFromAbsolute(normalizedScopeDir, normalizedAbsolutePath));
 
         return {
-            filename: path.basename(normalizedAbsolutePath),
-            filePath: path.join(syncScopeDir, path.basename(normalizedAbsolutePath)),
+            filename: workflowRelativePath,
+            filePath: workflowRelativePathToAbsolute(syncScopeDir, workflowRelativePath),
             absolutePath: normalizedAbsolutePath
         };
     }

--- a/packages/cli/src/core/services/workflow-path-utils.ts
+++ b/packages/cli/src/core/services/workflow-path-utils.ts
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import path from 'path';
+
+export function toPosixRelativePath(value: string): string {
+    return value.split(path.sep).join('/').replace(/\\/g, '/');
+}
+
+export function normalizeWorkflowRelativePath(value: string): string {
+    const normalized = path.posix.normalize(toPosixRelativePath(value).trim());
+    if (!normalized || normalized === '.') {
+        throw new Error('Workflow path must not be empty');
+    }
+    if (normalized.startsWith('../') || normalized === '..' || path.posix.isAbsolute(normalized)) {
+        throw new Error(`Workflow path escapes the sync scope: ${value}`);
+    }
+    const parts = normalized.split('/');
+    if (parts.some((part) => !part || part === '.' || part === '..' || /[\u0000-\u001f\u007f]/.test(part))) {
+        throw new Error(`Workflow path contains an unsafe segment: ${value}`);
+    }
+    return normalized;
+}
+
+export function workflowRelativePathToAbsolute(root: string, relativePath: string): string {
+    const safeRelativePath = normalizeWorkflowRelativePath(relativePath);
+    return path.join(root, ...safeRelativePath.split('/'));
+}
+
+export function relativePathFromAbsolute(root: string, absolutePath: string): string {
+    const relative = path.relative(root, absolutePath);
+    return normalizeWorkflowRelativePath(toPosixRelativePath(relative));
+}
+
+export function ensureParentDirectory(filePath: string): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+export function listWorkflowFilesRecursive(root: string): string[] {
+    const results: string[] = [];
+    const visit = (dir: string, relativeDir = '') => {
+        const entries = fs.readdirSync(dir, { withFileTypes: true });
+        for (const entry of entries) {
+            if (entry.name.startsWith('.')) continue;
+            const childRelative = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
+            const childAbsolute = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                visit(childAbsolute, childRelative);
+                continue;
+            }
+            if (entry.isFile() && entry.name.endsWith('.workflow.ts')) {
+                results.push(normalizeWorkflowRelativePath(childRelative));
+            }
+        }
+    };
+    if (fs.existsSync(root)) visit(root);
+    return results.sort();
+}

--- a/packages/cli/src/core/services/workflow-path-utils.ts
+++ b/packages/cli/src/core/services/workflow-path-utils.ts
@@ -1,10 +1,26 @@
 import fs from 'fs';
 import path from 'path';
 
+/**
+ * Rewrites a path to POSIX separators.
+ *
+ * Workflow paths are stored POSIX-style in `.n8n-state.json` so a repository
+ * checked out on Windows and on Linux produces the same state file.
+ */
 export function toPosixRelativePath(value: string): string {
     return value.split(path.sep).join('/').replace(/\\/g, '/');
 }
 
+/**
+ * Normalises a workflow path relative to the workflows directory and rejects
+ * anything that could escape it.
+ *
+ * @param value Path as written by a user, a state file, or the CLI.
+ * @returns The normalised POSIX-relative path.
+ * @throws If the path is empty, absolute, climbs above the root, or contains a
+ * control character — all of which would let a crafted state file or filename
+ * write outside the sync scope.
+ */
 export function normalizeWorkflowRelativePath(value: string): string {
     const normalized = path.posix.normalize(toPosixRelativePath(value).trim());
     if (!normalized || normalized === '.') {
@@ -20,20 +36,53 @@ export function normalizeWorkflowRelativePath(value: string): string {
     return normalized;
 }
 
+/**
+ * Resolves a workflow-relative path against the workflows directory.
+ *
+ * Validates before joining, so this is the only sanctioned way to turn a stored
+ * filename into an absolute path.
+ *
+ * @param root Absolute path of the workflows directory.
+ * @param relativePath Workflow-relative path (nested paths allowed).
+ */
 export function workflowRelativePathToAbsolute(root: string, relativePath: string): string {
     const safeRelativePath = normalizeWorkflowRelativePath(relativePath);
     return path.join(root, ...safeRelativePath.split('/'));
 }
 
+/**
+ * Inverse of {@link workflowRelativePathToAbsolute}: expresses an absolute path
+ * as a validated workflow-relative one.
+ *
+ * @throws If the file lies outside `root`.
+ */
 export function relativePathFromAbsolute(root: string, absolutePath: string): string {
     const relative = path.relative(root, absolutePath);
     return normalizeWorkflowRelativePath(toPosixRelativePath(relative));
 }
 
+/**
+ * Creates the parent directory of `filePath` if it is missing.
+ *
+ * Needed since workflows can live in nested folders: the first pull or push of
+ * `Reports/Weekly/summary.workflow.ts` has to create `Reports/Weekly` first.
+ */
 export function ensureParentDirectory(filePath: string): void {
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
 }
 
+/**
+ * Lists every `*.workflow.ts` file under `root`, recursively.
+ *
+ * Dot-prefixed entries are skipped, so `.n8n-state.json` and `.git` never show
+ * up. Results are workflow-relative, normalised, and sorted for deterministic
+ * ordering across platforms.
+ *
+ * Synchronous by design — it runs inside the tracker's synchronous scan path.
+ * Fine for the hundreds of workflows a project realistically holds.
+ *
+ * @returns Sorted workflow-relative paths; empty when `root` does not exist.
+ */
 export function listWorkflowFilesRecursive(root: string): string[] {
     const results: string[] = [];
     const visit = (dir: string, relativeDir = '') => {

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -723,13 +723,12 @@ export class WorkflowStateTracker extends EventEmitter {
         const hasWorkflowFolderFields = remoteWorkflows.some((workflow) =>
             workflow.parentFolderId !== undefined || workflow.parentFolder?.id,
         );
-        const getFolders = (this.client as any).getFolders;
-        if (!hasWorkflowFolderFields || typeof getFolders !== 'function') {
+        if (!hasWorkflowFolderFields || typeof this.client.getFolders !== 'function') {
             this.warnFolderMetadataUnavailable();
             return null;
         }
         try {
-            return new FolderPathResolver(await getFolders.call(this.client, this.projectId));
+            return new FolderPathResolver(await this.client.getFolders(this.projectId));
         } catch (error: any) {
             this.warnFolderMetadataUnavailable(error?.message);
             return null;
@@ -1334,9 +1333,9 @@ export class WorkflowStateTracker extends EventEmitter {
             this.remoteArchived.set(remoteWf.id, remoteWf.isArchived === true);
             const parentFolderId = remoteWf.parentFolderId ?? remoteWf.parentFolder?.id ?? null;
             let folderPath: string[] = [];
-            if (this.folderSync && parentFolderId && typeof (this.client as any).getFolders === 'function') {
+            if (this.folderSync && parentFolderId && typeof this.client.getFolders === 'function') {
                 try {
-                    const resolver = new FolderPathResolver(await (this.client as any).getFolders(this.projectId));
+                    const resolver = new FolderPathResolver(await this.client.getFolders(this.projectId));
                     folderPath = resolver.getPathForWorkflow(remoteWf);
                 } catch (error: any) {
                     this.warnFolderMetadataUnavailable(error?.message);

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -6,6 +6,8 @@ import { WorkflowTransformerAdapter } from './workflow-transformer-adapter.js';
 import { HashUtils } from './hash-utils.js';
 import { WorkflowSyncStatus, IWorkflowStatus, IWorkflow, IWorkflowDrift } from '../types.js';
 import { IWorkflowState, IInstanceState } from './state-manager.js';
+import { FolderPathResolver, sanitizePathSegment } from './folder-path-resolver.js';
+import { listWorkflowFilesRecursive, normalizeWorkflowRelativePath, workflowRelativePathToAbsolute } from './workflow-path-utils.js';
 
 const WINDOWS_RESERVED_FILENAMES = new Set([
     'CON',
@@ -53,6 +55,8 @@ export class WorkflowStateTracker extends EventEmitter {
     private ignoredTags: string[];
     private projectId: string;
     private stateFilePath: string;
+    private folderSync: boolean;
+    private warnedFolderMetadataUnavailable = false;
     private isConnected: boolean = true;
     /** True during the first refreshRemoteState() call — suppresses status broadcasts */
     private isInitialRemoteLoad: boolean = false;
@@ -73,6 +77,8 @@ export class WorkflowStateTracker extends EventEmitter {
     private remoteActive: Map<string, boolean> = new Map(); // workflowId -> active
     /** Remote archived flag per workflow (populated by refreshRemoteState / updateSingleRemoteState). */
     private remoteArchived: Map<string, boolean> = new Map(); // workflowId -> isArchived
+    private remoteParentFolderIds: Map<string, string | null> = new Map(); // workflowId -> parentFolderId
+    private remoteFolderPaths: Map<string, string[]> = new Map(); // workflowId -> folder path segments
 
     constructor(
         client: N8nApiClient,
@@ -81,6 +87,7 @@ export class WorkflowStateTracker extends EventEmitter {
             syncInactive: boolean;
             ignoredTags: string[];
             projectId: string;      // Project scope filter
+            folderSync?: boolean;
         }
     ) {
         super();
@@ -89,6 +96,7 @@ export class WorkflowStateTracker extends EventEmitter {
         this.syncInactive = options.syncInactive;
         this.ignoredTags = options.ignoredTags;
         this.projectId = options.projectId;
+        this.folderSync = options.folderSync ?? false;
         this.stateFilePath = path.join(this.directory, '.n8n-state.json');
 
         // Restore persisted mappings immediately so 'pull' and other commands can find workflows
@@ -115,7 +123,7 @@ export class WorkflowStateTracker extends EventEmitter {
             return;
         }
 
-        const files = fs.readdirSync(this.directory).filter(f => f.endsWith('.workflow.ts') && !f.startsWith('.'));
+        const files = listWorkflowFilesRecursive(this.directory);
         const currentFiles = new Set(files);
 
         // Remove entries for files that no longer exist
@@ -134,7 +142,7 @@ export class WorkflowStateTracker extends EventEmitter {
         const fileContents: Array<{ filename: string; content: any }> = [];
         const newlyTracked: string[] = [];
         for (const filename of files) {
-            const filePath = path.join(this.directory, filename);
+            const filePath = workflowRelativePathToAbsolute(this.directory, filename);
             const content = this.readJsonFile(filePath); // Quick ID extraction
             if (content) {
                 fileContents.push({ filename, content });
@@ -278,6 +286,11 @@ export class WorkflowStateTracker extends EventEmitter {
             this.remoteNames.clear();
             this.remoteActive.clear();
             this.remoteArchived.clear();
+            this.remoteParentFolderIds.clear();
+            this.remoteFolderPaths.clear();
+
+            const folderResolver = await this.createFolderResolver(remoteWorkflows);
+            const state = this.loadState();
 
             // Build set of already-assigned filenames to prevent collisions
             const assignedFilenames = new Set<string>();
@@ -296,9 +309,24 @@ export class WorkflowStateTracker extends EventEmitter {
                 // but `updatedAt` (already returned by /api/v1/workflows) is enough to
                 // detect "remote changed since last sync" without an extra API call.
                 if (wf.updatedAt) this.remoteTimestamps.set(wf.id, wf.updatedAt);
+                const parentFolderId = wf.parentFolderId ?? wf.parentFolder?.id ?? null;
+                const folderPath = folderResolver ? folderResolver.getPathForWorkflow(wf) : [];
+                this.remoteParentFolderIds.set(wf.id, parentFolderId);
+                this.remoteFolderPaths.set(wf.id, folderPath);
 
                 // CRITICAL: Use ID-based mapping with PERSISTED state as source of truth
                 let filename: string | undefined = this.idToFileMap.get(wf.id);
+
+                if (!filename) {
+                    const persistedFilename = state.workflows[wf.id]?.filename;
+                    if (persistedFilename) {
+                        try {
+                            filename = normalizeWorkflowRelativePath(persistedFilename);
+                        } catch {
+                            filename = undefined;
+                        }
+                    }
+                }
 
                 // If no valid mapping, scan local files to discover/rediscover the workflow
                 if (!filename) {
@@ -312,13 +340,13 @@ export class WorkflowStateTracker extends EventEmitter {
 
                 // If still not found, this is a NEW remote workflow - generate filename
                 if (!filename) {
-                    const baseName = `${this.safeName(wf.name)}.workflow.ts`;
+                    const baseName = this.buildRelativeFilename(wf, folderPath);
 
                     // Check if this base name is already assigned to another workflow
                     if (assignedFilenames.has(baseName)) {
                         // Name collision - generate unique filename with ID suffix
                         const idSuffix = wf.id.substring(0, 8);
-                        filename = `${this.safeName(wf.name)}_${idSuffix}.workflow.ts`;
+                        filename = this.buildRelativeFilename(wf, folderPath, idSuffix);
                     } else {
                         // Name is free - use it
                         filename = baseName;
@@ -402,9 +430,9 @@ export class WorkflowStateTracker extends EventEmitter {
         // If workflow not tracked yet (first sync of local-only workflow),
         // scan directory to find the file with this ID
         if (!filename) {
-            const files = fs.readdirSync(this.directory).filter(f => f.endsWith('.workflow.ts') && !f.startsWith('.'));
+            const files = listWorkflowFilesRecursive(this.directory);
             for (const file of files) {
-                const filePath = path.join(this.directory, file);
+                const filePath = workflowRelativePathToAbsolute(this.directory, file);
                 const content = this.readJsonFile(filePath);
                 if (content?.id === workflowId) {
                     filename = file;
@@ -421,7 +449,7 @@ export class WorkflowStateTracker extends EventEmitter {
         }
 
         // Get current reality
-        const filePath = path.join(this.directory, filename);
+        const filePath = workflowRelativePathToAbsolute(this.directory, filename);
         const content = this.readJsonFile(filePath);
 
         if (!content) {
@@ -481,6 +509,8 @@ export class WorkflowStateTracker extends EventEmitter {
         this.remoteNames.delete(id);
         this.remoteActive.delete(id);
         this.remoteArchived.delete(id);
+        this.remoteParentFolderIds.delete(id);
+        this.remoteFolderPaths.delete(id);
         this.remoteIds.delete(id);
     }
 
@@ -509,16 +539,22 @@ export class WorkflowStateTracker extends EventEmitter {
         for (const [workflowId, workflowState] of Object.entries(state.workflows)) {
             const filename = workflowState?.filename;
             if (!filename) continue;
+            let normalizedFilename: string;
+            try {
+                normalizedFilename = normalizeWorkflowRelativePath(filename);
+            } catch {
+                continue;
+            }
 
-            const filePath = path.join(this.directory, filename);
+            const filePath = workflowRelativePathToAbsolute(this.directory, normalizedFilename);
             if (!fs.existsSync(filePath)) continue;
 
             if (!this.idToFileMap.has(workflowId)) {
-                this.idToFileMap.set(workflowId, filename);
+                this.idToFileMap.set(workflowId, normalizedFilename);
             }
 
-            if (!this.fileToIdMap.has(filename)) {
-                this.fileToIdMap.set(filename, workflowId);
+            if (!this.fileToIdMap.has(normalizedFilename)) {
+                this.fileToIdMap.set(normalizedFilename, workflowId);
             }
         }
     }
@@ -682,6 +718,38 @@ export class WorkflowStateTracker extends EventEmitter {
         return finalName;
     }
 
+    private async createFolderResolver(remoteWorkflows: IWorkflow[]): Promise<FolderPathResolver | null> {
+        if (!this.folderSync) return null;
+        const hasWorkflowFolderFields = remoteWorkflows.some((workflow) =>
+            workflow.parentFolderId !== undefined || workflow.parentFolder?.id,
+        );
+        const getFolders = (this.client as any).getFolders;
+        if (!hasWorkflowFolderFields || typeof getFolders !== 'function') {
+            this.warnFolderMetadataUnavailable();
+            return null;
+        }
+        try {
+            return new FolderPathResolver(await getFolders.call(this.client, this.projectId));
+        } catch (error: any) {
+            this.warnFolderMetadataUnavailable(error?.message);
+            return null;
+        }
+    }
+
+    private warnFolderMetadataUnavailable(reason?: string): void {
+        if (this.warnedFolderMetadataUnavailable) return;
+        this.warnedFolderMetadataUnavailable = true;
+        console.warn(
+            `[WorkflowStateTracker] folderSync is enabled, but public workflow folder metadata is unavailable${reason ? `: ${reason}` : ''}. Falling back to flat workflow paths.`,
+        );
+    }
+
+    private buildRelativeFilename(workflow: IWorkflow, folderPath: string[] = [], idSuffix?: string): string {
+        const baseName = `${this.safeName(workflow.name)}${idSuffix ? `_${idSuffix}` : ''}.workflow.ts`;
+        if (!this.folderSync || folderPath.length === 0) return baseName;
+        return normalizeWorkflowRelativePath([...folderPath.map(sanitizePathSegment), baseName].join('/'));
+    }
+
     /**
      * Find local file that contains a specific workflow ID
      * Used when we have an ID but no filename mapping yet (e.g., after file rename)
@@ -691,11 +759,10 @@ export class WorkflowStateTracker extends EventEmitter {
             return undefined;
         }
 
-        const files = fs.readdirSync(this.directory)
-            .filter(f => f.endsWith('.workflow.ts') && !f.startsWith('.'));
+        const files = listWorkflowFilesRecursive(this.directory);
 
         for (const file of files) {
-            const content = this.readJsonFile(path.join(this.directory, file));
+            const content = this.readJsonFile(workflowRelativePathToAbsolute(this.directory, file));
             if (content?.id === workflowId) {
                 return file;
             }
@@ -841,7 +908,7 @@ export class WorkflowStateTracker extends EventEmitter {
             // For local-only files, extract the name from the @workflow decorator for an accurate display.
             // Fall back to filename-derived name as last resort.
             const workflowName = (workflowId && this.remoteNames.get(workflowId))
-                || this.readJsonFile(path.join(this.directory, filename))?.name
+                || this.readJsonFile(workflowRelativePathToAbsolute(this.directory, filename))?.name
                 || filename.replace('.workflow.ts', '');
 
             // Cheap drift signal: only computed when both reference state and the
@@ -865,6 +932,9 @@ export class WorkflowStateTracker extends EventEmitter {
                 drift,
                 lastSyncedAt: workflowId ? state.workflows[workflowId]?.lastSyncedAt : undefined,
                 remoteUpdatedAt: workflowId ? this.remoteTimestamps.get(workflowId) : undefined,
+                parentFolderId: workflowId ? this.remoteParentFolderIds.get(workflowId) : undefined,
+                folderPath: workflowId ? this.remoteFolderPaths.get(workflowId) : undefined,
+                folderPathString: workflowId ? this.remoteFolderPaths.get(workflowId)?.join('/') : undefined,
             });
         }
 
@@ -895,7 +965,10 @@ export class WorkflowStateTracker extends EventEmitter {
                     projectId: undefined, // Not available in lightweight mode
                     projectName: undefined, // Not available in lightweight mode
                     homeProject: undefined, // Not available in lightweight mode
-                    isArchived
+                    isArchived,
+                    parentFolderId: this.remoteParentFolderIds.get(workflowId),
+                    folderPath: this.remoteFolderPaths.get(workflowId),
+                    folderPathString: this.remoteFolderPaths.get(workflowId)?.join('/'),
                 });
             }
         }
@@ -978,18 +1051,12 @@ export class WorkflowStateTracker extends EventEmitter {
      * Get list of local workflow filenames (just checks file system, no parsing)
      */
     private getLocalWorkflowFilenames(): string[] {
-        const filenames: string[] = [];
         try {
-            const files = fs.readdirSync(this.directory);
-            for (const file of files) {
-                if (file.endsWith('.workflow.ts')) {
-                    filenames.push(file);
-                }
-            }
+            return listWorkflowFilesRecursive(this.directory);
         } catch (error) {
             console.debug('[WorkflowStateTracker] Failed to read local directory:', error);
         }
-        return filenames;
+        return [];
     }
 
     public async getStatusMatrix(): Promise<IWorkflowStatus[]> {
@@ -1001,7 +1068,7 @@ export class WorkflowStateTracker extends EventEmitter {
         try {
             // Read local workflows
             for (const [filename] of this.localHashes.entries()) {
-                const filePath = path.join(this.directory, filename);
+                const filePath = workflowRelativePathToAbsolute(this.directory, filename);
                 if (fs.existsSync(filePath)) {
                     try {
                         const workflow = await this.readWorkflowFile(filePath);
@@ -1039,7 +1106,10 @@ export class WorkflowStateTracker extends EventEmitter {
                 projectId: workflow?.projectId,
                 projectName: workflow?.projectName,
                 homeProject: workflow?.homeProject,
-                isArchived
+                isArchived,
+                parentFolderId: workflowId ? this.remoteParentFolderIds.get(workflowId) : undefined,
+                folderPath: workflowId ? this.remoteFolderPaths.get(workflowId) : undefined,
+                folderPathString: workflowId ? this.remoteFolderPaths.get(workflowId)?.join('/') : undefined,
             });
         }
 
@@ -1064,7 +1134,10 @@ export class WorkflowStateTracker extends EventEmitter {
                     projectId: workflow?.projectId,
                     projectName: workflow?.projectName,
                     homeProject: workflow?.homeProject,
-                    isArchived: workflow?.isArchived ?? false
+                    isArchived: workflow?.isArchived ?? false,
+                    parentFolderId: this.remoteParentFolderIds.get(workflowId),
+                    folderPath: this.remoteFolderPaths.get(workflowId),
+                    folderPathString: this.remoteFolderPaths.get(workflowId)?.join('/'),
                 });
             }
         }
@@ -1090,7 +1163,10 @@ export class WorkflowStateTracker extends EventEmitter {
                     projectId: workflow?.projectId,
                     projectName: workflow?.projectName,
                     homeProject: workflow?.homeProject,
-                    isArchived: workflow?.isArchived ?? false
+                    isArchived: workflow?.isArchived ?? false,
+                    parentFolderId: this.remoteParentFolderIds.get(id),
+                    folderPath: this.remoteFolderPaths.get(id),
+                    folderPathString: this.remoteFolderPaths.get(id)?.join('/'),
                 });
             }
         }
@@ -1140,7 +1216,7 @@ export class WorkflowStateTracker extends EventEmitter {
 
         // 1. Get all local workflows
         for (const [filename, _] of this.localHashes.entries()) {
-            const filepath = path.join(this.directory, filename);
+            const filepath = workflowRelativePathToAbsolute(this.directory, filename);
             try {
                 const workflow = await this.readWorkflowFile(filepath);
                 if (workflow) {
@@ -1210,6 +1286,18 @@ export class WorkflowStateTracker extends EventEmitter {
             this.remoteNames.set(newId, name);
         }
 
+        const parentFolderId = this.remoteParentFolderIds.get(oldId);
+        if (parentFolderId !== undefined) {
+            this.remoteParentFolderIds.delete(oldId);
+            this.remoteParentFolderIds.set(newId, parentFolderId);
+        }
+
+        const folderPath = this.remoteFolderPaths.get(oldId);
+        if (folderPath) {
+            this.remoteFolderPaths.delete(oldId);
+            this.remoteFolderPaths.set(newId, folderPath);
+        }
+
         // Migrate remote ID set
         if (this.remoteIds.has(oldId)) {
             this.remoteIds.delete(oldId);
@@ -1244,18 +1332,30 @@ export class WorkflowStateTracker extends EventEmitter {
             // Store active and archived flags
             this.remoteActive.set(remoteWf.id, remoteWf.active === true);
             this.remoteArchived.set(remoteWf.id, remoteWf.isArchived === true);
+            const parentFolderId = remoteWf.parentFolderId ?? remoteWf.parentFolder?.id ?? null;
+            let folderPath: string[] = [];
+            if (this.folderSync && parentFolderId && typeof (this.client as any).getFolders === 'function') {
+                try {
+                    const resolver = new FolderPathResolver(await (this.client as any).getFolders(this.projectId));
+                    folderPath = resolver.getPathForWorkflow(remoteWf);
+                } catch (error: any) {
+                    this.warnFolderMetadataUnavailable(error?.message);
+                }
+            }
+            this.remoteParentFolderIds.set(remoteWf.id, parentFolderId);
+            this.remoteFolderPaths.set(remoteWf.id, folderPath);
 
             // Establish mapping if it doesn't exist yet (allows 'pull' after single 'fetch')
             if (!this.idToFileMap.has(remoteWf.id)) {
                 let filename = this.findFilenameByWorkflowId(remoteWf.id);
                 
                 if (!filename) {
-                    const baseName = `${this.safeName(remoteWf.name || remoteWf.id)}.workflow.ts`;
+                    const baseName = this.buildRelativeFilename(remoteWf, folderPath);
                     filename = baseName;
                     
                     // Simple collision check against existing mappings
                     if (this.fileToIdMap.has(filename)) {
-                        filename = `${this.safeName(remoteWf.name || remoteWf.id)}_${remoteWf.id.substring(0, 8)}.workflow.ts`;
+                        filename = this.buildRelativeFilename(remoteWf, folderPath, remoteWf.id.substring(0, 8));
                     }
                 }
                 

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -718,6 +718,19 @@ export class WorkflowStateTracker extends EventEmitter {
         return finalName;
     }
 
+    /**
+     * Builds the resolver that turns a remote workflow's folder into local path
+     * segments — when n8n tells us what that folder is.
+     *
+     * As of n8n 2.32 it does not: `parentFolderId` is declared `writeOnly` in the
+     * public API spec, the read handlers never load the `parentFolder` relation,
+     * and no endpoint maps workflows to folders. This holds on every edition,
+     * Enterprise included, so pull lays workflows out flat and this returns null.
+     *
+     * The detection is deliberately based on the payload rather than a version
+     * check: the day a workflow read carries folder fields, nested pulls start
+     * working with no change here.
+     */
     private async createFolderResolver(remoteWorkflows: IWorkflow[]): Promise<FolderPathResolver | null> {
         if (!this.folderSync) return null;
         const hasWorkflowFolderFields = remoteWorkflows.some((workflow) =>
@@ -739,7 +752,8 @@ export class WorkflowStateTracker extends EventEmitter {
         if (this.warnedFolderMetadataUnavailable) return;
         this.warnedFolderMetadataUnavailable = true;
         console.warn(
-            `[WorkflowStateTracker] folderSync is enabled, but public workflow folder metadata is unavailable${reason ? `: ${reason}` : ''}. Falling back to flat workflow paths.`,
+            `[WorkflowStateTracker] folderSync is enabled, but n8n's public API does not report which folder a workflow is in${reason ? ` (${reason})` : ''}. ` +
+            `Pull keeps workflows flat; push still mirrors your local folders onto n8n.`,
         );
     }
 
@@ -1335,7 +1349,12 @@ export class WorkflowStateTracker extends EventEmitter {
             let folderPath: string[] = [];
             if (this.folderSync && parentFolderId && typeof this.client.getFolders === 'function') {
                 try {
-                    const resolver = new FolderPathResolver(await this.client.getFolders(this.projectId));
+                    // Same project-id caveat as the push path: the folder list endpoint
+                    // needs a real id, not the `personal` placeholder.
+                    const folderProjectId = typeof this.client.resolveFolderProjectId === 'function'
+                        ? await this.client.resolveFolderProjectId(this.projectId)
+                        : this.projectId;
+                    const resolver = new FolderPathResolver(await this.client.getFolders(folderProjectId ?? this.projectId));
                     folderPath = resolver.getPathForWorkflow(remoteWf);
                 } catch (error: any) {
                     this.warnFolderMetadataUnavailable(error?.message);

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -6,6 +6,8 @@ import { WorkflowTransformerAdapter } from './workflow-transformer-adapter.js';
 import { HashUtils } from './hash-utils.js';
 import { WorkflowSyncStatus, IWorkflowStatus, IWorkflow } from '../types.js';
 import { IWorkflowState, IInstanceState } from './state-manager.js';
+import { FolderPathResolver, sanitizePathSegment } from './folder-path-resolver.js';
+import { listWorkflowFilesRecursive, normalizeWorkflowRelativePath, workflowRelativePathToAbsolute } from './workflow-path-utils.js';
 
 const WINDOWS_RESERVED_FILENAMES = new Set([
     'CON',
@@ -53,6 +55,8 @@ export class WorkflowStateTracker extends EventEmitter {
     private ignoredTags: string[];
     private projectId: string;
     private stateFilePath: string;
+    private folderSync: boolean;
+    private warnedFolderMetadataUnavailable = false;
     private isConnected: boolean = true;
     /** True during the first refreshRemoteState() call — suppresses status broadcasts */
     private isInitialRemoteLoad: boolean = false;
@@ -73,6 +77,8 @@ export class WorkflowStateTracker extends EventEmitter {
     private remoteActive: Map<string, boolean> = new Map(); // workflowId -> active
     /** Remote archived flag per workflow (populated by refreshRemoteState / updateSingleRemoteState). */
     private remoteArchived: Map<string, boolean> = new Map(); // workflowId -> isArchived
+    private remoteParentFolderIds: Map<string, string | null> = new Map(); // workflowId -> parentFolderId
+    private remoteFolderPaths: Map<string, string[]> = new Map(); // workflowId -> folder path segments
 
     constructor(
         client: N8nApiClient,
@@ -81,6 +87,7 @@ export class WorkflowStateTracker extends EventEmitter {
             syncInactive: boolean;
             ignoredTags: string[];
             projectId: string;      // Project scope filter
+            folderSync?: boolean;
         }
     ) {
         super();
@@ -89,6 +96,7 @@ export class WorkflowStateTracker extends EventEmitter {
         this.syncInactive = options.syncInactive;
         this.ignoredTags = options.ignoredTags;
         this.projectId = options.projectId;
+        this.folderSync = options.folderSync ?? false;
         this.stateFilePath = path.join(this.directory, '.n8n-state.json');
 
         // Restore persisted mappings immediately so 'pull' and other commands can find workflows
@@ -115,7 +123,7 @@ export class WorkflowStateTracker extends EventEmitter {
             return;
         }
 
-        const files = fs.readdirSync(this.directory).filter(f => f.endsWith('.workflow.ts') && !f.startsWith('.'));
+        const files = listWorkflowFilesRecursive(this.directory);
         const currentFiles = new Set(files);
 
         // Remove entries for files that no longer exist
@@ -134,7 +142,7 @@ export class WorkflowStateTracker extends EventEmitter {
         const fileContents: Array<{ filename: string; content: any }> = [];
         const newlyTracked: string[] = [];
         for (const filename of files) {
-            const filePath = path.join(this.directory, filename);
+            const filePath = workflowRelativePathToAbsolute(this.directory, filename);
             const content = this.readJsonFile(filePath); // Quick ID extraction
             if (content) {
                 fileContents.push({ filename, content });
@@ -278,6 +286,11 @@ export class WorkflowStateTracker extends EventEmitter {
             this.remoteNames.clear();
             this.remoteActive.clear();
             this.remoteArchived.clear();
+            this.remoteParentFolderIds.clear();
+            this.remoteFolderPaths.clear();
+
+            const folderResolver = await this.createFolderResolver(remoteWorkflows);
+            const state = this.loadState();
 
             // Build set of already-assigned filenames to prevent collisions
             const assignedFilenames = new Set<string>();
@@ -291,9 +304,24 @@ export class WorkflowStateTracker extends EventEmitter {
                 // Store active and archived flags from API
                 this.remoteActive.set(wf.id, wf.active === true);
                 this.remoteArchived.set(wf.id, wf.isArchived === true);
+                const parentFolderId = wf.parentFolderId ?? wf.parentFolder?.id ?? null;
+                const folderPath = folderResolver ? folderResolver.getPathForWorkflow(wf) : [];
+                this.remoteParentFolderIds.set(wf.id, parentFolderId);
+                this.remoteFolderPaths.set(wf.id, folderPath);
 
                 // CRITICAL: Use ID-based mapping with PERSISTED state as source of truth
                 let filename: string | undefined = this.idToFileMap.get(wf.id);
+
+                if (!filename) {
+                    const persistedFilename = state.workflows[wf.id]?.filename;
+                    if (persistedFilename) {
+                        try {
+                            filename = normalizeWorkflowRelativePath(persistedFilename);
+                        } catch {
+                            filename = undefined;
+                        }
+                    }
+                }
 
                 // If no valid mapping, scan local files to discover/rediscover the workflow
                 if (!filename) {
@@ -307,13 +335,13 @@ export class WorkflowStateTracker extends EventEmitter {
 
                 // If still not found, this is a NEW remote workflow - generate filename
                 if (!filename) {
-                    const baseName = `${this.safeName(wf.name)}.workflow.ts`;
+                    const baseName = this.buildRelativeFilename(wf, folderPath);
 
                     // Check if this base name is already assigned to another workflow
                     if (assignedFilenames.has(baseName)) {
                         // Name collision - generate unique filename with ID suffix
                         const idSuffix = wf.id.substring(0, 8);
-                        filename = `${this.safeName(wf.name)}_${idSuffix}.workflow.ts`;
+                        filename = this.buildRelativeFilename(wf, folderPath, idSuffix);
                     } else {
                         // Name is free - use it
                         filename = baseName;
@@ -397,9 +425,9 @@ export class WorkflowStateTracker extends EventEmitter {
         // If workflow not tracked yet (first sync of local-only workflow),
         // scan directory to find the file with this ID
         if (!filename) {
-            const files = fs.readdirSync(this.directory).filter(f => f.endsWith('.workflow.ts') && !f.startsWith('.'));
+            const files = listWorkflowFilesRecursive(this.directory);
             for (const file of files) {
-                const filePath = path.join(this.directory, file);
+                const filePath = workflowRelativePathToAbsolute(this.directory, file);
                 const content = this.readJsonFile(filePath);
                 if (content?.id === workflowId) {
                     filename = file;
@@ -416,7 +444,7 @@ export class WorkflowStateTracker extends EventEmitter {
         }
 
         // Get current reality
-        const filePath = path.join(this.directory, filename);
+        const filePath = workflowRelativePathToAbsolute(this.directory, filename);
         const content = this.readJsonFile(filePath);
 
         if (!content) {
@@ -476,6 +504,8 @@ export class WorkflowStateTracker extends EventEmitter {
         this.remoteNames.delete(id);
         this.remoteActive.delete(id);
         this.remoteArchived.delete(id);
+        this.remoteParentFolderIds.delete(id);
+        this.remoteFolderPaths.delete(id);
         this.remoteIds.delete(id);
     }
 
@@ -504,16 +534,22 @@ export class WorkflowStateTracker extends EventEmitter {
         for (const [workflowId, workflowState] of Object.entries(state.workflows)) {
             const filename = workflowState?.filename;
             if (!filename) continue;
+            let normalizedFilename: string;
+            try {
+                normalizedFilename = normalizeWorkflowRelativePath(filename);
+            } catch {
+                continue;
+            }
 
-            const filePath = path.join(this.directory, filename);
+            const filePath = workflowRelativePathToAbsolute(this.directory, normalizedFilename);
             if (!fs.existsSync(filePath)) continue;
 
             if (!this.idToFileMap.has(workflowId)) {
-                this.idToFileMap.set(workflowId, filename);
+                this.idToFileMap.set(workflowId, normalizedFilename);
             }
 
-            if (!this.fileToIdMap.has(filename)) {
-                this.fileToIdMap.set(filename, workflowId);
+            if (!this.fileToIdMap.has(normalizedFilename)) {
+                this.fileToIdMap.set(normalizedFilename, workflowId);
             }
         }
     }
@@ -677,6 +713,38 @@ export class WorkflowStateTracker extends EventEmitter {
         return finalName;
     }
 
+    private async createFolderResolver(remoteWorkflows: IWorkflow[]): Promise<FolderPathResolver | null> {
+        if (!this.folderSync) return null;
+        const hasWorkflowFolderFields = remoteWorkflows.some((workflow) =>
+            workflow.parentFolderId !== undefined || workflow.parentFolder?.id,
+        );
+        const getFolders = (this.client as any).getFolders;
+        if (!hasWorkflowFolderFields || typeof getFolders !== 'function') {
+            this.warnFolderMetadataUnavailable();
+            return null;
+        }
+        try {
+            return new FolderPathResolver(await getFolders.call(this.client, this.projectId));
+        } catch (error: any) {
+            this.warnFolderMetadataUnavailable(error?.message);
+            return null;
+        }
+    }
+
+    private warnFolderMetadataUnavailable(reason?: string): void {
+        if (this.warnedFolderMetadataUnavailable) return;
+        this.warnedFolderMetadataUnavailable = true;
+        console.warn(
+            `[WorkflowStateTracker] folderSync is enabled, but public workflow folder metadata is unavailable${reason ? `: ${reason}` : ''}. Falling back to flat workflow paths.`,
+        );
+    }
+
+    private buildRelativeFilename(workflow: IWorkflow, folderPath: string[] = [], idSuffix?: string): string {
+        const baseName = `${this.safeName(workflow.name)}${idSuffix ? `_${idSuffix}` : ''}.workflow.ts`;
+        if (!this.folderSync || folderPath.length === 0) return baseName;
+        return normalizeWorkflowRelativePath([...folderPath.map(sanitizePathSegment), baseName].join('/'));
+    }
+
     /**
      * Find local file that contains a specific workflow ID
      * Used when we have an ID but no filename mapping yet (e.g., after file rename)
@@ -686,11 +754,10 @@ export class WorkflowStateTracker extends EventEmitter {
             return undefined;
         }
 
-        const files = fs.readdirSync(this.directory)
-            .filter(f => f.endsWith('.workflow.ts') && !f.startsWith('.'));
+        const files = listWorkflowFilesRecursive(this.directory);
 
         for (const file of files) {
-            const content = this.readJsonFile(path.join(this.directory, file));
+            const content = this.readJsonFile(workflowRelativePathToAbsolute(this.directory, file));
             if (content?.id === workflowId) {
                 return file;
             }
@@ -836,7 +903,7 @@ export class WorkflowStateTracker extends EventEmitter {
             // For local-only files, extract the name from the @workflow decorator for an accurate display.
             // Fall back to filename-derived name as last resort.
             const workflowName = (workflowId && this.remoteNames.get(workflowId))
-                || this.readJsonFile(path.join(this.directory, filename))?.name
+                || this.readJsonFile(workflowRelativePathToAbsolute(this.directory, filename))?.name
                 || filename.replace('.workflow.ts', '');
 
             results.set(filename, {
@@ -848,7 +915,10 @@ export class WorkflowStateTracker extends EventEmitter {
                 projectId: undefined, // Not available in lightweight mode
                 projectName: undefined, // Not available in lightweight mode
                 homeProject: undefined, // Not available in lightweight mode
-                isArchived
+                isArchived,
+                parentFolderId: workflowId ? this.remoteParentFolderIds.get(workflowId) : undefined,
+                folderPath: workflowId ? this.remoteFolderPaths.get(workflowId) : undefined,
+                folderPathString: workflowId ? this.remoteFolderPaths.get(workflowId)?.join('/') : undefined,
             });
         }
 
@@ -879,7 +949,10 @@ export class WorkflowStateTracker extends EventEmitter {
                     projectId: undefined, // Not available in lightweight mode
                     projectName: undefined, // Not available in lightweight mode
                     homeProject: undefined, // Not available in lightweight mode
-                    isArchived
+                    isArchived,
+                    parentFolderId: this.remoteParentFolderIds.get(workflowId),
+                    folderPath: this.remoteFolderPaths.get(workflowId),
+                    folderPathString: this.remoteFolderPaths.get(workflowId)?.join('/'),
                 });
             }
         }
@@ -891,18 +964,12 @@ export class WorkflowStateTracker extends EventEmitter {
      * Get list of local workflow filenames (just checks file system, no parsing)
      */
     private getLocalWorkflowFilenames(): string[] {
-        const filenames: string[] = [];
         try {
-            const files = fs.readdirSync(this.directory);
-            for (const file of files) {
-                if (file.endsWith('.workflow.ts')) {
-                    filenames.push(file);
-                }
-            }
+            return listWorkflowFilesRecursive(this.directory);
         } catch (error) {
             console.debug('[WorkflowStateTracker] Failed to read local directory:', error);
         }
-        return filenames;
+        return [];
     }
 
     public async getStatusMatrix(): Promise<IWorkflowStatus[]> {
@@ -914,7 +981,7 @@ export class WorkflowStateTracker extends EventEmitter {
         try {
             // Read local workflows
             for (const [filename] of this.localHashes.entries()) {
-                const filePath = path.join(this.directory, filename);
+                const filePath = workflowRelativePathToAbsolute(this.directory, filename);
                 if (fs.existsSync(filePath)) {
                     try {
                         const workflow = await this.readWorkflowFile(filePath);
@@ -952,7 +1019,10 @@ export class WorkflowStateTracker extends EventEmitter {
                 projectId: workflow?.projectId,
                 projectName: workflow?.projectName,
                 homeProject: workflow?.homeProject,
-                isArchived
+                isArchived,
+                parentFolderId: workflowId ? this.remoteParentFolderIds.get(workflowId) : undefined,
+                folderPath: workflowId ? this.remoteFolderPaths.get(workflowId) : undefined,
+                folderPathString: workflowId ? this.remoteFolderPaths.get(workflowId)?.join('/') : undefined,
             });
         }
 
@@ -977,7 +1047,10 @@ export class WorkflowStateTracker extends EventEmitter {
                     projectId: workflow?.projectId,
                     projectName: workflow?.projectName,
                     homeProject: workflow?.homeProject,
-                    isArchived: workflow?.isArchived ?? false
+                    isArchived: workflow?.isArchived ?? false,
+                    parentFolderId: this.remoteParentFolderIds.get(workflowId),
+                    folderPath: this.remoteFolderPaths.get(workflowId),
+                    folderPathString: this.remoteFolderPaths.get(workflowId)?.join('/'),
                 });
             }
         }
@@ -1003,7 +1076,10 @@ export class WorkflowStateTracker extends EventEmitter {
                     projectId: workflow?.projectId,
                     projectName: workflow?.projectName,
                     homeProject: workflow?.homeProject,
-                    isArchived: workflow?.isArchived ?? false
+                    isArchived: workflow?.isArchived ?? false,
+                    parentFolderId: this.remoteParentFolderIds.get(id),
+                    folderPath: this.remoteFolderPaths.get(id),
+                    folderPathString: this.remoteFolderPaths.get(id)?.join('/'),
                 });
             }
         }
@@ -1053,7 +1129,7 @@ export class WorkflowStateTracker extends EventEmitter {
 
         // 1. Get all local workflows
         for (const [filename, _] of this.localHashes.entries()) {
-            const filepath = path.join(this.directory, filename);
+            const filepath = workflowRelativePathToAbsolute(this.directory, filename);
             try {
                 const workflow = await this.readWorkflowFile(filepath);
                 if (workflow) {
@@ -1123,6 +1199,18 @@ export class WorkflowStateTracker extends EventEmitter {
             this.remoteNames.set(newId, name);
         }
 
+        const parentFolderId = this.remoteParentFolderIds.get(oldId);
+        if (parentFolderId !== undefined) {
+            this.remoteParentFolderIds.delete(oldId);
+            this.remoteParentFolderIds.set(newId, parentFolderId);
+        }
+
+        const folderPath = this.remoteFolderPaths.get(oldId);
+        if (folderPath) {
+            this.remoteFolderPaths.delete(oldId);
+            this.remoteFolderPaths.set(newId, folderPath);
+        }
+
         // Migrate remote ID set
         if (this.remoteIds.has(oldId)) {
             this.remoteIds.delete(oldId);
@@ -1157,18 +1245,30 @@ export class WorkflowStateTracker extends EventEmitter {
             // Store active and archived flags
             this.remoteActive.set(remoteWf.id, remoteWf.active === true);
             this.remoteArchived.set(remoteWf.id, remoteWf.isArchived === true);
+            const parentFolderId = remoteWf.parentFolderId ?? remoteWf.parentFolder?.id ?? null;
+            let folderPath: string[] = [];
+            if (this.folderSync && parentFolderId && typeof (this.client as any).getFolders === 'function') {
+                try {
+                    const resolver = new FolderPathResolver(await (this.client as any).getFolders(this.projectId));
+                    folderPath = resolver.getPathForWorkflow(remoteWf);
+                } catch (error: any) {
+                    this.warnFolderMetadataUnavailable(error?.message);
+                }
+            }
+            this.remoteParentFolderIds.set(remoteWf.id, parentFolderId);
+            this.remoteFolderPaths.set(remoteWf.id, folderPath);
 
             // Establish mapping if it doesn't exist yet (allows 'pull' after single 'fetch')
             if (!this.idToFileMap.has(remoteWf.id)) {
                 let filename = this.findFilenameByWorkflowId(remoteWf.id);
                 
                 if (!filename) {
-                    const baseName = `${this.safeName(remoteWf.name || remoteWf.id)}.workflow.ts`;
+                    const baseName = this.buildRelativeFilename(remoteWf, folderPath);
                     filename = baseName;
                     
                     // Simple collision check against existing mappings
                     if (this.fileToIdMap.has(filename)) {
-                        filename = `${this.safeName(remoteWf.name || remoteWf.id)}_${remoteWf.id.substring(0, 8)}.workflow.ts`;
+                        filename = this.buildRelativeFilename(remoteWf, folderPath, remoteWf.id.substring(0, 8));
                     }
                 }
                 

--- a/packages/cli/src/core/services/workflow-transformer-adapter.ts
+++ b/packages/cli/src/core/services/workflow-transformer-adapter.ts
@@ -224,8 +224,14 @@ export class WorkflowTransformerAdapter {
     
     /**
      * Clean workflow for pushing to n8n API
-     * 
-     * Removes read-only and organization metadata fields
+     *
+     * Removes read-only and organization metadata fields.
+     *
+     * Note the asymmetry in the folder fields: `parentFolder`, `folderPath` and
+     * `folderPathString` are display metadata and are stripped, but
+     * `parentFolderId` is deliberately kept — it is the writable field n8n uses
+     * to place a workflow in a folder (2.32+), and folderSync pushes depend on it
+     * surviving. Do not "tidy up" by adding it to the strip list.
      */
     private static cleanForPush(workflow: IWorkflow): IWorkflow {
         const { projectId, projectName, homeProject, isArchived, parentFolder, folderPath, folderPathString, ...clean } = workflow as any;

--- a/packages/cli/src/core/services/workflow-transformer-adapter.ts
+++ b/packages/cli/src/core/services/workflow-transformer-adapter.ts
@@ -228,7 +228,7 @@ export class WorkflowTransformerAdapter {
      * Removes read-only and organization metadata fields
      */
     private static cleanForPush(workflow: IWorkflow): IWorkflow {
-        const { projectId, projectName, homeProject, isArchived, ...clean } = workflow as any;
+        const { projectId, projectName, homeProject, isArchived, parentFolder, folderPath, folderPathString, ...clean } = workflow as any;
 
         if (projectId) {
             clean.projectId = projectId;

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -36,12 +36,6 @@ export interface IFolder {
     updatedAt?: string;
 }
 
-export interface IFolderCapability {
-    folders: boolean;
-    workflowFolderFields: boolean;
-    workflowParentFolderIdWritable?: boolean;
-}
-
 export interface ITag {
     id: string;
     name: string;
@@ -135,7 +129,24 @@ export interface ISyncConfig {
     instanceConfigPath?: string; // Optional: explicit path for n8nac-config.json
     projectId: string;           // REQUIRED: Project scope for sync
     projectName: string;         // REQUIRED: Project display name
+    /**
+     * Mirror the local folder structure onto n8n when pushing: a workflow stored
+     * at `Some Folder/foo.workflow.ts` is created/moved into `Some Folder` on the
+     * instance, creating the folder if needed.
+     *
+     * Push-only. n8n's public API never returns a workflow's folder, so pull
+     * cannot restore the remote layout — see docs/guides/folder-sync.md.
+     */
     folderSync?: boolean;
+    /**
+     * Also move workflows OUT of their remote folder when the local file sits at
+     * the workflows-directory root (sends `parentFolderId: null`).
+     *
+     * Off by default: with `folderSync` alone a push never undoes folders created
+     * from the n8n UI, it only ever places workflows the repository has an opinion
+     * about. Turn this on when the repository is the sole source of truth.
+     */
+    folderSyncMoveToRoot?: boolean;
     environmentId?: string;
     environmentName?: string;
     environmentTargetId?: string;

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -21,6 +21,25 @@ export interface IWorkflow {
     projectName?: string;        // Name of the project (from shared[0].project.name)
     homeProject?: IProject;      // Full project object for detailed info
     isArchived?: boolean;        // Whether workflow is archived
+    parentFolderId?: string | null;
+    parentFolder?: { id: string; name: string } | null;
+    folderPath?: string[];
+    folderPathString?: string;
+}
+
+export interface IFolder {
+    id: string;
+    name: string;
+    parentFolderId?: string | null;
+    path?: string | string[];
+    createdAt?: string;
+    updatedAt?: string;
+}
+
+export interface IFolderCapability {
+    folders: boolean;
+    workflowFolderFields: boolean;
+    workflowParentFolderIdWritable?: boolean;
 }
 
 export interface ITag {
@@ -77,6 +96,10 @@ export interface IWorkflowStatus {
     lastSyncedAt?: string;
     /** Remote `updatedAt` from the most recent lightweight fetch, if available. */
     remoteUpdatedAt?: string;
+    parentFolderId?: string | null;
+    parentFolder?: { id: string; name: string } | null;
+    folderPath?: string[];
+    folderPathString?: string;
 }
 
 /**

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -21,6 +21,25 @@ export interface IWorkflow {
     projectName?: string;        // Name of the project (from shared[0].project.name)
     homeProject?: IProject;      // Full project object for detailed info
     isArchived?: boolean;        // Whether workflow is archived
+    parentFolderId?: string | null;
+    parentFolder?: { id: string; name: string } | null;
+    folderPath?: string[];
+    folderPathString?: string;
+}
+
+export interface IFolder {
+    id: string;
+    name: string;
+    parentFolderId?: string | null;
+    path?: string | string[];
+    createdAt?: string;
+    updatedAt?: string;
+}
+
+export interface IFolderCapability {
+    folders: boolean;
+    workflowFolderFields: boolean;
+    workflowParentFolderIdWritable?: boolean;
 }
 
 export interface ITag {
@@ -53,6 +72,10 @@ export interface IWorkflowStatus {
     projectName?: string;
     homeProject?: IProject;
     isArchived?: boolean;
+    parentFolderId?: string | null;
+    parentFolder?: { id: string; name: string } | null;
+    folderPath?: string[];
+    folderPathString?: string;
 }
 
 export interface ISyncConfig {

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -27,6 +27,8 @@ export interface ILocalConfig {
     workflowDir?: string;
     customNodesPath?: string;
     folderSync?: boolean;
+    /** See ISyncConfig.folderSyncMoveToRoot — opt-in, push moves workflows out of remote folders. */
+    folderSyncMoveToRoot?: boolean;
 }
 
 export type IInstanceVerificationStatus = N8nInstanceVerificationStatus;
@@ -107,6 +109,8 @@ export interface IWorkspaceEnvironment {
     workflowsPath?: string;
     syncFolder?: string;
     folderSync?: boolean;
+    /** See ISyncConfig.folderSyncMoveToRoot — opt-in, push moves workflows out of remote folders. */
+    folderSyncMoveToRoot?: boolean;
     customNodesPath?: string;
     description?: string;
     sourceKind?: 'managed-instance' | 'external-instance';
@@ -413,6 +417,7 @@ export class ConfigService {
         syncFolder?: string;
         id?: string;
         folderSync?: boolean;
+        folderSyncMoveToRoot?: boolean;
         customNodesPath?: string;
         description?: string;
         nativeMcp?: IWorkspaceNativeMcpConfig;
@@ -442,6 +447,7 @@ export class ConfigService {
             projectName: cleanOptional(input.projectName),
             workflowsPath,
             folderSync: input.folderSync,
+            folderSyncMoveToRoot: input.folderSyncMoveToRoot,
             customNodesPath: input.customNodesPath,
             description: input.description,
             nativeMcp: this.sanitizeNativeMcpConfig(input.nativeMcp),
@@ -455,7 +461,7 @@ export class ConfigService {
         return environment;
     }
 
-    updateEnvironment(nameOrId: string, patch: Partial<Pick<IWorkspaceEnvironment, 'name' | 'projectId' | 'projectName' | 'workflowsPath' | 'workflowDir' | 'syncFolder' | 'folderSync' | 'customNodesPath' | 'description'>> & { environmentTarget?: string; nativeMcp?: IWorkspaceNativeMcpConfig | null }): IWorkspaceEnvironment {
+    updateEnvironment(nameOrId: string, patch: Partial<Pick<IWorkspaceEnvironment, 'name' | 'projectId' | 'projectName' | 'workflowsPath' | 'workflowDir' | 'syncFolder' | 'folderSync' | 'folderSyncMoveToRoot' | 'customNodesPath' | 'description'>> & { environmentTarget?: string; nativeMcp?: IWorkspaceNativeMcpConfig | null }): IWorkspaceEnvironment {
         const config = this.ensureV4WorkspaceConfig();
         const environment = this.findEnvironment(config, nameOrId);
         const currentTarget = this.findInstanceTarget(config, environment.environmentTargetId);
@@ -482,6 +488,7 @@ export class ConfigService {
             projectId: patch.projectId !== undefined ? cleanOptional(patch.projectId) : environment.projectId,
             projectName: patch.projectName !== undefined ? cleanOptional(patch.projectName) : environment.projectName,
             folderSync: patch.folderSync ?? environment.folderSync,
+            folderSyncMoveToRoot: patch.folderSyncMoveToRoot ?? environment.folderSyncMoveToRoot,
             customNodesPath: patch.customNodesPath ?? environment.customNodesPath,
             description: patch.description ?? environment.description,
             nativeMcp: patch.nativeMcp !== undefined ? this.sanitizeNativeMcpConfig(patch.nativeMcp) : environment.nativeMcp,
@@ -1265,6 +1272,7 @@ export class ConfigService {
             workflowsPath,
             syncFolder,
             folderSync: typeof environment.folderSync === 'boolean' ? environment.folderSync : undefined,
+            folderSyncMoveToRoot: typeof environment.folderSyncMoveToRoot === 'boolean' ? environment.folderSyncMoveToRoot : undefined,
             customNodesPath: cleanOptional(environment.customNodesPath),
             description: cleanOptional(environment.description),
             nativeMcp: this.sanitizeNativeMcpConfig(environment.nativeMcp),
@@ -1419,6 +1427,7 @@ export class ConfigService {
                 instanceUserIdentifier: identity.instanceUserIdentifier,
                 workflowDir: workflowsPath,
                 folderSync: environment.folderSync ?? false,
+                folderSyncMoveToRoot: environment.folderSyncMoveToRoot ?? false,
                 customNodesPath: environment.customNodesPath,
                 sources: {
                     environment: source,
@@ -1462,6 +1471,7 @@ export class ConfigService {
             instanceUserIdentifier: identity.instanceUserIdentifier,
             workflowDir: workflowsPath,
             folderSync: environment.folderSync ?? false,
+            folderSyncMoveToRoot: environment.folderSyncMoveToRoot ?? false,
             customNodesPath: environment.customNodesPath,
             sources: {
                 environment: source,
@@ -1537,6 +1547,7 @@ export class ConfigService {
             instanceUserIdentifier: environment.instanceUserIdentifier,
             customNodesPath: environment.customNodesPath,
             folderSync: environment.folderSync,
+            folderSyncMoveToRoot: environment.folderSyncMoveToRoot,
         });
     }
 
@@ -1649,6 +1660,7 @@ export class ConfigService {
             instanceUserIdentifier: environment.instanceUserIdentifier,
             customNodesPath: environment.customNodesPath,
             folderSync: environment.folderSync,
+            folderSyncMoveToRoot: environment.folderSyncMoveToRoot,
         });
     }
 
@@ -1678,6 +1690,7 @@ export class ConfigService {
             instanceIdentifier: environment.instanceIdentifier,
             instanceUserIdentifier: environment.instanceUserIdentifier,
             folderSync: environment.folderSync ?? false,
+            folderSyncMoveToRoot: environment.folderSyncMoveToRoot ?? false,
             customNodesPath: environment.customNodesPath,
             environmentId: environment.environmentId,
             environmentName: environment.environmentName,

--- a/packages/cli/tests/unit/n8n-api-client.test.ts
+++ b/packages/cli/tests/unit/n8n-api-client.test.ts
@@ -206,6 +206,51 @@ describe('N8nApiClient test workflow support', () => {
         }));
     });
 
+    it('only selects folder fields n8n accepts', async () => {
+        mockAxiosGet.mockResolvedValueOnce({ data: { count: 1, data: [{ id: 'f1', name: 'Parent', parentFolder: null }] } });
+        const client = new N8nApiClient({ host: 'https://n8n.local/', apiKey: 'secret' });
+
+        await client.getFolders('project-1');
+
+        // n8n's ListFolderQueryDto allow-list has `parentFolder`, not
+        // `parentFolderId` — asking for the latter 400s the whole query.
+        const select = JSON.parse(mockAxiosGet.mock.calls[0][1].params.select);
+        expect(select).toContain('parentFolder');
+        expect(select).not.toContain('parentFolderId');
+    });
+
+    it('resolves the folder project id from a workflow share when given the personal placeholder', async () => {
+        mockAxiosGet.mockResolvedValueOnce({ data: { data: [
+            { id: 'wf-1', shared: [{ projectId: 'real-project-id', role: 'workflow:owner' }] },
+        ] } });
+        const client = new N8nApiClient({ host: 'https://n8n.local/', apiKey: 'secret' });
+
+        // GET /api/v1/projects is Enterprise-gated, so a Community instance has to
+        // learn its own project id from a workflow payload instead.
+        await expect(client.resolveFolderProjectId('personal')).resolves.toBe('real-project-id');
+        expect(mockAxiosGet).toHaveBeenCalledWith('/api/v1/workflows', expect.objectContaining({
+            params: expect.objectContaining({ limit: 1 }),
+        }));
+
+        // Memoized: a second call must not re-hit the API.
+        await expect(client.resolveFolderProjectId('personal')).resolves.toBe('real-project-id');
+        expect(mockAxiosGet).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes a real project id straight through without an API round-trip', async () => {
+        const client = new N8nApiClient({ host: 'https://n8n.local/', apiKey: 'secret' });
+
+        await expect(client.resolveFolderProjectId('project-42')).resolves.toBe('project-42');
+        expect(mockAxiosGet).not.toHaveBeenCalled();
+    });
+
+    it('resolves to null instead of throwing when no project id can be found', async () => {
+        mockAxiosGet.mockRejectedValueOnce(Object.assign(new Error('forbidden'), { response: { status: 403 } }));
+        const client = new N8nApiClient({ host: 'https://n8n.local/', apiKey: 'secret' });
+
+        await expect(client.resolveFolderProjectId('personal')).resolves.toBeNull();
+    });
+
     it('preserves workflow parent folder metadata from workflow payloads', async () => {
         mockAxiosGet
             .mockResolvedValueOnce({ data: {

--- a/packages/cli/tests/unit/n8n-api-client.test.ts
+++ b/packages/cli/tests/unit/n8n-api-client.test.ts
@@ -187,6 +187,47 @@ describe('N8nApiClient test workflow support', () => {
         });
     });
 
+    it('fetches public project folders with pagination', async () => {
+        mockAxiosGet
+            .mockResolvedValueOnce({ data: { count: 2, data: [{ id: 'f1', name: 'Parent', parentFolderId: null }] } })
+            .mockResolvedValueOnce({ data: { count: 2, data: [{ id: 'f2', name: 'Child', parentFolderId: 'f1' }] } });
+        const client = new N8nApiClient({ host: 'https://n8n.local/', apiKey: 'secret' });
+
+        await expect(client.getFolders('project-1')).resolves.toEqual([
+            expect.objectContaining({ id: 'f1', name: 'Parent', parentFolderId: null }),
+            expect.objectContaining({ id: 'f2', name: 'Child', parentFolderId: 'f1' }),
+        ]);
+
+        expect(mockAxiosGet).toHaveBeenCalledWith('/api/v1/projects/project-1/folders', expect.objectContaining({
+            params: expect.objectContaining({ skip: '0', take: '100' }),
+        }));
+        expect(mockAxiosGet).toHaveBeenCalledWith('/api/v1/projects/project-1/folders', expect.objectContaining({
+            params: expect.objectContaining({ skip: '100', take: '100' }),
+        }));
+    });
+
+    it('preserves workflow parent folder metadata from workflow payloads', async () => {
+        mockAxiosGet
+            .mockResolvedValueOnce({ data: {
+                id: 'wf-1',
+                name: 'Foldered Workflow',
+                active: true,
+                nodes: [],
+                connections: {},
+                shared: [],
+                parentFolderId: 'folder-1',
+                parentFolder: { id: 'folder-1', name: 'Folder' },
+            } })
+            .mockRejectedValueOnce(new Error('tags unavailable'))
+            .mockResolvedValueOnce({ data: { data: [] } });
+        const client = new N8nApiClient({ host: 'https://n8n.local/', apiKey: 'secret' });
+
+        await expect(client.getWorkflow('wf-1')).resolves.toEqual(expect.objectContaining({
+            parentFolderId: 'folder-1',
+            parentFolder: { id: 'folder-1', name: 'Folder' },
+        }));
+    });
+
     it('uses a bounded text request for HTML instance identity fallback', async () => {
         mockAxiosGet.mockRejectedValue(new Error('not available'));
         mockAxiosCall.mockResolvedValueOnce({ data: '<html><script>{"instanceId":"instance-from-html"}</script></html>' });

--- a/packages/cli/tests/unit/n8n-api-client.test.ts
+++ b/packages/cli/tests/unit/n8n-api-client.test.ts
@@ -85,6 +85,47 @@ describe('N8nApiClient test workflow support', () => {
         });
     });
 
+    it('fetches public project folders with pagination', async () => {
+        mockAxiosGet
+            .mockResolvedValueOnce({ data: { count: 2, data: [{ id: 'f1', name: 'Parent', parentFolderId: null }] } })
+            .mockResolvedValueOnce({ data: { count: 2, data: [{ id: 'f2', name: 'Child', parentFolderId: 'f1' }] } });
+        const client = new N8nApiClient({ host: 'https://n8n.local/', apiKey: 'secret' });
+
+        await expect(client.getFolders('project-1')).resolves.toEqual([
+            expect.objectContaining({ id: 'f1', name: 'Parent', parentFolderId: null }),
+            expect.objectContaining({ id: 'f2', name: 'Child', parentFolderId: 'f1' }),
+        ]);
+
+        expect(mockAxiosGet).toHaveBeenCalledWith('/api/v1/projects/project-1/folders', expect.objectContaining({
+            params: expect.objectContaining({ skip: '0', take: '100' }),
+        }));
+        expect(mockAxiosGet).toHaveBeenCalledWith('/api/v1/projects/project-1/folders', expect.objectContaining({
+            params: expect.objectContaining({ skip: '100', take: '100' }),
+        }));
+    });
+
+    it('preserves workflow parent folder metadata from workflow payloads', async () => {
+        mockAxiosGet
+            .mockResolvedValueOnce({ data: {
+                id: 'wf-1',
+                name: 'Foldered Workflow',
+                active: true,
+                nodes: [],
+                connections: {},
+                shared: [],
+                parentFolderId: 'folder-1',
+                parentFolder: { id: 'folder-1', name: 'Folder' },
+            } })
+            .mockRejectedValueOnce(new Error('tags unavailable'))
+            .mockResolvedValueOnce({ data: { data: [] } });
+        const client = new N8nApiClient({ host: 'https://n8n.local/', apiKey: 'secret' });
+
+        await expect(client.getWorkflow('wf-1')).resolves.toEqual(expect.objectContaining({
+            parentFolderId: 'folder-1',
+            parentFolder: { id: 'folder-1', name: 'Folder' },
+        }));
+    });
+
     it('uses a bounded text request for HTML instance identity fallback', async () => {
         mockAxiosGet.mockRejectedValue(new Error('not available'));
         mockAxiosCall.mockResolvedValueOnce({ data: '<html><script>{"instanceId":"instance-from-html"}</script></html>' });

--- a/packages/cli/tests/unit/sync-engine.test.ts
+++ b/packages/cli/tests/unit/sync-engine.test.ts
@@ -5,9 +5,17 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SyncEngine } from '../../src/core/services/sync-engine.js';
 import { WorkflowTransformerAdapter } from '../../src/core/services/workflow-transformer-adapter.js';
 
-function createEngine(params: { projectId: string; createWorkflow: ReturnType<typeof vi.fn> }) {
+function createEngine(params: {
+    projectId: string;
+    createWorkflow: ReturnType<typeof vi.fn>;
+    filename?: string;
+    folderSync?: boolean;
+    getFolders?: ReturnType<typeof vi.fn>;
+    createFolder?: ReturnType<typeof vi.fn>;
+}) {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-sync-engine-'));
-    const filename = 'new.workflow.ts';
+    const filename = params.filename ?? 'new.workflow.ts';
+    fs.mkdirSync(path.dirname(path.join(directory, filename)), { recursive: true });
     fs.writeFileSync(path.join(directory, filename), '// workflow source', 'utf8');
 
     const watcher = {
@@ -16,9 +24,13 @@ function createEngine(params: { projectId: string; createWorkflow: ReturnType<ty
 
     const client = {
         createWorkflow: params.createWorkflow,
+        getFolders: params.getFolders,
+        createFolder: params.createFolder,
     } as any;
 
-    const engine = new SyncEngine(client, watcher, directory, params.projectId);
+    const engine = new SyncEngine(client, watcher, directory, params.projectId, undefined, {
+        folderSync: params.folderSync,
+    });
 
     return { engine, directory, filename, watcher };
 }
@@ -69,6 +81,44 @@ describe('SyncEngine create payload projectId behavior', () => {
 
         expect(createWorkflow).toHaveBeenCalledWith(expect.not.objectContaining({
             projectId: expect.anything(),
+        }));
+    });
+
+    it('sets parentFolderId on create for nested folderSync paths', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Nested Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        const createWorkflow = vi.fn(async (payload) => ({ ...payload, id: 'wf-nested' }));
+        const getFolders = vi.fn(async () => [
+            { id: 'folder-ai-chat', name: 'Ai Chat', parentFolderId: null },
+        ]);
+        const createFolder = vi.fn(async (_projectId, payload) => ({
+            id: 'folder-file-processing',
+            name: payload.name,
+            parentFolderId: payload.parentFolderId,
+        }));
+
+        const { engine, filename } = createEngine({
+            projectId: 'project-1',
+            createWorkflow,
+            filename: 'Ai Chat/File Processing/new.workflow.ts',
+            folderSync: true,
+            getFolders,
+            createFolder,
+        });
+
+        await expect(engine.push(filename)).resolves.toBe('wf-nested');
+
+        expect(createFolder).toHaveBeenCalledWith('project-1', {
+            name: 'File Processing',
+            parentFolderId: 'folder-ai-chat',
+        });
+        expect(createWorkflow).toHaveBeenCalledWith(expect.objectContaining({
+            parentFolderId: 'folder-file-processing',
         }));
     });
 });

--- a/packages/cli/tests/unit/sync-engine.test.ts
+++ b/packages/cli/tests/unit/sync-engine.test.ts
@@ -259,3 +259,228 @@ describe('SyncEngine create payload projectId behavior', () => {
         expect(parentFolderCalls).toHaveLength(1);
     });
 });
+
+
+// ---------------------------------------------------------------------------
+// Update path: folder-aware move (PR review fix for Codex P2 finding)
+// ---------------------------------------------------------------------------
+//
+// Mirrors the create-path folderSync tests but for executeUpdate(). The update
+// path used to drop `parentFolderId` on the floor — both because
+// `inferParentFolderIdFromFilename` was only called from executeCreate(), and
+// because `N8nApiClient.cleanWorkflowUpdatePayload()` did not include
+// `parentFolderId` in its allowedKeys set. Both are fixed; these tests guard
+// the contract.
+// ---------------------------------------------------------------------------
+
+function updateEngine(params: {
+    projectId: string;
+    updateWorkflow: ReturnType<typeof vi.fn>;
+    filename?: string;
+    folderSync?: boolean;
+    getFolders?: ReturnType<typeof vi.fn>;
+    createFolder?: ReturnType<typeof vi.fn>;
+    workflowId?: string;
+}) {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-sync-engine-update-'));
+    const filename = params.filename ?? 'existing.workflow.ts';
+    fs.mkdirSync(path.dirname(path.join(directory, filename)), { recursive: true });
+    fs.writeFileSync(path.join(directory, filename), '// workflow source', 'utf8');
+
+    const watcher = {
+        finalizeSync: vi.fn(async () => undefined),
+        setRemoteHash: vi.fn(),
+    } as any;
+
+    // Return undefined from getWorkflow to bypass OCC; tests don't exercise OCC.
+    const client = {
+        getWorkflow: vi.fn(async () => undefined),
+        updateWorkflow: params.updateWorkflow,
+        getFolders: params.getFolders,
+        createFolder: params.createFolder,
+    } as any;
+
+    const engine = new SyncEngine(client, watcher, directory, params.projectId, undefined, {
+        folderSync: params.folderSync,
+    });
+
+    return {
+        engine,
+        directory,
+        filename,
+        watcher,
+        client,
+        workflowId: params.workflowId ?? 'wf-existing',
+    };
+}
+
+describe('SyncEngine update payload folderSync behavior', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('sets parentFolderId on update for nested folderSync paths (move into folder)', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Existing Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        const updateWorkflow = vi.fn(async (id, payload) => ({
+            ...payload,
+            id,
+            updatedAt: '2026-06-23T00:00:00.000Z',
+        }));
+        const getFolders = vi.fn(async () => [
+            { id: 'folder-ai-chat', name: 'Ai Chat', parentFolderId: null },
+        ]);
+        const createFolder = vi.fn(async (_projectId, payload) => ({
+            id: 'folder-file-processing',
+            name: payload.name,
+            parentFolderId: payload.parentFolderId,
+        }));
+
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow,
+            filename: 'Ai Chat/File Processing/existing.workflow.ts',
+            folderSync: true,
+            getFolders,
+            createFolder,
+            workflowId: 'wf-existing',
+        });
+
+        await expect(engine.push(workflowId, filename)).resolves.toBe(workflowId);
+
+        expect(updateWorkflow).toHaveBeenCalledTimes(1);
+        expect(updateWorkflow).toHaveBeenCalledWith(workflowId, expect.objectContaining({
+            parentFolderId: 'folder-file-processing',
+        }));
+    });
+
+    it('does NOT send parentFolderId on update when filename has no nested folder', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Existing Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        const updateWorkflow = vi.fn(async (id, payload) => ({
+            ...payload,
+            id,
+            updatedAt: '2026-06-23T00:00:00.000Z',
+        }));
+        // folderSync: true but flat filename -> inferParentFolderIdFromFilename
+        // short-circuits before calling getFolders.
+        const getFolders = vi.fn(async () => []);
+        const createFolder = vi.fn(async () => ({ id: 'unused', name: 'unused', parentFolderId: null }));
+
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow,
+            filename: 'existing.workflow.ts',
+            folderSync: true,
+            getFolders,
+            createFolder,
+            workflowId: 'wf-existing',
+        });
+
+        await expect(engine.push(workflowId, filename)).resolves.toBe(workflowId);
+
+        expect(getFolders).not.toHaveBeenCalled();
+        expect(updateWorkflow).toHaveBeenCalledTimes(1);
+        expect(updateWorkflow).toHaveBeenCalledWith(
+            workflowId,
+            expect.not.objectContaining({ parentFolderId: expect.anything() }),
+        );
+    });
+
+    it('retries update without parentFolderId when n8n rejects it as an unknown field', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Existing Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        // First call rejects with a 400 mentioning parentFolderId; second call
+        // (without parentFolderId) succeeds.
+        const folderError: any = new Error('Request failed with status code 400');
+        folderError.response = {
+            status: 400,
+            data: { message: "property 'parentFolderId' should not exist" },
+        };
+        const updateWorkflow = vi.fn()
+            .mockRejectedValueOnce(folderError)
+            .mockImplementationOnce(async (id, payload) => ({
+                ...payload,
+                id,
+                updatedAt: '2026-06-23T00:00:00.000Z',
+            }));
+        const getFolders = vi.fn(async () => []);
+        const createFolder = vi.fn(async (_projectId, payload) => ({
+            id: 'folder-x',
+            name: payload.name,
+            parentFolderId: payload.parentFolderId,
+        }));
+
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow,
+            filename: 'X/existing.workflow.ts',
+            folderSync: true,
+            getFolders,
+            createFolder,
+            workflowId: 'wf-existing',
+        });
+
+        await expect(engine.push(workflowId, filename)).resolves.toBe(workflowId);
+
+        expect(updateWorkflow).toHaveBeenCalledTimes(2);
+        expect(updateWorkflow.mock.calls[0][0]).toBe(workflowId);
+        expect(updateWorkflow.mock.calls[0][1]).toEqual(expect.objectContaining({ parentFolderId: 'folder-x' }));
+        expect(updateWorkflow.mock.calls[1][1]).not.toHaveProperty('parentFolderId');
+    });
+
+    it('does NOT retry when n8n returns a generic 400 mentioning only "folder" (regression guard)', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Existing Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        // A 400 mentioning "folder" but NOT "parentFolderId" / "parentFolder"
+        // must NOT be misclassified as "unsupported parentFolderId". Doing so
+        // would silently drop the folder assignment on n8n instances that DO
+        // support it (the same regression the create-side fix addresses).
+        const genericFolderError: any = new Error('Request failed with status code 400');
+        genericFolderError.response = {
+            status: 400,
+            data: { message: 'A folder with this name already exists in another project' },
+        };
+        const updateWorkflow = vi.fn().mockRejectedValue(genericFolderError);
+        const getFolders = vi.fn(async () => []);
+        const createFolder = vi.fn(async (_projectId, payload) => ({
+            id: 'folder-x',
+            name: payload.name,
+            parentFolderId: payload.parentFolderId,
+        }));
+
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow,
+            filename: 'X/existing.workflow.ts',
+            folderSync: true,
+            getFolders,
+            createFolder,
+            workflowId: 'wf-existing',
+        });
+
+        await expect(engine.push(workflowId, filename)).rejects.toBe(genericFolderError);
+        expect(updateWorkflow).toHaveBeenCalledTimes(1);
+        expect(createFolder).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/cli/tests/unit/sync-engine.test.ts
+++ b/packages/cli/tests/unit/sync-engine.test.ts
@@ -121,4 +121,129 @@ describe('SyncEngine create payload projectId behavior', () => {
             parentFolderId: 'folder-file-processing',
         }));
     });
+
+    it('retries create without parentFolderId when n8n rejects it as an unknown field', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Nested Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        const folderError: any = new Error('Request failed with status code 400');
+        folderError.response = {
+            status: 400,
+            data: { message: "property 'parentFolderId' should not exist" },
+        };
+        const createWorkflow = vi.fn()
+            .mockRejectedValueOnce(folderError)
+            .mockImplementationOnce(async (payload) => ({ ...payload, id: 'wf-fallback' }));
+        const getFolders = vi.fn(async () => []);
+        const createFolder = vi.fn(async (_projectId, payload) => ({
+            id: 'folder-x',
+            name: payload.name,
+            parentFolderId: payload.parentFolderId,
+        }));
+
+        const { engine, filename } = createEngine({
+            projectId: 'project-1',
+            createWorkflow,
+            filename: 'X/new.workflow.ts',
+            folderSync: true,
+            getFolders,
+            createFolder,
+        });
+
+        await expect(engine.push(filename)).resolves.toBe('wf-fallback');
+
+        expect(createWorkflow).toHaveBeenCalledTimes(2);
+        expect(createWorkflow.mock.calls[0][0]).toEqual(expect.objectContaining({ parentFolderId: 'folder-x' }));
+        expect(createWorkflow.mock.calls[1][0]).not.toHaveProperty('parentFolderId');
+    });
+
+    it('does NOT retry when n8n returns a generic 400 mentioning only "folder" (regression guard for over-broad match)', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Nested Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        // A 400 whose body mentions "folder" but not "parentFolderId" / "parentFolder" must NOT be
+        // misclassified as "unsupported parentFolderId" — that would silently drop the folder assignment
+        // on n8n instances that DO support it.
+        const genericFolderError: any = new Error('Request failed with status code 400');
+        genericFolderError.response = {
+            status: 400,
+            data: { message: 'A folder with this name already exists in another project' },
+        };
+        const createWorkflow = vi.fn().mockRejectedValue(genericFolderError);
+        const getFolders = vi.fn(async () => []);
+        const createFolder = vi.fn(async (_projectId, payload) => ({
+            id: 'folder-x',
+            name: payload.name,
+            parentFolderId: payload.parentFolderId,
+        }));
+
+        const { engine, filename } = createEngine({
+            projectId: 'project-1',
+            createWorkflow,
+            filename: 'X/new.workflow.ts',
+            folderSync: true,
+            getFolders,
+            createFolder,
+        });
+
+        await expect(engine.push(filename)).rejects.toBe(genericFolderError);
+        expect(createWorkflow).toHaveBeenCalledTimes(1);
+        expect(createFolder).toHaveBeenCalledTimes(1);
+    });
+
+    it('deduplicates concurrent createFolder requests for the same parent folder', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Concurrent Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        const createWorkflow = vi.fn(async (payload: any) => ({
+            ...payload,
+            id: payload.name === 'x' ? 'wf-x' : 'wf-y',
+        }));
+
+        let createFolderCalls = 0;
+        const createFolder = vi.fn(async (_projectId: string, payload: { name: string; parentFolderId: string | null }) => {
+            createFolderCalls++;
+            // Yield to the event loop so the second push() can enter ensureFolder() before this resolves.
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            return {
+                id: `folder-${payload.name}-${createFolderCalls}`,
+                name: payload.name,
+                parentFolderId: payload.parentFolderId,
+            };
+        });
+        const getFolders = vi.fn(async () => []);
+
+        const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-sync-engine-concurrent-'));
+        const filenameX = 'Shared/Parent/x.workflow.ts';
+        const filenameY = 'Shared/Parent/y.workflow.ts';
+        fs.mkdirSync(path.join(directory, 'Shared', 'Parent'), { recursive: true });
+        fs.writeFileSync(path.join(directory, filenameX), '// x', 'utf8');
+        fs.writeFileSync(path.join(directory, filenameY), '// y', 'utf8');
+
+        const watcher = { finalizeSync: vi.fn(async () => undefined) } as any;
+        const client = { createWorkflow, getFolders, createFolder } as any;
+        const engine = new SyncEngine(client, watcher, directory, 'project-1', undefined, { folderSync: true });
+
+        await Promise.all([engine.push(filenameX), engine.push(filenameY)]);
+
+        // Both pushes share the "Shared" folder creation (parent null) and the
+        // "Parent" folder creation (parent = Shared). With the in-flight promise
+        // map, each folder must be created exactly once.
+        const sharedFolderCalls = createFolder.mock.calls.filter((call) => call[1].name === 'Shared');
+        const parentFolderCalls = createFolder.mock.calls.filter((call) => call[1].name === 'Parent');
+        expect(sharedFolderCalls).toHaveLength(1);
+        expect(parentFolderCalls).toHaveLength(1);
+    });
 });

--- a/packages/cli/tests/unit/sync-engine.test.ts
+++ b/packages/cli/tests/unit/sync-engine.test.ts
@@ -177,6 +177,54 @@ describe('SyncEngine create payload projectId behavior', () => {
         expect(callSnapshots[1]).not.toHaveProperty('parentFolderId');
     });
 
+    // The test above mocks an error that NAMES the field. Real n8n 2.19-2.31 licenses
+    // folders but has no `parentFolderId` in its workflow schema, and AJV rejects it
+    // without naming anything: "request/body must NOT have additional properties".
+    // That body matched none of the patterns, so push aborted instead of degrading and
+    // left an orphaned folder -- green CI, broken live. Captured on a real 2.25.6
+    // instance and reported on #527 by @Happily-Coding.
+    it('retries create without parentFolderId on n8n\'s generic additional-properties 400', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Nested Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        const genericError: any = new Error('Request failed with status code 400');
+        genericError.response = {
+            status: 400,
+            // verbatim from n8n 2.25.6
+            data: { message: 'request/body must NOT have additional properties' },
+        };
+        const callSnapshots: any[] = [];
+        const createWorkflow = vi.fn()
+            .mockImplementationOnce(async (payload) => {
+                callSnapshots.push({ ...payload });
+                throw genericError;
+            })
+            .mockImplementationOnce(async (payload) => {
+                callSnapshots.push({ ...payload });
+                return { ...payload, id: 'wf-generic-fallback' };
+            });
+
+        const { engine, filename } = createEngine({
+            projectId: 'project-1',
+            createWorkflow,
+            filename: 'X/new.workflow.ts',
+            folderSync: true,
+            getFolders: vi.fn(async () => []),
+            createFolder: vi.fn(async (_projectId, payload) => ({
+                id: 'folder-x', name: payload.name, parentFolderId: payload.parentFolderId,
+            })),
+        });
+
+        await expect(engine.push(filename)).resolves.toBe('wf-generic-fallback');
+        expect(createWorkflow).toHaveBeenCalledTimes(2);
+        expect(callSnapshots[0]).toEqual(expect.objectContaining({ parentFolderId: 'folder-x' }));
+        expect(callSnapshots[1]).not.toHaveProperty('parentFolderId');
+    });
+
     it('does NOT retry when n8n returns a generic 400 mentioning only "folder" (regression guard for over-broad match)', async () => {
         vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
             name: 'Nested Workflow',
@@ -403,6 +451,48 @@ describe('SyncEngine update payload folderSync behavior', () => {
             workflowId,
             expect.not.objectContaining({ parentFolderId: expect.anything() }),
         );
+    });
+
+    // Update-side twin of the create-side generic-400 case: n8n 2.19-2.31 rejects the
+    // unknown `parentFolderId` without naming it, so the retry never fired and the push
+    // aborted. Real body captured on 2.25.6, reported on #527 by @Happily-Coding.
+    it('retries update without parentFolderId on n8n\'s generic additional-properties 400', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Existing Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        const genericError: any = new Error('Request failed with status code 400');
+        genericError.response = {
+            status: 400,
+            data: { message: 'request/body must NOT have additional properties' },
+        };
+
+        const callSnapshots: Array<{ id: string; payload: any }> = [];
+        const updateWorkflow = vi.fn(async (id: string, payload: any) => {
+            callSnapshots.push({ id, payload: { ...payload } });
+            if (callSnapshots.length === 1) throw genericError;
+            return { ...payload, id, updatedAt: '2026-06-23T00:00:00.000Z' };
+        });
+
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow,
+            filename: 'Reports/existing.workflow.ts',
+            folderSync: true,
+            getFolders: vi.fn(async () => []),
+            createFolder: vi.fn(async (_projectId, payload) => ({
+                id: 'folder-x', name: payload.name, parentFolderId: payload.parentFolderId,
+            })),
+        });
+
+        await engine.push(filename, workflowId);
+
+        expect(updateWorkflow).toHaveBeenCalledTimes(2);
+        expect(callSnapshots[0].payload).toEqual(expect.objectContaining({ parentFolderId: 'folder-x' }));
+        expect(callSnapshots[1].payload).not.toHaveProperty('parentFolderId');
     });
 
     it('retries update without parentFolderId when n8n rejects it as an unknown field', async () => {

--- a/packages/cli/tests/unit/sync-engine.test.ts
+++ b/packages/cli/tests/unit/sync-engine.test.ts
@@ -10,8 +10,10 @@ function createEngine(params: {
     createWorkflow: ReturnType<typeof vi.fn>;
     filename?: string;
     folderSync?: boolean;
+    folderSyncMoveToRoot?: boolean;
     getFolders?: ReturnType<typeof vi.fn>;
     createFolder?: ReturnType<typeof vi.fn>;
+    resolveFolderProjectId?: ReturnType<typeof vi.fn>;
 }) {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-sync-engine-'));
     const filename = params.filename ?? 'new.workflow.ts';
@@ -26,10 +28,12 @@ function createEngine(params: {
         createWorkflow: params.createWorkflow,
         getFolders: params.getFolders,
         createFolder: params.createFolder,
+        resolveFolderProjectId: params.resolveFolderProjectId,
     } as any;
 
     const engine = new SyncEngine(client, watcher, directory, params.projectId, undefined, {
         folderSync: params.folderSync,
+        folderSyncMoveToRoot: params.folderSyncMoveToRoot,
     });
 
     return { engine, directory, filename, watcher };
@@ -278,8 +282,10 @@ function updateEngine(params: {
     updateWorkflow: ReturnType<typeof vi.fn>;
     filename?: string;
     folderSync?: boolean;
+    folderSyncMoveToRoot?: boolean;
     getFolders?: ReturnType<typeof vi.fn>;
     createFolder?: ReturnType<typeof vi.fn>;
+    resolveFolderProjectId?: ReturnType<typeof vi.fn>;
     workflowId?: string;
 }) {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-sync-engine-update-'));
@@ -298,10 +304,12 @@ function updateEngine(params: {
         updateWorkflow: params.updateWorkflow,
         getFolders: params.getFolders,
         createFolder: params.createFolder,
+        resolveFolderProjectId: params.resolveFolderProjectId,
     } as any;
 
     const engine = new SyncEngine(client, watcher, directory, params.projectId, undefined, {
         folderSync: params.folderSync,
+        folderSyncMoveToRoot: params.folderSyncMoveToRoot,
     });
 
     return {
@@ -489,5 +497,162 @@ describe('SyncEngine update payload folderSync behavior', () => {
         await expect(engine.push(filename, workflowId)).rejects.toBe(genericFolderError);
         expect(updateWorkflow).toHaveBeenCalledTimes(1);
         expect(createFolder).toHaveBeenCalledTimes(1);
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// Push-authoritative folder placement on API-key-only instances
+// ---------------------------------------------------------------------------
+//
+// n8n's public API lets us WRITE a workflow's folder (2.32+) but never READ it
+// back: `parentFolderId` is writeOnly and no endpoint maps workflows to folders.
+// So push is the only direction that can carry folder intent, and it must behave
+// predictably on a Community instance holding nothing but an API key:
+//   - resolve the project id without the Enterprise-gated projects API
+//   - degrade to a flat push (never fail) when folders are unlicensed/absent
+//   - only claim the project root when explicitly told to
+// ---------------------------------------------------------------------------
+
+describe('SyncEngine folder placement without session auth', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('resolves a real project id when configured with the personal placeholder', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Nested Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        const createWorkflow = vi.fn(async (payload) => ({ ...payload, id: 'wf-nested' }));
+        const getFolders = vi.fn(async () => [
+            { id: 'folder-reports', name: 'Reports', parentFolderId: null },
+        ]);
+        const createFolder = vi.fn();
+        // GET /api/v1/projects is Enterprise-gated, so the client reads the id off
+        // a workflow's shared[] instead.
+        const resolveFolderProjectId = vi.fn(async () => 'personal-project-abc');
+
+        const { engine, filename } = createEngine({
+            projectId: 'personal',
+            createWorkflow,
+            filename: 'Reports/new.workflow.ts',
+            folderSync: true,
+            getFolders,
+            createFolder,
+            resolveFolderProjectId,
+        });
+
+        await expect(engine.push(filename)).resolves.toBe('wf-nested');
+
+        expect(resolveFolderProjectId).toHaveBeenCalledWith('personal');
+        expect(getFolders).toHaveBeenCalledWith('personal-project-abc');
+        expect(createFolder).not.toHaveBeenCalled();
+        expect(createWorkflow).toHaveBeenCalledWith(expect.objectContaining({
+            parentFolderId: 'folder-reports',
+        }));
+    });
+
+    it('pushes flat instead of failing when the folders API is unlicensed (403)', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Nested Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        const createWorkflow = vi.fn(async (payload) => ({ ...payload, id: 'wf-flat' }));
+        // Unregistered Community instance: no `feat:folders`, so the folder
+        // endpoints answer 403.
+        const getFolders = vi.fn().mockRejectedValue({ response: { status: 403, data: { message: 'Plan lacks license for this feature' } } });
+        const createFolder = vi.fn();
+
+        const { engine, filename } = createEngine({
+            projectId: 'project-1',
+            createWorkflow,
+            filename: 'Reports/new.workflow.ts',
+            folderSync: true,
+            getFolders,
+            createFolder,
+        });
+
+        await expect(engine.push(filename)).resolves.toBe('wf-flat');
+
+        expect(createFolder).not.toHaveBeenCalled();
+        expect(createWorkflow).toHaveBeenCalledTimes(1);
+        expect(createWorkflow).toHaveBeenCalledWith(expect.not.objectContaining({
+            parentFolderId: expect.anything(),
+        }));
+    });
+
+    it('moves a workflow to the project root only when folderSyncMoveToRoot is on', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Existing Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        const payloads: any[] = [];
+        const updateWorkflow = vi.fn(async (id, payload) => {
+            payloads.push({ ...payload });
+            return { ...payload, id, updatedAt: '2026-07-23T00:00:00.000Z' };
+        });
+        const getFolders = vi.fn(async () => []);
+
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow,
+            filename: 'existing.workflow.ts',
+            folderSync: true,
+            folderSyncMoveToRoot: true,
+            getFolders,
+            workflowId: 'wf-existing',
+        });
+
+        await expect(engine.push(filename, workflowId)).resolves.toBe(workflowId);
+
+        // null (not undefined) is what tells n8n to move the workflow out of its
+        // folder; a flat local file with the flag off leaves the remote untouched.
+        expect(getFolders).not.toHaveBeenCalled();
+        expect(payloads).toHaveLength(1);
+        expect(payloads[0]).toHaveProperty('parentFolderId', null);
+    });
+
+    it('does not send a root move when the workflow already lives in a local folder', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Existing Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        const payloads: any[] = [];
+        const updateWorkflow = vi.fn(async (id, payload) => {
+            payloads.push({ ...payload });
+            return { ...payload, id, updatedAt: '2026-07-23T00:00:00.000Z' };
+        });
+        const getFolders = vi.fn(async () => [
+            { id: 'folder-reports', name: 'Reports', parentFolderId: null },
+        ]);
+        const createFolder = vi.fn();
+
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow,
+            filename: 'Reports/existing.workflow.ts',
+            folderSync: true,
+            folderSyncMoveToRoot: true,
+            getFolders,
+            createFolder,
+            workflowId: 'wf-existing',
+        });
+
+        await expect(engine.push(filename, workflowId)).resolves.toBe(workflowId);
+
+        expect(payloads[0]).toHaveProperty('parentFolderId', 'folder-reports');
     });
 });

--- a/packages/cli/tests/unit/sync-engine.test.ts
+++ b/packages/cli/tests/unit/sync-engine.test.ts
@@ -412,13 +412,20 @@ describe('SyncEngine update payload folderSync behavior', () => {
             status: 400,
             data: { message: "property 'parentFolderId' should not exist" },
         };
-        const updateWorkflow = vi.fn()
-            .mockRejectedValueOnce(folderError)
-            .mockImplementationOnce(async (id, payload) => ({
-                ...payload,
-                id,
-                updatedAt: '2026-06-23T00:00:00.000Z',
-            }));
+
+        // Snapshot each call's payload at call time. Vitest's vi.fn() records
+        // arguments by live reference, and SyncEngine mutates the same localWf
+        // between the two updateWorkflow calls (sets parentFolderId, then
+        // deletes it in the catch block) — so the recorded `calls` would
+        // reflect the post-mutation object by the time the assertion runs.
+        // Capturing { ...payload } at each call preserves call-time state.
+        // Same pattern as the create-side fix in commit c801ff43.
+        const callSnapshots: Array<{ id: string; payload: any }> = [];
+        const updateWorkflow = vi.fn(async (id: string, payload: any) => {
+            callSnapshots.push({ id, payload: { ...payload } });
+            if (callSnapshots.length === 1) throw folderError;
+            return { ...payload, id, updatedAt: '2026-06-23T00:00:00.000Z' };
+        });
         const getFolders = vi.fn(async () => []);
         const createFolder = vi.fn(async (_projectId, payload) => ({
             id: 'folder-x',
@@ -439,9 +446,9 @@ describe('SyncEngine update payload folderSync behavior', () => {
         await expect(engine.push(filename, workflowId)).resolves.toBe(workflowId);
 
         expect(updateWorkflow).toHaveBeenCalledTimes(2);
-        expect(updateWorkflow.mock.calls[0][0]).toBe(workflowId);
-        expect(updateWorkflow.mock.calls[0][1]).toEqual(expect.objectContaining({ parentFolderId: 'folder-x' }));
-        expect(updateWorkflow.mock.calls[1][1]).not.toHaveProperty('parentFolderId');
+        expect(callSnapshots[0].id).toBe(workflowId);
+        expect(callSnapshots[0].payload).toEqual(expect.objectContaining({ parentFolderId: 'folder-x' }));
+        expect(callSnapshots[1].payload).not.toHaveProperty('parentFolderId');
     });
 
     it('does NOT retry when n8n returns a generic 400 mentioning only "folder" (regression guard)', async () => {

--- a/packages/cli/tests/unit/sync-engine.test.ts
+++ b/packages/cli/tests/unit/sync-engine.test.ts
@@ -351,7 +351,7 @@ describe('SyncEngine update payload folderSync behavior', () => {
             workflowId: 'wf-existing',
         });
 
-        await expect(engine.push(workflowId, filename)).resolves.toBe(workflowId);
+        await expect(engine.push(filename, workflowId)).resolves.toBe(workflowId);
 
         expect(updateWorkflow).toHaveBeenCalledTimes(1);
         expect(updateWorkflow).toHaveBeenCalledWith(workflowId, expect.objectContaining({
@@ -387,7 +387,7 @@ describe('SyncEngine update payload folderSync behavior', () => {
             workflowId: 'wf-existing',
         });
 
-        await expect(engine.push(workflowId, filename)).resolves.toBe(workflowId);
+        await expect(engine.push(filename, workflowId)).resolves.toBe(workflowId);
 
         expect(getFolders).not.toHaveBeenCalled();
         expect(updateWorkflow).toHaveBeenCalledTimes(1);
@@ -436,7 +436,7 @@ describe('SyncEngine update payload folderSync behavior', () => {
             workflowId: 'wf-existing',
         });
 
-        await expect(engine.push(workflowId, filename)).resolves.toBe(workflowId);
+        await expect(engine.push(filename, workflowId)).resolves.toBe(workflowId);
 
         expect(updateWorkflow).toHaveBeenCalledTimes(2);
         expect(updateWorkflow.mock.calls[0][0]).toBe(workflowId);
@@ -479,7 +479,7 @@ describe('SyncEngine update payload folderSync behavior', () => {
             workflowId: 'wf-existing',
         });
 
-        await expect(engine.push(workflowId, filename)).rejects.toBe(genericFolderError);
+        await expect(engine.push(filename, workflowId)).rejects.toBe(genericFolderError);
         expect(updateWorkflow).toHaveBeenCalledTimes(1);
         expect(createFolder).toHaveBeenCalledTimes(1);
     });

--- a/packages/cli/tests/unit/sync-engine.test.ts
+++ b/packages/cli/tests/unit/sync-engine.test.ts
@@ -135,9 +135,20 @@ describe('SyncEngine create payload projectId behavior', () => {
             status: 400,
             data: { message: "property 'parentFolderId' should not exist" },
         };
+        // Snapshot each call's payload at call time. SyncEngine mutates the same
+        // localWf object between calls (sets parentFolderId, then deletes it in
+        // the catch block), so a live reference inspected via mock.calls[0][0]
+        // would reflect the post-mutation state and miss parentFolderId.
+        const callSnapshots: any[] = [];
         const createWorkflow = vi.fn()
-            .mockRejectedValueOnce(folderError)
-            .mockImplementationOnce(async (payload) => ({ ...payload, id: 'wf-fallback' }));
+            .mockImplementationOnce(async (payload) => {
+                callSnapshots.push({ ...payload });
+                throw folderError;
+            })
+            .mockImplementationOnce(async (payload) => {
+                callSnapshots.push({ ...payload });
+                return { ...payload, id: 'wf-fallback' };
+            });
         const getFolders = vi.fn(async () => []);
         const createFolder = vi.fn(async (_projectId, payload) => ({
             id: 'folder-x',
@@ -157,8 +168,9 @@ describe('SyncEngine create payload projectId behavior', () => {
         await expect(engine.push(filename)).resolves.toBe('wf-fallback');
 
         expect(createWorkflow).toHaveBeenCalledTimes(2);
-        expect(createWorkflow.mock.calls[0][0]).toEqual(expect.objectContaining({ parentFolderId: 'folder-x' }));
-        expect(createWorkflow.mock.calls[1][0]).not.toHaveProperty('parentFolderId');
+        expect(callSnapshots).toHaveLength(2);
+        expect(callSnapshots[0]).toEqual(expect.objectContaining({ parentFolderId: 'folder-x' }));
+        expect(callSnapshots[1]).not.toHaveProperty('parentFolderId');
     });
 
     it('does NOT retry when n8n returns a generic 400 mentioning only "folder" (regression guard for over-broad match)', async () => {

--- a/packages/cli/tests/unit/sync-manager.test.ts
+++ b/packages/cli/tests/unit/sync-manager.test.ts
@@ -116,7 +116,7 @@ describe('SyncManager push filename contract', () => {
         cwdSpy.mockRestore();
     });
 
-    it('rejects nested workflow paths inside the sync scope with a clear error', () => {
+    it('accepts nested workflow paths inside the sync scope', () => {
         const syncDir = path.join(TMP, 'n8nac-sync-manager-test');
         const manager = createSyncManager(syncDir);
 
@@ -125,8 +125,9 @@ describe('SyncManager push filename contract', () => {
         };
 
         const nestedPath = path.join(syncDir, 'nested', 'my-workflow.workflow.ts');
-        expect(() => manager.resolvePushTarget(nestedPath))
-            .toThrow(/nested workflow paths inside the sync scope are not supported/);
+        expect(manager.resolvePushTarget(nestedPath)).toEqual(expect.objectContaining({
+            filename: 'nested/my-workflow.workflow.ts',
+        }));
     });
 
     it('rejects empty paths', () => {

--- a/packages/cli/tests/unit/workflow-state-tracker.test.ts
+++ b/packages/cli/tests/unit/workflow-state-tracker.test.ts
@@ -252,6 +252,76 @@ export class OrderIdWorkflow {
         expect(tracker.getWorkflowIdForFilename('order-id.workflow.ts')).toBe('real-id');
         expect(tracker.getFilenameForId('real-id')).toBe('order-id.workflow.ts');
     });
+
+    it('recursively scans nested workflow files and stores relative paths', async () => {
+        const tracker = createTracker();
+        fs.mkdirSync(path.join(tempDir!, 'Ai Chat', 'File Processing'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tempDir!, 'Ai Chat', 'File Processing', 'nested.workflow.ts'),
+            `import { workflow, node } from '@n8n-as-code/transformer';
+
+@workflow({
+  id: 'nested-id',
+  name: 'Nested Workflow',
+  active: false
+})
+export class NestedWorkflow {
+  @node({
+    name: 'Webhook',
+    type: 'n8n-nodes-base.webhook',
+    version: 2.1,
+    position: [0, 0]
+  })
+  Webhook = { path: 'nested', httpMethod: 'POST' };
+}
+`,
+            'utf-8',
+        );
+
+        await tracker.refreshLocalState();
+
+        const relativePath = 'Ai Chat/File Processing/nested.workflow.ts';
+        expect(tracker.getWorkflowIdForFilename(relativePath)).toBe('nested-id');
+        expect(tracker.getFilenameForId('nested-id')).toBe(relativePath);
+    });
+
+    it('uses public folder metadata for new remote workflow paths when folderSync is enabled', async () => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-tracker-'));
+        const client = {
+            getAllWorkflows: vi.fn().mockResolvedValue([
+                {
+                    id: 'wf-foldered',
+                    name: 'Normalize Attachments',
+                    active: true,
+                    isArchived: false,
+                    parentFolderId: 'folder-file-processing',
+                },
+            ]),
+            getFolders: vi.fn().mockResolvedValue([
+                { id: 'folder-ai-chat', name: 'Ai Chat', parentFolderId: null },
+                { id: 'folder-file-processing', name: 'File Processing', parentFolderId: 'folder-ai-chat' },
+            ]),
+        } as any;
+
+        const tracker = new WorkflowStateTracker(client, {
+            directory: tempDir,
+            syncInactive: false,
+            ignoredTags: [],
+            projectId: 'project-1',
+            folderSync: true,
+        });
+
+        await tracker.refreshRemoteState();
+
+        const relativePath = 'Ai Chat/File Processing/Normalize Attachments.workflow.ts';
+        expect(tracker.getFilenameForId('wf-foldered')).toBe(relativePath);
+        const listed = await tracker.getLightweightList();
+        expect(listed[0]).toEqual(expect.objectContaining({
+            filename: relativePath,
+            folderPathString: 'Ai Chat/File Processing',
+            parentFolderId: 'folder-file-processing',
+        }));
+    });
 });
 
 describe('WorkflowStateTracker drift detection', () => {

--- a/packages/cli/tests/unit/workflow-state-tracker.test.ts
+++ b/packages/cli/tests/unit/workflow-state-tracker.test.ts
@@ -251,4 +251,74 @@ export class OrderIdWorkflow {
         expect(tracker.getWorkflowIdForFilename('order-id.workflow.ts')).toBe('real-id');
         expect(tracker.getFilenameForId('real-id')).toBe('order-id.workflow.ts');
     });
+
+    it('recursively scans nested workflow files and stores relative paths', async () => {
+        const tracker = createTracker();
+        fs.mkdirSync(path.join(tempDir!, 'Ai Chat', 'File Processing'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tempDir!, 'Ai Chat', 'File Processing', 'nested.workflow.ts'),
+            `import { workflow, node } from '@n8n-as-code/transformer';
+
+@workflow({
+  id: 'nested-id',
+  name: 'Nested Workflow',
+  active: false
+})
+export class NestedWorkflow {
+  @node({
+    name: 'Webhook',
+    type: 'n8n-nodes-base.webhook',
+    version: 2.1,
+    position: [0, 0]
+  })
+  Webhook = { path: 'nested', httpMethod: 'POST' };
+}
+`,
+            'utf-8',
+        );
+
+        await tracker.refreshLocalState();
+
+        const relativePath = 'Ai Chat/File Processing/nested.workflow.ts';
+        expect(tracker.getWorkflowIdForFilename(relativePath)).toBe('nested-id');
+        expect(tracker.getFilenameForId('nested-id')).toBe(relativePath);
+    });
+
+    it('uses public folder metadata for new remote workflow paths when folderSync is enabled', async () => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-tracker-'));
+        const client = {
+            getAllWorkflows: vi.fn().mockResolvedValue([
+                {
+                    id: 'wf-foldered',
+                    name: 'Normalize Attachments',
+                    active: true,
+                    isArchived: false,
+                    parentFolderId: 'folder-file-processing',
+                },
+            ]),
+            getFolders: vi.fn().mockResolvedValue([
+                { id: 'folder-ai-chat', name: 'Ai Chat', parentFolderId: null },
+                { id: 'folder-file-processing', name: 'File Processing', parentFolderId: 'folder-ai-chat' },
+            ]),
+        } as any;
+
+        const tracker = new WorkflowStateTracker(client, {
+            directory: tempDir,
+            syncInactive: false,
+            ignoredTags: [],
+            projectId: 'project-1',
+            folderSync: true,
+        });
+
+        await tracker.refreshRemoteState();
+
+        const relativePath = 'Ai Chat/File Processing/Normalize Attachments.workflow.ts';
+        expect(tracker.getFilenameForId('wf-foldered')).toBe(relativePath);
+        const listed = await tracker.getLightweightList();
+        expect(listed[0]).toEqual(expect.objectContaining({
+            filename: relativePath,
+            folderPathString: 'Ai Chat/File Processing',
+            parentFolderId: 'folder-file-processing',
+        }));
+    });
 });

--- a/packages/cli/tests/unit/workflow-transformer-adapter.test.ts
+++ b/packages/cli/tests/unit/workflow-transformer-adapter.test.ts
@@ -197,3 +197,44 @@ describe('WorkflowTransformerAdapter settings round-trip', () => {
         expect(hashWithMCP).not.toBe(hashWithCaller);
     });
 });
+
+describe('WorkflowTransformerAdapter folder metadata on push', () => {
+    // cleanForPush is private; folder metadata never survives a TypeScript
+    // round-trip, so exercise it directly rather than through compileToJson.
+    const cleanForPush = (workflow: any) =>
+        (WorkflowTransformerAdapter as any).cleanForPush(workflow);
+
+    it('keeps parentFolderId but strips display-only folder metadata', () => {
+        const clean = cleanForPush({
+            name: 'Foldered Workflow',
+            nodes: [],
+            connections: {},
+            settings: {},
+            // Writable: this is how n8n places a workflow in a folder.
+            parentFolderId: 'folder-1',
+            // Read-only display metadata the tracker attaches locally.
+            parentFolder: { id: 'folder-1', name: 'Reports' },
+            folderPath: ['Reports', 'Weekly'],
+            folderPathString: 'Reports/Weekly',
+        });
+
+        expect(clean).toHaveProperty('parentFolderId', 'folder-1');
+        expect(clean).not.toHaveProperty('parentFolder');
+        expect(clean).not.toHaveProperty('folderPath');
+        expect(clean).not.toHaveProperty('folderPathString');
+    });
+
+    it('preserves an explicit null parentFolderId (move to project root)', () => {
+        const clean = cleanForPush({
+            name: 'Root Workflow',
+            nodes: [],
+            connections: {},
+            settings: {},
+            parentFolderId: null,
+        });
+
+        // null and undefined mean different things to n8n: null moves the
+        // workflow to the project root, absent leaves its folder untouched.
+        expect(clean).toHaveProperty('parentFolderId', null);
+    });
+});


### PR DESCRIPTION
## Summary
- Add public n8n folder API support and preserve workflow folder metadata when available.
- Allow `folderSync` environments to derive nested workflow paths, recursively scan local workflows, and write/push nested workflow files safely.
- Add tests for folder API pagination, nested path resolution, recursive scans, and create-in-folder behavior.

## Review iterations

Four commits on `feat/folder-aware-sync`:

1. `cb71409e` — original feat (folder-aware workflow sync)
2. `2d3f86de` — review fixes:
   - **TOCTOU race** in `inferParentFolderIdFromFilename` — two concurrent `push()` calls could each see an empty `getFolders()` and POST `createFolder` twice. New `ensureFolder` helper dedupes round-trips per `(projectId, parentFolderId, name)` via an in-flight promise map.
   - Dropped `(this.client as any).getFolders / createFolder` duck-typing in `sync-engine.ts` and `workflow-state-tracker.ts`; `N8nApiClient` now exposes both methods and the typed call lets the compiler catch future refactors.
   - Tightened `isUnsupportedParentFolderError` — the original `folder` substring would misclassify unrelated 400/404 errors (e.g. "folder already exists in another project") and silently drop `parentFolderId` on n8n instances that DO support it. New check requires either a structured `parentFolderId` / `parentFolder` key in the response body, or a message matching `/(parentfolderid|parent folder id|parentfolder)/i`.
   - Added 3 retry-path tests covering: rejection → retry without `parentFolderId`, generic 400 mentioning "folder" must NOT trigger retry, two concurrent pushes sharing a parent folder create it exactly once.
3. `c801ff43` — test snapshot fix:
   - Vitest's `vi.fn()` records arguments by live reference. `SyncEngine` mutates the same `localWf` between the two `createWorkflow` calls (sets `parentFolderId`, then deletes it in the catch block). By the time the assertion ran, the recorded reference reflected the post-mutation object.
   - Captured `{ ...payload }` snapshots at each call so the assertion sees the payload as it was at call time. Structural intent unchanged.
4. `c5b280bf` — preserve folder assignment on update (Codex P2 review, discussion `r3362174895`):
   - `executeUpdate()` now mirrors `executeCreate()` — after the 0-nodes parse guard, it calls `inferParentFolderIdFromFilename(filename)` and forwards `parentFolderId` on `localWf`. The `updateWorkflow` call is wrapped in try/catch with the same retry-without-`parentFolderId` fallback `executeCreate()` already uses. Moving an existing workflow to e.g. `Some Folder/foo.workflow.ts` and running push now actually moves it on n8n, instead of updating contents in place and leaving the workflow in the old folder.
   - `N8nApiClient.cleanWorkflowUpdatePayload()` now includes `parentFolderId` in its `allowedKeys` set (sibling of the create-side `cleanWorkflowCreatePayload`, which already had it). Without this, the engine's `parentFolderId` would be silently stripped before PUT even with the engine fix.
   - New `SyncEngine update payload folderSync behavior` describe block in `tests/unit/sync-engine.test.ts` with 4 cases: nested-filename move, flat-filename no-op (no over-inference), retry-on-rejection, generic-400-no-retry regression guard (mirrors the create-side test).

## Validation
- `npm run build --workspace=n8nac` ✅
- `npx vitest run tests/unit/n8n-api-client.test.ts tests/unit/workflow-state-tracker.test.ts tests/unit/sync-manager.test.ts tests/unit/sync-engine.test.ts` ✅
- Full CI (`validate`, `build`, `build-and-test`, `CodeRabbit`) green on `c5b280bf`.

## Notes
- A broader `npm run test:unit --workspace=n8nac -- ...` invocation re-ran all CLI tests and hit an unrelated timeout in `tests/integration/update-ai.integration.test.ts`; the targeted folder-sync tests passed.
- Local Windows-side vitest runner is broken on the same `@rollup/rollup-win32-x64-msvc` optional-dep issue this PR already documented; CI runs the targeted suite.
- Edge case intentionally out of scope for `c5b280bf`: moving a workflow back out of a folder (`Foo/Bar.workflow.ts` → `Bar.workflow.ts`) leaves the old `parentFolderId` on n8n because the inference returns `undefined` and we don't send an explicit null. Worth a follow-up if needed — sending `parentFolderId: null` on the update path is a small additional change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional folder-aware synchronization for workflow creation and updates, mapping local folder structure to n8n parent folders.
  * Added folder listing/creation support with automatic capability detection.
  * Status outputs now include folder hierarchy metadata (parent folder and path) for tracked and remote workflows.
* **Bug Fixes**
  * Improved workflow path validation/normalization and local filesystem handling (including reliably creating missing parent directories).
  * Enhanced move/create/update behavior with a fallback when parent-folder fields are unsupported.
* **Tests**
  * Expanded unit tests for folder sync, nested-path push resolution, retry/fallback behavior, and concurrent folder creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
