### PR TITLE
[codex] Optimize VS Code extension performance

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -125,6 +125,7 @@ let telemetryClient: TelemetryClient | undefined;
 
 const conflictStore = new Map<string, string>();
 const processedSyncEventIds = new Set<string>();
+const syncEventJournalSignatures = new Map<string, string>();
 
 const AI_CONTEXT_METADATA_RELATIVE_PATH = path.join('.n8nac', 'ai-context.json');
 const AI_CONTEXT_SIGNATURE_SCHEMA_VERSION = 1;
@@ -140,12 +141,19 @@ type AiContextMetadata = {
 
 async function processSyncEventJournal(journalUri: vscode.Uri, source: string, markOnly = false): Promise<void> {
     if (!fs.existsSync(journalUri.fsPath)) return;
+    const signature = getFileChangeSignature(journalUri.fsPath);
+    if (!markOnly && signature && syncEventJournalSignatures.get(journalUri.fsPath) === signature) {
+        return;
+    }
     let raw: Uint8Array;
     try {
         raw = await vscode.workspace.fs.readFile(journalUri);
     } catch (err) {
         console.error('[n8n] Failed to read sync event journal', err);
         return;
+    }
+    if (signature) {
+        syncEventJournalSignatures.set(journalUri.fsPath, signature);
     }
 
     const lines = Buffer.from(raw).toString('utf8').split('\n').filter(Boolean);
@@ -172,6 +180,15 @@ async function processSyncEventJournal(journalUri: vscode.Uri, source: string, m
         }
         const reloaded = workflowWebviewRegistry.reloadIfMatching(event.workflowId);
         outputChannel.appendLine(`[n8n-agent-debug] ${source} push success workflowId=${event.workflowId} filename=${event.filename || 'none'} reloaded=${reloaded}`);
+    }
+}
+
+function getFileChangeSignature(filePath: string): string | undefined {
+    try {
+        const stat = fs.statSync(filePath);
+        return `${stat.mtimeMs}:${stat.size}`;
+    } catch {
+        return undefined;
     }
 }
 
@@ -914,6 +931,7 @@ async function openAgentWorkbench(context: vscode.ExtensionContext, workflow?: I
             outputChannel,
             {
                 listWorkflows: listAgentWorkflowOptions,
+                listWorkflowOptions: listAgentWorkflowContextOptions,
                 resolveWorkflow: resolveAgentWorkflowTarget,
                 listWorkflowNodes: listAgentWorkflowNodes,
                 listProviderOptions: listAgentProviderOptions,
@@ -973,8 +991,24 @@ async function listAgentWorkflowOptions(): Promise<IWorkflowStatus[]> {
     return selectAllWorkflows(store.getState());
 }
 
+async function listAgentWorkflowContextOptions(): Promise<AgentWorkflowContext[]> {
+    const workflows = selectAllWorkflows(store.getState());
+    // This transient menu path may refresh through cli.list, but it must not
+    // dispatch into the global store: listAgentWorkflowOptions owns that stateful
+    // refresh, and keeping this side-effect-free avoids extra webview churn.
+    const source = cli
+        ? await cli.list({ includeArchived: true }).catch(() => workflows)
+        : workflows;
+    return source.map((workflow) => ({
+        id: workflow.id || undefined,
+        name: workflow.name || workflow.id || workflow.filename || 'Workflow',
+        filename: workflow.filename || undefined,
+        filePath: getExistingWorkflowFileUri(workflow)?.fsPath,
+    }));
+}
+
 async function resolveAgentWorkflowTarget(workflowContext: AgentWorkflowContext): Promise<{ workflow?: IWorkflowStatus; workflowFilePath?: string; workflowUrl?: string; workflowReloadUrl?: string; workflowEndpoints?: WorkflowWebviewContext['endpoints'] }> {
-    const workflows = await listAgentWorkflowOptions();
+    const workflows = selectAllWorkflows(store.getState());
     const workflow = workflows.find((candidate) => (
         Boolean(workflowContext.id && candidate.id === workflowContext.id)
         || Boolean(workflowContext.filename && candidate.filename === workflowContext.filename)
@@ -1827,6 +1861,7 @@ function resetExtensionRuntimeState(): void {
     syncManager = undefined;
     cli = undefined;
     conflictStore.clear();
+    syncEventJournalSignatures.clear();
     enhancedTreeProvider.setSyncManager(undefined);
     clearSyncManager();
     store.dispatch(setWorkflows([]));
@@ -2282,7 +2317,7 @@ async function updateAiContextAfterSyncInitialization(
 ): Promise<void> {
     const currentVersion = versionHint || await resolveAiContextVersion(context, client, undefined, true);
     try {
-        await ensureAiContextFresh(context, 'sync-initialized', { force: true, versionHint: currentVersion });
+        await ensureAiContextFresh(context, 'sync-initialized', { versionHint: currentVersion });
     } catch (error: any) {
         outputChannel.appendLine(`[n8n] Failed to auto-generate AI context: ${error.message}`);
     }

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -29,6 +29,8 @@ const ACTIVE_WORKTREE_PATH_BY_SESSION_KEY = 'n8n.agent.activeWorktreePathBySessi
 const INVALID_TOOL_CALL_RECOVERY_MARKER = 'N8N_INVALID_TOOL_CALL_RECOVERY';
 const NON_FINAL_ASSISTANT_PHASE_RECOVERY_MARKER = 'N8N_NON_FINAL_ASSISTANT_PHASE_RECOVERY';
 const NON_FINAL_ASSISTANT_PHASE_MAX_RECOVERY_ATTEMPTS = 12;
+const STREAM_TEXT_FLUSH_INTERVAL_MS = 33;
+const STREAM_TEXT_FLUSH_CHAR_THRESHOLD = 512;
 
 type ActiveWorktreePathsBySession = Record<string, string | null>;
 
@@ -1512,12 +1514,16 @@ export class AgentRuntimeController implements vscode.Disposable {
         const writtenWorkflowPaths = new Set<string>();
         let authoritativeFinalEmitted = false;
         const loggedProjectionEvents = new Set<string>();
+        let pendingTextDelta = '';
+        let pendingTextFlushTimer: NodeJS.Timeout | undefined;
+        let textFlushChain = Promise.resolve();
+        let streamClosed = false;
         this.outputChannel.appendLine(`[n8n-agent-debug] deepagents.v3.run started sessionId=${input.sessionId || 'none'} workflowId=${input.workflowId || 'none'}`);
         const syncEntries = () => {
             if (!input.sessionId) return;
             this.writeSessionEntries(service, input.sessionId, entries);
         };
-        const emitStreamEvent = async (streamEvent: AgentStreamEvent) => {
+        const emitStreamEventNow = async (streamEvent: AgentStreamEvent) => {
             entries = this.applyStreamEvent(entries, streamEvent);
             syncEntries();
             await postMessage({ type: 'agent.streamEvent', event: streamEvent });
@@ -1529,9 +1535,51 @@ export class AgentRuntimeController implements vscode.Disposable {
                 }
             }
         };
+        const flushPendingTextDelta = async () => {
+            if (pendingTextFlushTimer) {
+                clearTimeout(pendingTextFlushTimer);
+                pendingTextFlushTimer = undefined;
+            }
+            const delta = pendingTextDelta;
+            pendingTextDelta = '';
+            if (!delta) {
+                await textFlushChain;
+                return;
+            }
+            const flush = async () => {
+                await emitStreamEventNow({ type: 'text-delta', delta });
+            };
+            textFlushChain = textFlushChain.then(flush, flush);
+            await textFlushChain;
+        };
+        const scheduleTextDeltaFlush = () => {
+            if (streamClosed) return;
+            if (pendingTextFlushTimer) return;
+            pendingTextFlushTimer = setTimeout(() => {
+                pendingTextFlushTimer = undefined;
+                if (streamClosed) return;
+                void flushPendingTextDelta().catch((error: any) => {
+                    this.outputChannel.appendLine(`[n8n-agent] Stream text flush failed: ${error?.message || String(error)}`);
+                });
+            }, STREAM_TEXT_FLUSH_INTERVAL_MS);
+        };
+        const emitStreamEvent = async (streamEvent: AgentStreamEvent) => {
+            if (streamEvent.type === 'text-delta') {
+                pendingTextDelta += streamEvent.delta;
+                if (pendingTextDelta.length >= STREAM_TEXT_FLUSH_CHAR_THRESHOLD) {
+                    await flushPendingTextDelta();
+                } else {
+                    scheduleTextDeltaFlush();
+                }
+                return;
+            }
+            await flushPendingTextDelta();
+            await emitStreamEventNow(streamEvent);
+        };
         const emitFinalEvent = async (response: string, finalState: string) => {
             if (authoritativeFinalEmitted) return;
             authoritativeFinalEmitted = true;
+            await flushPendingTextDelta();
             const activeRun = input.sessionId ? this.activeRuns.get(input.sessionId) : undefined;
             if (activeRun && activeRun.sessionId === input.sessionId) {
                 activeRun.visibleDone = true;
@@ -1575,47 +1623,63 @@ export class AgentRuntimeController implements vscode.Disposable {
             }
         };
 
-        this.outputChannel.appendLine(`[n8n-agent-debug] deepagents.v3.run.output await-start sessionId=${input.sessionId || 'none'} elapsedMs=${Date.now() - runStartedAt}`);
-        let finalOutput: unknown;
         try {
-            finalOutput = await this.raceAbort(Promise.resolve(run.output), signal);
-        } catch (error: any) {
-            const formatted = this.formatAgentRuntimeError(error);
-            this.outputChannel.appendLine(`[n8n-agent] DeepAgents v3 run failed: ${formatted}`);
-            logProjectionResults(await projectionConsumers);
-            await emitFinalEvent(`Run failed: ${formatted}`, 'error');
-            return { entries, workflowChanged: fileModificationDetected };
-        }
-        this.outputChannel.appendLine(`[n8n-agent-debug] deepagents.v3.run.output resolved sessionId=${input.sessionId || 'none'} elapsedMs=${Date.now() - runStartedAt} output=${this.summarizeAgentOutput(finalOutput)}`);
+            this.outputChannel.appendLine(`[n8n-agent-debug] deepagents.v3.run.output await-start sessionId=${input.sessionId || 'none'} elapsedMs=${Date.now() - runStartedAt}`);
+            let finalOutput: unknown;
+            try {
+                finalOutput = await this.raceAbort(Promise.resolve(run.output), signal);
+            } catch (error: any) {
+                const formatted = this.formatAgentRuntimeError(error);
+                this.outputChannel.appendLine(`[n8n-agent] DeepAgents v3 run failed: ${formatted}`);
+                logProjectionResults(await projectionConsumers);
+                await emitFinalEvent(`Run failed: ${formatted}`, 'error');
+                return { entries, workflowChanged: fileModificationDetected };
+            }
+            this.outputChannel.appendLine(`[n8n-agent-debug] deepagents.v3.run.output resolved sessionId=${input.sessionId || 'none'} elapsedMs=${Date.now() - runStartedAt} output=${this.summarizeAgentOutput(finalOutput)}`);
 
-        await this.throwIfAborted(signal);
-        if (accumulator.thinkingText) {
-            await emitStreamEvent({
-                type: 'operation',
-                operationId: accumulator.thinkingOperationId || `thinking:${randomUUID()}`,
-                label: 'Thinking',
-                category: 'thinking',
-                status: 'done',
-                body: accumulator.thinkingText,
-                startedAt: Date.now(),
-                endedAt: Date.now(),
-            });
-            accumulator.thinkingText = '';
-            accumulator.thinkingOperationId = undefined;
+            await this.throwIfAborted(signal);
+            if (accumulator.thinkingText) {
+                await emitStreamEvent({
+                    type: 'operation',
+                    operationId: accumulator.thinkingOperationId || `thinking:${randomUUID()}`,
+                    label: 'Thinking',
+                    category: 'thinking',
+                    status: 'done',
+                    body: accumulator.thinkingText,
+                    startedAt: Date.now(),
+                    endedAt: Date.now(),
+                });
+                accumulator.thinkingText = '';
+                accumulator.thinkingOperationId = undefined;
+            }
+            logProjectionResults(await projectionConsumers);
+            await emitFinalEvent(
+                this.extractAssistantTextFromAgentOutput(finalOutput) || accumulator.responseText || this.extractAgentText(finalOutput),
+                run.interrupted ? 'interrupted' : 'done',
+            );
+            if (fileModificationDetected) {
+                this.saveAutoCheckpointAfterFileModificationInBackground(service, input, entries);
+            }
+            const workflowContext = fileModificationDetected
+                ? await this.inferWorkflowContextFromWrittenFiles([...writtenWorkflowPaths], input.workspaceRoot)
+                : undefined;
+            this.outputChannel.appendLine(`[n8n-agent-debug] agent runtime completed sessionId=${input.sessionId || 'none'} workflowId=${input.workflowId || 'none'} stream=v3 workflowChanged=${String(fileModificationDetected)} elapsedMs=${Date.now() - runStartedAt}`);
+            return { entries, workflowChanged: fileModificationDetected, workflowContext };
+        } finally {
+            streamClosed = true;
+            if (pendingTextFlushTimer) {
+                clearTimeout(pendingTextFlushTimer);
+                pendingTextFlushTimer = undefined;
+            }
+            if (signal.aborted) {
+                pendingTextDelta = '';
+                await textFlushChain.catch(() => undefined);
+            } else {
+                await flushPendingTextDelta().catch((error: any) => {
+                    this.outputChannel.appendLine(`[n8n-agent] Stream text flush failed during cleanup: ${error?.message || String(error)}`);
+                });
+            }
         }
-        logProjectionResults(await projectionConsumers);
-        await emitFinalEvent(
-            this.extractAssistantTextFromAgentOutput(finalOutput) || accumulator.responseText || this.extractAgentText(finalOutput),
-            run.interrupted ? 'interrupted' : 'done',
-        );
-        if (fileModificationDetected) {
-            this.saveAutoCheckpointAfterFileModificationInBackground(service, input, entries);
-        }
-        const workflowContext = fileModificationDetected
-            ? await this.inferWorkflowContextFromWrittenFiles([...writtenWorkflowPaths], input.workspaceRoot)
-            : undefined;
-        this.outputChannel.appendLine(`[n8n-agent-debug] agent runtime completed sessionId=${input.sessionId || 'none'} workflowId=${input.workflowId || 'none'} stream=v3 workflowChanged=${String(fileModificationDetected)} elapsedMs=${Date.now() - runStartedAt}`);
-        return { entries, workflowChanged: fileModificationDetected, workflowContext };
     }
 
     private async consumeDeepAgentV3MessageProjection(

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -2777,6 +2777,21 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
             promptInput.selectionStart = promptInput.selectionEnd = promptInput.value.length;
         }
 
+        let renderAllFrame = 0;
+        function scheduleRenderAll() {
+            if (renderAllFrame) return;
+            renderAllFrame = requestAnimationFrame(() => {
+                renderAllFrame = 0;
+                renderAll();
+            });
+        }
+
+        function flushScheduledRenderAll() {
+            if (!renderAllFrame) return;
+            cancelAnimationFrame(renderAllFrame);
+            renderAllFrame = 0;
+        }
+
         function renderAll() {
             if (state && Array.isArray(state.availableWorkflows)) {
                 availableWorkflowCache = state.availableWorkflows;
@@ -3020,6 +3035,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
         function applyStreamEvent(event) {
             if (!state || !state.session) return;
             let entries = Array.isArray(state.session.entries) ? [...state.session.entries] : [];
+            let deferRender = false;
             if (event.type === 'start') {
                 entries = entries.filter((entry) => entry.kind !== 'context-usage');
                 state.session.contextUsage = undefined;
@@ -3045,6 +3061,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 } else {
                     entries.push({ kind: 'assistant-body', id: crypto.randomUUID(), text: event.delta || '', streaming: true });
                 }
+                deferRender = true;
             } else if (event.type === 'final') {
                 entries = finalizePendingOperations(entries, 'done');
                 entries = consolidateFinalAssistant(entries, event.response || '', event.finalState);
@@ -3106,7 +3123,11 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 entries.push({ kind: 'system-notice', id: crypto.randomUUID(), text: 'Error: ' + event.error, timestamp: Date.now() });
             }
             state.session.entries = entries;
-            renderAll();
+            if (deferRender) scheduleRenderAll();
+            else {
+                flushScheduledRenderAll();
+                renderAll();
+            }
         }
 
         function sendPrompt() {

--- a/packages/vscode-extension/src/ui/agent-workbench-webview.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-webview.ts
@@ -26,6 +26,7 @@ interface AgentWorkflowTarget {
 
 interface AgentWorkbenchWorkflowProviders {
     listWorkflows(): Promise<IWorkflowStatus[]>;
+    listWorkflowOptions(): Promise<AgentWorkflowContext[]>;
     resolveWorkflow(workflow: AgentWorkflowContext): Promise<AgentWorkflowTarget>;
     listWorkflowNodes(workflow: AgentWorkflowContext): Promise<AgentWorkbenchNodeContext[]>;
     listProviderOptions(): Promise<Array<Record<string, unknown>>>;
@@ -744,19 +745,7 @@ export class AgentWorkbenchWebview {
     }
 
     private async getWorkflowOptions(): Promise<AgentWorkflowContext[]> {
-        const workflows = await this._workflowProviders.listWorkflows().catch(() => []);
-        return Promise.all(workflows.map(async (workflow) => {
-            const base = {
-                id: workflow.id || undefined,
-                name: workflow.name || workflow.id || workflow.filename || 'Workflow',
-                filename: workflow.filename || undefined,
-            };
-            const target = await this._workflowProviders.resolveWorkflow(base).catch(() => undefined);
-            return {
-                ...base,
-                filePath: target?.workflowFilePath,
-            };
-        }));
+        return this._workflowProviders.listWorkflowOptions().catch(() => []);
     }
 
     private async getWorkflowNodeOptions(): Promise<AgentWorkbenchNodeContext[]> {

--- a/packages/vscode-extension/src/ui/configuration-instance-enrichment.ts
+++ b/packages/vscode-extension/src/ui/configuration-instance-enrichment.ts
@@ -1,0 +1,217 @@
+export type InstanceStatusResponse = {
+  status: string;
+  ready?: boolean;
+  instance?: { ownerCredentialsAvailable?: boolean };
+  blocked?: { code?: string; message?: string };
+  warnings?: string[];
+};
+
+export type InstanceAccessResponse = {
+  authUrl?: string;
+  publicN8nUrl?: string;
+  publicUrlEnabled?: boolean;
+  apiBaseUrl?: string;
+  warnings?: string[];
+  tunnel?: { running?: boolean };
+};
+
+export type InstanceEnrichmentFacade = {
+  status(input: { instanceId: string }): Promise<InstanceStatusResponse>;
+  resolveInstanceAccess(input: { instanceId: string; mode: 'observe' }): Promise<InstanceAccessResponse>;
+};
+
+type InstanceEnrichmentCacheEntry = {
+  signature: string;
+  expiresAt: number;
+  value: Record<string, unknown>;
+};
+
+type PendingInstanceEnrichment = {
+  signature: string;
+  promise: Promise<Record<string, unknown>>;
+};
+
+export const INSTANCE_ENRICHMENT_CACHE_TTL_MS = 5_000;
+const INSTANCE_ENRICHMENT_ERROR_CACHE_TTL_MS = 1_000;
+const INSTANCE_ENRICHMENT_FACADE_TIMEOUT_MS = 10_000;
+const MAX_CACHE_ENTRIES = 100;
+
+export class ConfigurationInstanceEnrichmentCache {
+  private readonly entries = new Map<string, InstanceEnrichmentCacheEntry>();
+  private readonly pending = new Map<string, PendingInstanceEnrichment>();
+
+  constructor(
+    private readonly ttlMs = INSTANCE_ENRICHMENT_CACHE_TTL_MS,
+    private readonly facadeTimeoutMs = INSTANCE_ENRICHMENT_FACADE_TIMEOUT_MS,
+  ) {}
+
+  async enrich(instance: any, instanceFacade: InstanceEnrichmentFacade): Promise<Record<string, unknown>> {
+    if (!instance?.id) {
+      return this.buildUnavailableInstance(instance, 'Runtime status unavailable.');
+    }
+
+    const signature = this.getInstanceEnrichmentSignature(instance);
+    const cached = this.entries.get(instance.id);
+    if (cached && cached.signature === signature && cached.expiresAt > Date.now()) {
+      return cached.value;
+    }
+
+    const pending = this.pending.get(instance.id);
+    if (pending && pending.signature === signature) {
+      return pending.promise;
+    }
+
+    let promise: Promise<Record<string, unknown>>;
+    promise = this.readInstanceEnrichment(instance, instanceFacade)
+      .then((result) => {
+        const currentPending = this.pending.get(instance.id);
+        if (currentPending?.promise === promise && currentPending.signature === signature && this.getInstanceEnrichmentSignature(instance) === signature) {
+          this.setEntry(instance.id, {
+            signature,
+            value: result.value,
+            expiresAt: Date.now() + result.cacheTtlMs,
+          });
+        }
+        return result.value;
+      })
+      .finally(() => {
+        const currentPending = this.pending.get(instance.id);
+        if (currentPending?.promise === promise) {
+          this.pending.delete(instance.id);
+        }
+      });
+    this.pending.set(instance.id, { signature, promise });
+    return promise;
+  }
+
+  invalidate(instanceId: string): void {
+    this.entries.delete(instanceId);
+    this.pending.delete(instanceId);
+  }
+
+  private async readInstanceEnrichment(instance: any, instanceFacade: InstanceEnrichmentFacade): Promise<{ value: Record<string, unknown>; cacheTtlMs: number }> {
+    const safeInstance = instance || {};
+    try {
+      const runtime = await this.withTimeout(
+        instanceFacade.status({ instanceId: safeInstance.id }),
+        this.facadeTimeoutMs,
+        'Runtime status',
+      );
+      const access = await this.withTimeout(
+        instanceFacade.resolveInstanceAccess({
+          instanceId: safeInstance.id,
+          mode: 'observe',
+        }),
+        this.facadeTimeoutMs,
+        'Instance access',
+      );
+      const accessWarnings = access.warnings || [];
+      // Prefer auth/public URLs; while public tunneling is enabled but pending,
+      // show no URL instead of a localhost API URL that cannot serve as public access.
+      const displayUrl = access.authUrl || access.publicN8nUrl || (access.publicUrlEnabled ? '' : access.apiBaseUrl || '');
+      return {
+        cacheTtlMs: this.ttlMs,
+        value: {
+          ...safeInstance,
+          host: displayUrl,
+          displayUrl,
+          authBridgePublicUrl: access.authUrl,
+          verificationStatus: safeInstance.verification?.status || 'unverified',
+          verificationLabel: this.getVerificationLabel(safeInstance),
+          runtimeStatus: runtime.status,
+          runtimeReady: 'ready' in runtime ? runtime.ready : runtime.status === 'ready',
+          ownerCredentialsAvailable: Boolean(runtime.instance?.ownerCredentialsAvailable),
+          runtimeBlockedCode: 'blocked' in runtime ? runtime.blocked?.code : undefined,
+          runtimeBlockedMessage: 'blocked' in runtime ? runtime.blocked?.message : undefined,
+          runtimeWarnings: accessWarnings.length ? accessWarnings : ('warnings' in runtime ? runtime.warnings : undefined),
+          tunnelRunning: access.tunnel?.running,
+          tunnelPublicUrl: access.publicN8nUrl || safeInstance.tunnelPublicUrl,
+          access,
+        },
+      };
+    } catch (error: any) {
+      return {
+        cacheTtlMs: Math.min(this.ttlMs, INSTANCE_ENRICHMENT_ERROR_CACHE_TTL_MS),
+        value: this.buildUnavailableInstance(safeInstance, error?.message || 'Runtime status unavailable.'),
+      };
+    }
+  }
+
+  private buildUnavailableInstance(instance: any, message: string): Record<string, unknown> {
+    const safeInstance = instance || {};
+    return {
+      ...safeInstance,
+      host: safeInstance.tunnelPublicUrl || safeInstance.baseUrl || '',
+      verificationStatus: safeInstance.verification?.status || 'unverified',
+      verificationLabel: this.getVerificationLabel(safeInstance),
+      runtimeStatus: 'unknown',
+      runtimeReady: false,
+      runtimeBlockedMessage: message,
+    };
+  }
+
+  private getVerificationLabel(instance: any): string {
+    return instance.verification?.status === 'verified'
+      ? 'Verified'
+      : instance.verification?.status === 'failed'
+        ? 'Verification failed'
+        : 'Not verified yet';
+  }
+
+  private getInstanceEnrichmentSignature(instance: any): string {
+    return JSON.stringify({
+      id: instance.id || '',
+      mode: instance.mode || '',
+      baseUrl: instance.baseUrl || '',
+      tunnelPublicUrl: instance.tunnelPublicUrl || '',
+      publicUrlEnabled: Boolean(instance.publicUrlEnabled),
+      verificationStatus: instance.verification?.status || '',
+      updatedAt: instance.updatedAt || '',
+    });
+  }
+
+  private setEntry(instanceId: string, entry: InstanceEnrichmentCacheEntry): void {
+    this.entries.set(instanceId, entry);
+    this.evictExpiredEntries(Date.now());
+    this.evictOverflowEntries();
+  }
+
+  private evictExpiredEntries(now: number): void {
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt <= now) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  private evictOverflowEntries(): void {
+    while (this.entries.size > MAX_CACHE_ENTRIES) {
+      let oldestKey: string | undefined;
+      let oldestExpiresAt = Number.POSITIVE_INFINITY;
+      for (const [key, entry] of this.entries) {
+        if (entry.expiresAt < oldestExpiresAt) {
+          oldestKey = key;
+          oldestExpiresAt = entry.expiresAt;
+        }
+      }
+      if (!oldestKey) return;
+      this.entries.delete(oldestKey);
+    }
+  }
+
+  private async withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
+  }
+}

--- a/packages/vscode-extension/src/ui/configuration-webview.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview.ts
@@ -7,6 +7,7 @@ import { getWorkspaceRoot } from '../utils/state-detection.js';
 import type { N8nConfigurationController, N8nConfigurationSnapshot } from '../services/n8n-configuration-controller.js';
 import { AgentProviderService, normalizeAgentProviderId } from '../services/agent-provider-service.js';
 import { getConfigurationHtml } from './configuration-webview-html.js';
+import { ConfigurationInstanceEnrichmentCache } from './configuration-instance-enrichment.js';
 import { loadProjectsForConfigurationWebview } from './configuration-webview-projects.js';
 
 type ManagedSetupJob = {
@@ -114,6 +115,7 @@ export class ConfigurationWebview {
   private _initialTab: string | undefined;
   private readonly _managedSetupJobs = new Map<string, ManagedSetupJob>();
   private readonly _managedSetupJobCleanupTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly _instanceEnrichmentCache = new ConfigurationInstanceEnrichmentCache();
   private _queuedPinEnvironmentId: string | undefined;
   private _pinEnvironmentTask: Promise<void> | undefined;
 
@@ -490,6 +492,7 @@ export class ConfigurationWebview {
             if (action === 'stop') await globalFacade.stopInstance(instanceId);
             if (action === 'restart') await globalFacade.restartInstance(instanceId);
           });
+          this.invalidateInstanceEnrichment(instanceId);
           await this._configurationController.refresh(`webview-${action}-instance`, { force: true });
           this.notifySaved();
           return;
@@ -509,6 +512,7 @@ export class ConfigurationWebview {
             mode: 'reconcile',
             refreshPublicUrl: true,
           }));
+          this.invalidateInstanceEnrichment(instanceId);
           await this._configurationController.refresh('webview-refresh-public-url', { force: true });
           this.notifySaved();
           if (access.warnings.length) {
@@ -965,51 +969,9 @@ export class ConfigurationWebview {
     const globalConfig = currentSnapshot.global;
     const workspaceOverrides = currentSnapshot.workspace;
     const effectiveContext = currentSnapshot.effective;
-    const instances = await Promise.all(globalConfig.instances.map(async (instance) => {
-      try {
-        const runtime = await instanceFacade.status({ instanceId: instance.id });
-        const access = await instanceFacade.resolveInstanceAccess({
-          instanceId: instance.id,
-          mode: 'observe',
-        });
-        const displayUrl = access.authUrl || access.publicN8nUrl || (access.publicUrlEnabled ? '' : access.apiBaseUrl || '');
-        return {
-          ...instance,
-          host: displayUrl,
-          displayUrl,
-          authBridgePublicUrl: access.authUrl,
-          verificationStatus: instance.verification?.status || 'unverified',
-          verificationLabel: instance.verification?.status === 'verified'
-            ? 'Verified'
-            : instance.verification?.status === 'failed'
-              ? 'Verification failed'
-              : 'Not verified yet',
-          runtimeStatus: runtime.status,
-          runtimeReady: 'ready' in runtime ? runtime.ready : runtime.status === 'ready',
-          ownerCredentialsAvailable: Boolean(runtime.instance?.ownerCredentialsAvailable),
-          runtimeBlockedCode: 'blocked' in runtime ? runtime.blocked?.code : undefined,
-          runtimeBlockedMessage: 'blocked' in runtime ? runtime.blocked?.message : undefined,
-          runtimeWarnings: access.warnings.length ? access.warnings : ('warnings' in runtime ? runtime.warnings : undefined),
-          tunnelRunning: access.tunnel?.running,
-          tunnelPublicUrl: access.publicN8nUrl || instance.tunnelPublicUrl,
-          access,
-        };
-      } catch (error: any) {
-        return {
-          ...instance,
-          host: instance.tunnelPublicUrl || instance.baseUrl || '',
-          verificationStatus: instance.verification?.status || 'unverified',
-          verificationLabel: instance.verification?.status === 'verified'
-            ? 'Verified'
-            : instance.verification?.status === 'failed'
-              ? 'Verification failed'
-              : 'Not verified yet',
-          runtimeStatus: 'unknown',
-          runtimeReady: false,
-          runtimeBlockedMessage: error?.message || 'Runtime status unavailable.',
-        };
-      }
-    }));
+    const instances = await Promise.all(globalConfig.instances.map((instance) => (
+      this._instanceEnrichmentCache.enrich(instance, instanceFacade)
+    )));
 
     this._panel.webview.postMessage({
       type: 'init',
@@ -1043,6 +1005,10 @@ export class ConfigurationWebview {
       this._panel.webview.postMessage({ type: 'activeTab', tab: this._initialTab });
       this._initialTab = undefined;
     }
+  }
+
+  private invalidateInstanceEnrichment(instanceId: string): void {
+    this._instanceEnrichmentCache.invalidate(instanceId);
   }
 
   private getHtmlForWebview(): string {

--- a/packages/vscode-extension/src/ui/settings-webview/app.tsx
+++ b/packages/vscode-extension/src/ui/settings-webview/app.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Provider, useDispatch, useSelector } from 'react-redux';
 import { actions, store, type EnvironmentDraft, type RootState } from './store.js';
@@ -8,13 +8,15 @@ declare const acquireVsCodeApi: undefined | (() => { postMessage(message: unknow
 
 const vscode = typeof acquireVsCodeApi === 'function' ? acquireVsCodeApi() : { postMessage: (message: unknown) => console.log(message) };
 const post = (message: Record<string, unknown>) => vscode.postMessage(message);
+const EMPTY_OBJECT: Record<string, never> = {};
+const EMPTY_ARRAY: any[] = [];
 
 function useAppDispatch() { return useDispatch<typeof store.dispatch>(); }
-function server(state: RootState): any { return state.server || {}; }
-function instances(state: RootState): any[] { return server(state).global?.instances || []; }
-function workspace(state: RootState): any { return server(state).workspace || {}; }
-function environments(state: RootState): any[] { return workspace(state).environments || []; }
-function targets(state: RootState): any[] { return workspace(state).environmentTargets || []; }
+function server(state: RootState): any { return state.server || EMPTY_OBJECT; }
+function instances(state: RootState): any[] { return server(state).global?.instances || EMPTY_ARRAY; }
+function workspace(state: RootState): any { return server(state).workspace || EMPTY_OBJECT; }
+function environments(state: RootState): any[] { return workspace(state).environments || EMPTY_ARRAY; }
+function targets(state: RootState): any[] { return workspace(state).environmentTargets || EMPTY_ARRAY; }
 function setupActive(state: RootState): boolean { return Object.values(state.jobs).some((job) => job.status === 'installing' || job.status === 'cancelling'); }
 
 function App() {
@@ -123,13 +125,12 @@ function EnvironmentCard({ env }: { env: any }) {
   const dispatch = useAppDispatch();
   const activeEnvironmentId = useSelector((state: RootState) => workspace(state).activeEnvironmentId || '');
   const allTargets = useSelector(targets);
-  const allEnvironments = useSelector(environments);
   const allInstances = useSelector(instances);
   const jobs = useSelector((state: RootState) => state.jobs);
   const pendingActiveEnvironmentId = useSelector((state: RootState) => state.ui.pendingActiveEnvironmentId || '');
-  const target = allTargets.find((item) => item.id === env.environmentTargetId);
-  const access = environmentAccessBadge(env.accessStatus || target?.accessStatus);
-  const managed = environmentManagedInstanceStatus(env, target, allInstances, jobs);
+  const target = useMemo(() => allTargets.find((item) => item.id === env.environmentTargetId), [allTargets, env.environmentTargetId]);
+  const access = useMemo(() => environmentAccessBadge(env.accessStatus || target?.accessStatus), [env.accessStatus, target?.accessStatus]);
+  const managed = useMemo(() => environmentManagedInstanceStatus(env, target, allInstances, jobs), [env, target, allInstances, jobs]);
   const effectiveActiveEnvironmentId = pendingActiveEnvironmentId || activeEnvironmentId;
   const isActive = env.id === effectiveActiveEnvironmentId;
   const isPending = env.id === pendingActiveEnvironmentId;
@@ -160,7 +161,8 @@ function EnvironmentCard({ env }: { env: any }) {
 
 function ManagedInstancesTab() {
   const dispatch = useAppDispatch();
-  const managed = useSelector(instances).filter((instance) => instance.mode === 'managed-local-docker');
+  const allInstances = useSelector(instances);
+  const managed = useMemo(() => allInstances.filter((instance) => instance.mode === 'managed-local-docker'), [allInstances]);
   const activeSetup = useSelector(setupActive);
   return <section className="stack">
     <header>
@@ -174,15 +176,15 @@ function ManagedInstancesTab() {
 
 function ManagedInstanceCard({ instance }: { instance: any }) {
   const dispatch = useAppDispatch();
-  const jobs = useSelector((state: RootState) => state.jobs);
+  const job = useSelector((state: RootState) => state.jobs[instance.id]);
   const envs = useSelector(environments);
   const allTargets = useSelector(targets);
-  const status = managedInstanceUiStatus(instance, jobs[instance.id]);
-  const usedBy = envs.filter((env) => {
+  const status = useMemo(() => managedInstanceUiStatus(instance, job), [instance, job]);
+  const usedBy = useMemo(() => envs.filter((env) => {
     const target = allTargets.find((item) => item.id === env.environmentTargetId);
     return env.managedInstanceId === instance.id || target?.managedInstanceId === instance.id;
-  });
-  const url = instanceUrl(instance);
+  }), [envs, allTargets, instance.id]);
+  const url = useMemo(() => instanceUrl(instance), [instance]);
   const openDetail = () => dispatch(actions.modalOpened({ kind: 'managed-detail', instanceId: instance.id }));
   return <article className="card clickable" role="button" tabIndex={0} onClick={openDetail} onKeyDown={(event) => {
     if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar' || event.code === 'Space') {
@@ -202,8 +204,8 @@ function ManagedInstanceCard({ instance }: { instance: any }) {
 }
 
 function AgentProvidersTab() {
-  const providers = useSelector((state: RootState) => server(state).providers || []);
-  const sortedProviders = [...providers].sort((left: any, right: any) => Number(Boolean(right.connected)) - Number(Boolean(left.connected)) || String(left.label || left.provider || left.id).localeCompare(String(right.label || right.provider || right.id)));
+  const providers = useSelector((state: RootState) => server(state).providers || EMPTY_ARRAY);
+  const sortedProviders = useMemo(() => [...providers].sort((left: any, right: any) => Number(Boolean(right.connected)) - Number(Boolean(left.connected)) || String(left.label || left.provider || left.id).localeCompare(String(right.label || right.provider || right.id))), [providers]);
   return <section className="stack"><header><div><h1>Agent providers</h1><p className="muted">AI provider connections used by agent workflows.</p></div></header><div className="stack">{sortedProviders.map((provider: any) => {
     const providerId = provider.provider || provider.id;
     return <article className="card" key={providerId}><div className="card-top"><div><h2>{provider.label || providerId}</h2><p className="subtle">{provider.model || provider.reason || ''}</p></div><span className={`badge ${provider.connected ? 'ready' : ''}`}>{provider.connected ? 'Connected' : 'Not connected'}</span></div><div className="row">{provider.connected ? null : <button onClick={() => post({ type: 'connectProvider', provider: providerId })}>Connect</button>}{provider.connected ? <button className="secondary" onClick={() => post({ type: 'disconnectProvider', provider: providerId })}>Disconnect</button> : null}</div></article>;
@@ -231,15 +233,16 @@ function EnvironmentFormModal({ environmentId }: { environmentId?: string }) {
   const allTargets = useSelector(targets);
   const allEnvironments = useSelector(environments);
   const allInstances = useSelector(instances);
-  const jobs = useSelector((state: RootState) => state.jobs);
   const activeSetup = useSelector(setupActive);
   const notice = useSelector((state: RootState) => state.ui.notice);
   const savePending = useSelector((state: RootState) => Boolean(state.ui.pendingEnvironmentSaves[draftId]));
-  const choices = buildEnvironmentInstanceChoices(allTargets, allInstances);
-  const selected = choices.find((choice) => choice.value === draft?.instanceChoice);
+  const choices = useMemo(() => buildEnvironmentInstanceChoices(allTargets, allInstances), [allTargets, allInstances]);
+  const selected = useMemo(() => choices.find((choice) => choice.value === draft?.instanceChoice), [choices, draft?.instanceChoice]);
+  const selectedInstanceId = selected?.instanceId;
+  const selectedJob = useSelector((state: RootState) => selectedInstanceId ? state.jobs[selectedInstanceId] : undefined);
   const editingEnvironment = Boolean(environmentId);
   const isManaged = selected?.mode === 'managed';
-  const status = isManaged ? managedInstanceUiStatus(allInstances.find((instance) => instance.id === selected.instanceId), selected.instanceId ? jobs[selected.instanceId] : undefined) : undefined;
+  const status = useMemo(() => isManaged ? managedInstanceUiStatus(allInstances.find((instance) => instance.id === selectedInstanceId), selectedJob) : undefined, [isManaged, allInstances, selectedInstanceId, selectedJob]);
   const patch = (patch: Partial<EnvironmentDraft>) => dispatch(actions.environmentDraftPatched({ id: draftId, patch }));
   const patchName = (name: string) => {
     const currentDefault = defaultWorkflowsPathForName(draft?.name || '', allEnvironments, environmentId);
@@ -250,9 +253,9 @@ function EnvironmentFormModal({ environmentId }: { environmentId?: string }) {
     patch(nextPatch);
   };
   const normalizedWorkflowsPath = normalizeWorkflowsPath(draft?.workflowsPath || '');
-  const workflowsPathConflict = Boolean(normalizedWorkflowsPath) && allEnvironments
+  const workflowsPathConflict = useMemo(() => Boolean(normalizedWorkflowsPath) && allEnvironments
     .filter((environment) => environment?.id !== environmentId)
-    .some((environment) => normalizeWorkflowsPath(environment?.workflowsPath || environment?.workflowDir || environment?.syncFolder || '') === normalizedWorkflowsPath);
+    .some((environment) => normalizeWorkflowsPath(environment?.workflowsPath || environment?.workflowDir || environment?.syncFolder || '') === normalizedWorkflowsPath), [allEnvironments, environmentId, normalizedWorkflowsPath]);
   const canContinue = draft && selected && selected.mode !== 'new-managed' && (isManaged || selected?.targetId || selected?.mode !== 'new-connected' || (draft.url && (draft.apiKey || draft.apiKeyAvailable)));
   if (!draft) return null;
   const save = () => {
@@ -314,7 +317,7 @@ function EnvironmentFormModal({ environmentId }: { environmentId?: string }) {
 
 function ProjectFields({ draft, patch, draftId, selected }: { draft: EnvironmentDraft; patch: (patch: Partial<EnvironmentDraft>) => void; draftId: string; selected: any }) {
   const dispatch = useAppDispatch();
-  const requestKey = `${selected?.value || ''}|${selected?.targetId || ''}|${draft.url || selected?.url || ''}|${draft.apiKey ? 'key' : draft.apiKeyAvailable ? 'stored' : ''}`;
+  const requestKey = useMemo(() => `${selected?.value || ''}|${selected?.targetId || ''}|${draft.url || selected?.url || ''}|${draft.apiKey ? 'key' : draft.apiKeyAvailable ? 'stored' : ''}`, [draft.apiKey, draft.apiKeyAvailable, draft.url, selected?.targetId, selected?.url, selected?.value]);
   useEffect(() => {
     if (!selected || selected.mode === 'managed' || selected.mode === 'new-managed') return;
     if (draft.projectsLoading && draft.projectRequestKey === requestKey) return;
@@ -322,10 +325,10 @@ function ProjectFields({ draft, patch, draftId, selected }: { draft: Environment
     dispatch(actions.environmentDraftProjectsLoading({ id: draftId, requestKey }));
     post({ type: 'loadProjects', scope: 'environment', draftId, requestKey, instanceId: selected?.instanceId || '', environmentTargetId: selected?.targetId || '', host: selected?.targetId ? '' : draft.url || selected?.url || '', apiKey: selected?.targetId ? '' : draft.apiKey, projectId: draft.projectId, projectName: draft.projectName });
   }, [dispatch, draft.apiKey, draft.apiKeyAvailable, draft.projectError, draft.projectId, draft.projectName, draft.projectRequestKey, draft.projects, draft.projectsLoading, draft.url, draftId, requestKey, selected]);
+  const projects = draft.projects || EMPTY_ARRAY;
+  const selectableProjects = useMemo(() => projects.filter((project) => project.id !== 'personal' || projects.length > 1), [projects]);
   if (draft.projectsLoading) return <div className="inline-message">Checking project access...</div>;
   if (draft.projectError) return null;
-  const projects = draft.projects || [];
-  const selectableProjects = projects.filter((project) => project.id !== 'personal' || projects.length > 1);
   if (selectableProjects.length <= 1 && selectableProjects[0]?.id === 'personal') return null;
   if (!selectableProjects.length) return null;
   return <div className="form-grid"><label>Project<select value={draft.projectId} onChange={(event) => { const project = projects.find((item) => item.id === event.target.value); patch({ projectId: event.target.value, projectName: project?.name || '' }); }}>{selectableProjects.map((project) => <option key={project.id} value={project.id}>{project.displayName || project.name}</option>)}</select></label></div>;
@@ -344,11 +347,12 @@ function ManagedInstanceFormModal({ returnToEnvironmentForm, returnToEnvironment
 
 function ManagedInstanceDetailModal({ instanceId }: { instanceId: string }) {
   const dispatch = useAppDispatch();
-  const instance = useSelector(instances).find((item) => item.id === instanceId);
-  const jobs = useSelector((state: RootState) => state.jobs);
-  const status = managedInstanceUiStatus(instance, jobs[instanceId]);
+  const allInstances = useSelector(instances);
+  const instance = useMemo(() => allInstances.find((item) => item.id === instanceId), [allInstances, instanceId]);
+  const job = useSelector((state: RootState) => state.jobs[instanceId]);
+  const status = useMemo(() => managedInstanceUiStatus(instance, job), [instance, job]);
   const credentials = useSelector((state: RootState) => state.ui.credentials);
-  const url = instance ? instanceUrl(instance) : '';
+  const url = useMemo(() => instance ? instanceUrl(instance) : '', [instance]);
   return <Modal title={instance?.name || instanceId} onClose={() => dispatch(actions.modalClosed())}>
     <div className="row"><span className={`badge ${status.tone}`}>{status.label}</span><span className="subtle">{status.message}</span></div>
     <p className="subtle">{url || 'URL pending'}</p>

--- a/packages/vscode-extension/tests/unit/activation-policy.test.ts
+++ b/packages/vscode-extension/tests/unit/activation-policy.test.ts
@@ -92,3 +92,32 @@ test('AI context auto-refresh requires explicit workspace configuration', () => 
         },
     }), true);
 });
+
+test('sync initialization does not force-regenerate fresh AI context', () => {
+    const updateFunction = extensionSource.slice(
+        extensionSource.indexOf('async function updateAiContextAfterSyncInitialization'),
+        extensionSource.indexOf('async function initializeSyncManager'),
+    );
+
+    assert.ok(updateFunction.includes("ensureAiContextFresh(context, 'sync-initialized'"), 'Sync init must still check AI context freshness');
+    assert.ok(!updateFunction.includes('force: true'), 'Sync init should use freshness metadata instead of forcing regeneration');
+});
+
+test('sync event journal polling skips unchanged files', () => {
+    const journalFunction = extensionSource.slice(
+        extensionSource.indexOf('async function processSyncEventJournal'),
+        extensionSource.indexOf('function trimProcessedSyncEvents'),
+    );
+    const resetFunction = extensionSource.slice(
+        extensionSource.indexOf('function resetExtensionRuntimeState'),
+        extensionSource.indexOf('async function determineInitialState'),
+    );
+
+    assert.ok(extensionSource.includes('const syncEventJournalSignatures = new Map<string, string>();'));
+    assert.ok(journalFunction.includes('const signature = getFileChangeSignature(journalUri.fsPath);'));
+    assert.ok(journalFunction.includes('syncEventJournalSignatures.get(journalUri.fsPath) === signature'));
+    assert.ok(journalFunction.includes('return;'), 'unchanged journal polls should avoid rereading JSONL');
+    assert.ok(journalFunction.includes('syncEventJournalSignatures.set(journalUri.fsPath, signature);'));
+    assert.ok(extensionSource.includes('return `${stat.mtimeMs}:${stat.size}`;'));
+    assert.ok(resetFunction.includes('syncEventJournalSignatures.clear();'));
+});

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -516,6 +516,26 @@ test('Agent Workbench state delivery: runtime states are lightweight and ordered
     assert.ok(source.includes('await this.postWorkbenchState(message.state, { enrich: false });'), 'Runtime state messages should use the lightweight path');
 });
 
+test('Agent Workbench streaming: text deltas are batched and rendered on animation frames', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const controller = fs.readFileSync(path.join(__dirname, '../../src/services/agent-runtime-controller.ts'), 'utf8');
+    const html = fs.readFileSync(path.join(__dirname, '../../src/ui/agent-workbench-html.ts'), 'utf8');
+
+    assert.ok(controller.includes('STREAM_TEXT_FLUSH_INTERVAL_MS'), 'Runtime should define a bounded stream flush interval');
+    assert.ok(controller.includes('pendingTextDelta += streamEvent.delta'), 'Runtime should coalesce text deltas before posting to the webview');
+    assert.ok(controller.includes('await flushPendingTextDelta();'), 'Runtime must flush text before non-text events and final output');
+    assert.ok(controller.includes("const delta = pendingTextDelta;\n            pendingTextDelta = '';\n            if (!delta) {\n                await textFlushChain;\n                return;\n            }\n            const flush = async () =>"), 'Runtime should snapshot buffered text and await in-flight flushes before non-text events');
+    assert.ok(controller.includes('streamClosed = true;'), 'Runtime should close the stream before cleanup');
+    assert.ok(controller.includes('clearTimeout(pendingTextFlushTimer);'), 'Runtime cleanup should cancel pending text flush timers');
+    assert.ok(controller.includes("pendingTextDelta = '';"), 'Aborted runs should drop buffered text before leaving cleanup');
+    assert.ok(html.includes('function scheduleRenderAll()'), 'Workbench webview should batch streaming renders');
+    assert.ok(html.includes('function flushScheduledRenderAll()'), 'Immediate workbench renders should cancel scheduled frames');
+    assert.ok(html.includes('cancelAnimationFrame(renderAllFrame);'), 'Scheduled render frames should be cancellable');
+    assert.ok(html.includes('requestAnimationFrame(() =>'), 'Streaming renders should align with browser frames');
+    assert.ok(html.includes('if (deferRender) scheduleRenderAll();'), 'Text-delta events should defer full feed rendering');
+});
+
 test('Agent Workbench webview: conversation deletion is confirmed and cleans panel ownership', () => {
     const fs = require('node:fs');
     const path = require('node:path');
@@ -543,9 +563,13 @@ test('Agent Workbench webview: workflow menu options preserve local file paths',
     const fs = require('node:fs');
     const path = require('node:path');
     const source = fs.readFileSync(path.join(__dirname, '../../src/ui/agent-workbench-webview.ts'), 'utf8');
+    const extensionSource = fs.readFileSync(path.join(__dirname, '../../src/extension.ts'), 'utf8');
 
-    assert.ok(source.includes('resolveWorkflow(base)'), 'Available workflows should resolve their local file targets');
-    assert.ok(source.includes('filePath: target?.workflowFilePath'), 'Available workflow options must include local file paths');
+    assert.ok(source.includes('listWorkflowOptions()'), 'Available workflow options should be provided as a lightweight list');
+    assert.ok(!source.includes('resolveWorkflow(base)'), 'Available workflows must not resolve every workflow target from the menu path');
+    assert.ok(extensionSource.includes('function listAgentWorkflowContextOptions'), 'Extension host must build lightweight workflow menu options');
+    assert.ok(extensionSource.includes('filePath: getExistingWorkflowFileUri(workflow)?.fsPath'), 'Available workflow options must include local file paths');
+    assert.ok(!extensionSource.includes('const workflows = await listAgentWorkflowOptions();\n    const workflow = workflows.find'), 'Resolving one workflow must not refresh the full remote workflow list');
     assert.ok(source.includes('workflowFilename: this._workflow?.filename'), 'Initial HTML must receive the current workflow filename');
     assert.ok(source.includes('workflowFilePath: this._workflowFilePath'), 'Initial HTML must receive the current workflow file path');
     assert.ok(source.includes("workflowFilename: workflow?.filename || ''"), 'Workflow update messages must preserve filename');

--- a/packages/vscode-extension/tests/unit/configuration-webview-html.test.ts
+++ b/packages/vscode-extension/tests/unit/configuration-webview-html.test.ts
@@ -1,5 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert';
+import {
+    ConfigurationInstanceEnrichmentCache,
+    INSTANCE_ENRICHMENT_CACHE_TTL_MS,
+    type InstanceEnrichmentFacade,
+    type InstanceStatusResponse,
+} from '../../src/ui/configuration-instance-enrichment.js';
 
 test('Configuration webview HTML: renders bundled React shell with CSP nonce', () => {
     const { getConfigurationHtml } = require('../../src/ui/configuration-webview-html.js');
@@ -12,4 +18,177 @@ test('Configuration webview HTML: renders bundled React shell with CSP nonce', (
     assert.ok(html.includes('<script nonce="nonce" src="vscode-resource://settings-webview.js"></script>'), 'Bundled webview script must be loaded with nonce');
     assert.ok(!html.includes('external instance'), 'Shell must not expose legacy external instance copy');
     assert.ok(!html.includes('existing instance'), 'Shell must not expose legacy existing instance copy');
+});
+
+test('Settings React webview: expensive derived values are memoized', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const source = fs.readFileSync(path.join(__dirname, '../../src/ui/settings-webview/app.tsx'), 'utf8');
+
+    assert.ok(source.includes('const EMPTY_ARRAY'), 'Selectors should use stable empty arrays');
+    assert.ok(source.includes('useMemo(() => buildEnvironmentInstanceChoices'), 'Environment choice derivation should be memoized');
+    assert.ok(source.includes('useMemo(() => allInstances.filter'), 'Managed instance filtering should be memoized');
+    assert.ok(source.includes('useMemo(() => [...providers].sort'), 'Provider sorting should be memoized');
+    assert.ok(source.includes('state.jobs[instance.id]'), 'Managed instance cards should subscribe to the specific setup job');
+    assert.ok(source.includes('state.jobs[instanceId]'), 'Managed instance detail should subscribe to the specific setup job');
+    assert.ok(source.includes('selectedInstanceId ? state.jobs[selectedInstanceId] : undefined'), 'Environment form status should subscribe to the selected instance job');
+});
+
+function createInstanceFacade() {
+    const calls = { status: 0, access: 0 };
+    const facade: InstanceEnrichmentFacade = {
+        async status() {
+            calls.status += 1;
+            return { status: 'ready', ready: true, instance: { ownerCredentialsAvailable: true } };
+        },
+        async resolveInstanceAccess() {
+            calls.access += 1;
+            return {
+                authUrl: '',
+                publicN8nUrl: '',
+                publicUrlEnabled: false,
+                apiBaseUrl: 'http://localhost:5678',
+                warnings: [],
+                tunnel: { running: false },
+            };
+        },
+    };
+    return { facade, calls };
+}
+
+test('Configuration instance enrichment cache reuses repeat calls within TTL', async () => {
+    const cache = new ConfigurationInstanceEnrichmentCache();
+    const { facade, calls } = createInstanceFacade();
+    const instance = { id: 'managed-1', mode: 'managed-local-docker', baseUrl: 'http://localhost:5678' };
+
+    const first = await cache.enrich(instance, facade);
+    const second = await cache.enrich(instance, facade);
+
+    assert.strictEqual(first, second);
+    assert.strictEqual(calls.status, 1);
+    assert.strictEqual(calls.access, 1);
+    assert.strictEqual(second.runtimeStatus, 'ready');
+});
+
+test('Configuration instance enrichment cache deduplicates concurrent reads', async () => {
+    const calls = { status: 0, access: 0 };
+    let releaseStatus: (() => void) | undefined;
+    const facade: InstanceEnrichmentFacade = {
+        async status() {
+            calls.status += 1;
+            return await new Promise<InstanceStatusResponse>((resolve) => {
+                releaseStatus = () => resolve({ status: 'ready', ready: true });
+            });
+        },
+        async resolveInstanceAccess() {
+            calls.access += 1;
+            return {
+                authUrl: '',
+                publicN8nUrl: '',
+                publicUrlEnabled: false,
+                apiBaseUrl: 'http://localhost:5678',
+                warnings: [],
+                tunnel: { running: false },
+            };
+        },
+    };
+    const cache = new ConfigurationInstanceEnrichmentCache();
+    const instance = { id: 'managed-1', mode: 'managed-local-docker', baseUrl: 'http://localhost:5678' };
+
+    const first = cache.enrich(instance, facade);
+    const second = cache.enrich(instance, facade);
+    assert.strictEqual(calls.status, 1);
+
+    releaseStatus?.();
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    assert.strictEqual(firstResult, secondResult);
+    assert.strictEqual(calls.status, 1);
+    assert.strictEqual(calls.access, 1);
+});
+
+test('Configuration instance enrichment cache fetches fresh data after TTL expiry', async () => {
+    const originalNow = Date.now;
+    let now = 10_000;
+    Date.now = () => now;
+    try {
+        const cache = new ConfigurationInstanceEnrichmentCache();
+        const { facade, calls } = createInstanceFacade();
+        const instance = { id: 'managed-1', mode: 'managed-local-docker', baseUrl: 'http://localhost:5678' };
+
+        await cache.enrich(instance, facade);
+        now += INSTANCE_ENRICHMENT_CACHE_TTL_MS + 1;
+        await cache.enrich(instance, facade);
+
+        assert.strictEqual(calls.status, 2);
+        assert.strictEqual(calls.access, 2);
+    } finally {
+        Date.now = originalNow;
+    }
+});
+
+test('Configuration instance enrichment cache refetches after invalidation', async () => {
+    const cache = new ConfigurationInstanceEnrichmentCache();
+    const { facade, calls } = createInstanceFacade();
+    const instance = { id: 'managed-1', mode: 'managed-local-docker', baseUrl: 'http://localhost:5678' };
+
+    await cache.enrich(instance, facade);
+    cache.invalidate(instance.id);
+    await cache.enrich(instance, facade);
+
+    assert.strictEqual(calls.status, 2);
+    assert.strictEqual(calls.access, 2);
+});
+
+test('Configuration instance enrichment cache evicts the oldest entry beyond its size limit', async () => {
+    const cache = new ConfigurationInstanceEnrichmentCache();
+    const { facade, calls } = createInstanceFacade();
+
+    for (let index = 0; index <= 100; index += 1) {
+        await cache.enrich({ id: `managed-${index}`, mode: 'managed-local-docker', baseUrl: `http://localhost:${5678 + index}` }, facade);
+    }
+    await cache.enrich({ id: 'managed-0', mode: 'managed-local-docker', baseUrl: 'http://localhost:5678' }, facade);
+
+    assert.strictEqual(calls.status, 102);
+    assert.strictEqual(calls.access, 102);
+});
+
+test('Configuration instance enrichment cache skips caching when instance id is missing', async () => {
+    const cache = new ConfigurationInstanceEnrichmentCache();
+    const { facade, calls } = createInstanceFacade();
+
+    const result = await cache.enrich({ baseUrl: 'http://localhost:5678' }, facade);
+
+    assert.strictEqual(calls.status, 0);
+    assert.strictEqual(calls.access, 0);
+    assert.strictEqual(result.runtimeStatus, 'unknown');
+});
+
+test('Configuration instance enrichment cache times out hung facade calls', async () => {
+    const calls = { status: 0, access: 0 };
+    const facade: InstanceEnrichmentFacade = {
+        async status() {
+            calls.status += 1;
+            return await new Promise(() => undefined);
+        },
+        async resolveInstanceAccess() {
+            calls.access += 1;
+            return {
+                authUrl: '',
+                publicN8nUrl: '',
+                publicUrlEnabled: false,
+                apiBaseUrl: 'http://localhost:5678',
+                warnings: [],
+                tunnel: { running: false },
+            };
+        },
+    };
+    const cache = new ConfigurationInstanceEnrichmentCache(INSTANCE_ENRICHMENT_CACHE_TTL_MS, 1);
+
+    const result = await cache.enrich({ id: 'managed-1', mode: 'managed-local-docker', baseUrl: 'http://localhost:5678' }, facade);
+
+    assert.strictEqual(calls.status, 1);
+    assert.strictEqual(calls.access, 0);
+    assert.strictEqual(result.runtimeStatus, 'unknown');
+    assert.ok(String(result.runtimeBlockedMessage).includes('Runtime status timed out after 1ms'));
 });


### PR DESCRIPTION
## Summary

This PR applies the prioritized VS Code extension performance optimizations from the audit.

- Avoids the Agent Workbench workflow menu N+1 by providing lightweight workflow context options from extension state and only resolving a selected workflow when needed.
- Batches LLM text streaming in the runtime and schedules Workbench text-delta renders on animation frames to reduce webview churn.
- Reduces React settings webview re-renders by stabilizing empty selector values and memoizing expensive derived values.
- Adds a short, signature-bound cache for managed instance runtime enrichment, with invalidation on runtime-changing actions.
- Stops forcing AI context regeneration after sync initialization when freshness metadata is already valid.
- Skips unchanged sync event journal reads during polling using an `mtime/size` signature.

## Impact

The changes target extension host work, webview rendering frequency, and repeated runtime/status IO without changing the n8n workspace source of truth or the underlying environment configuration model.

I left `retainContextWhenHidden` and proxy HTML buffering unchanged because they preserve webview state and bridge injection behavior; changing them safely needs dedicated runtime profiling.

## Validation

- `npm test --workspace packages/vscode-extension`
- `npm run package-bundle --workspace packages/vscode-extension`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lightweight workflow context options for Agent Workbench; improved workflow selection.
  * Instance enrichment cache to deliver richer configuration payloads.

* **Performance Improvements**
  * Buffered/batched assistant text streaming with ordered final events.
  * Coalesced UI rendering during streams to reduce jank.
  * Skip re-processing unchanged sync journals and memoized settings UI computations.

* **Bug Fixes**
  * Clearing journal signature cache on runtime reset to avoid stale skips.

* **Tests**
  * Added unit tests for streaming, caching, sync-skipping, and AI-context refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->