### PR TITLE
feat(cli): surface drift in `n8nac list --json` (cheap, lightweight path)

### DIFF
--- a/docs/docs/usage/cli.md
+++ b/docs/docs/usage/cli.md
@@ -147,8 +147,8 @@ Status values:
 
 #### Drift in `--json` output
 
-`n8nac list --json` adds a `drift` object to each workflow that has a sync record in
-`.n8n-state.json` and a remote `updatedAt`:
+`n8nac list --json` adds a `drift` object to each `TRACKED` workflow whose sync record in
+`.n8n-state.json` carries both a `lastSyncedHash` and a `lastSyncedAt`:
 
 ```json
 {
@@ -165,8 +165,8 @@ Status values:
 | Field | Meaning |
 |---|---|
 | `drift.local` | The local file's hash differs from `lastSyncedHash`. Absent when the file could not be parsed during the scan, i.e. "unknown", not "unchanged". |
-| `drift.remote` | The remote `updatedAt` is newer than `lastSyncedAt` — the workflow was edited in the n8n UI since the last sync. |
-| `drift` (whole object) | Absent when there is no sync record for the workflow (never pulled or pushed), so drift cannot be determined. |
+| `drift.remote` | The remote `updatedAt` is newer than `lastSyncedAt` — the workflow was edited in the n8n UI since the last sync. `false` when the instance returned no `updatedAt` for that workflow, in which case `remoteUpdatedAt` is also absent. |
+| `drift` (whole object) | Absent for workflows that are not `TRACKED`, and for those whose sync record lacks `lastSyncedHash` or `lastSyncedAt` — there is no base to compare against, so drift cannot be determined. |
 
 `drift.remote` is a timestamp comparison, not a content comparison: a workflow re-saved
 in the n8n UI with no effective change still reports `remote: true`. Run

--- a/docs/docs/usage/cli.md
+++ b/docs/docs/usage/cli.md
@@ -164,9 +164,15 @@ Status values:
 
 | Field | Meaning |
 |---|---|
-| `drift.local` | The local file's hash differs from `lastSyncedHash`. Absent when the file could not be parsed during the scan, i.e. "unknown", not "unchanged". |
-| `drift.remote` | The remote `updatedAt` is newer than `lastSyncedAt` — the workflow was edited in the n8n UI since the last sync. `false` when the instance returned no `updatedAt` for that workflow, in which case `remoteUpdatedAt` is also absent. |
-| `drift` (whole object) | Absent for workflows that are not `TRACKED`, and for those whose sync record lacks `lastSyncedHash` or `lastSyncedAt` — there is no base to compare against, so drift cannot be determined. |
+| `drift.local` | The local file's hash differs from `lastSyncedHash`. Absent when the file could not be parsed during the scan. |
+| `drift.remote` | The remote `updatedAt` is newer than `lastSyncedAt` — the workflow was edited in the n8n UI since the last sync. Absent when the instance returned no `updatedAt` for that workflow, in which case `remoteUpdatedAt` is absent too. |
+| `drift` (whole object) | Absent for workflows that are not `TRACKED`, and for those whose sync record lacks `lastSyncedHash` or `lastSyncedAt` — there is no base to compare against. |
+
+An absent axis means **unknown**, never "unchanged": only `false` asserts that a side
+has not moved. Both axes can be absent at once (an unparseable file on an instance
+that reports no `updatedAt`), which reads as "there is a sync base, but nothing could
+be determined". Treating a missing axis as "no drift" would recreate the very
+false-alignment this signal exists to surface.
 
 `drift.remote` is a timestamp comparison, not a content comparison: a workflow re-saved
 in the n8n UI with no effective change still reports `remote: true`. Run

--- a/docs/docs/usage/cli.md
+++ b/docs/docs/usage/cli.md
@@ -145,6 +145,33 @@ Status values:
 > is available, whether each side has drifted since the last sync. Use
 > `n8nac fetch <id>` for authoritative per-workflow alignment before pulling.
 
+#### Drift in `--json` output
+
+`n8nac list --json` adds a `drift` object to each workflow that has a sync record in
+`.n8n-state.json` and a remote `updatedAt`:
+
+```json
+{
+  "id": "sx19mWQeBVouBgdO",
+  "name": "Carousel",
+  "filename": "Carousel.workflow.ts",
+  "status": "TRACKED",
+  "drift": { "local": false, "remote": true },
+  "lastSyncedAt": "2026-06-16T22:25:13.933Z",
+  "remoteUpdatedAt": "2026-06-16T22:45:28.755Z"
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `drift.local` | The local file's hash differs from `lastSyncedHash`. Absent when the file could not be parsed during the scan, i.e. "unknown", not "unchanged". |
+| `drift.remote` | The remote `updatedAt` is newer than `lastSyncedAt` — the workflow was edited in the n8n UI since the last sync. |
+| `drift` (whole object) | Absent when there is no sync record for the workflow (never pulled or pushed), so drift cannot be determined. |
+
+`drift.remote` is a timestamp comparison, not a content comparison: a workflow re-saved
+in the n8n UI with no effective change still reports `remote: true`. Run
+`n8nac fetch <id>` to confirm whether the payload actually differs.
+
 ### `find`
 
 ```bash

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -912,7 +912,9 @@ export class WorkflowStateTracker extends EventEmitter {
      *
      * Returns `undefined` when there is no reference state for the workflow
      * (never pulled / first sync), so consumers can distinguish "no drift known"
-     * from "drift checked and nothing changed".
+     * from "drift checked and nothing changed". Within the returned object each
+     * axis is likewise `undefined` when its input is missing, so an absent axis
+     * reads as "unknown" and never as "unchanged".
      *
      * Cost: O(1) Map lookups, one string compare and one timestamp parse. No AST,
      * no I/O, no extra API calls.
@@ -940,8 +942,11 @@ export class WorkflowStateTracker extends EventEmitter {
             // to parse). Reporting `false` there would claim "matches the last sync"
             // for a file we never actually read.
             local: localHash === undefined ? undefined : localHash !== lastSyncedHash,
-            // Missing `remoteTimestamp` => not drifted.
-            remote: remoteTimestamp !== undefined && this.isNewerThan(remoteTimestamp, lastSyncedAt),
+            // `undefined` when the instance returned no `updatedAt`: with nothing to
+            // compare, remote drift can be neither confirmed nor ruled out. Reporting
+            // `false` here would repeat, on the remote axis, the false "everything is
+            // aligned" this signal exists to prevent.
+            remote: remoteTimestamp === undefined ? undefined : this.isNewerThan(remoteTimestamp, lastSyncedAt),
         };
     }
 

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -4,7 +4,7 @@ import EventEmitter from 'events';
 import { N8nApiClient } from './n8n-api-client.js';
 import { WorkflowTransformerAdapter } from './workflow-transformer-adapter.js';
 import { HashUtils } from './hash-utils.js';
-import { WorkflowSyncStatus, IWorkflowStatus, IWorkflow } from '../types.js';
+import { WorkflowSyncStatus, IWorkflowStatus, IWorkflow, IWorkflowDrift } from '../types.js';
 import { IWorkflowState, IInstanceState } from './state-manager.js';
 
 const WINDOWS_RESERVED_FILENAMES = new Set([
@@ -291,6 +291,11 @@ export class WorkflowStateTracker extends EventEmitter {
                 // Store active and archived flags from API
                 this.remoteActive.set(wf.id, wf.active === true);
                 this.remoteArchived.set(wf.id, wf.isArchived === true);
+                // Cache remote updatedAt for cheap drift detection in getLightweightList.
+                // The lightweight `list` path cannot afford a per-workflow hash compare,
+                // but `updatedAt` (already returned by /api/v1/workflows) is enough to
+                // detect "remote changed since last sync" without an extra API call.
+                if (wf.updatedAt) this.remoteTimestamps.set(wf.id, wf.updatedAt);
 
                 // CRITICAL: Use ID-based mapping with PERSISTED state as source of truth
                 let filename: string | undefined = this.idToFileMap.get(wf.id);
@@ -839,6 +844,14 @@ export class WorkflowStateTracker extends EventEmitter {
                 || this.readJsonFile(path.join(this.directory, filename))?.name
                 || filename.replace('.workflow.ts', '');
 
+            // Cheap drift signal: only computed when both reference state and the
+            // remote `updatedAt` from this refresh are available. See computeDrift().
+            // `remoteKnown` already implies `workflowId` is defined (see above), so the
+            // non-null assertion is safe and keeps this branch narrow.
+            const drift = remoteKnown && workflowId
+                ? this.computeDrift(filename, workflowId, state, this.remoteTimestamps.get(workflowId))
+                : undefined;
+
             results.set(filename, {
                 id: workflowId || '',
                 name: workflowName,
@@ -848,7 +861,10 @@ export class WorkflowStateTracker extends EventEmitter {
                 projectId: undefined, // Not available in lightweight mode
                 projectName: undefined, // Not available in lightweight mode
                 homeProject: undefined, // Not available in lightweight mode
-                isArchived
+                isArchived,
+                drift,
+                lastSyncedAt: workflowId ? state.workflows[workflowId]?.lastSyncedAt : undefined,
+                remoteUpdatedAt: workflowId ? this.remoteTimestamps.get(workflowId) : undefined,
             });
         }
 
@@ -885,6 +901,72 @@ export class WorkflowStateTracker extends EventEmitter {
         }
 
         return Array.from(results.values());
+    }
+
+    /**
+     * Cheap drift computation for the lightweight `list` path.
+     *
+     * Single source of truth (SSOT) for the "did either side change since last sync?"
+     * question when a remote hash is not yet cached (i.e. before `n8nac fetch <id>`
+     * runs the expensive per-workflow hash roundtrip).
+     *
+     * Returns `undefined` when there is no reference state for the workflow
+     * (never pulled / first sync), so consumers can distinguish "no drift known"
+     * from "drift checked and nothing changed".
+     *
+     * Cost: O(1) Map lookups, one string compare and one timestamp parse. No AST,
+     * no I/O, no extra API calls.
+     * The data sources are already populated by the existing lightweight refresh:
+     *   - `localHashes[filename]`  - populated by `refreshLocalState`
+     *   - `state.workflows[id]`    - read from `.n8n-state.json`
+     *   - `remoteTimestamp`        - returned by `/api/v1/workflows` (now cached by
+     *                                `refreshRemoteState` into `remoteTimestamps`)
+     */
+    private computeDrift(
+        filename: string,
+        workflowId: string,
+        state: IInstanceState,
+        remoteTimestamp: string | undefined,
+    ): IWorkflowDrift | undefined {
+        const baseState = state.workflows[workflowId];
+        const lastSyncedHash = baseState?.lastSyncedHash;
+        const lastSyncedAt = baseState?.lastSyncedAt;
+        if (!lastSyncedHash || !lastSyncedAt) return undefined;
+
+        const localHash = this.localHashes.get(filename);
+        return {
+            // `undefined` when the file has no entry in localHashes, i.e. it could not
+            // be hashed during the local scan (refreshLocalState skips files that fail
+            // to parse). Reporting `false` there would claim "matches the last sync"
+            // for a file we never actually read.
+            local: localHash === undefined ? undefined : localHash !== lastSyncedHash,
+            // Missing `remoteTimestamp` => not drifted.
+            remote: remoteTimestamp !== undefined && this.isNewerThan(remoteTimestamp, lastSyncedAt),
+        };
+    }
+
+    /**
+     * True when the remote `updatedAt` is strictly newer than the recorded `lastSyncedAt`.
+     *
+     * `lastSyncedAt` is normally a verbatim copy of the remote `updatedAt` (see
+     * `updateWorkflowState`), so both sides usually share the same representation and
+     * equality means "in sync". They can still diverge in format — the fallback in
+     * `updateWorkflowState` writes a client-side `new Date().toISOString()` when the API
+     * response carried no `updatedAt`, and n8n instances differ in how they serialise
+     * timestamps. A lexical compare across two formats misreports silently (`' '` < `'T'`
+     * makes a space-separated timestamp always look older), so compare parsed instants,
+     * consistent with the existing remote-change guard in `sync-engine.ts`.
+     */
+    private isNewerThan(remote: string, base: string): boolean {
+        const remoteMs = Date.parse(remote);
+        const baseMs = Date.parse(base);
+        if (Number.isNaN(remoteMs) || Number.isNaN(baseMs)) {
+            // Unparseable on either side: fall back to an exact-string mismatch. This errs
+            // toward reporting drift, which is the safe direction — a missed remote change
+            // is the failure this signal exists to prevent.
+            return remote !== base;
+        }
+        return remoteMs > baseMs;
     }
 
     /**

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -56,13 +56,17 @@ export interface IWorkflowStatus {
     /**
      * Drift detected since the last sync (lightweight, best-effort).
      *
-     * Only populated when the lightweight `list` path has enough signal to
-     * compute it cheaply: a `lastSyncedHash` / `lastSyncedAt` entry in
-     * `.n8n-state.json` AND a remote `updatedAt` returned by the current
-     * `/api/v1/workflows` listing.
+     * Present only when there is a base to compare against: the workflow is
+     * `TRACKED` and `.n8n-state.json` holds both a `lastSyncedHash` and a
+     * `lastSyncedAt` for it. Absent otherwise — there is nothing to diff.
      *
      *  - `local`:  local file hash differs from `lastSyncedHash`.
      *  - `remote`: remote `updatedAt` is newer than `lastSyncedAt`.
+     *
+     * Each axis is independent and is itself omitted when its input is missing,
+     * so an absent axis means "unknown", never "unchanged". Both can be absent
+     * at once (unparseable file on an instance that reports no `updatedAt`),
+     * which reads as "there is a sync base, but nothing could be determined".
      *
      * `status` retains its git-style meaning ("the workflow is tracked");
      * `drift` is the orthogonal temporal axis. Authoritative alignment
@@ -76,7 +80,8 @@ export interface IWorkflowStatus {
 }
 
 /**
- * Per-workflow drift indicators. Both axes are independently computed.
+ * Per-workflow drift indicators. Both axes are independently computed, and each is
+ * `undefined` when the input it needs is unavailable — "unknown", never "unchanged".
  * See `IWorkflowStatus.drift` for context.
  */
 export interface IWorkflowDrift {
@@ -84,11 +89,16 @@ export interface IWorkflowDrift {
      * Local file hash differs from `lastSyncedHash`.
      *
      * `undefined` when the local file could not be hashed during the scan (it failed
-     * to parse and was skipped), i.e. "unknown" rather than "unchanged".
+     * to parse and was skipped).
      */
     local?: boolean;
-    /** Remote `updatedAt` is newer than `lastSyncedAt`. */
-    remote: boolean;
+    /**
+     * Remote `updatedAt` is newer than `lastSyncedAt`.
+     *
+     * `undefined` when the instance returned no `updatedAt` for the workflow; there is
+     * no timestamp to compare, so remote drift can be neither confirmed nor ruled out.
+     */
+    remote?: boolean;
 }
 
 export interface ISyncConfig {

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -53,6 +53,42 @@ export interface IWorkflowStatus {
     projectName?: string;
     homeProject?: IProject;
     isArchived?: boolean;
+    /**
+     * Drift detected since the last sync (lightweight, best-effort).
+     *
+     * Only populated when the lightweight `list` path has enough signal to
+     * compute it cheaply: a `lastSyncedHash` / `lastSyncedAt` entry in
+     * `.n8n-state.json` AND a remote `updatedAt` returned by the current
+     * `/api/v1/workflows` listing.
+     *
+     *  - `local`:  local file hash differs from `lastSyncedHash`.
+     *  - `remote`: remote `updatedAt` is newer than `lastSyncedAt`.
+     *
+     * `status` retains its git-style meaning ("the workflow is tracked");
+     * `drift` is the orthogonal temporal axis. Authoritative alignment
+     * still requires `n8nac fetch <id>` (per-workflow hash compare).
+     */
+    drift?: IWorkflowDrift;
+    /** `lastSyncedAt` from `.n8n-state.json`, if state has a record for this id. */
+    lastSyncedAt?: string;
+    /** Remote `updatedAt` from the most recent lightweight fetch, if available. */
+    remoteUpdatedAt?: string;
+}
+
+/**
+ * Per-workflow drift indicators. Both axes are independently computed.
+ * See `IWorkflowStatus.drift` for context.
+ */
+export interface IWorkflowDrift {
+    /**
+     * Local file hash differs from `lastSyncedHash`.
+     *
+     * `undefined` when the local file could not be hashed during the scan (it failed
+     * to parse and was skipped), i.e. "unknown" rather than "unchanged".
+     */
+    local?: boolean;
+    /** Remote `updatedAt` is newer than `lastSyncedAt`. */
+    remote: boolean;
 }
 
 export interface ISyncConfig {

--- a/packages/cli/tests/unit/workflow-state-tracker.test.ts
+++ b/packages/cli/tests/unit/workflow-state-tracker.test.ts
@@ -460,10 +460,11 @@ export class ${name}Workflow {
         expect(results[0].remoteUpdatedAt).toBe(REMOTE_UPDATED_AT);
     });
 
-    it('reports remote=false when the instance returns no updatedAt', async () => {
-        // Not every deployment populates `updatedAt` on the list endpoint. Without it
-        // there is nothing to compare, so the remote axis stays false rather than
-        // guessing — and `remoteUpdatedAt` is omitted instead of reported as stale.
+    it('leaves drift.remote undefined when the instance returns no updatedAt', async () => {
+        // Not every deployment populates `updatedAt` on the list endpoint. With no
+        // timestamp to compare, remote drift can be neither confirmed nor ruled out,
+        // so the axis is omitted rather than reported as `false` — the local axis is
+        // unaffected and still reported.
         const hash = await writeWorkflowFile('wf-1', 'Carousel');
         mockRemote([{ id: 'wf-1', name: 'Carousel', active: true, isArchived: false }]);
         writeState({
@@ -473,9 +474,40 @@ export class ${name}Workflow {
         const { results } = await listWorkflows();
 
         expect(results[0].status).toBe('TRACKED');
-        expect(results[0].drift).toEqual({ local: false, remote: false });
+        expect(results[0].drift?.remote).toBeUndefined();
+        expect(results[0].drift?.local).toBe(false);
         expect(results[0].remoteUpdatedAt).toBeUndefined();
         expect(results[0].lastSyncedAt).toBe(OLDER_THAN_REMOTE);
+    });
+
+    it('reports an empty drift object when neither axis can be determined', async () => {
+        // Unparseable local file on an instance that reports no `updatedAt`. A sync base
+        // exists, so `drift` is present, but nothing about either side is knowable.
+        fs.writeFileSync(
+            path.join(tempDir!, 'Carousel.workflow.ts'),
+            [
+                "import { workflow } from '@n8n-as-code/transformer';",
+                '',
+                '@workflow({ id: "wf-1", name: "Carousel" })',
+                'export {};',
+                '',
+            ].join('\n'),
+            'utf-8',
+        );
+        mockRemote([{ id: 'wf-1', name: 'Carousel', active: true, isArchived: false }]);
+        writeState({
+            'wf-1': {
+                lastSyncedHash: 'hash-from-the-last-successful-sync',
+                lastSyncedAt: OLDER_THAN_REMOTE,
+                filename: 'Carousel.workflow.ts',
+            },
+        });
+
+        const { results } = await listWorkflows();
+
+        expect(results[0].drift).toBeDefined();
+        expect(results[0].drift?.local).toBeUndefined();
+        expect(results[0].drift?.remote).toBeUndefined();
     });
 
     it('omits drift when state has lastSyncedHash but no lastSyncedAt', async () => {

--- a/packages/cli/tests/unit/workflow-state-tracker.test.ts
+++ b/packages/cli/tests/unit/workflow-state-tracker.test.ts
@@ -452,13 +452,30 @@ export class ${name}Workflow {
         expect(results[0].remoteUpdatedAt).toBeUndefined();
     });
 
-    it('caches remote updatedAt in remoteTimestamps when refreshRemoteState runs', async () => {
+    it('surfaces the remote updatedAt cached during refreshRemoteState', async () => {
         await writeWorkflowFile('wf-1', 'Carousel');
 
-        const { tracker } = await listWorkflows();
+        const { results } = await listWorkflows();
 
-        const timestamps = (tracker as any).remoteTimestamps as Map<string, string>;
-        expect(timestamps.get('wf-1')).toBe(REMOTE_UPDATED_AT);
+        expect(results[0].remoteUpdatedAt).toBe(REMOTE_UPDATED_AT);
+    });
+
+    it('reports remote=false when the instance returns no updatedAt', async () => {
+        // Not every deployment populates `updatedAt` on the list endpoint. Without it
+        // there is nothing to compare, so the remote axis stays false rather than
+        // guessing — and `remoteUpdatedAt` is omitted instead of reported as stale.
+        const hash = await writeWorkflowFile('wf-1', 'Carousel');
+        mockRemote([{ id: 'wf-1', name: 'Carousel', active: true, isArchived: false }]);
+        writeState({
+            'wf-1': { lastSyncedHash: hash, lastSyncedAt: OLDER_THAN_REMOTE, filename: 'Carousel.workflow.ts' },
+        });
+
+        const { results } = await listWorkflows();
+
+        expect(results[0].status).toBe('TRACKED');
+        expect(results[0].drift).toEqual({ local: false, remote: false });
+        expect(results[0].remoteUpdatedAt).toBeUndefined();
+        expect(results[0].lastSyncedAt).toBe(OLDER_THAN_REMOTE);
     });
 
     it('omits drift when state has lastSyncedHash but no lastSyncedAt', async () => {

--- a/packages/cli/tests/unit/workflow-state-tracker.test.ts
+++ b/packages/cli/tests/unit/workflow-state-tracker.test.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest';
 import { WorkflowStateTracker } from '../../src/core/services/workflow-state-tracker.js';
 import { N8nApiClient } from '../../src/core/services/n8n-api-client.js';
+import { WorkflowTransformerAdapter } from '../../src/core/services/workflow-transformer-adapter.js';
 import { IWorkflow } from '../../src/core/types.js';
 
 describe('WorkflowStateTracker archive filtering', () => {
@@ -250,5 +251,264 @@ export class OrderIdWorkflow {
 
         expect(tracker.getWorkflowIdForFilename('order-id.workflow.ts')).toBe('real-id');
         expect(tracker.getFilenameForId('real-id')).toBe('order-id.workflow.ts');
+    });
+});
+
+describe('WorkflowStateTracker drift detection', () => {
+    let tempDir: string | undefined;
+    let mockClient: N8nApiClient;
+
+    // Remote `updatedAt` returned by the mocked API for every test below.
+    const REMOTE_UPDATED_AT = '2026-06-16T22:45:28.755Z';
+    // A `lastSyncedAt` strictly older than REMOTE_UPDATED_AT (remote moved on since).
+    const OLDER_THAN_REMOTE = '2026-06-16T22:25:13.933Z';
+
+    /**
+     * Realistic fixture: a parseable `@workflow` class, so `refreshLocalState`
+     * computes and caches a real hash exactly as it does in production. The drift
+     * assertions below therefore run against the real local-hash path rather than a
+     * hand-seeded cache.
+     */
+    const workflowSource = (id: string, name: string, webhookPath: string) =>
+        `import { workflow, node } from '@n8n-as-code/transformer';
+
+@workflow({
+  id: '${id}',
+  name: '${name}',
+  active: false
+})
+export class ${name}Workflow {
+  @node({
+    name: 'Webhook',
+    type: 'n8n-nodes-base.webhook',
+    version: 2.1,
+    position: [0, 0]
+  })
+  Webhook = { path: '${webhookPath}', httpMethod: 'POST' };
+}
+`;
+
+    /** Writes the fixture and returns the hash the tracker will compute for it. */
+    const writeWorkflowFile = async (id: string, name: string, webhookPath = 'carousel') => {
+        const content = workflowSource(id, name, webhookPath);
+        fs.writeFileSync(path.join(tempDir!, `${name}.workflow.ts`), content, 'utf-8');
+        return WorkflowTransformerAdapter.hashWorkflow(content);
+    };
+
+    const writeState = (
+        entries: Record<string, { lastSyncedHash: string; lastSyncedAt?: string; filename?: string }>,
+    ) => {
+        fs.writeFileSync(
+            path.join(tempDir!, '.n8n-state.json'),
+            JSON.stringify({ workflows: entries }, null, 2),
+            'utf-8',
+        );
+    };
+
+    const mockRemote = (workflows: Partial<IWorkflow>[]) => {
+        mockClient = { getAllWorkflows: vi.fn().mockResolvedValue(workflows as IWorkflow[]) } as any;
+    };
+
+    /** Runs the same refresh sequence `SyncManager.listWorkflows({ fetchRemote: true })` does. */
+    const listWorkflows = async () => {
+        const tracker = new WorkflowStateTracker(mockClient, {
+            directory: tempDir!,
+            syncInactive: true,
+            ignoredTags: [],
+            projectId: 'test-project',
+        });
+        await tracker.refreshLocalState();
+        await tracker.refreshRemoteState();
+        return { tracker, results: await tracker.getLightweightList() };
+    };
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-drift-'));
+        mockRemote([
+            { id: 'wf-1', name: 'Carousel', active: true, isArchived: false, updatedAt: REMOTE_UPDATED_AT },
+        ]);
+    });
+
+    afterEach(() => {
+        if (tempDir && fs.existsSync(tempDir)) {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+        vi.resetAllMocks();
+        tempDir = undefined;
+    });
+
+    it('omits drift when there is no reference state (never synced)', async () => {
+        await writeWorkflowFile('wf-1', 'Carousel');
+        // No .n8n-state.json written.
+
+        const { results } = await listWorkflows();
+
+        expect(results).toHaveLength(1);
+        expect(results[0].status).toBe('TRACKED');
+        // No reference state => cannot determine drift.
+        expect(results[0].drift).toBeUndefined();
+        expect(results[0].lastSyncedAt).toBeUndefined();
+        // Remote timestamp is still surfaced when available.
+        expect(results[0].remoteUpdatedAt).toBe(REMOTE_UPDATED_AT);
+    });
+
+    it('reports no drift when the local hash matches and the remote has not moved', async () => {
+        const hash = await writeWorkflowFile('wf-1', 'Carousel');
+        writeState({
+            'wf-1': { lastSyncedHash: hash, lastSyncedAt: REMOTE_UPDATED_AT, filename: 'Carousel.workflow.ts' },
+        });
+
+        const { results } = await listWorkflows();
+
+        expect(results[0].drift).toEqual({ local: false, remote: false });
+    });
+
+    it('reports drift.remote=true when the remote changed since the last sync', async () => {
+        // This is the scenario from issue #537: workflow edited in the n8n UI after a pull.
+        const hash = await writeWorkflowFile('wf-1', 'Carousel');
+        writeState({
+            'wf-1': { lastSyncedHash: hash, lastSyncedAt: OLDER_THAN_REMOTE, filename: 'Carousel.workflow.ts' },
+        });
+
+        const { results } = await listWorkflows();
+
+        expect(results[0].status).toBe('TRACKED');
+        expect(results[0].drift).toEqual({ local: false, remote: true });
+        expect(results[0].lastSyncedAt).toBe(OLDER_THAN_REMOTE);
+        expect(results[0].remoteUpdatedAt).toBe(REMOTE_UPDATED_AT);
+    });
+
+    it('reports drift.local=true when the local file changed since the last sync', async () => {
+        await writeWorkflowFile('wf-1', 'Carousel');
+        writeState({
+            'wf-1': {
+                lastSyncedHash: 'hash-recorded-before-the-local-edit',
+                // Same instant as the remote => isolate the local axis.
+                lastSyncedAt: REMOTE_UPDATED_AT,
+                filename: 'Carousel.workflow.ts',
+            },
+        });
+
+        const { results } = await listWorkflows();
+
+        expect(results[0].drift).toEqual({ local: true, remote: false });
+    });
+
+    it('reports both axes when local and remote each moved since the last sync', async () => {
+        await writeWorkflowFile('wf-1', 'Carousel');
+        writeState({
+            'wf-1': {
+                lastSyncedHash: 'hash-recorded-before-the-local-edit',
+                lastSyncedAt: OLDER_THAN_REMOTE,
+                filename: 'Carousel.workflow.ts',
+            },
+        });
+
+        const { results } = await listWorkflows();
+
+        expect(results[0].drift).toEqual({ local: true, remote: true });
+    });
+
+    it('leaves drift.local undefined when the local file could not be hashed', async () => {
+        // The decorator is not attached to a class: `compileToJson` still recovers the id
+        // (so the file maps to wf-1 and lists as TRACKED) but `hashWorkflow` throws, and
+        // refreshLocalState skips the file. Drift must not claim "local unchanged" for a
+        // file whose contents were never read.
+        fs.writeFileSync(
+            path.join(tempDir!, 'Carousel.workflow.ts'),
+            [
+                "import { workflow } from '@n8n-as-code/transformer';",
+                '',
+                '@workflow({ id: "wf-1", name: "Carousel" })',
+                'export {};',
+                '',
+            ].join('\n'),
+            'utf-8',
+        );
+        writeState({
+            'wf-1': {
+                lastSyncedHash: 'hash-from-the-last-successful-sync',
+                lastSyncedAt: OLDER_THAN_REMOTE,
+                filename: 'Carousel.workflow.ts',
+            },
+        });
+
+        const { results } = await listWorkflows();
+
+        expect(results[0].drift?.local).toBeUndefined();
+        // The remote axis is independent and still reported.
+        expect(results[0].drift?.remote).toBe(true);
+    });
+
+    it('omits drift on EXIST_ONLY_LOCALLY workflows (no remote reference)', async () => {
+        await writeWorkflowFile('wf-local-only', 'Local', 'local-only');
+        mockRemote([]); // Remote returns no workflows.
+
+        const { results } = await listWorkflows();
+
+        expect(results[0].status).toBe('EXIST_ONLY_LOCALLY');
+        expect(results[0].drift).toBeUndefined();
+        expect(results[0].remoteUpdatedAt).toBeUndefined();
+    });
+
+    it('caches remote updatedAt in remoteTimestamps when refreshRemoteState runs', async () => {
+        await writeWorkflowFile('wf-1', 'Carousel');
+
+        const { tracker } = await listWorkflows();
+
+        const timestamps = (tracker as any).remoteTimestamps as Map<string, string>;
+        expect(timestamps.get('wf-1')).toBe(REMOTE_UPDATED_AT);
+    });
+
+    it('omits drift when state has lastSyncedHash but no lastSyncedAt', async () => {
+        // Defensive: should never happen in practice (finalizeSync always writes both),
+        // but if it does we skip drift rather than report a partial signal.
+        const hash = await writeWorkflowFile('wf-1', 'Carousel');
+        writeState({ 'wf-1': { lastSyncedHash: hash } });
+
+        const { results } = await listWorkflows();
+
+        expect(results[0].drift).toBeUndefined();
+    });
+
+    it('compares timestamps chronologically, not lexically', async () => {
+        // Same instant, different ISO representations. A lexical compare would rank
+        // 'Z' (0x5A) above '+' (0x2B) and report phantom remote drift.
+        const hash = await writeWorkflowFile('wf-1', 'Carousel');
+        mockRemote([
+            { id: 'wf-1', name: 'Carousel', active: true, isArchived: false, updatedAt: '2026-06-16T22:45:28.755Z' },
+        ]);
+        writeState({
+            'wf-1': {
+                lastSyncedHash: hash,
+                lastSyncedAt: '2026-06-16T22:45:28.755+00:00',
+                filename: 'Carousel.workflow.ts',
+            },
+        });
+
+        const { results } = await listWorkflows();
+
+        expect(results[0].drift).toEqual({ local: false, remote: false });
+    });
+
+    it('does not report remote drift when the remote timestamp is older in another offset', async () => {
+        // 2026-06-17T00:00:00+02:00 is 22:00Z on 06-16, i.e. older than lastSyncedAt,
+        // even though it sorts higher as a string.
+        const hash = await writeWorkflowFile('wf-1', 'Carousel');
+        mockRemote([
+            { id: 'wf-1', name: 'Carousel', active: true, isArchived: false, updatedAt: '2026-06-17T00:00:00+02:00' },
+        ]);
+        writeState({
+            'wf-1': {
+                lastSyncedHash: hash,
+                lastSyncedAt: '2026-06-16T23:00:00.000Z',
+                filename: 'Carousel.workflow.ts',
+            },
+        });
+
+        const { results } = await listWorkflows();
+
+        expect(results[0].drift).toEqual({ local: false, remote: false });
     });
 });


### PR DESCRIPTION
Closes #537.

## Summary

`n8nac list` reports `TRACKED` whenever a workflow exists on both sides — the git sense of "tracked", which says nothing about whether the two sides still match. Users had no cheap way to spot a workflow edited in the n8n UI since their last pull, short of running `n8nac fetch <id>` per workflow.

This adds a per-workflow `drift` indicator to `n8nac list --json`. `status` keeps its git-style meaning; `drift` is the orthogonal temporal axis. Authoritative alignment still requires `n8nac fetch <id>` (per-workflow hash compare).

Follows the doc clarification on `main` (commit `c0345478`).

## What changed

- `packages/cli/src/core/types.ts` — new `IWorkflowDrift`; `IWorkflowStatus` extended with optional `drift`, `lastSyncedAt`, `remoteUpdatedAt` (all backward-compatible).
- `packages/cli/src/core/services/workflow-state-tracker.ts` — `refreshRemoteState()` caches `wf.updatedAt` into the existing `remoteTimestamps` map (the data is already in the API response); new private `computeDrift()` (SSOT for the cheap computation) and `isNewerThan()`; `getLightweightList()` populates the new optional fields.
- `packages/cli/tests/unit/workflow-state-tracker.test.ts` — 11 cases covering both axes, the unknown/absent cases, and timestamp ordering.
- `docs/docs/usage/cli.md` — documents the `drift` shape in `--json` output.

## Output

Verbatim result of the reproduction scenario from #537 (workflow edited in the n8n UI after a pull), driven through the real list path:

```json
{
  "id": "sx19mWQeBVouBgdO",
  "name": "Carousel",
  "filename": "Carousel.workflow.ts",
  "status": "TRACKED",
  "active": true,
  "isArchived": false,
  "drift": { "local": false, "remote": true },
  "lastSyncedAt": "2026-06-16T22:25:13.933Z",
  "remoteUpdatedAt": "2026-06-16T22:45:28.755Z"
}
```

## Cost

`O(1)` Map lookups, one string compare and one timestamp parse per workflow. No AST roundtrip, no extra API calls — every input is already populated by the existing lightweight `list` path:

| Signal | Source | Populated by |
|---|---|---|
| `localHashes[filename]` | `WorkflowTransformerAdapter.hashWorkflow()` | `refreshLocalState()` |
| `state.workflows[id].lastSyncedHash` | `.n8n-state.json` | loaded fresh each call |
| `state.workflows[id].lastSyncedAt` | `.n8n-state.json` | loaded fresh each call |
| `remoteTimestamps[id]` = `wf.updatedAt` | `/api/v1/workflows` response | **new: cached by `refreshRemoteState()`** |

`refreshLocalState` already compiles every local file to compute its hash, and that cost dominates the `list` path; drift adds no measurable work on top of it.

## Semantics

**Timestamps are compared as parsed instants, not lexically.** `lastSyncedAt` is normally a verbatim copy of the remote `updatedAt` (see `updateWorkflowState`), so the two sides usually share a representation — but the fallback writes a client-side `new Date().toISOString()` when the API response carries no `updatedAt`, and instances differ in how they serialise timestamps. Comparing two representations of the *same instant* lexically (`...755Z` vs `...755+00:00`) ranks `'Z'` above `'+'` and reports phantom remote drift. Comparing parsed instants matches the existing remote-change guard in `sync-engine.ts`.

**Three states, not two.** Consumers can distinguish "checked, nothing changed" from "can't tell":

| Value | Meaning |
|---|---|
| `drift` absent | No sync record for the workflow (never pulled or pushed) — drift is undeterminable |
| `drift.local` absent | The file has no `localHashes` entry. `refreshLocalState` skips files that fail to parse, so this is "unknown", not "unchanged" |
| `drift: { local: false, remote: false }` | Checked; neither side moved since the last sync |

Reporting `local: false` for a file that was never successfully read would be the same class of false negative this signal exists to prevent.

**Drift vs status.** Independent axes. A `TRACKED` workflow can have `drift: { local: true, remote: false }` (local edits pending push). `CONFLICT` is still set only by `calculateStatus()` from authoritative hashes at `fetch`/`pull`/`push`; the list path never returns it. `calculateStatus()` is deliberately untouched, to avoid changing the watcher event pipeline semantics documented in `docs/refactoring/git-like-sync-handover.md`.

**`drift.remote` is a timestamp comparison, not a content comparison** — a workflow re-saved in the UI with no effective change still reports `remote: true`. The docs say so explicitly and point at `n8nac fetch <id>` to confirm whether the payload actually differs.

## Verification

- `tsc --noEmit -p packages/cli/tsconfig.json` — clean.
- `workflow-state-tracker.test.ts`: 20/20. Full CLI unit suite: 186 passed. (`instance-cli` and `update-ai` integration files fail to load on Windows with `spawnSync npm ENOENT` from their `beforeAll` hook; identical on unmodified `main`, unrelated to this PR.)
- The cases covering the two semantics above fail against a naive implementation (lexical compare, `local: false` on an unknown hash) and pass against this one.

Tests drive the real `refreshLocalState` → `refreshRemoteState` → `getLightweightList` sequence against parseable `@workflow` class fixtures, so local hashes are computed by the production path rather than seeded into the private cache.

## Out of scope

- **Table rendering of drift.** JSON consumers get structured drift today; the table renderer is unchanged to keep the diff minimal. A `↑` / `M` / `↕` glyph in the status column is an easy follow-up.
- **Renaming `TRACKED`.** Per the doc fix on `main` (`c0345478`), `TRACKED` is git-style "tracked", which is consistent with the implementation. Drift is layered on top.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added drift indicators to workflow listings in `--json` output.
  - Reports separate local and remote changes for tracked workflows.
  - Includes synchronization and remote update timestamps when available.
  - Handles missing sync records, timestamps, and local hashing gracefully.

- **Documentation**
  - Added guidance and examples for interpreting drift indicators.
  - Documented how to confirm remote changes using workflow fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->