### PR TITLE
Folder-aware sync over /rest session auth (folderSync on sub-Enterprise n8n)

### DIFF
--- a/packages/cli/src/commands/base.ts
+++ b/packages/cli/src/commands/base.ts
@@ -162,15 +162,21 @@ export class BaseCommand {
      * Validates that required project fields are present; exits with a clear error if not.
      */
     /**
-     * Resolve optional session-login credentials for reading n8n folders over the
-     * internal `/rest` API. Needed for folderSync on sub-Enterprise instances where
-     * the public folder API is unavailable; Enterprise users do not need this (the
-     * public folder path is used automatically). When present, the session source
-     * takes precedence. Read from env only — never committed:
-     *   N8NAC_ENV_<ENV>_FOLDER_USER / _FOLDER_PASS  (per-environment, preferred)
-     *   N8NAC_FOLDER_LOGIN_USER     / _PASS         (generic fallback)
+     * Resolve optional session auth for reading n8n folders over the internal
+     * `/rest` API. Needed for folderSync on sub-Enterprise instances where the
+     * public folder API is unavailable; Enterprise users need nothing (the public
+     * folder path is used automatically). When present, the session source takes
+     * precedence over the public path.
+     *
+     * A token (stored or env) is used directly; creds are used to mint a cookie
+     * when no token is present, and to silently re-login if a token has expired.
+     * Cookie precedence: stored per-target token (from `n8nac env auth
+     * folder-login`) → env token. Env vars are never committed:
+     *   N8NAC_ENV_<ENV>_FOLDER_USER / _FOLDER_PASS   (per-environment creds)
+     *   N8NAC_ENV_<ENV>_FOLDER_TOKEN                 (per-environment cookie/jwt)
+     *   N8NAC_FOLDER_LOGIN_USER / _PASS / _TOKEN     (generic fallback)
      */
-    protected resolveFolderLogin(): { user: string; pass: string } | undefined {
+    protected resolveFolderAuth(): { cookie?: string; user?: string; pass?: string } | undefined {
         const clean = (v?: string) => v?.trim().replace(/^['"]|['"]$/g, '') || '';
         const slugify = (v?: string) =>
             (v || '').toUpperCase().replace(/[^A-Z0-9]+/g, '_').replace(/^_+|_+$/g, '');
@@ -179,14 +185,37 @@ export class BaseCommand {
             this.activeEnvironment?.environmentId,
         ].map(slugify).filter(Boolean);
 
+        let user = '';
+        let pass = '';
+        let envToken = '';
         for (const slug of slugs) {
-            const user = clean(process.env[`N8NAC_ENV_${slug}_FOLDER_USER`]);
-            const pass = clean(process.env[`N8NAC_ENV_${slug}_FOLDER_PASS`]);
-            if (user && pass) return { user, pass };
+            user = user || clean(process.env[`N8NAC_ENV_${slug}_FOLDER_USER`]);
+            pass = pass || clean(process.env[`N8NAC_ENV_${slug}_FOLDER_PASS`]);
+            envToken = envToken || clean(process.env[`N8NAC_ENV_${slug}_FOLDER_TOKEN`]);
         }
-        const user = clean(process.env.N8NAC_FOLDER_LOGIN_USER);
-        const pass = clean(process.env.N8NAC_FOLDER_LOGIN_PASS);
-        return user && pass ? { user, pass } : undefined;
+        user = user || clean(process.env.N8NAC_FOLDER_LOGIN_USER);
+        pass = pass || clean(process.env.N8NAC_FOLDER_LOGIN_PASS);
+        envToken = envToken || clean(process.env.N8NAC_FOLDER_LOGIN_TOKEN);
+
+        // Stored per-target token wins (skips a login round-trip), if unexpired.
+        let cookie = '';
+        const targetId = this.activeEnvironment?.environmentTargetId;
+        if (targetId) {
+            const session = this.configService.getFolderSession(targetId);
+            if (session?.cookie && (!session.expiresAt || Date.parse(session.expiresAt) > Date.now())) {
+                cookie = session.cookie;
+            }
+        }
+        cookie = cookie || envToken;
+        // Accept a bare JWT in the env token by adding the cookie name.
+        if (cookie && !cookie.includes('=')) cookie = `n8n-auth=${cookie}`;
+
+        if (!cookie && !(user && pass)) return undefined;
+        return {
+            cookie: cookie || undefined,
+            user: user || undefined,
+            pass: pass || undefined,
+        };
     }
 
     protected async getSyncConfig(): Promise<any> {
@@ -230,7 +259,7 @@ export class BaseCommand {
             projectName: localConfig.projectName,
             folderSync: localConfig.folderSync ?? false,
             host: this.config.host,
-            folderLogin: this.resolveFolderLogin(),
+            folderAuth: this.resolveFolderAuth(),
             environmentId: this.activeEnvironment?.environmentId,
             environmentName: this.activeEnvironment?.environmentName,
             environmentTargetId: this.activeEnvironment?.environmentTargetId,

--- a/packages/cli/src/commands/base.ts
+++ b/packages/cli/src/commands/base.ts
@@ -161,6 +161,34 @@ export class BaseCommand {
      * Get sync config with instance identifier.
      * Validates that required project fields are present; exits with a clear error if not.
      */
+    /**
+     * Resolve optional session-login credentials for reading n8n folders over the
+     * internal `/rest` API. Needed for folderSync on sub-Enterprise instances where
+     * the public folder API is unavailable; Enterprise users do not need this (the
+     * public folder path is used automatically). When present, the session source
+     * takes precedence. Read from env only — never committed:
+     *   N8NAC_ENV_<ENV>_FOLDER_USER / _FOLDER_PASS  (per-environment, preferred)
+     *   N8NAC_FOLDER_LOGIN_USER     / _PASS         (generic fallback)
+     */
+    protected resolveFolderLogin(): { user: string; pass: string } | undefined {
+        const clean = (v?: string) => v?.trim().replace(/^['"]|['"]$/g, '') || '';
+        const slugify = (v?: string) =>
+            (v || '').toUpperCase().replace(/[^A-Z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+        const slugs = [
+            this.activeEnvironment?.environmentName,
+            this.activeEnvironment?.environmentId,
+        ].map(slugify).filter(Boolean);
+
+        for (const slug of slugs) {
+            const user = clean(process.env[`N8NAC_ENV_${slug}_FOLDER_USER`]);
+            const pass = clean(process.env[`N8NAC_ENV_${slug}_FOLDER_PASS`]);
+            if (user && pass) return { user, pass };
+        }
+        const user = clean(process.env.N8NAC_FOLDER_LOGIN_USER);
+        const pass = clean(process.env.N8NAC_FOLDER_LOGIN_PASS);
+        return user && pass ? { user, pass } : undefined;
+    }
+
     protected async getSyncConfig(): Promise<any> {
         await this.prepareRuntimeContext();
         const instanceIdentifier = await this.ensureInstanceIdentifier();
@@ -201,6 +229,8 @@ export class BaseCommand {
             projectId: localConfig.projectId,
             projectName: localConfig.projectName,
             folderSync: localConfig.folderSync ?? false,
+            host: this.config.host,
+            folderLogin: this.resolveFolderLogin(),
             environmentId: this.activeEnvironment?.environmentId,
             environmentName: this.activeEnvironment?.environmentName,
             environmentTargetId: this.activeEnvironment?.environmentTargetId,

--- a/packages/cli/src/core/index.ts
+++ b/packages/cli/src/core/index.ts
@@ -12,5 +12,6 @@ export * from './services/directory-utils.js';
 export * from './services/workflow-dir-name.js';
 export * from './services/instance-identifier.js';
 export * from './services/workspace-setup-service.js';
+export * from './services/workflow-path-utils.js';
+export * from './services/folder-path-resolver.js';
 export * from './helpers/index.js';
-

--- a/packages/cli/src/core/services/folder-path-resolver.ts
+++ b/packages/cli/src/core/services/folder-path-resolver.ts
@@ -1,0 +1,95 @@
+import { IFolder, IWorkflow } from '../types.js';
+
+const WINDOWS_RESERVED_FILENAMES = new Set([
+    'CON', 'PRN', 'AUX', 'NUL',
+    'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
+    'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9',
+]);
+
+export function sanitizePathSegment(name: string): string {
+    let safeName = (name || '')
+        .replace(/[\u0000-\u001f\u007f<>:"/\\|?*]/g, '_')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .replace(/[. ]+$/g, '');
+
+    if (!safeName || safeName === '.' || safeName === '..') safeName = 'folder';
+
+    const firstDotIndex = safeName.indexOf('.');
+    const baseName = firstDotIndex === -1 ? safeName : safeName.slice(0, firstDotIndex);
+    const rest = firstDotIndex === -1 ? '' : safeName.slice(firstDotIndex);
+    if (WINDOWS_RESERVED_FILENAMES.has(baseName.toUpperCase())) {
+        safeName = `${baseName}_${rest}`;
+    }
+
+    return safeName.replace(/[. ]+$/g, '') || 'folder';
+}
+
+export class FolderPathResolver {
+    private foldersById = new Map<string, IFolder>();
+    private memo = new Map<string, string[]>();
+    private siblingSegmentById = new Map<string, string>();
+
+    constructor(folders: IFolder[]) {
+        for (const folder of folders) {
+            if (folder?.id) this.foldersById.set(folder.id, folder);
+        }
+        this.buildSiblingSegments(folders);
+    }
+
+    getPathForWorkflow(workflow: IWorkflow): string[] {
+        const folderId = workflow.parentFolderId ?? workflow.parentFolder?.id ?? null;
+        if (!folderId) return [];
+        return this.getPathForFolderId(folderId);
+    }
+
+    getPathForFolderId(folderId: string): string[] {
+        return this.resolve(folderId, new Set());
+    }
+
+    private buildSiblingSegments(folders: IFolder[]): void {
+        const siblings = new Map<string, IFolder[]>();
+        for (const folder of folders) {
+            const parentKey = folder.parentFolderId ?? '';
+            const current = siblings.get(parentKey) ?? [];
+            current.push(folder);
+            siblings.set(parentKey, current);
+        }
+
+        for (const group of siblings.values()) {
+            const used = new Map<string, string>();
+            for (const folder of group.sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id))) {
+                const base = sanitizePathSegment(folder.name);
+                let segment = base;
+                const existingId = used.get(segment.toLowerCase());
+                if (existingId && existingId !== folder.id) {
+                    segment = `${base}_${folder.id.slice(0, 8)}`;
+                }
+                used.set(segment.toLowerCase(), folder.id);
+                this.siblingSegmentById.set(folder.id, segment);
+            }
+        }
+    }
+
+    private resolve(folderId: string, seen: Set<string>): string[] {
+        const cached = this.memo.get(folderId);
+        if (cached) return cached;
+
+        const folder = this.foldersById.get(folderId);
+        if (!folder || seen.has(folderId)) {
+            const fallback = ['_Unresolved Folder', sanitizePathSegment(folderId)];
+            this.memo.set(folderId, fallback);
+            return fallback;
+        }
+
+        seen.add(folderId);
+        const parentSegments = folder.parentFolderId
+            ? this.resolve(folder.parentFolderId, seen)
+            : [];
+        const segment = this.siblingSegmentById.get(folderId) ?? sanitizePathSegment(folder.name);
+        const segments = [...parentSegments, segment];
+        this.memo.set(folderId, segments);
+        seen.delete(folderId);
+        return segments;
+    }
+}

--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -808,6 +808,10 @@ export class N8nApiClient {
             'settings',
             'staticData',
             'pinData',
+            // parentFolderId is forwarded on update so a folderSync push of an
+            // already-tracked workflow moves it to the inferred folder on n8n.
+            // The create path was already wired up; the update path was missing.
+            'parentFolderId',
         ]);
 
         const clean: Record<string, unknown> = {};

--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance } from 'axios';
 import * as dns from 'dns';
 import * as http from 'http';
 import * as https from 'https';
-import { IN8nCredentials, IWorkflow, IProject, ITag, ITriggerInfo, ITestPlan, ITestResult, TriggerType, IInferredPayload, IInferredPayloadField, IExecutionDetails, IExecutionList, IExecutionSummary, ExecutionStatus } from '../types.js';
+import { IN8nCredentials, IWorkflow, IProject, ITag, ITriggerInfo, ITestPlan, ITestResult, TriggerType, IInferredPayload, IInferredPayloadField, IExecutionDetails, IExecutionList, IExecutionSummary, ExecutionStatus, IFolder, IFolderCapability } from '../types.js';
 
 type AgentLookup = NonNullable<http.AgentOptions['lookup']>;
 
@@ -266,6 +266,96 @@ export class N8nApiClient {
             console.error(`[N8nApiClient] Failed to fetch projects: ${error.message}`);
             return [];
         }
+    }
+
+    async getFolders(projectId: string): Promise<IFolder[]> {
+        const folders: IFolder[] = [];
+        const seen = new Set<string>();
+        let skip = 0;
+        const take = 100;
+        let useSelect = true;
+
+        while (true) {
+            const params: Record<string, string> = {
+                skip: String(skip),
+                take: String(take),
+            };
+            if (useSelect) {
+                params.select = JSON.stringify(['id', 'name', 'parentFolderId', 'path', 'createdAt', 'updatedAt']);
+            }
+
+            let res: any;
+            try {
+                res = await this.client.get(`/api/v1/projects/${encodeURIComponent(projectId)}/folders`, { params });
+            } catch (error: any) {
+                if (useSelect && error?.response?.status === 400) {
+                    useSelect = false;
+                    continue;
+                }
+                throw error;
+            }
+
+            const data = Array.isArray(res.data?.data) ? res.data.data : (Array.isArray(res.data) ? res.data : []);
+            const beforeCount = folders.length;
+            for (const folder of data) {
+                if (!folder?.id || seen.has(folder.id)) continue;
+                seen.add(folder.id);
+                folders.push({
+                    id: folder.id,
+                    name: folder.name ?? 'Folder',
+                    parentFolderId: folder.parentFolderId ?? folder.parentFolder?.id ?? null,
+                    path: folder.path,
+                    createdAt: folder.createdAt,
+                    updatedAt: folder.updatedAt,
+                });
+            }
+
+            const count = typeof res.data?.count === 'number' ? res.data.count : undefined;
+            if (count !== undefined && folders.length >= count) break;
+            if (folders.length === beforeCount) break;
+            if (data.length === 0 || (count === undefined && data.length < take)) break;
+            skip += take;
+        }
+
+        return folders;
+    }
+
+    async createFolder(projectId: string, input: { name: string; parentFolderId?: string | null }): Promise<IFolder> {
+        const payload: Record<string, unknown> = { name: input.name };
+        if (input.parentFolderId) payload.parentFolderId = input.parentFolderId;
+        const res = await this.client.post(`/api/v1/projects/${encodeURIComponent(projectId)}/folders`, payload);
+        return {
+            id: res.data.id,
+            name: res.data.name,
+            parentFolderId: res.data.parentFolderId ?? res.data.parentFolder?.id ?? null,
+            path: res.data.path,
+            createdAt: res.data.createdAt,
+            updatedAt: res.data.updatedAt,
+        };
+    }
+
+    async getFolderCapability(projectId: string): Promise<IFolderCapability> {
+        let folders = false;
+        try {
+            await this.client.get(`/api/v1/projects/${encodeURIComponent(projectId)}/folders`, {
+                params: { take: '1' },
+            });
+            folders = true;
+        } catch (error: any) {
+            if (![403, 404].includes(error?.response?.status)) throw error;
+        }
+
+        let workflowFolderFields = false;
+        try {
+            const res = await this.client.get('/api/v1/workflows', { params: { limit: 1 } });
+            const data = res.data && res.data.data ? res.data.data : (Array.isArray(res.data) ? res.data : []);
+            const workflow = Array.isArray(data) ? data[0] : undefined;
+            workflowFolderFields = !!(workflow && ('parentFolderId' in workflow || 'parentFolder' in workflow));
+        } catch {
+            workflowFolderFields = false;
+        }
+
+        return { folders, workflowFolderFields };
     }
 
     /**
@@ -545,6 +635,23 @@ export class N8nApiClient {
         if (workflow.isArchived !== undefined) {
             enriched.isArchived = workflow.isArchived;
         }
+
+        if ('parentFolderId' in workflow) {
+            enriched.parentFolderId = workflow.parentFolderId ?? null;
+        } else if (workflow.parentFolder?.id) {
+            enriched.parentFolderId = workflow.parentFolder.id;
+        }
+
+        if ('parentFolder' in workflow) {
+            enriched.parentFolder = workflow.parentFolder ?? null;
+        }
+        if (workflow.folderPath && Array.isArray(workflow.folderPath)) {
+            enriched.folderPath = workflow.folderPath;
+            enriched.folderPathString = workflow.folderPath.join('/');
+        } else if (typeof workflow.folderPathString === 'string') {
+            enriched.folderPathString = workflow.folderPathString;
+            enriched.folderPath = workflow.folderPathString.split('/').filter(Boolean);
+        }
         
         return enriched;
     }
@@ -585,6 +692,7 @@ export class N8nApiClient {
             'settings',
             'staticData',
             'projectId',
+            'parentFolderId',
         ]);
 
         const clean: Record<string, unknown> = {};

--- a/packages/cli/src/core/services/resolution-manager.ts
+++ b/packages/cli/src/core/services/resolution-manager.ts
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import path from 'path';
 import { SyncEngine } from './sync-engine.js';
 import { WorkflowStateTracker } from './workflow-state-tracker.js';
 import { WorkflowSanitizer } from './workflow-sanitizer.js';
@@ -7,6 +6,7 @@ import { HashUtils } from './hash-utils.js';
 import { WorkflowTransformerAdapter } from './workflow-transformer-adapter.js';
 import { WorkflowSyncStatus } from '../types.js';
 import { N8nApiClient } from './n8n-api-client.js';
+import { workflowRelativePathToAbsolute } from './workflow-path-utils.js';
 
 /**
  * Resolution & Validation Manager
@@ -67,7 +67,7 @@ export class ResolutionManager {
         remoteHash: string;
     }> {
         // Get local content
-        const filePath = path.join(this.directory, filename);
+        const filePath = workflowRelativePathToAbsolute(this.directory, filename);
         const localContent = this.readJsonFile(filePath);
         
         // Get remote content
@@ -147,7 +147,7 @@ export class ResolutionManager {
     }> {
         // Recompute local hash from disk — do NOT use the in-memory cache which may be
         // stale in VSCode mode (change events are suppressed by the file system watcher).
-        const filePath = path.join(this.directory, filename);
+        const filePath = workflowRelativePathToAbsolute(this.directory, filename);
         let localHash: string | undefined;
         if (fs.existsSync(filePath)) {
             try {
@@ -168,7 +168,7 @@ export class ResolutionManager {
 
         return {
             status,
-            localExists: !!localHash || fs.existsSync(path.join(this.directory, filename)),
+            localExists: !!localHash || fs.existsSync(workflowRelativePathToAbsolute(this.directory, filename)),
             remoteExists: !!remoteHash || (this.watcher as any).remoteIds?.has(workflowId),
             lastSyncedHash,
             localHash,

--- a/packages/cli/src/core/services/rest-folder-source.ts
+++ b/packages/cli/src/core/services/rest-folder-source.ts
@@ -1,9 +1,23 @@
 import axios, { AxiosInstance } from 'axios';
 import { IFolder } from '../types.js';
 
-export interface RestFolderLogin {
-    user: string;
-    pass: string;
+/**
+ * Folder-auth material. Either a previously-stored session `cookie`
+ * (`n8n-auth=<jwt>`, valid ~7 days) or raw `user`/`pass` to log in with.
+ * A cookie is preferred; creds are used to mint one and to silently re-login
+ * if the cookie has expired (401).
+ */
+export interface RestFolderAuth {
+    cookie?: string;
+    user?: string;
+    pass?: string;
+}
+
+export interface RestFolderLoginResult {
+    /** Cookie header value, e.g. `n8n-auth=<jwt>`. */
+    cookie: string;
+    /** ISO expiry parsed from the Set-Cookie (Max-Age/Expires), if available. */
+    expiresAt?: string;
 }
 
 export interface RestFolderData {
@@ -11,6 +25,27 @@ export interface RestFolderData {
     folders: IFolder[];
     /** `workflowId -> parentFolderId` for every foldered workflow. */
     workflowParentFolderId: Map<string, string>;
+}
+
+/** Reduce a Set-Cookie array to the `n8n-auth=<value>` cookie pair. */
+function extractAuthCookie(setCookie: string[] | undefined): string | undefined {
+    if (!setCookie?.length) return undefined;
+    const auth = setCookie.find((c) => c.startsWith('n8n-auth='));
+    return (auth ?? setCookie[0]).split(';')[0];
+}
+
+/** Parse an absolute expiry from a Set-Cookie entry's Max-Age/Expires. */
+function parseCookieExpiry(setCookie: string[] | undefined, now: number): string | undefined {
+    const auth = setCookie?.find((c) => c.startsWith('n8n-auth=')) ?? setCookie?.[0];
+    if (!auth) return undefined;
+    const maxAge = /max-age=(\d+)/i.exec(auth)?.[1];
+    if (maxAge) return new Date(now + Number(maxAge) * 1000).toISOString();
+    const expires = /expires=([^;]+)/i.exec(auth)?.[1];
+    if (expires) {
+        const ts = Date.parse(expires);
+        if (!Number.isNaN(ts)) return new Date(ts).toISOString();
+    }
+    return undefined;
 }
 
 /**
@@ -35,23 +70,41 @@ export class RestFolderSource {
     constructor(
         private readonly host: string,
         private readonly projectId: string,
-        private readonly login: RestFolderLogin,
+        private readonly auth: RestFolderAuth,
     ) {
         this.client = axios.create({
             baseURL: host.replace(/\/+$/, ''),
             timeout: 30000,
         });
+        this.cookie = auth.cookie;
+    }
+
+    /**
+     * Log in once and return the session cookie + its expiry. Used by the
+     * `env auth folder-login` command to mint a token to store, and internally
+     * to refresh an expired one.
+     */
+    static async login(host: string, user: string, pass: string, now = Date.now()): Promise<RestFolderLoginResult> {
+        const res = await axios.post(
+            `${host.replace(/\/+$/, '')}/rest/login`,
+            { emailOrLdapLoginId: user, password: pass },
+            { headers: { 'Content-Type': 'application/json' }, timeout: 30000 },
+        );
+        const setCookie: string[] | undefined = res.headers?.['set-cookie'];
+        const cookie = extractAuthCookie(setCookie);
+        if (!cookie) throw new Error('session login returned no cookie');
+        return { cookie, expiresAt: parseCookieExpiry(setCookie, now) };
     }
 
     /** Fetch the folder tree and the workflow→folder mapping in one shot. */
     async load(): Promise<RestFolderData> {
-        await this.authenticate();
-        const folders = await this.fetchAll<IFolder>(
+        await this.ensureCookie();
+        const folders = await this.getAll<IFolder>(
             `/rest/projects/${encodeURIComponent(this.projectId)}/folders`,
         );
 
         const workflowParentFolderId = new Map<string, string>();
-        const workflows = await this.fetchAll<any>('/rest/workflows');
+        const workflows = await this.getAll<any>('/rest/workflows');
         for (const wf of workflows) {
             if (!wf?.id) continue;
             const folderId = wf.parentFolder?.id ?? wf.parentFolderId ?? null;
@@ -61,22 +114,31 @@ export class RestFolderSource {
         return { folders, workflowParentFolderId };
     }
 
-    private async authenticate(): Promise<void> {
-        const res = await this.client.post(
-            '/rest/login',
-            { emailOrLdapLoginId: this.login.user, password: this.login.pass },
-            { headers: { 'Content-Type': 'application/json' } },
-        );
-        const setCookie: string[] | undefined = res.headers?.['set-cookie'];
-        if (!setCookie || setCookie.length === 0) {
-            throw new Error('session login returned no cookie');
+    private async ensureCookie(): Promise<void> {
+        if (this.cookie) return;
+        if (this.auth.user && this.auth.pass) {
+            this.cookie = (await RestFolderSource.login(this.host, this.auth.user, this.auth.pass)).cookie;
+            return;
         }
-        // Keep only the `name=value` part of each Set-Cookie entry.
-        this.cookie = setCookie.map((c) => c.split(';')[0]).join('; ');
+        throw new Error('no folder-login cookie or credentials available');
     }
 
-    /** Paginated GET over an n8n `/rest` collection (`{ count, data }` shape). */
-    private async fetchAll<T>(pathname: string): Promise<T[]> {
+    /** Paginated GET with one transparent re-login if a stored cookie has expired. */
+    private async getAll<T>(pathname: string): Promise<T[]> {
+        try {
+            return await this.fetchAllPages<T>(pathname);
+        } catch (error: any) {
+            const status = error?.response?.status;
+            const canRelogin = status === 401 && this.auth.user && this.auth.pass;
+            if (!canRelogin) throw error;
+            // Stored cookie expired/revoked — mint a fresh one and retry once.
+            this.cookie = (await RestFolderSource.login(this.host, this.auth.user!, this.auth.pass!)).cookie;
+            return await this.fetchAllPages<T>(pathname);
+        }
+    }
+
+    private async fetchAllPages<T>(pathname: string): Promise<T[]> {
+        await this.ensureCookie();
         const all: T[] = [];
         const take = 200;
         let skip = 0;

--- a/packages/cli/src/core/services/rest-folder-source.ts
+++ b/packages/cli/src/core/services/rest-folder-source.ts
@@ -1,0 +1,104 @@
+import axios, { AxiosInstance } from 'axios';
+import { IFolder } from '../types.js';
+
+export interface RestFolderLogin {
+    user: string;
+    pass: string;
+}
+
+export interface RestFolderData {
+    /** Raw folder tree (feeds {@link FolderPathResolver}). */
+    folders: IFolder[];
+    /** `workflowId -> parentFolderId` for every foldered workflow. */
+    workflowParentFolderId: Map<string, string>;
+}
+
+/**
+ * Reads the n8n folder hierarchy over the INTERNAL `/rest` API using session
+ * (cookie) authentication.
+ *
+ * Rationale: on Community / sub-Enterprise instances the public API key cannot
+ * read folders — `GET /api/v1/projects/{id}/folders` is license-gated (403) and
+ * the public workflows API omits `parentFolderId` entirely, so the public folder
+ * path falls back to a flat layout. The n8n UI itself uses these `/rest`
+ * endpoints with a login cookie, which work on every edition. This source
+ * replicates that path so `folderSync` can mirror the real folder tree where the
+ * public folder API is unavailable.
+ *
+ * It only fetches data; folder→path resolution is delegated to the existing
+ * {@link FolderPathResolver} so behavior matches the public-API code path.
+ */
+export class RestFolderSource {
+    private readonly client: AxiosInstance;
+    private cookie?: string;
+
+    constructor(
+        private readonly host: string,
+        private readonly projectId: string,
+        private readonly login: RestFolderLogin,
+    ) {
+        this.client = axios.create({
+            baseURL: host.replace(/\/+$/, ''),
+            timeout: 30000,
+        });
+    }
+
+    /** Fetch the folder tree and the workflow→folder mapping in one shot. */
+    async load(): Promise<RestFolderData> {
+        await this.authenticate();
+        const folders = await this.fetchAll<IFolder>(
+            `/rest/projects/${encodeURIComponent(this.projectId)}/folders`,
+        );
+
+        const workflowParentFolderId = new Map<string, string>();
+        const workflows = await this.fetchAll<any>('/rest/workflows');
+        for (const wf of workflows) {
+            if (!wf?.id) continue;
+            const folderId = wf.parentFolder?.id ?? wf.parentFolderId ?? null;
+            if (folderId) workflowParentFolderId.set(wf.id, folderId);
+        }
+
+        return { folders, workflowParentFolderId };
+    }
+
+    private async authenticate(): Promise<void> {
+        const res = await this.client.post(
+            '/rest/login',
+            { emailOrLdapLoginId: this.login.user, password: this.login.pass },
+            { headers: { 'Content-Type': 'application/json' } },
+        );
+        const setCookie: string[] | undefined = res.headers?.['set-cookie'];
+        if (!setCookie || setCookie.length === 0) {
+            throw new Error('session login returned no cookie');
+        }
+        // Keep only the `name=value` part of each Set-Cookie entry.
+        this.cookie = setCookie.map((c) => c.split(';')[0]).join('; ');
+    }
+
+    /** Paginated GET over an n8n `/rest` collection (`{ count, data }` shape). */
+    private async fetchAll<T>(pathname: string): Promise<T[]> {
+        const all: T[] = [];
+        const take = 200;
+        let skip = 0;
+        for (;;) {
+            const res = await this.client.get(pathname, {
+                params: { take, skip },
+                headers: { Cookie: this.cookie ?? '' },
+            });
+            const body = res.data;
+            const data: T[] = Array.isArray(body?.data)
+                ? body.data
+                : Array.isArray(body)
+                ? body
+                : [];
+            all.push(...data);
+            const count: number | undefined =
+                typeof body?.count === 'number' ? body.count : undefined;
+            if (data.length === 0) break;
+            if (count !== undefined && all.length >= count) break;
+            if (data.length < take) break;
+            skip += take;
+        }
+        return all;
+    }
+}

--- a/packages/cli/src/core/services/rest-folder-source.ts
+++ b/packages/cli/src/core/services/rest-folder-source.ts
@@ -140,7 +140,7 @@ export class RestFolderSource {
     private async fetchAllPages<T>(pathname: string): Promise<T[]> {
         await this.ensureCookie();
         const all: T[] = [];
-        const take = 200;
+        const take = 100;
         let skip = 0;
         for (;;) {
             const res = await this.client.get(pathname, {
@@ -158,8 +158,13 @@ export class RestFolderSource {
                 typeof body?.count === 'number' ? body.count : undefined;
             if (data.length === 0) break;
             if (count !== undefined && all.length >= count) break;
-            if (data.length < take) break;
-            skip += take;
+            // Advance by what the server actually returned: n8n's /rest endpoints
+            // cap page size (100) regardless of the requested `take`, so neither
+            // `skip += take` nor a `data.length < take` stop are safe — they'd
+            // skip pages or stop after the first short page.
+            skip += data.length;
+            // Last-resort stop only when the server gives no count to page against.
+            if (count === undefined && data.length < take) break;
         }
         return all;
     }

--- a/packages/cli/src/core/services/state-manager.ts
+++ b/packages/cli/src/core/services/state-manager.ts
@@ -5,7 +5,7 @@ import { IWorkflow } from '../types.js';
 export interface IWorkflowState {
     lastSyncedHash: string;
     lastSyncedAt: string;
-    /** Recovery hint: last known local filename for this workflow ID. */
+    /** Recovery hint: sync-root-relative local workflow path for this workflow ID. */
     filename?: string;
 }
 

--- a/packages/cli/src/core/services/sync-engine.ts
+++ b/packages/cli/src/core/services/sync-engine.ts
@@ -5,7 +5,7 @@ import { WorkflowTransformerAdapter } from './workflow-transformer-adapter.js';
 import { HashUtils } from './hash-utils.js';
 import { WorkflowStateTracker } from './workflow-state-tracker.js';
 import { SyncEventJournal } from './sync-event-journal.js';
-import { WorkflowSyncStatus, IWorkflow } from '../types.js';
+import { WorkflowSyncStatus, IWorkflow, IFolder } from '../types.js';
 import { ensureParentDirectory, normalizeWorkflowRelativePath, workflowRelativePathToAbsolute } from './workflow-path-utils.js';
 
 /**
@@ -25,6 +25,17 @@ export class SyncEngine {
     private projectId: string;
     private syncEventJournal: SyncEventJournal | undefined;
     private folderSync: boolean;
+    /**
+     * In-flight `createFolder` requests, keyed by
+     * `${projectId}::${parentFolderId ?? ''}::${name}`.
+     *
+     * Multiple concurrent `push()` calls that need the same parent folder
+     * (e.g. `AI Chat/x.workflow.ts` and `AI Chat/y.workflow.ts`) deduplicate
+     * their `createFolder` round-trips through this map so we never POST
+     * twice for the same folder — even if two invocations interleave after
+     * `getFolders` returns an empty array.
+     */
+    private inFlightFolderCreates: Map<string, Promise<IFolder>> = new Map();
 
     constructor(
         client: N8nApiClient,
@@ -304,7 +315,8 @@ export class SyncEngine {
         } catch (error: any) {
             if (!localWf.parentFolderId || !this.isUnsupportedParentFolderError(error)) throw error;
             console.warn(`[SyncEngine] n8n rejected parentFolderId while creating "${filename}"; retrying without folder assignment.`);
-            delete (localWf as any).parentFolderId;
+            // parentFolderId is a known IWorkflow field; strip it without an `any` cast.
+            delete localWf.parentFolderId;
             newWf = await this.client.createWorkflow(localWf);
         }
         if (!newWf || !newWf.id) {
@@ -328,34 +340,87 @@ export class SyncEngine {
         const normalized = normalizeWorkflowRelativePath(filename);
         const segments = normalized.split('/');
         if (segments.length <= 1) return undefined;
-        const folderSegments = segments.slice(0, -1);
-        const getFolders = (this.client as any).getFolders;
-        const createFolder = (this.client as any).createFolder;
-        if (typeof getFolders !== 'function' || typeof createFolder !== 'function') return undefined;
 
-        const folders = await getFolders.call(this.client, this.projectId);
+        // Soft capability check: N8nApiClient exposes both methods, but mocks in
+        // unit tests may not. Skip folder inference gracefully rather than throw.
+        if (typeof this.client.getFolders !== 'function' || typeof this.client.createFolder !== 'function') {
+            return undefined;
+        }
+
+        const folderSegments = segments.slice(0, -1);
+        const folders = await this.client.getFolders(this.projectId);
         let parentFolderId: string | null = null;
         for (const segment of folderSegments) {
-            let folder = folders.find((candidate: any) =>
-                candidate.name === segment && (candidate.parentFolderId ?? null) === parentFolderId,
-            );
-            if (!folder) {
-                folder = await createFolder.call(this.client, this.projectId, {
-                    name: segment,
-                    parentFolderId,
-                });
-                folders.push(folder);
-            }
+            const folder = await this.ensureFolder(folders, this.projectId, segment, parentFolderId);
             parentFolderId = folder.id;
         }
 
         return parentFolderId ?? undefined;
     }
 
+    /**
+     * Returns the folder named `name` under `parentFolderId`, creating it if
+     * missing. Concurrent calls for the same `(projectId, parentFolderId, name)`
+     * triple share a single in-flight `createFolder` promise so we never POST
+     * twice for the same folder.
+     */
+    private async ensureFolder(
+        folders: IFolder[],
+        projectId: string,
+        name: string,
+        parentFolderId: string | null,
+    ): Promise<IFolder> {
+        const existing = folders.find(
+            (candidate) => candidate.name === name && (candidate.parentFolderId ?? null) === parentFolderId,
+        );
+        if (existing) return existing;
+
+        const key = `${projectId}::${parentFolderId ?? ''}::${name}`;
+        const inFlight = this.inFlightFolderCreates.get(key);
+        if (inFlight) return inFlight;
+
+        const promise = this.client
+            .createFolder(projectId, { name, parentFolderId })
+            .then((created) => {
+                folders.push(created);
+                return created;
+            })
+            .finally(() => {
+                this.inFlightFolderCreates.delete(key);
+            });
+        this.inFlightFolderCreates.set(key, promise);
+        return promise;
+    }
+
+    /**
+     * Returns true when n8n rejected the create call specifically because it
+     * does not understand the `parentFolderId` field — in which case we retry
+     * without it so the sync still completes against older n8n instances.
+     *
+     * Tightened from the original `'folder'` substring match (which would have
+     * silently swallowed unrelated 400/404 errors) to require either a
+     * structured `parentFolderId` / `parentFolder` field in the response body,
+     * or a message that explicitly mentions one of those tokens.
+     */
     private isUnsupportedParentFolderError(error: any): boolean {
         const status = error?.response?.status;
-        const message = String(error?.response?.data?.message ?? error?.message ?? '').toLowerCase();
-        return [400, 404, 422].includes(status) && (message.includes('parentfolder') || message.includes('folder'));
+        if (![400, 404, 422].includes(status)) return false;
+
+        const PARENT_FOLDER_PATTERN = /(parentfolderid|parent folder id|parentfolder)/i;
+        const PARENT_FOLDER_KEYS = new Set(['parentfolderid', 'parentfolder']);
+
+        const data = error?.response?.data;
+        if (data && typeof data === 'object' && !Array.isArray(data)) {
+            for (const key of Object.keys(data)) {
+                if (PARENT_FOLDER_KEYS.has(key.toLowerCase())) return true;
+            }
+            const dataMessage = String(data.message ?? '').toLowerCase();
+            if (PARENT_FOLDER_PATTERN.test(dataMessage)) return true;
+            return false;
+        }
+
+        const errorMessage = String(error?.message ?? '').toLowerCase();
+        return PARENT_FOLDER_PATTERN.test(errorMessage);
     }
 
     private readTypeScriptFile(filePath: string): string | null {

--- a/packages/cli/src/core/services/sync-engine.ts
+++ b/packages/cli/src/core/services/sync-engine.ts
@@ -228,7 +228,28 @@ export class SyncEngine {
             );
         }
 
-        const updatedWf = await this.client.updateWorkflow(workflowId, localWf);
+        // Folder-aware move: when folderSync is enabled and `filename` lives under a
+        // nested folder path, mirror the create-path logic and forward parentFolderId
+        // to n8n so the existing workflow actually moves to that folder on update.
+        // Mirrors inferParentFolderIdFromFilename() usage in executeCreate().
+        const inferredParentFolderId = await this.inferParentFolderIdFromFilename(filename);
+        if (inferredParentFolderId) {
+            localWf.parentFolderId = inferredParentFolderId;
+        }
+
+        let updatedWf: IWorkflow;
+        try {
+            updatedWf = await this.client.updateWorkflow(workflowId, localWf);
+        } catch (error: any) {
+            // Retry without parentFolderId when n8n rejects it as an unknown field
+            // (older n8n instances that don't support folder assignment on update).
+            // Same fallback used by executeCreate().
+            if (!localWf.parentFolderId || !this.isUnsupportedParentFolderError(error)) throw error;
+            console.warn(`[SyncEngine] n8n rejected parentFolderId while updating "${filename}"; retrying without folder assignment.`);
+            // parentFolderId is a known IWorkflow field; strip it without an `any` cast.
+            delete localWf.parentFolderId;
+            updatedWf = await this.client.updateWorkflow(workflowId, localWf);
+        }
 
         if (!updatedWf?.id || updatedWf.id !== workflowId || !Array.isArray(updatedWf.nodes)) {
             throw new Error('Failed to update remote workflow: n8n did not return an updated workflow payload');

--- a/packages/cli/src/core/services/sync-engine.ts
+++ b/packages/cli/src/core/services/sync-engine.ts
@@ -6,6 +6,7 @@ import { HashUtils } from './hash-utils.js';
 import { WorkflowStateTracker } from './workflow-state-tracker.js';
 import { SyncEventJournal } from './sync-event-journal.js';
 import { WorkflowSyncStatus, IWorkflow } from '../types.js';
+import { ensureParentDirectory, normalizeWorkflowRelativePath, workflowRelativePathToAbsolute } from './workflow-path-utils.js';
 
 /**
  * Sync Engine - State Mutation Component
@@ -23,6 +24,7 @@ export class SyncEngine {
     private directory: string;
     private projectId: string;
     private syncEventJournal: SyncEventJournal | undefined;
+    private folderSync: boolean;
 
     constructor(
         client: N8nApiClient,
@@ -30,12 +32,14 @@ export class SyncEngine {
         directory: string,
         projectId: string,
         syncEventJournal?: SyncEventJournal,
+        options?: { folderSync?: boolean },
     ) {
         this.client = client;
         this.watcher = watcher;
         this.directory = directory;
         this.projectId = projectId;
         this.syncEventJournal = syncEventJournal;
+        this.folderSync = options?.folderSync ?? false;
     }
 
     /**
@@ -164,7 +168,8 @@ export class SyncEngine {
             commentStyle: 'verbose'
         });
         
-        const filePath = path.join(this.directory, filename);
+        const filePath = workflowRelativePathToAbsolute(this.directory, filename);
+        ensureParentDirectory(filePath);
         fs.writeFileSync(filePath, tsCode, 'utf-8');
 
         // Update Watcher's remote hash cache since we just fetched the workflow
@@ -177,7 +182,7 @@ export class SyncEngine {
     }
 
     private async executeUpdate(workflowId: string, filename: string, skipOcc = false): Promise<string | undefined> {
-        const filePath = path.join(this.directory, filename);
+        const filePath = workflowRelativePathToAbsolute(this.directory, filename);
         const tsContent = this.readTypeScriptFile(filePath);
         if (!tsContent) {
             throw new Error('Local file not found during push');
@@ -235,6 +240,7 @@ export class SyncEngine {
             format: true,
             commentStyle: 'verbose'
         });
+        ensureParentDirectory(filePath);
         fs.writeFileSync(filePath, tsCode, 'utf-8');
 
         // Update Watcher's remote hash cache with the updated workflow
@@ -260,7 +266,7 @@ export class SyncEngine {
     }
 
     private async executeCreate(filename: string): Promise<{ id: string, updatedAt?: string }> {
-        const filePath = path.join(this.directory, filename);
+        const filePath = workflowRelativePathToAbsolute(this.directory, filename);
         const tsContent = this.readTypeScriptFile(filePath);
         if (!tsContent) {
             throw new Error('Local file not found during creation');
@@ -287,7 +293,20 @@ export class SyncEngine {
             localWf.projectId = this.projectId;
         }
 
-        const newWf = await this.client.createWorkflow(localWf);
+        const inferredParentFolderId = await this.inferParentFolderIdFromFilename(filename);
+        if (inferredParentFolderId) {
+            localWf.parentFolderId = inferredParentFolderId;
+        }
+
+        let newWf: IWorkflow;
+        try {
+            newWf = await this.client.createWorkflow(localWf);
+        } catch (error: any) {
+            if (!localWf.parentFolderId || !this.isUnsupportedParentFolderError(error)) throw error;
+            console.warn(`[SyncEngine] n8n rejected parentFolderId while creating "${filename}"; retrying without folder assignment.`);
+            delete (localWf as any).parentFolderId;
+            newWf = await this.client.createWorkflow(localWf);
+        }
         if (!newWf || !newWf.id) {
             throw new Error('Failed to create remote workflow');
         }
@@ -298,9 +317,45 @@ export class SyncEngine {
             format: true,
             commentStyle: 'verbose'
         });
+        ensureParentDirectory(filePath);
         fs.writeFileSync(filePath, tsCode, 'utf-8');
 
         return { id: newWf.id, updatedAt: newWf.updatedAt };
+    }
+
+    private async inferParentFolderIdFromFilename(filename: string): Promise<string | undefined> {
+        if (!this.folderSync || !this.projectId || this.projectId === 'personal') return undefined;
+        const normalized = normalizeWorkflowRelativePath(filename);
+        const segments = normalized.split('/');
+        if (segments.length <= 1) return undefined;
+        const folderSegments = segments.slice(0, -1);
+        const getFolders = (this.client as any).getFolders;
+        const createFolder = (this.client as any).createFolder;
+        if (typeof getFolders !== 'function' || typeof createFolder !== 'function') return undefined;
+
+        const folders = await getFolders.call(this.client, this.projectId);
+        let parentFolderId: string | null = null;
+        for (const segment of folderSegments) {
+            let folder = folders.find((candidate: any) =>
+                candidate.name === segment && (candidate.parentFolderId ?? null) === parentFolderId,
+            );
+            if (!folder) {
+                folder = await createFolder.call(this.client, this.projectId, {
+                    name: segment,
+                    parentFolderId,
+                });
+                folders.push(folder);
+            }
+            parentFolderId = folder.id;
+        }
+
+        return parentFolderId ?? undefined;
+    }
+
+    private isUnsupportedParentFolderError(error: any): boolean {
+        const status = error?.response?.status;
+        const message = String(error?.response?.data?.message ?? error?.message ?? '').toLowerCase();
+        return [400, 404, 422].includes(status) && (message.includes('parentfolder') || message.includes('folder'));
     }
 
     private readTypeScriptFile(filePath: string): string | null {

--- a/packages/cli/src/core/services/sync-manager.ts
+++ b/packages/cli/src/core/services/sync-manager.ts
@@ -10,6 +10,7 @@ import { ResolutionManager } from './resolution-manager.js';
 import { ISyncConfig, IWorkflow, WorkflowSyncStatus, IWorkflowStatus } from '../types.js';
 import { createProjectSlug } from './directory-utils.js';
 import { WorkspaceSetupService } from './workspace-setup-service.js';
+import { normalizeWorkflowRelativePath, relativePathFromAbsolute, workflowRelativePathToAbsolute } from './workflow-path-utils.js';
 
 export class SyncManager extends EventEmitter {
     private client: N8nApiClient;
@@ -63,11 +64,14 @@ export class SyncManager extends EventEmitter {
             directory: instanceDir,
             syncInactive: true,
             ignoredTags: [],
-            projectId: this.config.projectId
+            projectId: this.config.projectId,
+            folderSync: this.config.folderSync ?? false,
         });
 
         this.syncEventJournal = new SyncEventJournal(instanceDir);
-        this.syncEngine = new SyncEngine(this.client, this.watcher, instanceDir, this.config.projectId, this.syncEventJournal);
+        this.syncEngine = new SyncEngine(this.client, this.watcher, instanceDir, this.config.projectId, this.syncEventJournal, {
+            folderSync: this.config.folderSync ?? false,
+        });
         this.resolutionManager = new ResolutionManager(this.syncEngine, this.watcher, this.client);
 
         this.watcher.on('statusChange', (data) => {
@@ -413,16 +417,11 @@ export class SyncManager extends EventEmitter {
             );
         }
 
-        if (relativePath.includes(path.sep)) {
-            throw new Error(
-                `Cannot push "${trimmed}": nested workflow paths inside the sync scope are not supported.\n` +
-                `Expected a workflow file at the scope root, for example ${this.quoteShellArg(path.join(normalizedScopeDir, path.basename(normalizedAbsolutePath)))}`
-            );
-        }
+        const workflowRelativePath = normalizeWorkflowRelativePath(relativePathFromAbsolute(normalizedScopeDir, normalizedAbsolutePath));
 
         return {
-            filename: path.basename(normalizedAbsolutePath),
-            filePath: path.join(syncScopeDir, path.basename(normalizedAbsolutePath)),
+            filename: workflowRelativePath,
+            filePath: workflowRelativePathToAbsolute(syncScopeDir, workflowRelativePath),
             absolutePath: normalizedAbsolutePath
         };
     }

--- a/packages/cli/src/core/services/sync-manager.ts
+++ b/packages/cli/src/core/services/sync-manager.ts
@@ -66,6 +66,8 @@ export class SyncManager extends EventEmitter {
             ignoredTags: [],
             projectId: this.config.projectId,
             folderSync: this.config.folderSync ?? false,
+            host: this.config.host,
+            folderLogin: this.config.folderLogin,
         });
 
         this.syncEventJournal = new SyncEventJournal(instanceDir);

--- a/packages/cli/src/core/services/sync-manager.ts
+++ b/packages/cli/src/core/services/sync-manager.ts
@@ -67,7 +67,7 @@ export class SyncManager extends EventEmitter {
             projectId: this.config.projectId,
             folderSync: this.config.folderSync ?? false,
             host: this.config.host,
-            folderLogin: this.config.folderLogin,
+            folderAuth: this.config.folderAuth,
         });
 
         this.syncEventJournal = new SyncEventJournal(instanceDir);

--- a/packages/cli/src/core/services/workflow-path-utils.ts
+++ b/packages/cli/src/core/services/workflow-path-utils.ts
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import path from 'path';
+
+export function toPosixRelativePath(value: string): string {
+    return value.split(path.sep).join('/').replace(/\\/g, '/');
+}
+
+export function normalizeWorkflowRelativePath(value: string): string {
+    const normalized = path.posix.normalize(toPosixRelativePath(value).trim());
+    if (!normalized || normalized === '.') {
+        throw new Error('Workflow path must not be empty');
+    }
+    if (normalized.startsWith('../') || normalized === '..' || path.posix.isAbsolute(normalized)) {
+        throw new Error(`Workflow path escapes the sync scope: ${value}`);
+    }
+    const parts = normalized.split('/');
+    if (parts.some((part) => !part || part === '.' || part === '..' || /[\u0000-\u001f\u007f]/.test(part))) {
+        throw new Error(`Workflow path contains an unsafe segment: ${value}`);
+    }
+    return normalized;
+}
+
+export function workflowRelativePathToAbsolute(root: string, relativePath: string): string {
+    const safeRelativePath = normalizeWorkflowRelativePath(relativePath);
+    return path.join(root, ...safeRelativePath.split('/'));
+}
+
+export function relativePathFromAbsolute(root: string, absolutePath: string): string {
+    const relative = path.relative(root, absolutePath);
+    return normalizeWorkflowRelativePath(toPosixRelativePath(relative));
+}
+
+export function ensureParentDirectory(filePath: string): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+export function listWorkflowFilesRecursive(root: string): string[] {
+    const results: string[] = [];
+    const visit = (dir: string, relativeDir = '') => {
+        const entries = fs.readdirSync(dir, { withFileTypes: true });
+        for (const entry of entries) {
+            if (entry.name.startsWith('.')) continue;
+            const childRelative = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
+            const childAbsolute = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                visit(childAbsolute, childRelative);
+                continue;
+            }
+            if (entry.isFile() && entry.name.endsWith('.workflow.ts')) {
+                results.push(normalizeWorkflowRelativePath(childRelative));
+            }
+        }
+    };
+    if (fs.existsSync(root)) visit(root);
+    return results.sort();
+}

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -6,6 +6,8 @@ import { WorkflowTransformerAdapter } from './workflow-transformer-adapter.js';
 import { HashUtils } from './hash-utils.js';
 import { WorkflowSyncStatus, IWorkflowStatus, IWorkflow } from '../types.js';
 import { IWorkflowState, IInstanceState } from './state-manager.js';
+import { FolderPathResolver, sanitizePathSegment } from './folder-path-resolver.js';
+import { listWorkflowFilesRecursive, normalizeWorkflowRelativePath, workflowRelativePathToAbsolute } from './workflow-path-utils.js';
 
 const WINDOWS_RESERVED_FILENAMES = new Set([
     'CON',
@@ -53,6 +55,8 @@ export class WorkflowStateTracker extends EventEmitter {
     private ignoredTags: string[];
     private projectId: string;
     private stateFilePath: string;
+    private folderSync: boolean;
+    private warnedFolderMetadataUnavailable = false;
     private isConnected: boolean = true;
     /** True during the first refreshRemoteState() call — suppresses status broadcasts */
     private isInitialRemoteLoad: boolean = false;
@@ -73,6 +77,8 @@ export class WorkflowStateTracker extends EventEmitter {
     private remoteActive: Map<string, boolean> = new Map(); // workflowId -> active
     /** Remote archived flag per workflow (populated by refreshRemoteState / updateSingleRemoteState). */
     private remoteArchived: Map<string, boolean> = new Map(); // workflowId -> isArchived
+    private remoteParentFolderIds: Map<string, string | null> = new Map(); // workflowId -> parentFolderId
+    private remoteFolderPaths: Map<string, string[]> = new Map(); // workflowId -> folder path segments
 
     constructor(
         client: N8nApiClient,
@@ -81,6 +87,7 @@ export class WorkflowStateTracker extends EventEmitter {
             syncInactive: boolean;
             ignoredTags: string[];
             projectId: string;      // Project scope filter
+            folderSync?: boolean;
         }
     ) {
         super();
@@ -89,6 +96,7 @@ export class WorkflowStateTracker extends EventEmitter {
         this.syncInactive = options.syncInactive;
         this.ignoredTags = options.ignoredTags;
         this.projectId = options.projectId;
+        this.folderSync = options.folderSync ?? false;
         this.stateFilePath = path.join(this.directory, '.n8n-state.json');
 
         // Restore persisted mappings immediately so 'pull' and other commands can find workflows
@@ -115,7 +123,7 @@ export class WorkflowStateTracker extends EventEmitter {
             return;
         }
 
-        const files = fs.readdirSync(this.directory).filter(f => f.endsWith('.workflow.ts') && !f.startsWith('.'));
+        const files = listWorkflowFilesRecursive(this.directory);
         const currentFiles = new Set(files);
 
         // Remove entries for files that no longer exist
@@ -134,7 +142,7 @@ export class WorkflowStateTracker extends EventEmitter {
         const fileContents: Array<{ filename: string; content: any }> = [];
         const newlyTracked: string[] = [];
         for (const filename of files) {
-            const filePath = path.join(this.directory, filename);
+            const filePath = workflowRelativePathToAbsolute(this.directory, filename);
             const content = this.readJsonFile(filePath); // Quick ID extraction
             if (content) {
                 fileContents.push({ filename, content });
@@ -278,6 +286,11 @@ export class WorkflowStateTracker extends EventEmitter {
             this.remoteNames.clear();
             this.remoteActive.clear();
             this.remoteArchived.clear();
+            this.remoteParentFolderIds.clear();
+            this.remoteFolderPaths.clear();
+
+            const folderResolver = await this.createFolderResolver(remoteWorkflows);
+            const state = this.loadState();
 
             // Build set of already-assigned filenames to prevent collisions
             const assignedFilenames = new Set<string>();
@@ -291,9 +304,24 @@ export class WorkflowStateTracker extends EventEmitter {
                 // Store active and archived flags from API
                 this.remoteActive.set(wf.id, wf.active === true);
                 this.remoteArchived.set(wf.id, wf.isArchived === true);
+                const parentFolderId = wf.parentFolderId ?? wf.parentFolder?.id ?? null;
+                const folderPath = folderResolver ? folderResolver.getPathForWorkflow(wf) : [];
+                this.remoteParentFolderIds.set(wf.id, parentFolderId);
+                this.remoteFolderPaths.set(wf.id, folderPath);
 
                 // CRITICAL: Use ID-based mapping with PERSISTED state as source of truth
                 let filename: string | undefined = this.idToFileMap.get(wf.id);
+
+                if (!filename) {
+                    const persistedFilename = state.workflows[wf.id]?.filename;
+                    if (persistedFilename) {
+                        try {
+                            filename = normalizeWorkflowRelativePath(persistedFilename);
+                        } catch {
+                            filename = undefined;
+                        }
+                    }
+                }
 
                 // If no valid mapping, scan local files to discover/rediscover the workflow
                 if (!filename) {
@@ -307,13 +335,13 @@ export class WorkflowStateTracker extends EventEmitter {
 
                 // If still not found, this is a NEW remote workflow - generate filename
                 if (!filename) {
-                    const baseName = `${this.safeName(wf.name)}.workflow.ts`;
+                    const baseName = this.buildRelativeFilename(wf, folderPath);
 
                     // Check if this base name is already assigned to another workflow
                     if (assignedFilenames.has(baseName)) {
                         // Name collision - generate unique filename with ID suffix
                         const idSuffix = wf.id.substring(0, 8);
-                        filename = `${this.safeName(wf.name)}_${idSuffix}.workflow.ts`;
+                        filename = this.buildRelativeFilename(wf, folderPath, idSuffix);
                     } else {
                         // Name is free - use it
                         filename = baseName;
@@ -397,9 +425,9 @@ export class WorkflowStateTracker extends EventEmitter {
         // If workflow not tracked yet (first sync of local-only workflow),
         // scan directory to find the file with this ID
         if (!filename) {
-            const files = fs.readdirSync(this.directory).filter(f => f.endsWith('.workflow.ts') && !f.startsWith('.'));
+            const files = listWorkflowFilesRecursive(this.directory);
             for (const file of files) {
-                const filePath = path.join(this.directory, file);
+                const filePath = workflowRelativePathToAbsolute(this.directory, file);
                 const content = this.readJsonFile(filePath);
                 if (content?.id === workflowId) {
                     filename = file;
@@ -416,7 +444,7 @@ export class WorkflowStateTracker extends EventEmitter {
         }
 
         // Get current reality
-        const filePath = path.join(this.directory, filename);
+        const filePath = workflowRelativePathToAbsolute(this.directory, filename);
         const content = this.readJsonFile(filePath);
 
         if (!content) {
@@ -476,6 +504,8 @@ export class WorkflowStateTracker extends EventEmitter {
         this.remoteNames.delete(id);
         this.remoteActive.delete(id);
         this.remoteArchived.delete(id);
+        this.remoteParentFolderIds.delete(id);
+        this.remoteFolderPaths.delete(id);
         this.remoteIds.delete(id);
     }
 
@@ -504,16 +534,22 @@ export class WorkflowStateTracker extends EventEmitter {
         for (const [workflowId, workflowState] of Object.entries(state.workflows)) {
             const filename = workflowState?.filename;
             if (!filename) continue;
+            let normalizedFilename: string;
+            try {
+                normalizedFilename = normalizeWorkflowRelativePath(filename);
+            } catch {
+                continue;
+            }
 
-            const filePath = path.join(this.directory, filename);
+            const filePath = workflowRelativePathToAbsolute(this.directory, normalizedFilename);
             if (!fs.existsSync(filePath)) continue;
 
             if (!this.idToFileMap.has(workflowId)) {
-                this.idToFileMap.set(workflowId, filename);
+                this.idToFileMap.set(workflowId, normalizedFilename);
             }
 
-            if (!this.fileToIdMap.has(filename)) {
-                this.fileToIdMap.set(filename, workflowId);
+            if (!this.fileToIdMap.has(normalizedFilename)) {
+                this.fileToIdMap.set(normalizedFilename, workflowId);
             }
         }
     }
@@ -677,6 +713,38 @@ export class WorkflowStateTracker extends EventEmitter {
         return finalName;
     }
 
+    private async createFolderResolver(remoteWorkflows: IWorkflow[]): Promise<FolderPathResolver | null> {
+        if (!this.folderSync) return null;
+        const hasWorkflowFolderFields = remoteWorkflows.some((workflow) =>
+            workflow.parentFolderId !== undefined || workflow.parentFolder?.id,
+        );
+        const getFolders = (this.client as any).getFolders;
+        if (!hasWorkflowFolderFields || typeof getFolders !== 'function') {
+            this.warnFolderMetadataUnavailable();
+            return null;
+        }
+        try {
+            return new FolderPathResolver(await getFolders.call(this.client, this.projectId));
+        } catch (error: any) {
+            this.warnFolderMetadataUnavailable(error?.message);
+            return null;
+        }
+    }
+
+    private warnFolderMetadataUnavailable(reason?: string): void {
+        if (this.warnedFolderMetadataUnavailable) return;
+        this.warnedFolderMetadataUnavailable = true;
+        console.warn(
+            `[WorkflowStateTracker] folderSync is enabled, but public workflow folder metadata is unavailable${reason ? `: ${reason}` : ''}. Falling back to flat workflow paths.`,
+        );
+    }
+
+    private buildRelativeFilename(workflow: IWorkflow, folderPath: string[] = [], idSuffix?: string): string {
+        const baseName = `${this.safeName(workflow.name)}${idSuffix ? `_${idSuffix}` : ''}.workflow.ts`;
+        if (!this.folderSync || folderPath.length === 0) return baseName;
+        return normalizeWorkflowRelativePath([...folderPath.map(sanitizePathSegment), baseName].join('/'));
+    }
+
     /**
      * Find local file that contains a specific workflow ID
      * Used when we have an ID but no filename mapping yet (e.g., after file rename)
@@ -686,11 +754,10 @@ export class WorkflowStateTracker extends EventEmitter {
             return undefined;
         }
 
-        const files = fs.readdirSync(this.directory)
-            .filter(f => f.endsWith('.workflow.ts') && !f.startsWith('.'));
+        const files = listWorkflowFilesRecursive(this.directory);
 
         for (const file of files) {
-            const content = this.readJsonFile(path.join(this.directory, file));
+            const content = this.readJsonFile(workflowRelativePathToAbsolute(this.directory, file));
             if (content?.id === workflowId) {
                 return file;
             }
@@ -836,7 +903,7 @@ export class WorkflowStateTracker extends EventEmitter {
             // For local-only files, extract the name from the @workflow decorator for an accurate display.
             // Fall back to filename-derived name as last resort.
             const workflowName = (workflowId && this.remoteNames.get(workflowId))
-                || this.readJsonFile(path.join(this.directory, filename))?.name
+                || this.readJsonFile(workflowRelativePathToAbsolute(this.directory, filename))?.name
                 || filename.replace('.workflow.ts', '');
 
             results.set(filename, {
@@ -848,7 +915,10 @@ export class WorkflowStateTracker extends EventEmitter {
                 projectId: undefined, // Not available in lightweight mode
                 projectName: undefined, // Not available in lightweight mode
                 homeProject: undefined, // Not available in lightweight mode
-                isArchived
+                isArchived,
+                parentFolderId: workflowId ? this.remoteParentFolderIds.get(workflowId) : undefined,
+                folderPath: workflowId ? this.remoteFolderPaths.get(workflowId) : undefined,
+                folderPathString: workflowId ? this.remoteFolderPaths.get(workflowId)?.join('/') : undefined,
             });
         }
 
@@ -879,7 +949,10 @@ export class WorkflowStateTracker extends EventEmitter {
                     projectId: undefined, // Not available in lightweight mode
                     projectName: undefined, // Not available in lightweight mode
                     homeProject: undefined, // Not available in lightweight mode
-                    isArchived
+                    isArchived,
+                    parentFolderId: this.remoteParentFolderIds.get(workflowId),
+                    folderPath: this.remoteFolderPaths.get(workflowId),
+                    folderPathString: this.remoteFolderPaths.get(workflowId)?.join('/'),
                 });
             }
         }
@@ -891,18 +964,12 @@ export class WorkflowStateTracker extends EventEmitter {
      * Get list of local workflow filenames (just checks file system, no parsing)
      */
     private getLocalWorkflowFilenames(): string[] {
-        const filenames: string[] = [];
         try {
-            const files = fs.readdirSync(this.directory);
-            for (const file of files) {
-                if (file.endsWith('.workflow.ts')) {
-                    filenames.push(file);
-                }
-            }
+            return listWorkflowFilesRecursive(this.directory);
         } catch (error) {
             console.debug('[WorkflowStateTracker] Failed to read local directory:', error);
         }
-        return filenames;
+        return [];
     }
 
     public async getStatusMatrix(): Promise<IWorkflowStatus[]> {
@@ -914,7 +981,7 @@ export class WorkflowStateTracker extends EventEmitter {
         try {
             // Read local workflows
             for (const [filename] of this.localHashes.entries()) {
-                const filePath = path.join(this.directory, filename);
+                const filePath = workflowRelativePathToAbsolute(this.directory, filename);
                 if (fs.existsSync(filePath)) {
                     try {
                         const workflow = await this.readWorkflowFile(filePath);
@@ -952,7 +1019,10 @@ export class WorkflowStateTracker extends EventEmitter {
                 projectId: workflow?.projectId,
                 projectName: workflow?.projectName,
                 homeProject: workflow?.homeProject,
-                isArchived
+                isArchived,
+                parentFolderId: workflowId ? this.remoteParentFolderIds.get(workflowId) : undefined,
+                folderPath: workflowId ? this.remoteFolderPaths.get(workflowId) : undefined,
+                folderPathString: workflowId ? this.remoteFolderPaths.get(workflowId)?.join('/') : undefined,
             });
         }
 
@@ -977,7 +1047,10 @@ export class WorkflowStateTracker extends EventEmitter {
                     projectId: workflow?.projectId,
                     projectName: workflow?.projectName,
                     homeProject: workflow?.homeProject,
-                    isArchived: workflow?.isArchived ?? false
+                    isArchived: workflow?.isArchived ?? false,
+                    parentFolderId: this.remoteParentFolderIds.get(workflowId),
+                    folderPath: this.remoteFolderPaths.get(workflowId),
+                    folderPathString: this.remoteFolderPaths.get(workflowId)?.join('/'),
                 });
             }
         }
@@ -1003,7 +1076,10 @@ export class WorkflowStateTracker extends EventEmitter {
                     projectId: workflow?.projectId,
                     projectName: workflow?.projectName,
                     homeProject: workflow?.homeProject,
-                    isArchived: workflow?.isArchived ?? false
+                    isArchived: workflow?.isArchived ?? false,
+                    parentFolderId: this.remoteParentFolderIds.get(id),
+                    folderPath: this.remoteFolderPaths.get(id),
+                    folderPathString: this.remoteFolderPaths.get(id)?.join('/'),
                 });
             }
         }
@@ -1053,7 +1129,7 @@ export class WorkflowStateTracker extends EventEmitter {
 
         // 1. Get all local workflows
         for (const [filename, _] of this.localHashes.entries()) {
-            const filepath = path.join(this.directory, filename);
+            const filepath = workflowRelativePathToAbsolute(this.directory, filename);
             try {
                 const workflow = await this.readWorkflowFile(filepath);
                 if (workflow) {
@@ -1123,6 +1199,18 @@ export class WorkflowStateTracker extends EventEmitter {
             this.remoteNames.set(newId, name);
         }
 
+        const parentFolderId = this.remoteParentFolderIds.get(oldId);
+        if (parentFolderId !== undefined) {
+            this.remoteParentFolderIds.delete(oldId);
+            this.remoteParentFolderIds.set(newId, parentFolderId);
+        }
+
+        const folderPath = this.remoteFolderPaths.get(oldId);
+        if (folderPath) {
+            this.remoteFolderPaths.delete(oldId);
+            this.remoteFolderPaths.set(newId, folderPath);
+        }
+
         // Migrate remote ID set
         if (this.remoteIds.has(oldId)) {
             this.remoteIds.delete(oldId);
@@ -1157,18 +1245,30 @@ export class WorkflowStateTracker extends EventEmitter {
             // Store active and archived flags
             this.remoteActive.set(remoteWf.id, remoteWf.active === true);
             this.remoteArchived.set(remoteWf.id, remoteWf.isArchived === true);
+            const parentFolderId = remoteWf.parentFolderId ?? remoteWf.parentFolder?.id ?? null;
+            let folderPath: string[] = [];
+            if (this.folderSync && parentFolderId && typeof (this.client as any).getFolders === 'function') {
+                try {
+                    const resolver = new FolderPathResolver(await (this.client as any).getFolders(this.projectId));
+                    folderPath = resolver.getPathForWorkflow(remoteWf);
+                } catch (error: any) {
+                    this.warnFolderMetadataUnavailable(error?.message);
+                }
+            }
+            this.remoteParentFolderIds.set(remoteWf.id, parentFolderId);
+            this.remoteFolderPaths.set(remoteWf.id, folderPath);
 
             // Establish mapping if it doesn't exist yet (allows 'pull' after single 'fetch')
             if (!this.idToFileMap.has(remoteWf.id)) {
                 let filename = this.findFilenameByWorkflowId(remoteWf.id);
                 
                 if (!filename) {
-                    const baseName = `${this.safeName(remoteWf.name || remoteWf.id)}.workflow.ts`;
+                    const baseName = this.buildRelativeFilename(remoteWf, folderPath);
                     filename = baseName;
                     
                     // Simple collision check against existing mappings
                     if (this.fileToIdMap.has(filename)) {
-                        filename = `${this.safeName(remoteWf.name || remoteWf.id)}_${remoteWf.id.substring(0, 8)}.workflow.ts`;
+                        filename = this.buildRelativeFilename(remoteWf, folderPath, remoteWf.id.substring(0, 8));
                     }
                 }
                 

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -718,13 +718,12 @@ export class WorkflowStateTracker extends EventEmitter {
         const hasWorkflowFolderFields = remoteWorkflows.some((workflow) =>
             workflow.parentFolderId !== undefined || workflow.parentFolder?.id,
         );
-        const getFolders = (this.client as any).getFolders;
-        if (!hasWorkflowFolderFields || typeof getFolders !== 'function') {
+        if (!hasWorkflowFolderFields || typeof this.client.getFolders !== 'function') {
             this.warnFolderMetadataUnavailable();
             return null;
         }
         try {
-            return new FolderPathResolver(await getFolders.call(this.client, this.projectId));
+            return new FolderPathResolver(await this.client.getFolders(this.projectId));
         } catch (error: any) {
             this.warnFolderMetadataUnavailable(error?.message);
             return null;
@@ -1247,9 +1246,9 @@ export class WorkflowStateTracker extends EventEmitter {
             this.remoteArchived.set(remoteWf.id, remoteWf.isArchived === true);
             const parentFolderId = remoteWf.parentFolderId ?? remoteWf.parentFolder?.id ?? null;
             let folderPath: string[] = [];
-            if (this.folderSync && parentFolderId && typeof (this.client as any).getFolders === 'function') {
+            if (this.folderSync && parentFolderId && typeof this.client.getFolders === 'function') {
                 try {
-                    const resolver = new FolderPathResolver(await (this.client as any).getFolders(this.projectId));
+                    const resolver = new FolderPathResolver(await this.client.getFolders(this.projectId));
                     folderPath = resolver.getPathForWorkflow(remoteWf);
                 } catch (error: any) {
                     this.warnFolderMetadataUnavailable(error?.message);

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -8,6 +8,7 @@ import { WorkflowSyncStatus, IWorkflowStatus, IWorkflow } from '../types.js';
 import { IWorkflowState, IInstanceState } from './state-manager.js';
 import { FolderPathResolver, sanitizePathSegment } from './folder-path-resolver.js';
 import { listWorkflowFilesRecursive, normalizeWorkflowRelativePath, workflowRelativePathToAbsolute } from './workflow-path-utils.js';
+import { RestFolderSource, RestFolderLogin } from './rest-folder-source.js';
 
 const WINDOWS_RESERVED_FILENAMES = new Set([
     'CON',
@@ -57,6 +58,15 @@ export class WorkflowStateTracker extends EventEmitter {
     private stateFilePath: string;
     private folderSync: boolean;
     private warnedFolderMetadataUnavailable = false;
+    /**
+     * Optional session-auth source for the folder hierarchy, used when the public
+     * folder API is unavailable (e.g. sub-Enterprise instances). Present only when
+     * folderSync is on and host + login creds are configured.
+     */
+    private folderSource?: RestFolderSource;
+    /** Cached session folder data (resolver + workflowId->parentFolderId map). */
+    private sessionFolders?: { resolver: FolderPathResolver; parentMap: Map<string, string> };
+    private sessionFoldersLoaded = false;
     private isConnected: boolean = true;
     /** True during the first refreshRemoteState() call — suppresses status broadcasts */
     private isInitialRemoteLoad: boolean = false;
@@ -88,6 +98,8 @@ export class WorkflowStateTracker extends EventEmitter {
             ignoredTags: string[];
             projectId: string;      // Project scope filter
             folderSync?: boolean;
+            host?: string;          // n8n base URL (for the session-auth folder source)
+            folderLogin?: RestFolderLogin; // Session creds for /rest folder reads
         }
     ) {
         super();
@@ -97,6 +109,12 @@ export class WorkflowStateTracker extends EventEmitter {
         this.ignoredTags = options.ignoredTags;
         this.projectId = options.projectId;
         this.folderSync = options.folderSync ?? false;
+        // When folderSync is on and session creds are provided, prefer reading
+        // folders over /rest — it works on every edition, including instances
+        // where the public folder API is license-gated.
+        if (this.folderSync && options.host && options.folderLogin && this.projectId) {
+            this.folderSource = new RestFolderSource(options.host, this.projectId, options.folderLogin);
+        }
         this.stateFilePath = path.join(this.directory, '.n8n-state.json');
 
         // Restore persisted mappings immediately so 'pull' and other commands can find workflows
@@ -713,8 +731,46 @@ export class WorkflowStateTracker extends EventEmitter {
         return finalName;
     }
 
+    /**
+     * Lazily load (and cache) the folder hierarchy over the session-auth `/rest`
+     * source. Returns undefined when no source is configured or the load fails,
+     * so callers fall back to the public-API path. The workflow→parentFolderId
+     * map fills the gap the public workflows API leaves (it omits that field).
+     */
+    private async ensureSessionFolders(): Promise<{ resolver: FolderPathResolver; parentMap: Map<string, string> } | undefined> {
+        if (this.sessionFoldersLoaded) return this.sessionFolders;
+        this.sessionFoldersLoaded = true;
+        if (!this.folderSource) return undefined;
+        try {
+            const { folders, workflowParentFolderId } = await this.folderSource.load();
+            this.sessionFolders = {
+                resolver: new FolderPathResolver(folders),
+                parentMap: workflowParentFolderId,
+            };
+        } catch (error: any) {
+            this.warnFolderMetadataUnavailable(error?.message);
+            this.sessionFolders = undefined;
+        }
+        return this.sessionFolders;
+    }
+
     private async createFolderResolver(remoteWorkflows: IWorkflow[]): Promise<FolderPathResolver | null> {
         if (!this.folderSync) return null;
+
+        // Creds-first: when a session folder source is configured, use it. It
+        // supplies the workflow→folder link the public API omits, so we backfill
+        // parentFolderId onto the workflow objects before path resolution.
+        const session = await this.ensureSessionFolders();
+        if (session) {
+            for (const wf of remoteWorkflows) {
+                const folderId = session.parentMap.get(wf.id);
+                if (folderId) wf.parentFolderId = folderId;
+            }
+            return session.resolver;
+        }
+
+        // Public-API path: works on Enterprise / where workflows carry folder
+        // metadata. No login required.
         const hasWorkflowFolderFields = remoteWorkflows.some((workflow) =>
             workflow.parentFolderId !== undefined || workflow.parentFolder?.id,
         );
@@ -1244,14 +1300,26 @@ export class WorkflowStateTracker extends EventEmitter {
             // Store active and archived flags
             this.remoteActive.set(remoteWf.id, remoteWf.active === true);
             this.remoteArchived.set(remoteWf.id, remoteWf.isArchived === true);
-            const parentFolderId = remoteWf.parentFolderId ?? remoteWf.parentFolder?.id ?? null;
+            let parentFolderId = remoteWf.parentFolderId ?? remoteWf.parentFolder?.id ?? null;
             let folderPath: string[] = [];
-            if (this.folderSync && parentFolderId && typeof this.client.getFolders === 'function') {
-                try {
-                    const resolver = new FolderPathResolver(await this.client.getFolders(this.projectId));
-                    folderPath = resolver.getPathForWorkflow(remoteWf);
-                } catch (error: any) {
-                    this.warnFolderMetadataUnavailable(error?.message);
+            if (this.folderSync) {
+                // Creds-first: backfill the folder link from the session source
+                // (the public workflow API omits parentFolderId).
+                const session = await this.ensureSessionFolders();
+                if (session) {
+                    const folderId = session.parentMap.get(remoteWf.id) ?? null;
+                    if (folderId) {
+                        remoteWf.parentFolderId = folderId;
+                        parentFolderId = folderId;
+                    }
+                    folderPath = session.resolver.getPathForWorkflow(remoteWf);
+                } else if (parentFolderId && typeof this.client.getFolders === 'function') {
+                    try {
+                        const resolver = new FolderPathResolver(await this.client.getFolders(this.projectId));
+                        folderPath = resolver.getPathForWorkflow(remoteWf);
+                    } catch (error: any) {
+                        this.warnFolderMetadataUnavailable(error?.message);
+                    }
                 }
             }
             this.remoteParentFolderIds.set(remoteWf.id, parentFolderId);

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -8,7 +8,7 @@ import { WorkflowSyncStatus, IWorkflowStatus, IWorkflow } from '../types.js';
 import { IWorkflowState, IInstanceState } from './state-manager.js';
 import { FolderPathResolver, sanitizePathSegment } from './folder-path-resolver.js';
 import { listWorkflowFilesRecursive, normalizeWorkflowRelativePath, workflowRelativePathToAbsolute } from './workflow-path-utils.js';
-import { RestFolderSource, RestFolderLogin } from './rest-folder-source.js';
+import { RestFolderSource, RestFolderAuth } from './rest-folder-source.js';
 
 const WINDOWS_RESERVED_FILENAMES = new Set([
     'CON',
@@ -99,7 +99,7 @@ export class WorkflowStateTracker extends EventEmitter {
             projectId: string;      // Project scope filter
             folderSync?: boolean;
             host?: string;          // n8n base URL (for the session-auth folder source)
-            folderLogin?: RestFolderLogin; // Session creds for /rest folder reads
+            folderAuth?: RestFolderAuth; // Session token or creds for /rest folder reads
         }
     ) {
         super();
@@ -112,8 +112,8 @@ export class WorkflowStateTracker extends EventEmitter {
         // When folderSync is on and session creds are provided, prefer reading
         // folders over /rest — it works on every edition, including instances
         // where the public folder API is license-gated.
-        if (this.folderSync && options.host && options.folderLogin && this.projectId) {
-            this.folderSource = new RestFolderSource(options.host, this.projectId, options.folderLogin);
+        if (this.folderSync && options.host && options.folderAuth && this.projectId) {
+            this.folderSource = new RestFolderSource(options.host, this.projectId, options.folderAuth);
         }
         this.stateFilePath = path.join(this.directory, '.n8n-state.json');
 

--- a/packages/cli/src/core/services/workflow-transformer-adapter.ts
+++ b/packages/cli/src/core/services/workflow-transformer-adapter.ts
@@ -228,7 +228,7 @@ export class WorkflowTransformerAdapter {
      * Removes read-only and organization metadata fields
      */
     private static cleanForPush(workflow: IWorkflow): IWorkflow {
-        const { projectId, projectName, homeProject, isArchived, ...clean } = workflow as any;
+        const { projectId, projectName, homeProject, isArchived, parentFolder, folderPath, folderPathString, ...clean } = workflow as any;
 
         if (projectId) {
             clean.projectId = projectId;

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -21,6 +21,25 @@ export interface IWorkflow {
     projectName?: string;        // Name of the project (from shared[0].project.name)
     homeProject?: IProject;      // Full project object for detailed info
     isArchived?: boolean;        // Whether workflow is archived
+    parentFolderId?: string | null;
+    parentFolder?: { id: string; name: string } | null;
+    folderPath?: string[];
+    folderPathString?: string;
+}
+
+export interface IFolder {
+    id: string;
+    name: string;
+    parentFolderId?: string | null;
+    path?: string | string[];
+    createdAt?: string;
+    updatedAt?: string;
+}
+
+export interface IFolderCapability {
+    folders: boolean;
+    workflowFolderFields: boolean;
+    workflowParentFolderIdWritable?: boolean;
 }
 
 export interface ITag {
@@ -53,6 +72,10 @@ export interface IWorkflowStatus {
     projectName?: string;
     homeProject?: IProject;
     isArchived?: boolean;
+    parentFolderId?: string | null;
+    parentFolder?: { id: string; name: string } | null;
+    folderPath?: string[];
+    folderPathString?: string;
 }
 
 export interface ISyncConfig {

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -36,6 +36,16 @@ export interface IFolder {
     updatedAt?: string;
 }
 
+/** A stored n8n `/rest` session cookie for folder reads (per target). */
+export interface IFolderSession {
+    /** Cookie header value, e.g. `n8n-auth=<jwt>`. */
+    cookie: string;
+    /** ISO expiry, if known (n8n's auth cookie lasts ~7 days). */
+    expiresAt?: string;
+    /** Login identifier used to mint it (for display / re-login hints; never the password). */
+    user?: string;
+}
+
 export interface IFolderCapability {
     folders: boolean;
     workflowFolderFields: boolean;
@@ -91,8 +101,8 @@ export interface ISyncConfig {
     projectName: string;         // REQUIRED: Project display name
     folderSync?: boolean;
     host?: string;               // n8n base URL (used by the session-auth folder source)
-    /** Optional session-login creds for reading folders over /rest when folderSync is on. */
-    folderLogin?: { user: string; pass: string };
+    /** Optional session auth (stored cookie or creds) for reading folders over /rest when folderSync is on. */
+    folderAuth?: { cookie?: string; user?: string; pass?: string };
     environmentId?: string;
     environmentName?: string;
     environmentTargetId?: string;

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -90,6 +90,9 @@ export interface ISyncConfig {
     projectId: string;           // REQUIRED: Project scope for sync
     projectName: string;         // REQUIRED: Project display name
     folderSync?: boolean;
+    host?: string;               // n8n base URL (used by the session-auth folder source)
+    /** Optional session-login creds for reading folders over /rest when folderSync is on. */
+    folderLogin?: { user: string; pass: string };
     environmentId?: string;
     environmentName?: string;
     environmentTargetId?: string;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,6 +20,7 @@ import { parsePositiveIntegerOption } from './utils/option-parsers.js';
 import { spawn } from 'child_process';
 import { createN8nManagerFacade } from '@n8n-as-code/manager-adapter';
 import { ConfigService, type ILegacyWorkspaceMigrationResult, type IWorkspaceMigrationReport } from './services/config-service.js';
+import { RestFolderSource } from './core/services/rest-folder-source.js';
 import { WorkspaceMigrationFacade } from './services/workspace-migration-facade.js';
 import {
     N8N_FACADE_SETUP_MODES,
@@ -902,6 +903,41 @@ environmentAuthProgram.command('set')
             options,
             redactResolvedEnvironment(resolved),
             chalk.green(`✔ Local API key stored for environment: ${resolved.environmentName}`),
+        );
+    });
+
+environmentAuthProgram.command('folder-login')
+    .description('Store a session token for folderSync on instances where the public folder API is unavailable (sub-Enterprise). Logs in once via /rest and saves the ~7-day cookie locally — never the password.')
+    .argument('<name-or-id>', 'Environment name or ID')
+    .option('--user <email>', 'Login email / identifier')
+    .option('--password <password>', 'Login password (prefer --password-stdin)')
+    .option('--password-stdin', 'Read the login password from stdin')
+    .option('--json', 'Output result as JSON')
+    .action(async (nameOrId, options) => {
+        const configService = new ConfigService();
+        abortIfWorkspaceMigrationRequired(configService, options);
+        const environment = configService.resolveEnvironment(nameOrId);
+        if (environment.sourceKind === 'managed-instance') {
+            throw new Error(`Environment "${environment.environmentName}" uses a managed instance; folder-login is for remote n8n environments.`);
+        }
+        if (!environment.host) {
+            throw new Error(`Environment "${environment.environmentName}" has no host URL to log in against.`);
+        }
+        const user = (options.user || '').trim();
+        if (!user) throw new Error('Provide --user <email>.');
+        if (options.passwordStdin) options.password = await readSecretFromStdin();
+        const password = options.password || '';
+        if (!password) throw new Error('Provide --password or --password-stdin.');
+
+        const { cookie, expiresAt } = await RestFolderSource.login(environment.host, user, password);
+        configService.saveFolderSession(environment.environmentTargetId, { cookie, expiresAt, user });
+        printJsonOrText(
+            options,
+            { environment: environment.environmentName, user, expiresAt: expiresAt ?? null },
+            chalk.green(
+                `✔ Folder-login session stored for "${environment.environmentName}"` +
+                (expiresAt ? ` (expires ${expiresAt}).` : '.'),
+            ),
         );
     });
 

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import Conf from 'conf';
+import type { IFolderSession } from '../core/types.js';
 import {
     N8nConfigurationService,
     N8nRuntimeOrchestrator,
@@ -1128,6 +1129,58 @@ export class ConfigService {
     saveWorkspaceTargetApiKey(targetId: string, apiKey: string): void {
         const target = this.getInstanceTarget(targetId);
         this.manager.saveApiKey(target.id, apiKey);
+    }
+
+    // ── Folder-sync session tokens ────────────────────────────────────────────
+    // Folder reads on sub-Enterprise instances use the internal /rest API, which
+    // needs session (cookie) auth. We store the resulting cookie per target — the
+    // same per-target granularity as API keys — in a local 0o600 store, alongside
+    // the existing 'credentials' conf store. The password is never persisted.
+
+    private folderSessionStore?: Conf<Record<string, unknown>>;
+
+    private getFolderSessionStore(): Conf<Record<string, unknown>> {
+        if (!this.folderSessionStore) {
+            this.folderSessionStore = new Conf<Record<string, unknown>>({
+                projectName: 'n8nac',
+                configName: 'folder-sessions',
+                configFileMode: 0o600,
+            });
+        }
+        return this.folderSessionStore;
+    }
+
+    /** Canonical target id (accepts a name or id); falls back to the input if unresolvable. */
+    private resolveFolderSessionKey(targetId: string): string {
+        try {
+            return this.getInstanceTarget(targetId).id;
+        } catch {
+            return targetId;
+        }
+    }
+
+    saveFolderSession(targetId: string, session: IFolderSession): void {
+        const key = this.resolveFolderSessionKey(targetId);
+        const store = this.getFolderSessionStore();
+        const all = (store.get('sessions') as Record<string, IFolderSession>) ?? {};
+        all[key] = session;
+        store.set('sessions', all);
+    }
+
+    getFolderSession(targetId: string): IFolderSession | undefined {
+        const key = this.resolveFolderSessionKey(targetId);
+        const all = (this.getFolderSessionStore().get('sessions') as Record<string, IFolderSession>) ?? {};
+        return all[key];
+    }
+
+    clearFolderSession(targetId: string): void {
+        const key = this.resolveFolderSessionKey(targetId);
+        const store = this.getFolderSessionStore();
+        const all = (store.get('sessions') as Record<string, IFolderSession>) ?? {};
+        if (all[key]) {
+            delete all[key];
+            store.set('sessions', all);
+        }
     }
 
     upsertRemoteInstancePreset(input: { host: string; apiKey?: string; name?: string }): IInstanceProfile {

--- a/packages/cli/tests/unit/n8n-api-client.test.ts
+++ b/packages/cli/tests/unit/n8n-api-client.test.ts
@@ -85,6 +85,47 @@ describe('N8nApiClient test workflow support', () => {
         });
     });
 
+    it('fetches public project folders with pagination', async () => {
+        mockAxiosGet
+            .mockResolvedValueOnce({ data: { count: 2, data: [{ id: 'f1', name: 'Parent', parentFolderId: null }] } })
+            .mockResolvedValueOnce({ data: { count: 2, data: [{ id: 'f2', name: 'Child', parentFolderId: 'f1' }] } });
+        const client = new N8nApiClient({ host: 'https://n8n.local/', apiKey: 'secret' });
+
+        await expect(client.getFolders('project-1')).resolves.toEqual([
+            expect.objectContaining({ id: 'f1', name: 'Parent', parentFolderId: null }),
+            expect.objectContaining({ id: 'f2', name: 'Child', parentFolderId: 'f1' }),
+        ]);
+
+        expect(mockAxiosGet).toHaveBeenCalledWith('/api/v1/projects/project-1/folders', expect.objectContaining({
+            params: expect.objectContaining({ skip: '0', take: '100' }),
+        }));
+        expect(mockAxiosGet).toHaveBeenCalledWith('/api/v1/projects/project-1/folders', expect.objectContaining({
+            params: expect.objectContaining({ skip: '100', take: '100' }),
+        }));
+    });
+
+    it('preserves workflow parent folder metadata from workflow payloads', async () => {
+        mockAxiosGet
+            .mockResolvedValueOnce({ data: {
+                id: 'wf-1',
+                name: 'Foldered Workflow',
+                active: true,
+                nodes: [],
+                connections: {},
+                shared: [],
+                parentFolderId: 'folder-1',
+                parentFolder: { id: 'folder-1', name: 'Folder' },
+            } })
+            .mockRejectedValueOnce(new Error('tags unavailable'))
+            .mockResolvedValueOnce({ data: { data: [] } });
+        const client = new N8nApiClient({ host: 'https://n8n.local/', apiKey: 'secret' });
+
+        await expect(client.getWorkflow('wf-1')).resolves.toEqual(expect.objectContaining({
+            parentFolderId: 'folder-1',
+            parentFolder: { id: 'folder-1', name: 'Folder' },
+        }));
+    });
+
     it('uses a bounded text request for HTML instance identity fallback', async () => {
         mockAxiosGet.mockRejectedValue(new Error('not available'));
         mockAxiosCall.mockResolvedValueOnce({ data: '<html><script>{"instanceId":"instance-from-html"}</script></html>' });

--- a/packages/cli/tests/unit/rest-folder-source.test.ts
+++ b/packages/cli/tests/unit/rest-folder-source.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RestFolderSource } from '../../src/core/services/rest-folder-source.js';
+
+const { mockAxiosGet, mockAxiosPost, mockAxiosCreate } = vi.hoisted(() => ({
+    mockAxiosGet: vi.fn(),
+    mockAxiosPost: vi.fn(),
+    mockAxiosCreate: vi.fn(),
+}));
+
+vi.mock('axios', () => {
+    mockAxiosCreate.mockImplementation(() => ({ get: mockAxiosGet }));
+    return {
+        default: Object.assign(vi.fn(), { create: mockAxiosCreate, post: mockAxiosPost }),
+    };
+});
+
+const HOST = 'https://n8n.local';
+const PROJECT = 'proj-1';
+
+/**
+ * Simulate n8n's `/rest/workflows`, which caps a page at 100 items regardless of
+ * the requested `take` and reports the grand total in `count`. This is the exact
+ * shape that broke the original pagination (`skip += take` + `data.length < take`
+ * stop): only the first 100 workflows were ever read.
+ */
+function makeCappedWorkflowsEndpoint(total: number, pageCap = 100) {
+    return (params: { take: number; skip: number }) => {
+        const { skip } = params;
+        const pageSize = Math.min(pageCap, Math.max(0, total - skip));
+        const data = Array.from({ length: pageSize }, (_, i) => {
+            const n = skip + i;
+            return { id: `wf-${n}`, parentFolder: { id: `folder-${n % 5}` } };
+        });
+        return { data: { data, count: total } };
+    };
+}
+
+describe('RestFolderSource pagination', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockAxiosCreate.mockImplementation(() => ({ get: mockAxiosGet }));
+    });
+
+    it('reads every workflow across pages when the server caps page size below `take`', async () => {
+        const total = 229; // > 2 pages of 100, with a short final page
+        const workflowsEndpoint = makeCappedWorkflowsEndpoint(total);
+
+        mockAxiosGet.mockImplementation((pathname: string, config: { params: { take: number; skip: number } }) => {
+            if (pathname.includes('/folders')) {
+                return Promise.resolve({ data: { data: [{ id: 'folder-0', name: 'F0' }], count: 1 } });
+            }
+            return Promise.resolve(workflowsEndpoint(config.params));
+        });
+
+        const source = new RestFolderSource(HOST, PROJECT, { cookie: 'n8n-auth=token' });
+        const { workflowParentFolderId } = await source.load();
+
+        // The bug stopped after the first 100; the fix must map all 229.
+        expect(workflowParentFolderId.size).toBe(total);
+        expect(workflowParentFolderId.get('wf-0')).toBe('folder-0');
+        expect(workflowParentFolderId.get('wf-150')).toBeDefined();
+        expect(workflowParentFolderId.get('wf-228')).toBeDefined();
+
+        // skip must advance by the items actually returned (100), not by `take`,
+        // so no page is skipped: skips seen should be 0, 100, 200.
+        const workflowSkips = mockAxiosGet.mock.calls
+            .filter(([p]) => String(p).includes('/workflows'))
+            .map(([, c]) => c.params.skip);
+        expect(workflowSkips).toEqual([0, 100, 200]);
+    });
+});

--- a/packages/cli/tests/unit/sync-engine.test.ts
+++ b/packages/cli/tests/unit/sync-engine.test.ts
@@ -5,9 +5,17 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SyncEngine } from '../../src/core/services/sync-engine.js';
 import { WorkflowTransformerAdapter } from '../../src/core/services/workflow-transformer-adapter.js';
 
-function createEngine(params: { projectId: string; createWorkflow: ReturnType<typeof vi.fn> }) {
+function createEngine(params: {
+    projectId: string;
+    createWorkflow: ReturnType<typeof vi.fn>;
+    filename?: string;
+    folderSync?: boolean;
+    getFolders?: ReturnType<typeof vi.fn>;
+    createFolder?: ReturnType<typeof vi.fn>;
+}) {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-sync-engine-'));
-    const filename = 'new.workflow.ts';
+    const filename = params.filename ?? 'new.workflow.ts';
+    fs.mkdirSync(path.dirname(path.join(directory, filename)), { recursive: true });
     fs.writeFileSync(path.join(directory, filename), '// workflow source', 'utf8');
 
     const watcher = {
@@ -16,9 +24,13 @@ function createEngine(params: { projectId: string; createWorkflow: ReturnType<ty
 
     const client = {
         createWorkflow: params.createWorkflow,
+        getFolders: params.getFolders,
+        createFolder: params.createFolder,
     } as any;
 
-    const engine = new SyncEngine(client, watcher, directory, params.projectId);
+    const engine = new SyncEngine(client, watcher, directory, params.projectId, undefined, {
+        folderSync: params.folderSync,
+    });
 
     return { engine, directory, filename, watcher };
 }
@@ -69,6 +81,44 @@ describe('SyncEngine create payload projectId behavior', () => {
 
         expect(createWorkflow).toHaveBeenCalledWith(expect.not.objectContaining({
             projectId: expect.anything(),
+        }));
+    });
+
+    it('sets parentFolderId on create for nested folderSync paths', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Nested Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        const createWorkflow = vi.fn(async (payload) => ({ ...payload, id: 'wf-nested' }));
+        const getFolders = vi.fn(async () => [
+            { id: 'folder-ai-chat', name: 'Ai Chat', parentFolderId: null },
+        ]);
+        const createFolder = vi.fn(async (_projectId, payload) => ({
+            id: 'folder-file-processing',
+            name: payload.name,
+            parentFolderId: payload.parentFolderId,
+        }));
+
+        const { engine, filename } = createEngine({
+            projectId: 'project-1',
+            createWorkflow,
+            filename: 'Ai Chat/File Processing/new.workflow.ts',
+            folderSync: true,
+            getFolders,
+            createFolder,
+        });
+
+        await expect(engine.push(filename)).resolves.toBe('wf-nested');
+
+        expect(createFolder).toHaveBeenCalledWith('project-1', {
+            name: 'File Processing',
+            parentFolderId: 'folder-ai-chat',
+        });
+        expect(createWorkflow).toHaveBeenCalledWith(expect.objectContaining({
+            parentFolderId: 'folder-file-processing',
         }));
     });
 });

--- a/packages/cli/tests/unit/sync-engine.test.ts
+++ b/packages/cli/tests/unit/sync-engine.test.ts
@@ -259,3 +259,228 @@ describe('SyncEngine create payload projectId behavior', () => {
         expect(parentFolderCalls).toHaveLength(1);
     });
 });
+
+
+// ---------------------------------------------------------------------------
+// Update path: folder-aware move (PR review fix for Codex P2 finding)
+// ---------------------------------------------------------------------------
+//
+// Mirrors the create-path folderSync tests but for executeUpdate(). The update
+// path used to drop `parentFolderId` on the floor — both because
+// `inferParentFolderIdFromFilename` was only called from executeCreate(), and
+// because `N8nApiClient.cleanWorkflowUpdatePayload()` did not include
+// `parentFolderId` in its allowedKeys set. Both are fixed; these tests guard
+// the contract.
+// ---------------------------------------------------------------------------
+
+function updateEngine(params: {
+    projectId: string;
+    updateWorkflow: ReturnType<typeof vi.fn>;
+    filename?: string;
+    folderSync?: boolean;
+    getFolders?: ReturnType<typeof vi.fn>;
+    createFolder?: ReturnType<typeof vi.fn>;
+    workflowId?: string;
+}) {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-sync-engine-update-'));
+    const filename = params.filename ?? 'existing.workflow.ts';
+    fs.mkdirSync(path.dirname(path.join(directory, filename)), { recursive: true });
+    fs.writeFileSync(path.join(directory, filename), '// workflow source', 'utf8');
+
+    const watcher = {
+        finalizeSync: vi.fn(async () => undefined),
+        setRemoteHash: vi.fn(),
+    } as any;
+
+    // Return undefined from getWorkflow to bypass OCC; tests don't exercise OCC.
+    const client = {
+        getWorkflow: vi.fn(async () => undefined),
+        updateWorkflow: params.updateWorkflow,
+        getFolders: params.getFolders,
+        createFolder: params.createFolder,
+    } as any;
+
+    const engine = new SyncEngine(client, watcher, directory, params.projectId, undefined, {
+        folderSync: params.folderSync,
+    });
+
+    return {
+        engine,
+        directory,
+        filename,
+        watcher,
+        client,
+        workflowId: params.workflowId ?? 'wf-existing',
+    };
+}
+
+describe('SyncEngine update payload folderSync behavior', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('sets parentFolderId on update for nested folderSync paths (move into folder)', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Existing Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        const updateWorkflow = vi.fn(async (id, payload) => ({
+            ...payload,
+            id,
+            updatedAt: '2026-06-23T00:00:00.000Z',
+        }));
+        const getFolders = vi.fn(async () => [
+            { id: 'folder-ai-chat', name: 'Ai Chat', parentFolderId: null },
+        ]);
+        const createFolder = vi.fn(async (_projectId, payload) => ({
+            id: 'folder-file-processing',
+            name: payload.name,
+            parentFolderId: payload.parentFolderId,
+        }));
+
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow,
+            filename: 'Ai Chat/File Processing/existing.workflow.ts',
+            folderSync: true,
+            getFolders,
+            createFolder,
+            workflowId: 'wf-existing',
+        });
+
+        await expect(engine.push(workflowId, filename)).resolves.toBe(workflowId);
+
+        expect(updateWorkflow).toHaveBeenCalledTimes(1);
+        expect(updateWorkflow).toHaveBeenCalledWith(workflowId, expect.objectContaining({
+            parentFolderId: 'folder-file-processing',
+        }));
+    });
+
+    it('does NOT send parentFolderId on update when filename has no nested folder', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Existing Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        const updateWorkflow = vi.fn(async (id, payload) => ({
+            ...payload,
+            id,
+            updatedAt: '2026-06-23T00:00:00.000Z',
+        }));
+        // folderSync: true but flat filename -> inferParentFolderIdFromFilename
+        // short-circuits before calling getFolders.
+        const getFolders = vi.fn(async () => []);
+        const createFolder = vi.fn(async () => ({ id: 'unused', name: 'unused', parentFolderId: null }));
+
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow,
+            filename: 'existing.workflow.ts',
+            folderSync: true,
+            getFolders,
+            createFolder,
+            workflowId: 'wf-existing',
+        });
+
+        await expect(engine.push(workflowId, filename)).resolves.toBe(workflowId);
+
+        expect(getFolders).not.toHaveBeenCalled();
+        expect(updateWorkflow).toHaveBeenCalledTimes(1);
+        expect(updateWorkflow).toHaveBeenCalledWith(
+            workflowId,
+            expect.not.objectContaining({ parentFolderId: expect.anything() }),
+        );
+    });
+
+    it('retries update without parentFolderId when n8n rejects it as an unknown field', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Existing Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        // First call rejects with a 400 mentioning parentFolderId; second call
+        // (without parentFolderId) succeeds.
+        const folderError: any = new Error('Request failed with status code 400');
+        folderError.response = {
+            status: 400,
+            data: { message: "property 'parentFolderId' should not exist" },
+        };
+        const updateWorkflow = vi.fn()
+            .mockRejectedValueOnce(folderError)
+            .mockImplementationOnce(async (id, payload) => ({
+                ...payload,
+                id,
+                updatedAt: '2026-06-23T00:00:00.000Z',
+            }));
+        const getFolders = vi.fn(async () => []);
+        const createFolder = vi.fn(async (_projectId, payload) => ({
+            id: 'folder-x',
+            name: payload.name,
+            parentFolderId: payload.parentFolderId,
+        }));
+
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow,
+            filename: 'X/existing.workflow.ts',
+            folderSync: true,
+            getFolders,
+            createFolder,
+            workflowId: 'wf-existing',
+        });
+
+        await expect(engine.push(workflowId, filename)).resolves.toBe(workflowId);
+
+        expect(updateWorkflow).toHaveBeenCalledTimes(2);
+        expect(updateWorkflow.mock.calls[0][0]).toBe(workflowId);
+        expect(updateWorkflow.mock.calls[0][1]).toEqual(expect.objectContaining({ parentFolderId: 'folder-x' }));
+        expect(updateWorkflow.mock.calls[1][1]).not.toHaveProperty('parentFolderId');
+    });
+
+    it('does NOT retry when n8n returns a generic 400 mentioning only "folder" (regression guard)', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Existing Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        // A 400 mentioning "folder" but NOT "parentFolderId" / "parentFolder"
+        // must NOT be misclassified as "unsupported parentFolderId". Doing so
+        // would silently drop the folder assignment on n8n instances that DO
+        // support it (the same regression the create-side fix addresses).
+        const genericFolderError: any = new Error('Request failed with status code 400');
+        genericFolderError.response = {
+            status: 400,
+            data: { message: 'A folder with this name already exists in another project' },
+        };
+        const updateWorkflow = vi.fn().mockRejectedValue(genericFolderError);
+        const getFolders = vi.fn(async () => []);
+        const createFolder = vi.fn(async (_projectId, payload) => ({
+            id: 'folder-x',
+            name: payload.name,
+            parentFolderId: payload.parentFolderId,
+        }));
+
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow,
+            filename: 'X/existing.workflow.ts',
+            folderSync: true,
+            getFolders,
+            createFolder,
+            workflowId: 'wf-existing',
+        });
+
+        await expect(engine.push(workflowId, filename)).rejects.toBe(genericFolderError);
+        expect(updateWorkflow).toHaveBeenCalledTimes(1);
+        expect(createFolder).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/cli/tests/unit/sync-engine.test.ts
+++ b/packages/cli/tests/unit/sync-engine.test.ts
@@ -121,4 +121,129 @@ describe('SyncEngine create payload projectId behavior', () => {
             parentFolderId: 'folder-file-processing',
         }));
     });
+
+    it('retries create without parentFolderId when n8n rejects it as an unknown field', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Nested Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        const folderError: any = new Error('Request failed with status code 400');
+        folderError.response = {
+            status: 400,
+            data: { message: "property 'parentFolderId' should not exist" },
+        };
+        const createWorkflow = vi.fn()
+            .mockRejectedValueOnce(folderError)
+            .mockImplementationOnce(async (payload) => ({ ...payload, id: 'wf-fallback' }));
+        const getFolders = vi.fn(async () => []);
+        const createFolder = vi.fn(async (_projectId, payload) => ({
+            id: 'folder-x',
+            name: payload.name,
+            parentFolderId: payload.parentFolderId,
+        }));
+
+        const { engine, filename } = createEngine({
+            projectId: 'project-1',
+            createWorkflow,
+            filename: 'X/new.workflow.ts',
+            folderSync: true,
+            getFolders,
+            createFolder,
+        });
+
+        await expect(engine.push(filename)).resolves.toBe('wf-fallback');
+
+        expect(createWorkflow).toHaveBeenCalledTimes(2);
+        expect(createWorkflow.mock.calls[0][0]).toEqual(expect.objectContaining({ parentFolderId: 'folder-x' }));
+        expect(createWorkflow.mock.calls[1][0]).not.toHaveProperty('parentFolderId');
+    });
+
+    it('does NOT retry when n8n returns a generic 400 mentioning only "folder" (regression guard for over-broad match)', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Nested Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        // A 400 whose body mentions "folder" but not "parentFolderId" / "parentFolder" must NOT be
+        // misclassified as "unsupported parentFolderId" — that would silently drop the folder assignment
+        // on n8n instances that DO support it.
+        const genericFolderError: any = new Error('Request failed with status code 400');
+        genericFolderError.response = {
+            status: 400,
+            data: { message: 'A folder with this name already exists in another project' },
+        };
+        const createWorkflow = vi.fn().mockRejectedValue(genericFolderError);
+        const getFolders = vi.fn(async () => []);
+        const createFolder = vi.fn(async (_projectId, payload) => ({
+            id: 'folder-x',
+            name: payload.name,
+            parentFolderId: payload.parentFolderId,
+        }));
+
+        const { engine, filename } = createEngine({
+            projectId: 'project-1',
+            createWorkflow,
+            filename: 'X/new.workflow.ts',
+            folderSync: true,
+            getFolders,
+            createFolder,
+        });
+
+        await expect(engine.push(filename)).rejects.toBe(genericFolderError);
+        expect(createWorkflow).toHaveBeenCalledTimes(1);
+        expect(createFolder).toHaveBeenCalledTimes(1);
+    });
+
+    it('deduplicates concurrent createFolder requests for the same parent folder', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Concurrent Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        const createWorkflow = vi.fn(async (payload: any) => ({
+            ...payload,
+            id: payload.name === 'x' ? 'wf-x' : 'wf-y',
+        }));
+
+        let createFolderCalls = 0;
+        const createFolder = vi.fn(async (_projectId: string, payload: { name: string; parentFolderId: string | null }) => {
+            createFolderCalls++;
+            // Yield to the event loop so the second push() can enter ensureFolder() before this resolves.
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            return {
+                id: `folder-${payload.name}-${createFolderCalls}`,
+                name: payload.name,
+                parentFolderId: payload.parentFolderId,
+            };
+        });
+        const getFolders = vi.fn(async () => []);
+
+        const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-sync-engine-concurrent-'));
+        const filenameX = 'Shared/Parent/x.workflow.ts';
+        const filenameY = 'Shared/Parent/y.workflow.ts';
+        fs.mkdirSync(path.join(directory, 'Shared', 'Parent'), { recursive: true });
+        fs.writeFileSync(path.join(directory, filenameX), '// x', 'utf8');
+        fs.writeFileSync(path.join(directory, filenameY), '// y', 'utf8');
+
+        const watcher = { finalizeSync: vi.fn(async () => undefined) } as any;
+        const client = { createWorkflow, getFolders, createFolder } as any;
+        const engine = new SyncEngine(client, watcher, directory, 'project-1', undefined, { folderSync: true });
+
+        await Promise.all([engine.push(filenameX), engine.push(filenameY)]);
+
+        // Both pushes share the "Shared" folder creation (parent null) and the
+        // "Parent" folder creation (parent = Shared). With the in-flight promise
+        // map, each folder must be created exactly once.
+        const sharedFolderCalls = createFolder.mock.calls.filter((call) => call[1].name === 'Shared');
+        const parentFolderCalls = createFolder.mock.calls.filter((call) => call[1].name === 'Parent');
+        expect(sharedFolderCalls).toHaveLength(1);
+        expect(parentFolderCalls).toHaveLength(1);
+    });
 });

--- a/packages/cli/tests/unit/sync-engine.test.ts
+++ b/packages/cli/tests/unit/sync-engine.test.ts
@@ -412,13 +412,20 @@ describe('SyncEngine update payload folderSync behavior', () => {
             status: 400,
             data: { message: "property 'parentFolderId' should not exist" },
         };
-        const updateWorkflow = vi.fn()
-            .mockRejectedValueOnce(folderError)
-            .mockImplementationOnce(async (id, payload) => ({
-                ...payload,
-                id,
-                updatedAt: '2026-06-23T00:00:00.000Z',
-            }));
+
+        // Snapshot each call's payload at call time. Vitest's vi.fn() records
+        // arguments by live reference, and SyncEngine mutates the same localWf
+        // between the two updateWorkflow calls (sets parentFolderId, then
+        // deletes it in the catch block) — so the recorded `calls` would
+        // reflect the post-mutation object by the time the assertion runs.
+        // Capturing { ...payload } at each call preserves call-time state.
+        // Same pattern as the create-side fix in commit c801ff43.
+        const callSnapshots: Array<{ id: string; payload: any }> = [];
+        const updateWorkflow = vi.fn(async (id: string, payload: any) => {
+            callSnapshots.push({ id, payload: { ...payload } });
+            if (callSnapshots.length === 1) throw folderError;
+            return { ...payload, id, updatedAt: '2026-06-23T00:00:00.000Z' };
+        });
         const getFolders = vi.fn(async () => []);
         const createFolder = vi.fn(async (_projectId, payload) => ({
             id: 'folder-x',
@@ -439,9 +446,9 @@ describe('SyncEngine update payload folderSync behavior', () => {
         await expect(engine.push(filename, workflowId)).resolves.toBe(workflowId);
 
         expect(updateWorkflow).toHaveBeenCalledTimes(2);
-        expect(updateWorkflow.mock.calls[0][0]).toBe(workflowId);
-        expect(updateWorkflow.mock.calls[0][1]).toEqual(expect.objectContaining({ parentFolderId: 'folder-x' }));
-        expect(updateWorkflow.mock.calls[1][1]).not.toHaveProperty('parentFolderId');
+        expect(callSnapshots[0].id).toBe(workflowId);
+        expect(callSnapshots[0].payload).toEqual(expect.objectContaining({ parentFolderId: 'folder-x' }));
+        expect(callSnapshots[1].payload).not.toHaveProperty('parentFolderId');
     });
 
     it('does NOT retry when n8n returns a generic 400 mentioning only "folder" (regression guard)', async () => {

--- a/packages/cli/tests/unit/sync-engine.test.ts
+++ b/packages/cli/tests/unit/sync-engine.test.ts
@@ -351,7 +351,7 @@ describe('SyncEngine update payload folderSync behavior', () => {
             workflowId: 'wf-existing',
         });
 
-        await expect(engine.push(workflowId, filename)).resolves.toBe(workflowId);
+        await expect(engine.push(filename, workflowId)).resolves.toBe(workflowId);
 
         expect(updateWorkflow).toHaveBeenCalledTimes(1);
         expect(updateWorkflow).toHaveBeenCalledWith(workflowId, expect.objectContaining({
@@ -387,7 +387,7 @@ describe('SyncEngine update payload folderSync behavior', () => {
             workflowId: 'wf-existing',
         });
 
-        await expect(engine.push(workflowId, filename)).resolves.toBe(workflowId);
+        await expect(engine.push(filename, workflowId)).resolves.toBe(workflowId);
 
         expect(getFolders).not.toHaveBeenCalled();
         expect(updateWorkflow).toHaveBeenCalledTimes(1);
@@ -436,7 +436,7 @@ describe('SyncEngine update payload folderSync behavior', () => {
             workflowId: 'wf-existing',
         });
 
-        await expect(engine.push(workflowId, filename)).resolves.toBe(workflowId);
+        await expect(engine.push(filename, workflowId)).resolves.toBe(workflowId);
 
         expect(updateWorkflow).toHaveBeenCalledTimes(2);
         expect(updateWorkflow.mock.calls[0][0]).toBe(workflowId);
@@ -479,7 +479,7 @@ describe('SyncEngine update payload folderSync behavior', () => {
             workflowId: 'wf-existing',
         });
 
-        await expect(engine.push(workflowId, filename)).rejects.toBe(genericFolderError);
+        await expect(engine.push(filename, workflowId)).rejects.toBe(genericFolderError);
         expect(updateWorkflow).toHaveBeenCalledTimes(1);
         expect(createFolder).toHaveBeenCalledTimes(1);
     });

--- a/packages/cli/tests/unit/sync-engine.test.ts
+++ b/packages/cli/tests/unit/sync-engine.test.ts
@@ -135,9 +135,20 @@ describe('SyncEngine create payload projectId behavior', () => {
             status: 400,
             data: { message: "property 'parentFolderId' should not exist" },
         };
+        // Snapshot each call's payload at call time. SyncEngine mutates the same
+        // localWf object between calls (sets parentFolderId, then deletes it in
+        // the catch block), so a live reference inspected via mock.calls[0][0]
+        // would reflect the post-mutation state and miss parentFolderId.
+        const callSnapshots: any[] = [];
         const createWorkflow = vi.fn()
-            .mockRejectedValueOnce(folderError)
-            .mockImplementationOnce(async (payload) => ({ ...payload, id: 'wf-fallback' }));
+            .mockImplementationOnce(async (payload) => {
+                callSnapshots.push({ ...payload });
+                throw folderError;
+            })
+            .mockImplementationOnce(async (payload) => {
+                callSnapshots.push({ ...payload });
+                return { ...payload, id: 'wf-fallback' };
+            });
         const getFolders = vi.fn(async () => []);
         const createFolder = vi.fn(async (_projectId, payload) => ({
             id: 'folder-x',
@@ -157,8 +168,9 @@ describe('SyncEngine create payload projectId behavior', () => {
         await expect(engine.push(filename)).resolves.toBe('wf-fallback');
 
         expect(createWorkflow).toHaveBeenCalledTimes(2);
-        expect(createWorkflow.mock.calls[0][0]).toEqual(expect.objectContaining({ parentFolderId: 'folder-x' }));
-        expect(createWorkflow.mock.calls[1][0]).not.toHaveProperty('parentFolderId');
+        expect(callSnapshots).toHaveLength(2);
+        expect(callSnapshots[0]).toEqual(expect.objectContaining({ parentFolderId: 'folder-x' }));
+        expect(callSnapshots[1]).not.toHaveProperty('parentFolderId');
     });
 
     it('does NOT retry when n8n returns a generic 400 mentioning only "folder" (regression guard for over-broad match)', async () => {

--- a/packages/cli/tests/unit/sync-manager.test.ts
+++ b/packages/cli/tests/unit/sync-manager.test.ts
@@ -116,7 +116,7 @@ describe('SyncManager push filename contract', () => {
         cwdSpy.mockRestore();
     });
 
-    it('rejects nested workflow paths inside the sync scope with a clear error', () => {
+    it('accepts nested workflow paths inside the sync scope', () => {
         const syncDir = path.join(TMP, 'n8nac-sync-manager-test');
         const manager = createSyncManager(syncDir);
 
@@ -125,8 +125,9 @@ describe('SyncManager push filename contract', () => {
         };
 
         const nestedPath = path.join(syncDir, 'nested', 'my-workflow.workflow.ts');
-        expect(() => manager.resolvePushTarget(nestedPath))
-            .toThrow(/nested workflow paths inside the sync scope are not supported/);
+        expect(manager.resolvePushTarget(nestedPath)).toEqual(expect.objectContaining({
+            filename: 'nested/my-workflow.workflow.ts',
+        }));
     });
 
     it('rejects empty paths', () => {

--- a/packages/cli/tests/unit/workflow-state-tracker.test.ts
+++ b/packages/cli/tests/unit/workflow-state-tracker.test.ts
@@ -251,4 +251,74 @@ export class OrderIdWorkflow {
         expect(tracker.getWorkflowIdForFilename('order-id.workflow.ts')).toBe('real-id');
         expect(tracker.getFilenameForId('real-id')).toBe('order-id.workflow.ts');
     });
+
+    it('recursively scans nested workflow files and stores relative paths', async () => {
+        const tracker = createTracker();
+        fs.mkdirSync(path.join(tempDir!, 'Ai Chat', 'File Processing'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tempDir!, 'Ai Chat', 'File Processing', 'nested.workflow.ts'),
+            `import { workflow, node } from '@n8n-as-code/transformer';
+
+@workflow({
+  id: 'nested-id',
+  name: 'Nested Workflow',
+  active: false
+})
+export class NestedWorkflow {
+  @node({
+    name: 'Webhook',
+    type: 'n8n-nodes-base.webhook',
+    version: 2.1,
+    position: [0, 0]
+  })
+  Webhook = { path: 'nested', httpMethod: 'POST' };
+}
+`,
+            'utf-8',
+        );
+
+        await tracker.refreshLocalState();
+
+        const relativePath = 'Ai Chat/File Processing/nested.workflow.ts';
+        expect(tracker.getWorkflowIdForFilename(relativePath)).toBe('nested-id');
+        expect(tracker.getFilenameForId('nested-id')).toBe(relativePath);
+    });
+
+    it('uses public folder metadata for new remote workflow paths when folderSync is enabled', async () => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-tracker-'));
+        const client = {
+            getAllWorkflows: vi.fn().mockResolvedValue([
+                {
+                    id: 'wf-foldered',
+                    name: 'Normalize Attachments',
+                    active: true,
+                    isArchived: false,
+                    parentFolderId: 'folder-file-processing',
+                },
+            ]),
+            getFolders: vi.fn().mockResolvedValue([
+                { id: 'folder-ai-chat', name: 'Ai Chat', parentFolderId: null },
+                { id: 'folder-file-processing', name: 'File Processing', parentFolderId: 'folder-ai-chat' },
+            ]),
+        } as any;
+
+        const tracker = new WorkflowStateTracker(client, {
+            directory: tempDir,
+            syncInactive: false,
+            ignoredTags: [],
+            projectId: 'project-1',
+            folderSync: true,
+        });
+
+        await tracker.refreshRemoteState();
+
+        const relativePath = 'Ai Chat/File Processing/Normalize Attachments.workflow.ts';
+        expect(tracker.getFilenameForId('wf-foldered')).toBe(relativePath);
+        const listed = await tracker.getLightweightList();
+        expect(listed[0]).toEqual(expect.objectContaining({
+            filename: relativePath,
+            folderPathString: 'Ai Chat/File Processing',
+            parentFolderId: 'folder-file-processing',
+        }));
+    });
 });


### PR DESCRIPTION
Stacks on top of #527 (targets its `feat/folder-aware-sync` branch, not `main`) so folderSync also works on **Community / sub-Enterprise** n8n, where the public folder API is unavailable.

### Why
On Community 2.25.6, `GET /api/v1/projects/{id}/folders` is license-gated (403) and the public workflows API omits `parentFolderId`, so #527's `createFolderResolver()` correctly falls back to flat. The same data is available over the internal `/rest` API (what the n8n UI uses) on every edition.

### What this adds (2 commits, additive; inert unless folderSync is on **and** session creds are configured)
1. **`RestFolderSource`** — session-cookie login via `/rest`, paginated reads of `/rest/projects/{id}/folders` + `/rest/workflows`. Wired as the fallback **inside the existing `createFolderResolver()` / `updateSingleRemoteState()`**: backfills `parentFolderId` and reuses your `FolderPathResolver` / `buildRelativeFilename`. Enterprise/public path is unchanged and used automatically when no creds are set.
2. **`n8nac env auth folder-login <env>`** — stores the ~7-day `n8n-auth` cookie per target in a `0600` conf store (password never persisted).

### Tested
Against a live n8n 2.25.6 Community instance (~260 workflows / 27 folders, 3 levels deep): nested pulls confirmed for single `pull` and bulk `list`; flat fallback with no creds (no regression); stored-token pull with only the API key; `tsc -b` green.

### Known gaps (details in the #527 comment)
Push-side folder *creation* over `/rest` not implemented (public `createFolder` 403s on Community); SSO instances unsupported by password login; no interactive prompt / unit tests yet; only validated on one instance.

Full write-up and test table: see my comment on #527. Opening this as a PR into the feature branch (with maintainer edits enabled) so it's easy to merge or iterate on directly — reshape command name / token storage / precedence to your preference as needed.