### PR TITLE
fix(cli): bind n8n API keys to environments instead of shared URL targets

### DIFF
--- a/architecture/target/workspace-environments-and-promotion.md
+++ b/architecture/target/workspace-environments-and-promotion.md
@@ -1124,6 +1124,8 @@ Credentials are outside the tracked environment definition. For v4 environments,
 
 Environment-scoped storage is what keeps two environments isolated when they share one base URL, which happens when a single n8n instance hosts several accounts. Target-scoped and URL-matched lookups are shared by every environment on that target, so they are fallbacks only.
 
+Steps 2 and 3 apply to embedded targets. A managed instance owns its credentials, so environments on a global reference resolve only a scoped environment variable or the managed instance key; workspace-stored keys must not shadow it, because an environment moved from an embedded target to a managed one would otherwise keep authenticating with the old remote key.
+
 Workspace-local ignored secret files are not part of the MVP lookup order. This spec does not require n8nac to create or own a workspace-local secrets file, because secrets remain the user’s responsibility. If workspace-local secret lookup is added later, it must define exact file paths, schema, gitignore behavior, precedence, and malformed-file diagnostics.
 
 Recommended ignored files if implemented later:

--- a/architecture/target/workspace-environments-and-promotion.md
+++ b/architecture/target/workspace-environments-and-promotion.md
@@ -1117,8 +1117,12 @@ canManageRuntime: boolean;
 Credentials are outside the tracked environment definition. For v4 environments, n8nac should avoid using one generic API key for every environment; it should resolve API keys in this order:
 
 1. explicit scoped environment variables, for example `N8NAC_ENV_PROD_API_KEY` or `N8NAC_TARGET_PROD_N8N_API_KEY`;
-2. global n8n-manager secret store, where the environment target is a global reference or the embedded target can be matched safely by URL;
-4. missing.
+2. the secret stored for the environment itself, keyed by environment ID;
+3. the secret stored for the environment target, keyed by target ID;
+4. global n8n-manager secret store, where the environment target is a global reference or the embedded target can be matched safely by URL;
+5. missing.
+
+Environment-scoped storage is what keeps two environments isolated when they share one base URL, which happens when a single n8n instance hosts several accounts. Target-scoped and URL-matched lookups are shared by every environment on that target, so they are fallbacks only.
 
 Workspace-local ignored secret files are not part of the MVP lookup order. This spec does not require n8nac to create or own a workspace-local secrets file, because secrets remain the user’s responsibility. If workspace-local secret lookup is added later, it must define exact file paths, schema, gitignore behavior, precedence, and malformed-file diagnostics.
 

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -80,6 +80,22 @@ running Node 22.15 or newer.
 The n8n-as-code output channel lists every anchor that was loaded and every bundle that could not
 be read.
 
+### An environment sees another account's workflows
+
+This happens when two environments point at the same base URL and only one of them has its own key.
+
+```bash
+n8nac env status <environment> --json
+```
+
+`apiKeySource` tells you which key is in use. `workspace-local` or `global` means the environment falls back to a key shared with the other environments on that URL. Give it its own key:
+
+```bash
+n8nac env auth set <environment> --api-key-stdin
+```
+
+`workspace-environment` confirms the environment authenticates with its own key.
+
 ## Missing Configuration
 
 ### `n8nac-config.json` not found

--- a/docs/docs/usage/cli.md
+++ b/docs/docs/usage/cli.md
@@ -117,10 +117,12 @@ printf '%s' "$PREPROD_N8N_API_KEY" | n8nac env auth set Preprod --api-key-stdin
 |---|---|
 | `env` | `N8NAC_ENV_<ENVIRONMENT>_API_KEY` or `N8NAC_TARGET_<TARGET>_API_KEY` |
 | `workspace-environment` | stored for this environment by `env auth set` |
-| `workspace-local` | stored for the shared target by `env add --api-key`, used by environments that have no key of their own |
+| `workspace-local` | stored for the shared target by the VS Code environment editor, used by environments that have no key of their own |
 | `global` | stored on the global `n8n-manager` instance matching the URL |
 
-Use `n8nac env auth clear <environment>` to drop an environment key and fall back to the entries below it.
+`env add --api-key` and `env update --api-key` bind the key to that one environment and never to the shared target, so configuring one environment cannot change the key another environment authenticates with.
+
+Use `n8nac env auth clear <environment>` to drop an environment key. The environment is then left without a credential of its own rather than borrowing one from another environment on the same URL, so commands fail with `apiKeySource: missing` until you store a new key.
 
 Local managed instance environments do not take a stored key: they resolve either a scoped environment variable or the managed instance credentials, so `env auth set` and `env add --api-key` are rejected for them.
 

--- a/docs/docs/usage/cli.md
+++ b/docs/docs/usage/cli.md
@@ -111,7 +111,7 @@ printf '%s' "$PROD_N8N_API_KEY"    | n8nac env auth set Prod    --api-key-stdin
 printf '%s' "$PREPROD_N8N_API_KEY" | n8nac env auth set Preprod --api-key-stdin
 ```
 
-`n8nac env status <name> --json` reports which key an environment resolves, in `apiKeySource`:
+`n8nac env status <name> --json` reports which key a remote environment resolves, in `apiKeySource`:
 
 | `apiKeySource` | Where the key comes from |
 |---|---|
@@ -121,6 +121,8 @@ printf '%s' "$PREPROD_N8N_API_KEY" | n8nac env auth set Preprod --api-key-stdin
 | `global` | stored on the global `n8n-manager` instance matching the URL |
 
 Use `n8nac env auth clear <environment>` to drop an environment key and fall back to the entries below it.
+
+Local managed instance environments do not take a stored key: they resolve either a scoped environment variable or the managed instance credentials, so `env auth set` and `env add --api-key` are rejected for them.
 
 ### Local managed instance environments
 

--- a/docs/docs/usage/cli.md
+++ b/docs/docs/usage/cli.md
@@ -86,6 +86,7 @@ n8nac env add Dev --base-url <url> --workflows-path workflows/dev
 n8nac env add Local --managed-instance <id> --workflows-path workflows/local
 n8nac env use Dev
 n8nac env auth set Dev --api-key-stdin
+n8nac env auth clear Dev
 n8nac env remove Dev
 ```
 
@@ -97,6 +98,29 @@ Remote environments store the URL in `n8nac-config.json`, but the API key stays 
 n8nac env add Staging --base-url https://staging.example.com --workflows-path workflows/staging
 n8nac env auth set Staging --api-key-stdin
 ```
+
+### Several accounts on one n8n URL
+
+`n8nac env auth set` binds the key to the environment, not to the URL. Two environments that point at the same base URL — for example one account per n8n user on a single instance — each keep their own key.
+
+```bash
+n8nac env add Prod    --base-url https://n8n.example.com --workflows-path workflows/prod
+n8nac env add Preprod --base-url https://n8n.example.com --workflows-path workflows/preprod
+
+printf '%s' "$PROD_N8N_API_KEY"    | n8nac env auth set Prod    --api-key-stdin
+printf '%s' "$PREPROD_N8N_API_KEY" | n8nac env auth set Preprod --api-key-stdin
+```
+
+`n8nac env status <name> --json` reports which key an environment resolves, in `apiKeySource`:
+
+| `apiKeySource` | Where the key comes from |
+|---|---|
+| `env` | `N8NAC_ENV_<ENVIRONMENT>_API_KEY` or `N8NAC_TARGET_<TARGET>_API_KEY` |
+| `workspace-environment` | stored for this environment by `env auth set` |
+| `workspace-local` | stored for the shared target by `env add --api-key`, used by environments that have no key of their own |
+| `global` | stored on the global `n8n-manager` instance matching the URL |
+
+Use `n8nac env auth clear <environment>` to drop an environment key and fall back to the entries below it.
 
 ### Local managed instance environments
 

--- a/docs/docs/usage/commands.md
+++ b/docs/docs/usage/commands.md
@@ -27,6 +27,7 @@ n8nac env add <name> --base-url <url> --workflows-path <path>
 n8nac env add <name> --managed-instance <id> --workflows-path <path>
 n8nac env use <environment>
 n8nac env auth set <environment> --api-key-stdin
+n8nac env auth clear <environment>
 n8nac env remove <environment>
 ```
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -49,6 +49,15 @@ printf '%s' "$N8N_API_KEY" | n8nac env auth set Dev --api-key-stdin
 n8nac env use Dev
 ```
 
+`env auth set` binds the key to the environment, so two environments on the same base URL — one per n8n account on a single instance — keep separate credentials:
+
+```bash
+n8nac env add Prod    --base-url https://n8n.example.com --workflows-path workflows/prod
+n8nac env add Preprod --base-url https://n8n.example.com --workflows-path workflows/preprod
+printf '%s' "$PROD_N8N_API_KEY"    | n8nac env auth set Prod    --api-key-stdin
+printf '%s' "$PREPROD_N8N_API_KEY" | n8nac env auth set Preprod --api-key-stdin
+```
+
 Attach a workspace environment to a local managed instance:
 
 ```bash

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -554,7 +554,6 @@ environmentProgram.command('add')
                 url: urlOption,
             });
             environmentTarget = target.id;
-            if (options.apiKey) configService.saveWorkspaceTargetApiKey(target.id, options.apiKey);
         }
         if (options.managedInstance) {
             const target = await ensureManagedLocalTarget(configService, options.managedInstance);
@@ -574,7 +573,10 @@ environmentProgram.command('add')
             customNodesPath: options.customNodesPath,
             description: options.description,
         });
-        // Bind the key to this environment so environments sharing a base URL keep separate credentials.
+        // Bind the key to this environment only. It must never also be written to the shared
+        // environment target: that slot is read by every key-less environment on the same base URL,
+        // so copying a per-environment credential into it lets one environment silently
+        // authenticate as another (and the last `env add --api-key` would repoint them all).
         if (options.apiKey && urlOption) configService.saveWorkspaceEnvironmentApiKey(environment.id, options.apiKey);
         printJsonOrText(options, environment, chalk.green(`✔ Workspace environment added: ${environment.name}`));
     });
@@ -613,7 +615,6 @@ environmentProgram.command('update')
                 url: urlOption,
             });
             environmentTarget = target.id;
-            if (options.apiKey) configService.saveWorkspaceTargetApiKey(target.id, options.apiKey);
         }
         if (options.managedInstance) {
             const target = await ensureManagedLocalTarget(configService, options.managedInstance);
@@ -636,7 +637,7 @@ environmentProgram.command('update')
             }
         }
         const environment = configService.updateEnvironment(nameOrId, patch);
-        // Bind the key to this environment so environments sharing a base URL keep separate credentials.
+        // Bind the key to this environment only -- see the note in `env add`.
         if (options.apiKey) configService.saveWorkspaceEnvironmentApiKey(environment.id, options.apiKey);
         printJsonOrText(options, environment, chalk.green(`✔ Workspace environment updated: ${environment.name}`));
     });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -45,6 +45,8 @@ async function readSecretFromStdin(): Promise<string> {
     return Buffer.concat(chunks).toString('utf8').trim().replace(/^['"]|['"]$/g, '');
 }
 
+const MANAGED_INSTANCE_API_KEY_ERROR = 'Managed instance environments do not take an API key. Configure credentials through the managed n8n instance instead.';
+
 async function hydrateApiKeyFromStdin(options: { apiKey?: string; apiKeyStdin?: boolean }): Promise<void> {
     if (options.apiKey || !options.apiKeyStdin) {
         return;
@@ -542,6 +544,9 @@ environmentProgram.command('add')
         if ((options.projectId && !options.projectName) || (!options.projectId && options.projectName)) {
             throw new Error('Provide both --project-id and --project-name, or omit both.');
         }
+        if (options.apiKey && options.managedInstance) {
+            throw new Error(MANAGED_INSTANCE_API_KEY_ERROR);
+        }
         let environmentTarget: string | undefined;
         if (urlOption) {
             const target = configService.ensureEmbeddedInstanceTarget({
@@ -598,6 +603,9 @@ environmentProgram.command('update')
         if (selectors.length > 1) {
             throw new Error('Provide at most one of --base-url or --managed-instance.');
         }
+        if (options.apiKey && options.managedInstance) {
+            throw new Error(MANAGED_INSTANCE_API_KEY_ERROR);
+        }
         let environmentTarget: string | undefined;
         if (urlOption) {
             const target = configService.ensureEmbeddedInstanceTarget({
@@ -621,9 +629,15 @@ environmentProgram.command('update')
             customNodesPath: options.customNodesPath,
             description: options.description,
         };
+        if (options.apiKey) {
+            const nextTargetId = environmentTarget || configService.getEnvironment(nameOrId).environmentTargetId;
+            if (configService.getInstanceTarget(nextTargetId).kind === 'managed-instance') {
+                throw new Error(MANAGED_INSTANCE_API_KEY_ERROR);
+            }
+        }
         const environment = configService.updateEnvironment(nameOrId, patch);
         // Bind the key to this environment so environments sharing a base URL keep separate credentials.
-        if (options.apiKey && urlOption) configService.saveWorkspaceEnvironmentApiKey(environment.id, options.apiKey);
+        if (options.apiKey) configService.saveWorkspaceEnvironmentApiKey(environment.id, options.apiKey);
         printJsonOrText(options, environment, chalk.green(`✔ Workspace environment updated: ${environment.name}`));
     });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -521,8 +521,8 @@ environmentProgram.command('add')
     .argument('<name>', 'Environment display name')
     .option('--base-url <url>', 'Remote n8n URL to store in this workspace environment')
     .option('--managed-instance <id>', 'Local managed n8n instance ID to reference')
-    .option('--api-key <key>', 'Store a local API key for --base-url without committing it')
-    .option('--api-key-stdin', 'Read the local API key for --base-url from stdin')
+    .option('--api-key <key>', 'Store a local API key for this environment without committing it')
+    .option('--api-key-stdin', 'Read this environment local API key from stdin')
     .option('--project-id <id>', 'n8n project ID')
     .option('--project-name <name>', 'n8n project display name')
     .option('--workflows-path <path>', 'Directory that contains this environment workflows')
@@ -569,6 +569,8 @@ environmentProgram.command('add')
             customNodesPath: options.customNodesPath,
             description: options.description,
         });
+        // Bind the key to this environment so environments sharing a base URL keep separate credentials.
+        if (options.apiKey && urlOption) configService.saveWorkspaceEnvironmentApiKey(environment.id, options.apiKey);
         printJsonOrText(options, environment, chalk.green(`✔ Workspace environment added: ${environment.name}`));
     });
 
@@ -578,8 +580,8 @@ environmentProgram.command('update')
     .option('--name <name>', 'New display name')
     .option('--base-url <url>', 'Move this environment to a remote n8n URL')
     .option('--managed-instance <id>', 'Move this environment to a local managed n8n instance')
-    .option('--api-key <key>', 'Store a local API key for --base-url without committing it')
-    .option('--api-key-stdin', 'Read the local API key for --base-url from stdin')
+    .option('--api-key <key>', 'Store a local API key for this environment without committing it')
+    .option('--api-key-stdin', 'Read this environment local API key from stdin')
     .option('--project-id <id>', 'n8n project ID')
     .option('--project-name <name>', 'n8n project display name')
     .option('--workflows-path <path>', 'Directory that contains this environment workflows')
@@ -620,6 +622,8 @@ environmentProgram.command('update')
             description: options.description,
         };
         const environment = configService.updateEnvironment(nameOrId, patch);
+        // Bind the key to this environment so environments sharing a base URL keep separate credentials.
+        if (options.apiKey && urlOption) configService.saveWorkspaceEnvironmentApiKey(environment.id, options.apiKey);
         printJsonOrText(options, environment, chalk.green(`✔ Workspace environment updated: ${environment.name}`));
     });
 
@@ -668,12 +672,28 @@ environmentAuthProgram.command('set')
         if (!options.apiKey) {
             throw new Error('Provide --api-key or --api-key-stdin.');
         }
-        configService.saveWorkspaceTargetApiKey(environment.environmentTargetId, options.apiKey);
+        configService.saveWorkspaceEnvironmentApiKey(environment.environmentId, options.apiKey);
         const resolved = await configService.prepareEnvironment(nameOrId);
         printJsonOrText(
             options,
             redactResolvedEnvironment(resolved),
             chalk.green(`✔ Local API key stored for environment: ${resolved.environmentName}`),
+        );
+    });
+
+environmentAuthProgram.command('clear')
+    .description('Remove the API key stored for a single environment')
+    .argument('<name-or-id>', 'Environment name or ID')
+    .option('--json', 'Output resolved environment as JSON')
+    .action((nameOrId, options) => {
+        const configService = new ConfigService();
+        const environment = configService.getEnvironment(nameOrId);
+        configService.deleteWorkspaceEnvironmentApiKey(environment.id);
+        const resolved = configService.resolveEnvironment(environment.id);
+        printJsonOrText(
+            options,
+            redactResolvedEnvironment(resolved),
+            chalk.green(`✔ Local API key cleared for environment: ${resolved.environmentName}`),
         );
     });
 

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -38,6 +38,10 @@ export type IInstanceVerification = N8nInstanceVerification;
  * - `workspace-environment`: key stored for this single environment (`n8nac env auth set`).
  * - `workspace-local`: key stored for the environment target, shared by every environment on it.
  * - `global`: key stored on the global n8n-manager instance that matches the host.
+ *
+ * `workspace-environment` and `workspace-local` apply to remote (external) environments only.
+ * A managed instance owns its credentials, so those environments resolve either a scoped
+ * environment variable or the managed instance key.
  */
 export type EnvironmentCredentialSource = 'env' | 'workspace-environment' | 'workspace-local' | 'global' | 'missing';
 
@@ -1368,9 +1372,10 @@ export class ConfigService {
             if (!instance) throw new Error(`Workspace environment "${environment.name}" references missing global n8n-manager instance: ${target.managedInstanceId}`);
             const host = instance.baseUrl || instance.tunnelPublicUrl || '';
             const envApiKey = this.readEnvApiKey(environment, target);
-            const environmentApiKey = this.readEnvironmentApiKey(environment);
+            // Managed instances own their credentials, so an environment-scoped key left over from
+            // a previous external target must not shadow the managed instance key.
             const globalApiKey = this.manager.getApiKey(instance.id);
-            const apiKey = envApiKey || environmentApiKey || globalApiKey;
+            const apiKey = envApiKey || globalApiKey;
             const projectId = environment.projectId || instance.defaultProject?.id;
             const projectName = environment.projectName || instance.defaultProject?.name;
             const identity = this.resolveManagedEnvironmentIdentity(instance, host, apiKey);
@@ -1390,9 +1395,9 @@ export class ConfigService {
                 instance: this.toInstanceProfile(instance),
                 host,
                 apiKey,
-                apiKeySource: envApiKey ? 'env' : environmentApiKey ? 'workspace-environment' : globalApiKey ? 'global' : 'missing',
+                apiKeySource: envApiKey ? 'env' : globalApiKey ? 'global' : 'missing',
                 apiKeyAvailable: Boolean(apiKey),
-                accessStatus: this.deriveAccessStatus({ host, apiKey, projectId, projectName, verification: envApiKey || environmentApiKey ? undefined : instance.verification }),
+                accessStatus: this.deriveAccessStatus({ host, apiKey, projectId, projectName, verification: envApiKey ? undefined : instance.verification }),
                 nativeMcp: this.nativeMcpToSnapshot(environment.nativeMcp, environment.id),
                 workflowsPath,
                 syncFolder,

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -979,6 +979,14 @@ export class ConfigService {
         this.manager.saveApiKey(target.id, apiKey);
     }
 
+    deleteWorkspaceTargetApiKey(targetId: string): void {
+        try {
+            this.manager.deleteApiKey(this.getInstanceTarget(targetId).id);
+        } catch {
+            this.manager.deleteApiKey(targetId);
+        }
+    }
+
     /**
      * API key stored for a single environment. Environments that share an environment target
      * (for example two accounts on the same n8n base URL) keep their own key this way.

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -32,6 +32,15 @@ export interface ILocalConfig {
 export type IInstanceVerificationStatus = N8nInstanceVerificationStatus;
 export type IInstanceVerification = N8nInstanceVerification;
 
+/**
+ * Where the API key used for an environment came from, most specific first.
+ * - `env`: `N8NAC_ENV_*` / `N8NAC_TARGET_*` environment variable.
+ * - `workspace-environment`: key stored for this single environment (`n8nac env auth set`).
+ * - `workspace-local`: key stored for the environment target, shared by every environment on it.
+ * - `global`: key stored on the global n8n-manager instance that matches the host.
+ */
+export type EnvironmentCredentialSource = 'env' | 'workspace-environment' | 'workspace-local' | 'global' | 'missing';
+
 export interface IInstanceProfile extends ILocalConfig {
     id: string;
     name: string;
@@ -50,7 +59,7 @@ export interface IManagedEnvironmentTarget {
     instanceIdentifier?: string;
     instanceUserIdentifier?: string;
     apiKeyAvailable?: boolean;
-    credentialSource?: 'env' | 'workspace-local' | 'global' | 'missing';
+    credentialSource?: EnvironmentCredentialSource;
     accessStatus?: EnvironmentAccessStatus;
 }
 
@@ -64,7 +73,7 @@ export interface IExternalEnvironmentTarget {
     verification?: IInstanceVerification;
     description?: string;
     apiKeyAvailable?: boolean;
-    credentialSource?: 'env' | 'workspace-local' | 'global' | 'missing';
+    credentialSource?: EnvironmentCredentialSource;
     accessStatus?: EnvironmentAccessStatus;
 }
 
@@ -106,7 +115,7 @@ export interface IWorkspaceEnvironment {
     instanceIdentifier?: string;
     instanceUserIdentifier?: string;
     apiKeyAvailable?: boolean;
-    credentialSource?: 'env' | 'workspace-local' | 'global' | 'missing';
+    credentialSource?: EnvironmentCredentialSource;
     accessStatus?: EnvironmentAccessStatus;
     nativeMcp?: IWorkspaceNativeMcpConfig;
 }
@@ -139,7 +148,7 @@ export interface IWorkspaceConfig extends ILocalConfig {
     environmentTargetId?: string;
     environmentTargetName?: string;
     apiKeyAvailable?: boolean;
-    credentialSource?: 'env' | 'workspace-local' | 'global' | 'missing';
+    credentialSource?: EnvironmentCredentialSource;
 }
 
 export interface IResolvedWorkspaceEnvironment extends ILocalConfig {
@@ -156,7 +165,7 @@ export interface IResolvedWorkspaceEnvironment extends ILocalConfig {
     managedInstanceId?: string;
     host: string;
     apiKey?: string;
-    apiKeySource: 'env' | 'workspace-local' | 'global' | 'missing';
+    apiKeySource: EnvironmentCredentialSource;
     apiKeyAvailable: boolean;
     accessStatus: EnvironmentAccessStatus;
     nativeMcp?: IWorkspaceNativeMcpConfig;
@@ -498,6 +507,7 @@ export class ConfigService {
             throw new Error(`Workspace environment "${environment.name}" is active. Pin another environment first, or re-run with --force to remove it and clear the active environment.`);
         }
         this.deleteNativeMcpToken(environment.id);
+        this.manager.deleteApiKey(this.environmentSecretKey(environment.id));
         const nextEnvironments = config.environments.filter((item) => item.id !== environment.id);
         this.writeWorkspaceConfigV4({
             ...config,
@@ -961,6 +971,29 @@ export class ConfigService {
         this.manager.saveApiKey(target.id, apiKey);
     }
 
+    /**
+     * API key stored for a single environment. Environments that share an environment target
+     * (for example two accounts on the same n8n base URL) keep their own key this way.
+     */
+    getWorkspaceEnvironmentApiKey(environmentNameOrId: string): string | undefined {
+        const environment = this.findEnvironment(this.ensureV4WorkspaceConfig(), environmentNameOrId);
+        return this.manager.getApiKey(this.environmentSecretKey(environment.id));
+    }
+
+    saveWorkspaceEnvironmentApiKey(environmentNameOrId: string, apiKey: string): void {
+        const environment = this.findEnvironment(this.ensureV4WorkspaceConfig(), environmentNameOrId);
+        this.manager.saveApiKey(this.environmentSecretKey(environment.id), cleanRequired(apiKey, 'n8n API key'));
+    }
+
+    deleteWorkspaceEnvironmentApiKey(environmentNameOrId: string): void {
+        try {
+            const environment = this.findEnvironment(this.ensureV4WorkspaceConfig(), environmentNameOrId);
+            this.manager.deleteApiKey(this.environmentSecretKey(environment.id));
+        } catch {
+            this.manager.deleteApiKey(this.environmentSecretKey(environmentNameOrId));
+        }
+    }
+
     getNativeMcpToken(environmentNameOrId?: string): string | undefined {
         const environment = environmentNameOrId
             ? this.findEnvironment(this.ensureV4WorkspaceConfig(), environmentNameOrId)
@@ -1335,8 +1368,9 @@ export class ConfigService {
             if (!instance) throw new Error(`Workspace environment "${environment.name}" references missing global n8n-manager instance: ${target.managedInstanceId}`);
             const host = instance.baseUrl || instance.tunnelPublicUrl || '';
             const envApiKey = this.readEnvApiKey(environment, target);
+            const environmentApiKey = this.readEnvironmentApiKey(environment);
             const globalApiKey = this.manager.getApiKey(instance.id);
-            const apiKey = envApiKey || globalApiKey;
+            const apiKey = envApiKey || environmentApiKey || globalApiKey;
             const projectId = environment.projectId || instance.defaultProject?.id;
             const projectName = environment.projectName || instance.defaultProject?.name;
             const identity = this.resolveManagedEnvironmentIdentity(instance, host, apiKey);
@@ -1356,9 +1390,9 @@ export class ConfigService {
                 instance: this.toInstanceProfile(instance),
                 host,
                 apiKey,
-                apiKeySource: envApiKey ? 'env' : globalApiKey ? 'global' : 'missing',
+                apiKeySource: envApiKey ? 'env' : environmentApiKey ? 'workspace-environment' : globalApiKey ? 'global' : 'missing',
                 apiKeyAvailable: Boolean(apiKey),
-                accessStatus: this.deriveAccessStatus({ host, apiKey, projectId, projectName, verification: envApiKey ? undefined : instance.verification }),
+                accessStatus: this.deriveAccessStatus({ host, apiKey, projectId, projectName, verification: envApiKey || environmentApiKey ? undefined : instance.verification }),
                 nativeMcp: this.nativeMcpToSnapshot(environment.nativeMcp, environment.id),
                 workflowsPath,
                 syncFolder,
@@ -1380,9 +1414,10 @@ export class ConfigService {
 
         const host = target.url;
         const envApiKey = this.readEnvApiKey(environment, target);
+        const environmentApiKey = this.readEnvironmentApiKey(environment);
         const workspaceApiKey = this.manager.getApiKey(target.id);
         const globalApiKey = this.getApiKey(host);
-        const apiKey = envApiKey || workspaceApiKey || globalApiKey;
+        const apiKey = envApiKey || environmentApiKey || workspaceApiKey || globalApiKey;
         const identity = this.resolveExternalEnvironmentIdentity(target, apiKey);
         const workflowsPath = this.resolveEnvironmentWorkflowsPath(environment);
         const syncFolder = workflowsPath;
@@ -1398,9 +1433,9 @@ export class ConfigService {
             instance: target,
             host,
             apiKey,
-            apiKeySource: envApiKey ? 'env' : workspaceApiKey ? 'workspace-local' : globalApiKey ? 'global' : 'missing',
+            apiKeySource: envApiKey ? 'env' : environmentApiKey ? 'workspace-environment' : workspaceApiKey ? 'workspace-local' : globalApiKey ? 'global' : 'missing',
             apiKeyAvailable: Boolean(apiKey),
-            accessStatus: this.deriveAccessStatus({ host, apiKey, projectId: environment.projectId, projectName: environment.projectName, verification: target.verification }),
+            accessStatus: this.deriveAccessStatus({ host, apiKey, projectId: environment.projectId, projectName: environment.projectName, verification: envApiKey || environmentApiKey ? undefined : target.verification }),
             nativeMcp: this.nativeMcpToSnapshot(environment.nativeMcp, environment.id),
             workflowsPath,
             syncFolder,
@@ -1418,6 +1453,14 @@ export class ConfigService {
                 syncFolder: 'environment',
             },
         };
+    }
+
+    private readEnvironmentApiKey(environment: IWorkspaceEnvironment): string | undefined {
+        return cleanOptional(this.manager.getApiKey(this.environmentSecretKey(environment.id)));
+    }
+
+    private environmentSecretKey(environmentId: string): string {
+        return `environment:${environmentId}`;
     }
 
     private readEnvApiKey(environment: IWorkspaceEnvironment, target: IEnvironmentTarget): string | undefined {

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -491,6 +491,10 @@ export class ConfigService {
             environments: config.environments.map((item) => item.id === environment.id ? nextEnvironment : item),
         };
         this.writeWorkspaceConfigV4(next);
+        if (nextEnvironment.environmentTargetId !== environment.environmentTargetId) {
+            // The stored key belongs to the previous instance; it must never reach the new one.
+            this.manager.deleteApiKey(this.environmentSecretKey(environment.id));
+        }
         return nextEnvironment;
     }
 

--- a/packages/cli/tests/integration/instance-cli.integration.test.ts
+++ b/packages/cli/tests/integration/instance-cli.integration.test.ts
@@ -228,10 +228,50 @@ describe('CLI workspace integration', () => {
             environmentName: 'Dev',
             sourceKind: 'external-instance',
             apiKeyAvailable: true,
-            apiKeySource: 'workspace-local',
+            apiKeySource: 'workspace-environment',
         });
         expect(authOutput).not.toContain('dev-key');
     }, INTEGRATION_TIMEOUT);
+
+    it('keeps separate API keys for two environments on the same base URL', () => {
+        const workspaceDir = createTempDir('n8nac-cli-shared-url-workspace-');
+        const homeDir = createTempDir('n8nac-cli-shared-url-home-');
+
+        const prod = JSON.parse(runCli(workspaceDir, homeDir, [
+            'env', 'add', 'Prod',
+            '--base-url', 'https://shared.example.com',
+            '--workflows-path', 'workflows/prod',
+            '--json',
+        ]));
+        const preprod = JSON.parse(runCli(workspaceDir, homeDir, [
+            'env', 'add', 'Preprod',
+            '--base-url', 'https://shared.example.com',
+            '--workflows-path', 'workflows/preprod',
+            '--json',
+        ]));
+        expect(preprod.environmentTargetId).toBe(prod.environmentTargetId);
+
+        runCliWithInput(workspaceDir, homeDir, ['env', 'auth', 'set', 'Preprod', '--api-key-stdin', '--json'], 'preprod-key');
+        runCliWithInput(workspaceDir, homeDir, ['env', 'auth', 'set', 'Prod', '--api-key-stdin', '--json'], 'prod-key');
+
+        const secrets = JSON.parse(fs.readFileSync(path.join(homeDir, '.n8n-manager', 'secrets.json'), 'utf8'));
+        expect(secrets.instanceApiKeys[`environment:${prod.id}`]).toBe('prod-key');
+        expect(secrets.instanceApiKeys[`environment:${preprod.id}`]).toBe('preprod-key');
+
+        for (const name of ['Prod', 'Preprod']) {
+            expect(JSON.parse(runCli(workspaceDir, homeDir, ['env', 'status', name, '--json']))).toMatchObject({
+                environmentName: name,
+                apiKeyAvailable: true,
+                apiKeySource: 'workspace-environment',
+            });
+        }
+
+        const cleared = JSON.parse(runCli(workspaceDir, homeDir, ['env', 'auth', 'clear', 'Preprod', '--json']));
+        expect(cleared).toMatchObject({ environmentName: 'Preprod', apiKeyAvailable: false, apiKeySource: 'missing' });
+        expect(JSON.parse(runCli(workspaceDir, homeDir, ['env', 'status', 'Prod', '--json']))).toMatchObject({
+            apiKeySource: 'workspace-environment',
+        });
+    });
 
     it('configures native MCP assist per environment without committing the token', () => {
         const workspaceDir = createTempDir('n8nac-cli-native-mcp-workspace-');

--- a/packages/cli/tests/integration/instance-cli.integration.test.ts
+++ b/packages/cli/tests/integration/instance-cli.integration.test.ts
@@ -267,15 +267,91 @@ describe('CLI workspace integration', () => {
             });
         }
 
-        // Clearing an environment key falls back to the target key shared by both environments.
+        // Clearing an environment key leaves that environment with no credential. It must not fall
+        // back to `shared-key`, which was supplied as Prod's `--api-key` and belongs to Prod alone.
         const cleared = JSON.parse(runCli(workspaceDir, homeDir, ['env', 'auth', 'clear', 'Preprod', '--json']));
-        expect(cleared).toMatchObject({ environmentName: 'Preprod', apiKeyAvailable: true, apiKeySource: 'workspace-local' });
+        expect(cleared).toMatchObject({ environmentName: 'Preprod', apiKeyAvailable: false, apiKeySource: 'missing' });
         const secretsAfterClear = JSON.parse(fs.readFileSync(path.join(homeDir, '.n8n-manager', 'secrets.json'), 'utf8'));
         expect(secretsAfterClear.instanceApiKeys[`environment:${preprod.id}`]).toBeUndefined();
-        expect(secretsAfterClear.instanceApiKeys[prod.environmentTargetId]).toBe('shared-key');
+        expect(secretsAfterClear.instanceApiKeys[prod.environmentTargetId]).toBeUndefined();
         expect(JSON.parse(runCli(workspaceDir, homeDir, ['env', 'status', 'Prod', '--json']))).toMatchObject({
             apiKeySource: 'workspace-environment',
         });
+    });
+
+    it('never authenticates an environment with a credential supplied for another environment', () => {
+        const workspaceDir = createTempDir('n8nac-cli-key-leak-workspace-');
+        const homeDir = createTempDir('n8nac-cli-key-leak-home-');
+        const secretsPath = path.join(homeDir, '.n8n-manager', 'secrets.json');
+        const readSecrets = () => JSON.parse(fs.readFileSync(secretsPath, 'utf8')).instanceApiKeys;
+
+        const prod = JSON.parse(runCli(workspaceDir, homeDir, [
+            'env', 'add', 'Prod',
+            '--base-url', 'https://shared.example.com',
+            '--api-key', 'prod-key',
+            '--workflows-path', 'workflows/prod',
+            '--json',
+        ]));
+        const preprod = JSON.parse(runCli(workspaceDir, homeDir, [
+            'env', 'add', 'Preprod',
+            '--base-url', 'https://shared.example.com',
+            '--api-key', 'preprod-key',
+            '--workflows-path', 'workflows/preprod',
+            '--json',
+        ]));
+        expect(preprod.environmentTargetId).toBe(prod.environmentTargetId);
+
+        // Adding Preprod must not repoint the credential any other environment resolves.
+        expect(Object.values(readSecrets())).not.toContain('preprod-key-shared-slot');
+        expect(readSecrets()[prod.environmentTargetId]).toBeUndefined();
+        expect(JSON.parse(runCli(workspaceDir, homeDir, ['env', 'status', 'Prod', '--json']))).toMatchObject({
+            apiKeySource: 'workspace-environment',
+        });
+
+        // Clearing Prod's own key must leave Prod with no credential, never Preprod's.
+        const cleared = JSON.parse(runCli(workspaceDir, homeDir, ['env', 'auth', 'clear', 'Prod', '--json']));
+        expect(cleared).toMatchObject({
+            environmentName: 'Prod',
+            apiKeyAvailable: false,
+            apiKeySource: 'missing',
+        });
+        expect(readSecrets()[`environment:${prod.id}`]).toBeUndefined();
+        expect(readSecrets()[`environment:${preprod.id}`]).toBe('preprod-key');
+    });
+
+    it('does not repoint a key-less environment when another environment is added', () => {
+        const workspaceDir = createTempDir('n8nac-cli-key-flip-workspace-');
+        const homeDir = createTempDir('n8nac-cli-key-flip-home-');
+        const secretsPath = path.join(homeDir, '.n8n-manager', 'secrets.json');
+
+        const prod = JSON.parse(runCli(workspaceDir, homeDir, [
+            'env', 'add', 'Prod',
+            '--base-url', 'https://shared.example.com',
+            '--api-key', 'prod-key',
+            '--workflows-path', 'workflows/prod',
+            '--json',
+        ]));
+        runCli(workspaceDir, homeDir, [
+            'env', 'add', 'Shared',
+            '--base-url', 'https://shared.example.com',
+            '--workflows-path', 'workflows/shared',
+            '--json',
+        ]);
+        // The credential the key-less Shared environment would resolve, before Preprod exists.
+        const before = JSON.parse(fs.readFileSync(secretsPath, 'utf8')).instanceApiKeys[prod.environmentTargetId];
+
+        runCli(workspaceDir, homeDir, [
+            'env', 'add', 'Preprod',
+            '--base-url', 'https://shared.example.com',
+            '--api-key', 'preprod-key',
+            '--workflows-path', 'workflows/preprod',
+            '--json',
+        ]);
+        const after = JSON.parse(fs.readFileSync(secretsPath, 'utf8')).instanceApiKeys[prod.environmentTargetId];
+
+        // Adding Preprod must not change the credential the untouched Shared environment resolves.
+        expect(after).toBe(before);
+        expect(after).not.toBe('preprod-key');
     });
 
     it('does not carry an environment API key to a new base URL', () => {

--- a/packages/cli/tests/integration/instance-cli.integration.test.ts
+++ b/packages/cli/tests/integration/instance-cli.integration.test.ts
@@ -240,6 +240,7 @@ describe('CLI workspace integration', () => {
         const prod = JSON.parse(runCli(workspaceDir, homeDir, [
             'env', 'add', 'Prod',
             '--base-url', 'https://shared.example.com',
+            '--api-key', 'shared-key',
             '--workflows-path', 'workflows/prod',
             '--json',
         ]));
@@ -266,11 +267,29 @@ describe('CLI workspace integration', () => {
             });
         }
 
+        // Clearing an environment key falls back to the target key shared by both environments.
         const cleared = JSON.parse(runCli(workspaceDir, homeDir, ['env', 'auth', 'clear', 'Preprod', '--json']));
-        expect(cleared).toMatchObject({ environmentName: 'Preprod', apiKeyAvailable: false, apiKeySource: 'missing' });
+        expect(cleared).toMatchObject({ environmentName: 'Preprod', apiKeyAvailable: true, apiKeySource: 'workspace-local' });
+        const secretsAfterClear = JSON.parse(fs.readFileSync(path.join(homeDir, '.n8n-manager', 'secrets.json'), 'utf8'));
+        expect(secretsAfterClear.instanceApiKeys[`environment:${preprod.id}`]).toBeUndefined();
+        expect(secretsAfterClear.instanceApiKeys[prod.environmentTargetId]).toBe('shared-key');
         expect(JSON.parse(runCli(workspaceDir, homeDir, ['env', 'status', 'Prod', '--json']))).toMatchObject({
             apiKeySource: 'workspace-environment',
         });
+    });
+
+    it('rejects --api-key for managed instance environments', () => {
+        const workspaceDir = createTempDir('n8nac-cli-managed-key-workspace-');
+        const homeDir = createTempDir('n8nac-cli-managed-key-home-');
+
+        const failure = stripAnsi(runCliExpectFailure(workspaceDir, homeDir, [
+            'env', 'add', 'Local',
+            '--managed-instance', 'some-instance',
+            '--api-key', 'local-key',
+            '--workflows-path', 'workflows/local',
+            '--json',
+        ]));
+        expect(failure).toContain('Managed instance environments do not take an API key.');
     });
 
     it('configures native MCP assist per environment without committing the token', () => {

--- a/packages/cli/tests/integration/instance-cli.integration.test.ts
+++ b/packages/cli/tests/integration/instance-cli.integration.test.ts
@@ -278,6 +278,30 @@ describe('CLI workspace integration', () => {
         });
     });
 
+    it('does not carry an environment API key to a new base URL', () => {
+        const workspaceDir = createTempDir('n8nac-cli-move-url-workspace-');
+        const homeDir = createTempDir('n8nac-cli-move-url-home-');
+
+        const prod = JSON.parse(runCli(workspaceDir, homeDir, [
+            'env', 'add', 'Prod',
+            '--base-url', 'https://alpha.example.com',
+            '--api-key', 'alpha-key',
+            '--workflows-path', 'workflows/prod',
+            '--json',
+        ]));
+        runCli(workspaceDir, homeDir, ['env', 'update', 'Prod', '--base-url', 'https://beta.example.com', '--json']);
+
+        expect(JSON.parse(runCli(workspaceDir, homeDir, ['env', 'status', 'Prod', '--json']))).toMatchObject({
+            host: 'https://beta.example.com',
+            apiKeyAvailable: false,
+            apiKeySource: 'missing',
+        });
+
+        runCliWithInput(workspaceDir, homeDir, ['env', 'auth', 'set', 'Prod', '--api-key-stdin', '--json'], 'beta-key');
+        const secrets = JSON.parse(fs.readFileSync(path.join(homeDir, '.n8n-manager', 'secrets.json'), 'utf8'));
+        expect(secrets.instanceApiKeys[`environment:${prod.id}`]).toBe('beta-key');
+    });
+
     it('rejects --api-key for managed instance environments', () => {
         const workspaceDir = createTempDir('n8nac-cli-managed-key-workspace-');
         const homeDir = createTempDir('n8nac-cli-managed-key-home-');

--- a/packages/cli/tests/unit/config-service.test.ts
+++ b/packages/cli/tests/unit/config-service.test.ts
@@ -148,6 +148,125 @@ describe('ConfigService V4 workspace environments', () => {
         expect(() => configService.getWorkspaceConfig()).toThrow(/nativeMcp\.token must not contain secrets/);
     });
 
+    it('keeps one API key per environment when environments share a base URL', () => {
+        const configService = new ConfigService(workspaceRoot);
+        const target = configService.ensureEmbeddedInstanceTarget({
+            name: 'Shared',
+            url: 'https://n8n.example.test',
+        });
+        const prod = configService.addEnvironment({
+            name: 'Prod',
+            environmentTarget: target.id,
+            workflowsPath: 'workflows/prod',
+        });
+        const preprod = configService.addEnvironment({
+            name: 'Preprod',
+            environmentTarget: target.id,
+            workflowsPath: 'workflows/preprod',
+        });
+        expect(preprod.environmentTargetId).toBe(prod.environmentTargetId);
+
+        configService.saveWorkspaceEnvironmentApiKey(prod.id, 'prod-key');
+        configService.saveWorkspaceEnvironmentApiKey(preprod.id, 'preprod-key');
+
+        expect(configService.resolveEnvironment(prod.id)).toMatchObject({
+            apiKey: 'prod-key',
+            apiKeySource: 'workspace-environment',
+        });
+        expect(configService.resolveEnvironment(preprod.id)).toMatchObject({
+            apiKey: 'preprod-key',
+            apiKeySource: 'workspace-environment',
+        });
+        expect(configService.getWorkspaceEnvironmentApiKey(preprod.id)).toBe('preprod-key');
+    });
+
+    it('falls back to the environment target API key and lets the environment key win', () => {
+        const configService = new ConfigService(workspaceRoot);
+        const target = configService.ensureEmbeddedInstanceTarget({
+            name: 'Shared',
+            url: 'https://n8n.example.test',
+        });
+        const prod = configService.addEnvironment({
+            name: 'Prod',
+            environmentTarget: target.id,
+            workflowsPath: 'workflows/prod',
+        });
+        const preprod = configService.addEnvironment({
+            name: 'Preprod',
+            environmentTarget: target.id,
+            workflowsPath: 'workflows/preprod',
+        });
+        configService.saveWorkspaceTargetApiKey(target.id, 'target-key');
+
+        expect(configService.resolveEnvironment(preprod.id)).toMatchObject({
+            apiKey: 'target-key',
+            apiKeySource: 'workspace-local',
+        });
+
+        configService.saveWorkspaceEnvironmentApiKey(prod.id, 'prod-key');
+
+        expect(configService.resolveEnvironment(prod.id)).toMatchObject({
+            apiKey: 'prod-key',
+            apiKeySource: 'workspace-environment',
+        });
+        expect(configService.resolveEnvironment(preprod.id)).toMatchObject({
+            apiKey: 'target-key',
+            apiKeySource: 'workspace-local',
+        });
+    });
+
+    it('lets an environment variable override the stored environment API key', () => {
+        const configService = new ConfigService(workspaceRoot);
+        const target = configService.ensureEmbeddedInstanceTarget({
+            name: 'Shared',
+            url: 'https://n8n.example.test',
+        });
+        const prod = configService.addEnvironment({
+            name: 'Prod',
+            environmentTarget: target.id,
+            workflowsPath: 'workflows/prod',
+        });
+        configService.saveWorkspaceEnvironmentApiKey(prod.id, 'prod-key');
+
+        process.env.N8NAC_ENV_PROD_API_KEY = 'ci-key';
+        try {
+            expect(configService.resolveEnvironment(prod.id)).toMatchObject({
+                apiKey: 'ci-key',
+                apiKeySource: 'env',
+            });
+        } finally {
+            delete process.env.N8NAC_ENV_PROD_API_KEY;
+        }
+    });
+
+    it('drops the stored API key when an environment is removed', () => {
+        const configService = new ConfigService(workspaceRoot);
+        const target = configService.ensureEmbeddedInstanceTarget({
+            name: 'Shared',
+            url: 'https://n8n.example.test',
+        });
+        configService.addEnvironment({
+            name: 'Prod',
+            id: 'prod',
+            environmentTarget: target.id,
+            workflowsPath: 'workflows/prod',
+        });
+        configService.saveWorkspaceEnvironmentApiKey('prod', 'prod-key');
+        configService.removeEnvironment('prod', { force: true });
+
+        const recreated = configService.addEnvironment({
+            name: 'Prod',
+            id: 'prod',
+            environmentTarget: target.id,
+            workflowsPath: 'workflows/prod',
+        });
+
+        expect(configService.resolveEnvironment(recreated.id)).toMatchObject({
+            apiKeyAvailable: false,
+            apiKeySource: 'missing',
+        });
+    });
+
     it('prepares a string-requested workspace environment', async () => {
         const configService = new ConfigService(workspaceRoot);
         const devTarget = configService.ensureEmbeddedInstanceTarget({

--- a/packages/cli/tests/unit/config-service.test.ts
+++ b/packages/cli/tests/unit/config-service.test.ts
@@ -215,6 +215,34 @@ describe('ConfigService V4 workspace environments', () => {
         });
     });
 
+    it('leaves an environment without a credential when its own key is cleared', () => {
+        const configService = new ConfigService(workspaceRoot);
+        const target = configService.ensureEmbeddedInstanceTarget({
+            name: 'Shared',
+            url: 'https://n8n.example.test',
+        });
+        const prod = configService.addEnvironment({
+            name: 'Prod',
+            environmentTarget: target.id,
+            workflowsPath: 'workflows/prod',
+        });
+        const preprod = configService.addEnvironment({
+            name: 'Preprod',
+            environmentTarget: target.id,
+            workflowsPath: 'workflows/preprod',
+        });
+        configService.saveWorkspaceEnvironmentApiKey(prod.id, 'prod-key');
+        configService.saveWorkspaceEnvironmentApiKey(preprod.id, 'preprod-key');
+
+        configService.deleteWorkspaceEnvironmentApiKey(prod.id);
+
+        // Clearing Prod must not hand Prod the credential stored for Preprod.
+        const resolved = configService.resolveEnvironment(prod.id);
+        expect(resolved.apiKey).toBeUndefined();
+        expect(resolved).toMatchObject({ apiKeyAvailable: false, apiKeySource: 'missing' });
+        expect(configService.getWorkspaceEnvironmentApiKey(preprod.id)).toBe('preprod-key');
+    });
+
     it('lets an environment variable override the stored environment API key', () => {
         const configService = new ConfigService(workspaceRoot);
         const target = configService.ensureEmbeddedInstanceTarget({

--- a/packages/cli/tests/unit/config-service.test.ts
+++ b/packages/cli/tests/unit/config-service.test.ts
@@ -228,6 +228,7 @@ describe('ConfigService V4 workspace environments', () => {
         });
         configService.saveWorkspaceEnvironmentApiKey(prod.id, 'prod-key');
 
+        const previousEnvApiKey = process.env.N8NAC_ENV_PROD_API_KEY;
         process.env.N8NAC_ENV_PROD_API_KEY = 'ci-key';
         try {
             expect(configService.resolveEnvironment(prod.id)).toMatchObject({
@@ -235,7 +236,11 @@ describe('ConfigService V4 workspace environments', () => {
                 apiKeySource: 'env',
             });
         } finally {
-            delete process.env.N8NAC_ENV_PROD_API_KEY;
+            if (previousEnvApiKey === undefined) {
+                delete process.env.N8NAC_ENV_PROD_API_KEY;
+            } else {
+                process.env.N8NAC_ENV_PROD_API_KEY = previousEnvApiKey;
+            }
         }
     });
 

--- a/packages/cli/tests/unit/config-service.test.ts
+++ b/packages/cli/tests/unit/config-service.test.ts
@@ -244,6 +244,54 @@ describe('ConfigService V4 workspace environments', () => {
         }
     });
 
+    it('drops the stored API key when an environment moves to another target', () => {
+        const configService = new ConfigService(workspaceRoot);
+        const alpha = configService.ensureEmbeddedInstanceTarget({
+            name: 'Alpha',
+            url: 'https://alpha.example.test',
+        });
+        const beta = configService.ensureEmbeddedInstanceTarget({
+            name: 'Beta',
+            url: 'https://beta.example.test',
+        });
+        const environment = configService.addEnvironment({
+            name: 'Prod',
+            environmentTarget: alpha.id,
+            workflowsPath: 'workflows/prod',
+        });
+        configService.saveWorkspaceEnvironmentApiKey(environment.id, 'alpha-key');
+
+        configService.updateEnvironment(environment.id, { environmentTarget: beta.id });
+
+        expect(configService.resolveEnvironment(environment.id)).toMatchObject({
+            host: 'https://beta.example.test',
+            apiKeyAvailable: false,
+            apiKeySource: 'missing',
+        });
+        expect(configService.getWorkspaceEnvironmentApiKey(environment.id)).toBeUndefined();
+    });
+
+    it('keeps the stored API key when an environment is updated on the same target', () => {
+        const configService = new ConfigService(workspaceRoot);
+        const target = configService.ensureEmbeddedInstanceTarget({
+            name: 'Alpha',
+            url: 'https://alpha.example.test',
+        });
+        const environment = configService.addEnvironment({
+            name: 'Prod',
+            environmentTarget: target.id,
+            workflowsPath: 'workflows/prod',
+        });
+        configService.saveWorkspaceEnvironmentApiKey(environment.id, 'alpha-key');
+
+        configService.updateEnvironment(environment.id, { description: 'Production' });
+
+        expect(configService.resolveEnvironment(environment.id)).toMatchObject({
+            apiKey: 'alpha-key',
+            apiKeySource: 'workspace-environment',
+        });
+    });
+
     it('drops the stored API key when an environment is removed', () => {
         const configService = new ConfigService(workspaceRoot);
         const target = configService.ensureEmbeddedInstanceTarget({

--- a/packages/skills/src/agent-skills/n8n-architect/SKILL.md
+++ b/packages/skills/src/agent-skills/n8n-architect/SKILL.md
@@ -82,6 +82,7 @@ Use `{{N8NAC_CMD}} env ...` for workspace environments, remote URLs, active envi
 
 - Prefer `--api-key-stdin` for API keys.
 - Do not pass secrets inline in shell arguments.
+- `env auth set` binds the key to one environment, so several environments may share a base URL with one key each. Run it once per environment; `apiKeySource` in `env status --json` is `workspace-environment` when the environment uses its own key.
 - Do not ask for host/API key when the user wants a managed local Docker instance.
 - Do not print API keys or credential secret values back to the user.
 - If a command or flag is unfamiliar, run `{{N8NAC_CMD}} env --help` or `{{N8NAC_CMD}} env <subcommand> --help`.

--- a/packages/vscode-extension/src/ui/configuration-webview.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview.ts
@@ -390,7 +390,11 @@ export class ConfigurationWebview {
               });
             }
           }
-          if (environmentTargetId && url && apiKey) {
+          if (environmentTargetId && configService.getInstanceTarget(environmentTargetId).kind === 'managed-instance') {
+            // A managed instance owns its credentials, so a workspace key stored against it would
+            // never be read. Drop any legacy one instead of persisting a dead secret.
+            configService.deleteWorkspaceTargetApiKey(environmentTargetId);
+          } else if (environmentTargetId && url && apiKey) {
             configService.saveWorkspaceTargetApiKey(environmentTargetId, apiKey);
           }
           const workflowsPath = normalizeWorkflowsPath(String(payload.workflowsPath || '').trim());

--- a/packages/vscode-extension/src/ui/configuration-webview.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview.ts
@@ -417,17 +417,13 @@ export class ConfigurationWebview {
           const savedEnvironment = environmentId
             ? configService.updateEnvironment(environmentId, input)
             : configService.addEnvironment(input);
-          const savedTargetKind = configService.getInstanceTarget(savedEnvironment.environmentTargetId).kind;
-          const savedTargetChanged = Boolean(existingEnvironmentTargetId && savedEnvironment.environmentTargetId !== existingEnvironmentTargetId);
-          if (savedTargetKind === 'managed-instance') {
+          // Moving an environment to another target already drops its stored key in updateEnvironment.
+          if (configService.getInstanceTarget(savedEnvironment.environmentTargetId).kind === 'managed-instance') {
             // Managed instances own their credentials, so this environment must not keep a workspace key.
             configService.deleteWorkspaceEnvironmentApiKey(savedEnvironment.id);
           } else if (apiKey) {
             // Bind the key to this environment so environments sharing a base URL keep separate credentials.
             configService.saveWorkspaceEnvironmentApiKey(savedEnvironment.id, apiKey);
-          } else if (savedTargetChanged) {
-            // Moving an environment to another target must not carry the previous target credential over.
-            configService.deleteWorkspaceEnvironmentApiKey(savedEnvironment.id);
           }
           if (nativeMcpToken) {
             (configService as NativeMcpConfigService).saveNativeMcpToken(savedEnvironment.id, nativeMcpToken);

--- a/packages/vscode-extension/src/ui/configuration-webview.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview.ts
@@ -394,9 +394,11 @@ export class ConfigurationWebview {
             // A managed instance owns its credentials, so a workspace key stored against it would
             // never be read. Drop any legacy one instead of persisting a dead secret.
             configService.deleteWorkspaceTargetApiKey(environmentTargetId);
-          } else if (environmentTargetId && url && apiKey) {
-            configService.saveWorkspaceTargetApiKey(environmentTargetId, apiKey);
           }
+          // The key entered here belongs to this one environment and is stored against it below.
+          // It must not also be written to the shared environment target, which every key-less
+          // environment on the same base URL reads: that would let one environment silently
+          // authenticate as another, and each save would repoint every environment sharing the URL.
           const workflowsPath = normalizeWorkflowsPath(String(payload.workflowsPath || '').trim());
           const folderSync = typeof payload.folderSync === 'boolean' ? payload.folderSync : undefined;
           const nativeMcpToken = String(payload.nativeMcpToken || '').trim();

--- a/packages/vscode-extension/src/ui/configuration-webview.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview.ts
@@ -417,9 +417,17 @@ export class ConfigurationWebview {
           const savedEnvironment = environmentId
             ? configService.updateEnvironment(environmentId, input)
             : configService.addEnvironment(input);
-          if (apiKey) {
+          const savedTargetKind = configService.getInstanceTarget(savedEnvironment.environmentTargetId).kind;
+          const savedTargetChanged = Boolean(existingEnvironmentTargetId && savedEnvironment.environmentTargetId !== existingEnvironmentTargetId);
+          if (savedTargetKind === 'managed-instance') {
+            // Managed instances own their credentials, so this environment must not keep a workspace key.
+            configService.deleteWorkspaceEnvironmentApiKey(savedEnvironment.id);
+          } else if (apiKey) {
             // Bind the key to this environment so environments sharing a base URL keep separate credentials.
             configService.saveWorkspaceEnvironmentApiKey(savedEnvironment.id, apiKey);
+          } else if (savedTargetChanged) {
+            // Moving an environment to another target must not carry the previous target credential over.
+            configService.deleteWorkspaceEnvironmentApiKey(savedEnvironment.id);
           }
           if (nativeMcpToken) {
             (configService as NativeMcpConfigService).saveNativeMcpToken(savedEnvironment.id, nativeMcpToken);

--- a/packages/vscode-extension/src/ui/configuration-webview.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview.ts
@@ -417,6 +417,10 @@ export class ConfigurationWebview {
           const savedEnvironment = environmentId
             ? configService.updateEnvironment(environmentId, input)
             : configService.addEnvironment(input);
+          if (apiKey) {
+            // Bind the key to this environment so environments sharing a base URL keep separate credentials.
+            configService.saveWorkspaceEnvironmentApiKey(savedEnvironment.id, apiKey);
+          }
           if (nativeMcpToken) {
             (configService as NativeMcpConfigService).saveNativeMcpToken(savedEnvironment.id, nativeMcpToken);
           } else if (nativeMcp && nativeMcp.enabled === false) {

--- a/plugins/claude/n8n-as-code/skills/n8n-architect/SKILL.md
+++ b/plugins/claude/n8n-as-code/skills/n8n-architect/SKILL.md
@@ -82,6 +82,7 @@ npx --yes n8nac env use <name>
 
 - Prefer `--api-key-stdin` for API keys.
 - Do not pass secrets inline in shell arguments.
+- `env auth set` binds the key to one environment, so several environments may share a base URL with one key each. Run it once per environment; `apiKeySource` in `env status --json` is `workspace-environment` when the environment uses its own key.
 - Do not ask for host/API key when the user wants a managed local Docker instance.
 - Do not print API keys or credential secret values back to the user.
 - If a command or flag is unfamiliar, run `npx --yes n8nac env --help` or `npx --yes n8nac env <subcommand> --help`.

--- a/plugins/cursor/n8n-as-code/skills/n8n-architect/SKILL.md
+++ b/plugins/cursor/n8n-as-code/skills/n8n-architect/SKILL.md
@@ -82,6 +82,7 @@ npx --yes n8nac env use <name>
 
 - Prefer `--api-key-stdin` for API keys.
 - Do not pass secrets inline in shell arguments.
+- `env auth set` binds the key to one environment, so several environments may share a base URL with one key each. Run it once per environment; `apiKeySource` in `env status --json` is `workspace-environment` when the environment uses its own key.
 - Do not ask for host/API key when the user wants a managed local Docker instance.
 - Do not print API keys or credential secret values back to the user.
 - If a command or flag is unfamiliar, run `npx --yes n8nac env --help` or `npx --yes n8nac env <subcommand> --help`.

--- a/plugins/openclaw/n8n-as-code/skills/n8n-architect/SKILL.md
+++ b/plugins/openclaw/n8n-as-code/skills/n8n-architect/SKILL.md
@@ -82,6 +82,7 @@ npx --yes n8nac env use <name>
 
 - Prefer `--api-key-stdin` for API keys.
 - Do not pass secrets inline in shell arguments.
+- `env auth set` binds the key to one environment, so several environments may share a base URL with one key each. Run it once per environment; `apiKeySource` in `env status --json` is `workspace-environment` when the environment uses its own key.
 - Do not ask for host/API key when the user wants a managed local Docker instance.
 - Do not print API keys or credential secret values back to the user.
 - If a command or flag is unfamiliar, run `npx --yes n8nac env --help` or `npx --yes n8nac env <subcommand> --help`.

--- a/skills/n8n-architect/SKILL.md
+++ b/skills/n8n-architect/SKILL.md
@@ -82,6 +82,7 @@ npx --yes n8nac env use <name>
 
 - Prefer `--api-key-stdin` for API keys.
 - Do not pass secrets inline in shell arguments.
+- `env auth set` binds the key to one environment, so several environments may share a base URL with one key each. Run it once per environment; `apiKeySource` in `env status --json` is `workspace-environment` when the environment uses its own key.
 - Do not ask for host/API key when the user wants a managed local Docker instance.
 - Do not print API keys or credential secret values back to the user.
 - If a command or flag is unfamiliar, run `npx --yes n8nac env --help` or `npx --yes n8nac env <subcommand> --help`.


### PR DESCRIPTION
**What does this PR do?**

Two n8nac environments pointing at the same n8n base URL ended up authenticating with the same API key, so one environment could see the other account's workflows.

Root cause is two behaviours combining:

1. `ensureEmbeddedInstanceTarget` de-duplicates external targets by normalized base URL, so `env add prod --base-url X` and `env add preprod --base-url X` share one environment target.
2. API keys were stored per **target id**, and `env auth set <env>` wrote to `environment.environmentTargetId` — so the second `env auth set` overwrote the first.

Keys are now stored per **environment** (`environment:<environmentId>` in the n8n-manager secret store) and resolved most-specific-first, for remote environments:

| `apiKeySource` | source |
|---|---|
| `env` | `N8NAC_ENV_*` / `N8NAC_TARGET_*` variable |
| `workspace-environment` | **new** — key stored for this one environment |
| `workspace-local` | key stored on the shared target |
| `global` | global n8n-manager instance matching the host |

- `env auth set <env>` writes the environment-scoped key only — that alone fixes the reported repro.
- `env add/update --base-url --api-key` writes **both** the environment key and the target key, so a later key-less environment on the same URL still inherits one (prod/preprod under a single account would otherwise regress).
- New `env auth clear <env>` drops an environment key and falls back down the chain.
- Removing an environment deletes its stored key.
- A shared target's verification status is no longer applied to an environment authenticating with its own key.
- The VS Code environment editor binds keys per environment too.

Managed local instances own their credentials, so those environments never carry a workspace-stored key: `env auth set` and `env add/update --api-key` are rejected for them, and resolution ignores any environment-scoped leftovers.

Existing workspaces need one `env auth set` per environment after upgrading; the old shared target key survives as a fallback for environments that are not re-keyed.

**Tests**

- 4 new `ConfigService` unit tests: isolation across a shared target, target fallback, env-var precedence, key cleanup on environment removal.
- New CLI integration tests: two environments on one base URL land under distinct secret entries, `env auth clear` falls back to the target key, and `--api-key` is rejected for managed instances.
- Full CLI suite green (160 tests); manually verified the issue's repro against the built CLI.

Also adds `shell: process.platform === 'win32'` to the `npm run build` hook in two integration test files — node refuses to spawn `npm.cmd` without a shell, so those files could not run on Windows at all. No effect on Linux CI.

Closes #562

> Base branch: targets `main` per maintainer decision. `CONTRIBUTING.md` and the PR template still say `next`, but `origin/next` is currently 14 commits behind `main` (it sits at this branch's merge-base), and recent merged PRs — including feature PR #532 — all targeted `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API keys can now be stored and managed separately for each environment, even when environments share a base URL.
  * Added `env auth clear` to remove an environment-specific API key.
  * Environment status now identifies the source of the resolved credentials.
  * Managed-instance environments reject API-key configuration.

* **Bug Fixes**
  * Prevented credentials from leaking between environments or persisting after target changes.

* **Documentation**
  * Added setup guidance and troubleshooting information for environment-specific authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->