### PR TITLE
fix(vscode): honor extra CA certificates when connecting to n8n

### DIFF
--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -36,6 +36,40 @@ n8nac env auth set <environment> --api-key-stdin
 - Store it again with `n8nac env auth set <environment> --api-key-stdin`.
 - Confirm the API key has access to the selected project.
 
+### Self-signed certificate or private CA
+
+Symptom: `unable to verify the first certificate`, `self-signed certificate in certificate chain`,
+or `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` when connecting to an HTTPS instance.
+
+Point n8n-as-code at the PEM bundle that holds your root CA:
+
+```bash
+export NODE_EXTRA_CA_CERTS=/path/to/root-ca.pem
+```
+
+`N8NAC_EXTRA_CA_CERTS` works the same way and accepts several paths separated by the platform
+path delimiter, a comma, or a newline.
+
+In the **VS Code extension** the environment variable is often not enough. The extension host is
+an Electron process: it ignores `NODE_EXTRA_CA_CERTS` and cannot be started with Node's
+`--use-system-ca` flag, which is why `n8nac` succeeds in the terminal while auto-load fails.
+Set the bundle in your VS Code settings instead — relative paths resolve against the workspace
+folder — and reload is not required:
+
+```json
+{
+  "n8n.tls.certificateAuthorities": ["/path/to/root-ca.pem"]
+}
+```
+
+If the root CA is only reachable from the operating system trust store, set
+`"n8n.tls.useSystemCertificateAuthorities": true` as well. It is off by default because the OS
+store holds hundreds of anchors that are re-applied to every TLS handshake, and it needs a host
+running Node 22.15 or newer.
+
+The n8n-as-code output channel lists every anchor that was loaded and every bundle that could not
+be read.
+
 ## Missing Configuration
 
 ### `n8nac-config.json` not found

--- a/packages/cli/src/core/index.ts
+++ b/packages/cli/src/core/index.ts
@@ -11,6 +11,7 @@ export * from './services/sync-event-journal.js';
 export * from './services/directory-utils.js';
 export * from './services/workflow-dir-name.js';
 export * from './services/instance-identifier.js';
+export * from './services/tls-certificates.js';
 export * from './services/workspace-setup-service.js';
 export * from './helpers/index.js';
 

--- a/packages/cli/src/core/services/tls-certificates.ts
+++ b/packages/cli/src/core/services/tls-certificates.ts
@@ -1,0 +1,256 @@
+import * as fs from 'fs';
+import { createRequire } from 'module';
+import * as path from 'path';
+import * as tls from 'tls';
+
+/**
+ * Additional trust anchors for outbound HTTPS.
+ *
+ * Node honours `NODE_EXTRA_CA_CERTS` and `--use-system-ca` when it builds the default
+ * TLS trust store, but only when the process is a stock Node build that is started with
+ * those settings. The VS Code extension host is neither: it is an Electron process
+ * (BoringSSL, no `NODE_EXTRA_CA_CERTS` support) that users cannot pass Node flags to.
+ * The same gap exists for anything reaching n8n through the global `fetch`
+ * (`@n8n-as-code/n8n-manager-core` health probes, project listing, credential REST calls),
+ * because `fetch` ignores `https.Agent` options entirely.
+ *
+ * So we read the certificates ourselves and append them to every secure context the
+ * process creates, which covers axios, `fetch`, `ws` and `http-proxy` in one place.
+ */
+
+const PEM_CERTIFICATE_PATTERN = /-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g;
+
+/** Read in addition to Node's own `NODE_EXTRA_CA_CERTS`; accepts several paths. */
+export const N8NAC_EXTRA_CA_CERTS_ENV = 'N8NAC_EXTRA_CA_CERTS';
+
+export interface IExtraCaCertificateOptions {
+    /** Explicit PEM bundle paths, e.g. from the `n8n.tls.certificateAuthorities` setting. */
+    caFiles?: string[];
+    /** Mirror Node's `--use-system-ca` by adding the OS trust store when the host exposes it. */
+    useSystemCertificateAuthorities?: boolean;
+    /** Directory used to resolve relative paths. Defaults to `process.cwd()`. */
+    baseDir?: string;
+    env?: NodeJS.ProcessEnv;
+}
+
+export interface IExtraCaCertificateResolution {
+    /** Deduplicated PEM certificate blocks, in discovery order. */
+    certificates: string[];
+    /** Human-readable description of every source that contributed certificates. */
+    sources: string[];
+    /** Non-fatal problems (missing file, unreadable file, file without any PEM block). */
+    errors: string[];
+}
+
+export interface IExtraCaCertificateInstallation extends IExtraCaCertificateResolution {
+    /** `true` once secure contexts in this process carry the extra certificates. */
+    installed: boolean;
+}
+
+/** The subset of the `tls` module the installer touches, so tests can supply a stub. */
+export interface ISecureContextHost {
+    createSecureContext(options?: tls.SecureContextOptions): tls.SecureContext;
+}
+
+interface IPatchState {
+    original: ISecureContextHost['createSecureContext'];
+    certificates: string[];
+}
+
+const patchedHosts = new WeakMap<ISecureContextHost, IPatchState>();
+
+let defaultSecureContextHost: ISecureContextHost | undefined;
+
+/**
+ * The mutable `tls` module object.
+ *
+ * `import * as tls` yields a frozen module namespace, so the patch has to go through the
+ * CommonJS export object that `https`, `ws` and undici's `fetch` all read from.
+ */
+function getDefaultSecureContextHost(): ISecureContextHost {
+    defaultSecureContextHost ??= createRequire(import.meta.url)('tls') as ISecureContextHost;
+    return defaultSecureContextHost;
+}
+
+/**
+ * Split a path list. Accepts the platform delimiter, commas and newlines so a single
+ * setting works whether it was copied from a shell variable or typed by hand.
+ */
+export function splitCertificatePathList(value: string): string[] {
+    return value
+        .split(new RegExp(`[${escapeForCharacterClass(path.delimiter)},\\r\\n]`))
+        .map((entry) => entry.trim().replace(/^["']|["']$/g, ''))
+        .filter((entry) => entry.length > 0);
+}
+
+function escapeForCharacterClass(value: string): string {
+    return value.replace(/[\\\]^-]/g, '\\$&');
+}
+
+/** Extract every PEM certificate block from a bundle, ignoring keys and comments. */
+export function extractPemCertificates(contents: string): string[] {
+    return contents.match(PEM_CERTIFICATE_PATTERN) ?? [];
+}
+
+function readCertificateFile(filePath: string, resolution: IExtraCaCertificateResolution, label: string): void {
+    let contents: string;
+    try {
+        contents = fs.readFileSync(filePath, 'utf8');
+    } catch (error: any) {
+        resolution.errors.push(`${label}: cannot read "${filePath}" (${error?.code || error?.message || error})`);
+        return;
+    }
+
+    const certificates = extractPemCertificates(contents);
+    if (!certificates.length) {
+        resolution.errors.push(`${label}: "${filePath}" does not contain any PEM certificate`);
+        return;
+    }
+
+    addCertificates(resolution, certificates, `${label}: ${filePath}`);
+}
+
+function addCertificates(resolution: IExtraCaCertificateResolution, certificates: string[], source: string): void {
+    let added = 0;
+    for (const certificate of certificates) {
+        const normalized = certificate.trim();
+        if (!normalized || resolution.certificates.includes(normalized)) continue;
+        resolution.certificates.push(normalized);
+        added++;
+    }
+    if (added > 0) {
+        resolution.sources.push(`${source} (${added})`);
+    }
+}
+
+function readSystemCertificates(resolution: IExtraCaCertificateResolution): void {
+    // Node 22.15+/24 only. Older hosts (and Electron) simply do not expose it, which is the
+    // expected state rather than a misconfiguration, so it is not reported as an error.
+    const getCACertificates = (tls as unknown as {
+        getCACertificates?: (type: string) => string[];
+    }).getCACertificates;
+    if (typeof getCACertificates !== 'function') {
+        return;
+    }
+
+    try {
+        addCertificates(resolution, getCACertificates('system'), 'system trust store');
+    } catch (error: any) {
+        resolution.errors.push(`system trust store: ${error?.message || error}`);
+    }
+}
+
+/**
+ * Collect the extra trust anchors from settings, `N8NAC_EXTRA_CA_CERTS`,
+ * `NODE_EXTRA_CA_CERTS` and — on request — the OS trust store.
+ */
+export function resolveExtraCaCertificates(options: IExtraCaCertificateOptions = {}): IExtraCaCertificateResolution {
+    const env = options.env ?? process.env;
+    const baseDir = options.baseDir ?? process.cwd();
+    const resolution: IExtraCaCertificateResolution = { certificates: [], sources: [], errors: [] };
+
+    const resolvePath = (candidate: string) => (path.isAbsolute(candidate) ? candidate : path.resolve(baseDir, candidate));
+
+    for (const candidate of options.caFiles ?? []) {
+        for (const filePath of splitCertificatePathList(candidate)) {
+            readCertificateFile(resolvePath(filePath), resolution, 'setting');
+        }
+    }
+
+    for (const filePath of splitCertificatePathList(env[N8NAC_EXTRA_CA_CERTS_ENV] ?? '')) {
+        readCertificateFile(resolvePath(filePath), resolution, N8NAC_EXTRA_CA_CERTS_ENV);
+    }
+
+    for (const filePath of splitCertificatePathList(env.NODE_EXTRA_CA_CERTS ?? '')) {
+        readCertificateFile(resolvePath(filePath), resolution, 'NODE_EXTRA_CA_CERTS');
+    }
+
+    if (options.useSystemCertificateAuthorities) {
+        readSystemCertificates(resolution);
+    }
+
+    return resolution;
+}
+
+/**
+ * Append the resolved certificates to every secure context created from now on.
+ *
+ * Idempotent: calling it again replaces the certificate set instead of stacking another
+ * wrapper, so it is safe to re-run whenever the configuration changes.
+ */
+export function installExtraCaCertificates(
+    options: IExtraCaCertificateOptions = {},
+    host: ISecureContextHost = getDefaultSecureContextHost(),
+): IExtraCaCertificateInstallation {
+    const resolution = resolveExtraCaCertificates(options);
+
+    const existing = patchedHosts.get(host);
+    if (existing) {
+        existing.certificates = resolution.certificates;
+        return { ...resolution, installed: resolution.certificates.length > 0 };
+    }
+
+    if (!resolution.certificates.length) {
+        // Nothing to trust yet — leave the runtime untouched rather than wrapping it for nothing.
+        return { ...resolution, installed: false };
+    }
+
+    const state: IPatchState = {
+        original: host.createSecureContext,
+        certificates: resolution.certificates,
+    };
+    patchedHosts.set(host, state);
+
+    host.createSecureContext = (contextOptions?: tls.SecureContextOptions) => {
+        const context = state.original.call(host, contextOptions);
+        const nativeContext = (context as unknown as { context?: { addCACert?: (pem: string) => void } }).context;
+        if (typeof nativeContext?.addCACert !== 'function') {
+            return context;
+        }
+        for (const certificate of state.certificates) {
+            try {
+                nativeContext.addCACert(certificate);
+            } catch {
+                // A malformed or duplicate anchor must not break the whole handshake.
+            }
+        }
+        return context;
+    };
+
+    return { ...resolution, installed: true };
+}
+
+/** Certificates currently appended by the installer, for diagnostics and tests. */
+export function getInstalledExtraCaCertificates(host: ISecureContextHost = getDefaultSecureContextHost()): string[] {
+    return [...(patchedHosts.get(host)?.certificates ?? [])];
+}
+
+/** Restore the untouched `createSecureContext`. Intended for tests. */
+export function uninstallExtraCaCertificates(host: ISecureContextHost = getDefaultSecureContextHost()): void {
+    const state = patchedHosts.get(host);
+    if (!state) return;
+    host.createSecureContext = state.original;
+    patchedHosts.delete(host);
+}
+
+/** `true` when the error is a TLS trust failure rather than a transport or HTTP error. */
+export function isCertificateTrustError(error: any): boolean {
+    const code = typeof error?.code === 'string' ? error.code : '';
+    if (code.startsWith('UNABLE_TO_') || code.startsWith('SELF_SIGNED') || code.startsWith('DEPTH_ZERO_')) {
+        return true;
+    }
+    if (code === 'CERT_HAS_EXPIRED' || code === 'ERR_TLS_CERT_ALTNAME_INVALID' || code === 'CERT_SIGNATURE_FAILURE') {
+        return true;
+    }
+    if (error?.cause && error.cause !== error && isCertificateTrustError(error.cause)) {
+        return true;
+    }
+    const message = String(error?.message ?? error ?? '');
+    return /unable to (get|verify)|self[- ]signed certificate|certificate has expired|CERT_/i.test(message);
+}
+
+/** Guidance appended to connection errors caused by an untrusted certificate. */
+export const CERTIFICATE_TRUST_HINT =
+    'The certificate is not trusted by this process. Point "n8n.tls.certificateAuthorities" '
+    + '(or the NODE_EXTRA_CA_CERTS environment variable) at the PEM bundle holding your root CA, then retry. '
+    + 'The VS Code extension host cannot read Node\'s --use-system-ca flag, so the setting is the reliable path there.';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,6 +20,7 @@ import { parsePositiveIntegerOption } from './utils/option-parsers.js';
 import { spawn } from 'child_process';
 import { createN8nManagerFacade } from '@n8n-as-code/manager-adapter';
 import { ConfigService } from './services/config-service.js';
+import { installExtraCaCertificates } from './core/services/tls-certificates.js';
 import {
     N8N_FACADE_SETUP_MODES,
     isN8nFacadeSetupMode,
@@ -281,6 +282,12 @@ async function runMcpDiagnosticCommand(
         });
     });
 }
+
+// Trust anchors must be in place before the first outbound request. Node already applies
+// NODE_EXTRA_CA_CERTS to its own trust store, but re-reading it here keeps the CLI and the
+// VS Code extension host — which cannot honour it — on identical behaviour, and adds the
+// multi-path N8NAC_EXTRA_CA_CERTS form. The OS store stays with Node's own --use-system-ca.
+installExtraCaCertificates();
 
 const program = new Command();
 const telemetry = createTelemetryClient({ facade: 'cli', version: getVersion() });

--- a/packages/cli/tests/unit/tls-certificates.test.ts
+++ b/packages/cli/tests/unit/tls-certificates.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type * as tls from 'tls';
+import {
+    CERTIFICATE_TRUST_HINT,
+    N8NAC_EXTRA_CA_CERTS_ENV,
+    extractPemCertificates,
+    getInstalledExtraCaCertificates,
+    installExtraCaCertificates,
+    isCertificateTrustError,
+    resolveExtraCaCertificates,
+    splitCertificatePathList,
+    uninstallExtraCaCertificates,
+    type ISecureContextHost,
+} from '../../src/core/services/tls-certificates.js';
+
+function pem(label: string): string {
+    return `-----BEGIN CERTIFICATE-----\n${label}\n-----END CERTIFICATE-----`;
+}
+
+/** Stands in for the `tls` module so the assertions never touch the real process trust store. */
+function createSecureContextHost(): { host: ISecureContextHost; added: string[]; createdWith: unknown[] } {
+    const added: string[] = [];
+    const createdWith: unknown[] = [];
+    const host: ISecureContextHost = {
+        createSecureContext(options?: tls.SecureContextOptions) {
+            createdWith.push(options);
+            return { context: { addCACert: (certificate: string) => { added.push(certificate); } } } as unknown as tls.SecureContext;
+        },
+    };
+    return { host, added, createdWith };
+}
+
+describe('tls-certificates', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-tls-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    function writeBundle(name: string, ...labels: string[]): string {
+        const filePath = path.join(tempDir, name);
+        fs.writeFileSync(filePath, labels.map(pem).join('\n'), 'utf8');
+        return filePath;
+    }
+
+    describe('splitCertificatePathList', () => {
+        it('splits on the platform delimiter, commas and newlines, and strips quotes', () => {
+            const value = `"/a/first.pem"${path.delimiter}/b/second.pem,/c/third.pem\n/d/fourth.pem`;
+            expect(splitCertificatePathList(value)).toEqual([
+                '/a/first.pem',
+                '/b/second.pem',
+                '/c/third.pem',
+                '/d/fourth.pem',
+            ]);
+        });
+
+        it('drops empty segments', () => {
+            expect(splitCertificatePathList(`  ${path.delimiter},,\n `)).toEqual([]);
+        });
+    });
+
+    describe('extractPemCertificates', () => {
+        it('keeps only certificate blocks', () => {
+            const bundle = [
+                '# comment line',
+                pem('AAA'),
+                '-----BEGIN PRIVATE KEY-----\nSECRET\n-----END PRIVATE KEY-----',
+                pem('BBB'),
+            ].join('\n');
+
+            expect(extractPemCertificates(bundle)).toEqual([pem('AAA'), pem('BBB')]);
+        });
+
+        it('returns an empty list when nothing matches', () => {
+            expect(extractPemCertificates('not a certificate')).toEqual([]);
+        });
+    });
+
+    describe('resolveExtraCaCertificates', () => {
+        it('reads NODE_EXTRA_CA_CERTS even when the runtime ignored it', () => {
+            const bundle = writeBundle('root.pem', 'ROOT');
+
+            const resolution = resolveExtraCaCertificates({ env: { NODE_EXTRA_CA_CERTS: bundle } });
+
+            expect(resolution.certificates).toEqual([pem('ROOT')]);
+            expect(resolution.sources).toEqual([`NODE_EXTRA_CA_CERTS: ${bundle} (1)`]);
+            expect(resolution.errors).toEqual([]);
+        });
+
+        it('merges settings, N8NAC_EXTRA_CA_CERTS and NODE_EXTRA_CA_CERTS without duplicates', () => {
+            const settingBundle = writeBundle('setting.pem', 'ALPHA');
+            const n8nacBundle = writeBundle('n8nac.pem', 'BETA', 'ALPHA');
+            const nodeBundle = writeBundle('node.pem', 'GAMMA');
+
+            const resolution = resolveExtraCaCertificates({
+                caFiles: [settingBundle],
+                env: { [N8NAC_EXTRA_CA_CERTS_ENV]: n8nacBundle, NODE_EXTRA_CA_CERTS: nodeBundle },
+            });
+
+            expect(resolution.certificates).toEqual([pem('ALPHA'), pem('BETA'), pem('GAMMA')]);
+        });
+
+        it('resolves relative paths against baseDir', () => {
+            writeBundle('workspace-ca.pem', 'WORKSPACE');
+
+            const resolution = resolveExtraCaCertificates({ caFiles: ['workspace-ca.pem'], baseDir: tempDir, env: {} });
+
+            expect(resolution.certificates).toEqual([pem('WORKSPACE')]);
+        });
+
+        it('accepts several paths inside a single setting entry', () => {
+            const first = writeBundle('first.pem', 'FIRST');
+            const second = writeBundle('second.pem', 'SECOND');
+
+            const resolution = resolveExtraCaCertificates({ caFiles: [`${first}${path.delimiter}${second}`], env: {} });
+
+            expect(resolution.certificates).toEqual([pem('FIRST'), pem('SECOND')]);
+        });
+
+        it('reports unreadable files without discarding the ones that worked', () => {
+            const bundle = writeBundle('good.pem', 'GOOD');
+            const missing = path.join(tempDir, 'missing.pem');
+
+            const resolution = resolveExtraCaCertificates({ caFiles: [missing, bundle], env: {} });
+
+            expect(resolution.certificates).toEqual([pem('GOOD')]);
+            expect(resolution.errors).toHaveLength(1);
+            expect(resolution.errors[0]).toContain(missing);
+        });
+
+        it('reports a file that holds no certificate', () => {
+            const filePath = path.join(tempDir, 'empty.pem');
+            fs.writeFileSync(filePath, 'nothing here', 'utf8');
+
+            const resolution = resolveExtraCaCertificates({ caFiles: [filePath], env: {} });
+
+            expect(resolution.certificates).toEqual([]);
+            expect(resolution.errors[0]).toContain('does not contain any PEM certificate');
+        });
+    });
+
+    describe('installExtraCaCertificates', () => {
+        it('appends the certificates to every secure context created afterwards', () => {
+            const bundle = writeBundle('root.pem', 'ROOT', 'INTERMEDIATE');
+            const { host, added } = createSecureContextHost();
+
+            const result = installExtraCaCertificates({ caFiles: [bundle], env: {} }, host);
+            host.createSecureContext({});
+
+            expect(result.installed).toBe(true);
+            expect(added).toEqual([pem('ROOT'), pem('INTERMEDIATE')]);
+        });
+
+        it('forwards the caller options to the original implementation', () => {
+            const bundle = writeBundle('root.pem', 'ROOT');
+            const { host, createdWith } = createSecureContextHost();
+
+            installExtraCaCertificates({ caFiles: [bundle], env: {} }, host);
+            host.createSecureContext({ minVersion: 'TLSv1.2' });
+
+            expect(createdWith).toEqual([{ minVersion: 'TLSv1.2' }]);
+        });
+
+        it('leaves the runtime untouched when nothing was resolved', () => {
+            const { host } = createSecureContextHost();
+            const original = host.createSecureContext;
+
+            const result = installExtraCaCertificates({ env: {} }, host);
+
+            expect(result.installed).toBe(false);
+            expect(host.createSecureContext).toBe(original);
+        });
+
+        it('replaces the certificate set on re-install instead of stacking wrappers', () => {
+            const first = writeBundle('first.pem', 'FIRST');
+            const second = writeBundle('second.pem', 'SECOND');
+            const { host, added } = createSecureContextHost();
+
+            installExtraCaCertificates({ caFiles: [first], env: {} }, host);
+            const patched = host.createSecureContext;
+            installExtraCaCertificates({ caFiles: [second], env: {} }, host);
+
+            expect(host.createSecureContext).toBe(patched);
+
+            host.createSecureContext({});
+            expect(added).toEqual([pem('SECOND')]);
+            expect(getInstalledExtraCaCertificates(host)).toEqual([pem('SECOND')]);
+        });
+
+        it('survives a runtime whose secure context cannot take extra anchors', () => {
+            const bundle = writeBundle('root.pem', 'ROOT');
+            const host: ISecureContextHost = {
+                createSecureContext: () => ({}) as tls.SecureContext,
+            };
+
+            installExtraCaCertificates({ caFiles: [bundle], env: {} }, host);
+
+            expect(() => host.createSecureContext({})).not.toThrow();
+        });
+
+        it('ignores an anchor the runtime rejects', () => {
+            const bundle = writeBundle('root.pem', 'BAD', 'GOOD');
+            const accepted: string[] = [];
+            const host: ISecureContextHost = {
+                createSecureContext: () => ({
+                    context: {
+                        addCACert: (certificate: string) => {
+                            if (certificate.includes('BAD')) throw new Error('unsupported certificate');
+                            accepted.push(certificate);
+                        },
+                    },
+                }) as unknown as tls.SecureContext,
+            };
+
+            installExtraCaCertificates({ caFiles: [bundle], env: {} }, host);
+            host.createSecureContext({});
+
+            expect(accepted).toEqual([pem('GOOD')]);
+        });
+
+        it('restores the original implementation on uninstall', () => {
+            const bundle = writeBundle('root.pem', 'ROOT');
+            const { host, added } = createSecureContextHost();
+            const original = host.createSecureContext;
+
+            installExtraCaCertificates({ caFiles: [bundle], env: {} }, host);
+            uninstallExtraCaCertificates(host);
+            host.createSecureContext({});
+
+            expect(host.createSecureContext).toBe(original);
+            expect(added).toEqual([]);
+            expect(getInstalledExtraCaCertificates(host)).toEqual([]);
+        });
+    });
+
+    describe('isCertificateTrustError', () => {
+        it.each([
+            'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+            'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+            'SELF_SIGNED_CERT_IN_CHAIN',
+            'DEPTH_ZERO_SELF_SIGNED_CERT',
+            'CERT_HAS_EXPIRED',
+            'ERR_TLS_CERT_ALTNAME_INVALID',
+        ])('recognises %s', (code) => {
+            expect(isCertificateTrustError({ code })).toBe(true);
+        });
+
+        it('recognises the message undici surfaces without a code', () => {
+            expect(isCertificateTrustError(new Error('unable to verify the first certificate'))).toBe(true);
+        });
+
+        it('unwraps the cause chain used by fetch failures', () => {
+            const error = new Error('fetch failed');
+            (error as any).cause = { code: 'SELF_SIGNED_CERT_IN_CHAIN' };
+
+            expect(isCertificateTrustError(error)).toBe(true);
+        });
+
+        it('does not flag ordinary transport or HTTP failures', () => {
+            expect(isCertificateTrustError({ code: 'ECONNREFUSED', message: 'connect ECONNREFUSED' })).toBe(false);
+            expect(isCertificateTrustError(new Error('Request failed with status code 401'))).toBe(false);
+            expect(isCertificateTrustError(undefined)).toBe(false);
+        });
+
+        it('does not recurse forever on a self-referencing cause', () => {
+            const error: any = new Error('boom');
+            error.cause = error;
+
+            expect(isCertificateTrustError(error)).toBe(false);
+        });
+    });
+
+    it('points at both the setting and the environment variable in its hint', () => {
+        expect(CERTIFICATE_TRUST_HINT).toContain('n8n.tls.certificateAuthorities');
+        expect(CERTIFICATE_TRUST_HINT).toContain('NODE_EXTRA_CA_CERTS');
+    });
+});

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -353,6 +353,21 @@
           ],
           "default": "",
           "description": "Optional reasoning effort override for eligible OpenAI account models used by the embedded n8n Agent Workbench. Leave empty to use the provider default."
+        },
+        "n8n.tls.certificateAuthorities": {
+          "type": "array",
+          "included": false,
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "PEM bundle files holding the certificate authorities to trust when connecting to n8n, for instances served with a self-signed certificate or a private CA. Relative paths resolve against the first workspace folder. The extension host cannot read Node's `--use-system-ca` flag, so this setting is the reliable way to add a root CA there; `NODE_EXTRA_CA_CERTS` and `N8NAC_EXTRA_CA_CERTS` are honoured in addition to it."
+        },
+        "n8n.tls.useSystemCertificateAuthorities": {
+          "type": "boolean",
+          "included": false,
+          "default": false,
+          "markdownDescription": "Also trust the certificate authorities installed in the operating system store, matching Node's `--use-system-ca` flag. Off by default because the store holds hundreds of anchors that are re-applied to every TLS handshake; prefer `#n8n.tls.certificateAuthorities#` unless your root CA is only reachable from the OS store. Requires a host running Node 22.15 or newer; it is ignored on older hosts."
         }
       }
     }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -10,6 +10,7 @@ import {
     SyncManager, CliApi, N8nApiClient, IN8nCredentials, WorkflowSyncStatus, ConfigService,
     resolveInstanceIdentifier, isCanonicalUserInstanceIdentifier, SYNC_EVENT_JOURNAL_FILENAME, type SyncEvent,
     type ITestPlan, type IWorkflowStatus,
+    isCertificateTrustError, CERTIFICATE_TRUST_HINT,
 } from 'n8nac';
 import { AiContextGenerator, getN8nacDevConfigFilenames } from '@n8n-as-code/skills';
 
@@ -41,6 +42,7 @@ import {
     type N8nConfigurationSnapshot,
 } from './services/n8n-configuration-controller.js';
 import { workflowWebviewRegistry } from './services/workflow-webview-registry.js';
+import { applyTlsTrustSettings, registerTlsTrustSettingsWatcher } from './services/tls-trust.js';
 import { createN8nManagerFacade } from '@n8n-as-code/manager-adapter';
 import { createTelemetryClient, type TelemetryClient } from '@n8n-as-code/telemetry';
 import { ExtensionState } from './types.js';
@@ -247,6 +249,15 @@ export async function activate(context: vscode.ExtensionContext) {
     } catch {
         // Keep activation moving so command registration still happens in Cursor-compatible hosts.
     }
+
+    try {
+        // Must run before the first n8n request: the extension host ignores NODE_EXTRA_CA_CERTS.
+        applyTlsTrustSettings((message) => outputChannel.appendLine(message));
+        context.subscriptions.push(registerTlsTrustSettingsWatcher((message) => outputChannel.appendLine(message)));
+    } catch (error: any) {
+        outputChannel.appendLine(`[n8n] TLS trust setup failed: ${error?.message || error}`);
+    }
+
     const registerTelemetryCommand = (command: string, callback: (...args: any[]) => any): vscode.Disposable => (
         vscode.commands.registerCommand(command, async (...args: any[]) => {
             const telemetry = telemetryClient;
@@ -2010,7 +2021,8 @@ function formatN8nApiError(error: any, host: string): string {
         return `The n8n workflows API is not available at "${host}". Check the instance URL.`;
     }
     if (!error?.response) {
-        return `Cannot connect to n8n at "${host}": ${error?.message || error}`;
+        const hint = isCertificateTrustError(error) ? ` ${CERTIFICATE_TRUST_HINT}` : '';
+        return `Cannot connect to n8n at "${host}": ${error?.message || error}${hint}`;
     }
     return `n8n API request failed at "${host}" with status ${status}: ${error?.message || error}`;
 }
@@ -2425,7 +2437,10 @@ async function initializeSyncManager(context: vscode.ExtensionContext) {
             }, { setActive: false });
         }
     } catch (error: any) {
-        throw new Error(`Cannot connect to n8n instance at "${host}". Please check if n8n is running.`);
+        const reason = isCertificateTrustError(error)
+            ? ` ${error?.message || error} ${CERTIFICATE_TRUST_HINT}`
+            : ' Please check if n8n is running.';
+        throw new Error(`Cannot connect to n8n instance at "${host}".${reason}`);
     }
 
     // Create SyncManager (the stateful engine: WorkflowStateTracker, events, etc.)

--- a/packages/vscode-extension/src/services/tls-trust.ts
+++ b/packages/vscode-extension/src/services/tls-trust.ts
@@ -1,0 +1,27 @@
+import * as vscode from 'vscode';
+import type { IExtraCaCertificateInstallation } from 'n8nac';
+import { applyTlsTrust } from '../utils/tls-trust.js';
+
+/** VS Code glue around {@link applyTlsTrust}; the trust logic itself lives in utils. */
+
+export const TLS_CONFIGURATION_SECTION = 'n8n.tls';
+
+const CERTIFICATE_AUTHORITIES_SETTING = 'certificateAuthorities';
+const SYSTEM_CERTIFICATE_AUTHORITIES_SETTING = 'useSystemCertificateAuthorities';
+
+export function applyTlsTrustSettings(log: (message: string) => void): IExtraCaCertificateInstallation {
+    const configuration = vscode.workspace.getConfiguration(TLS_CONFIGURATION_SECTION);
+    return applyTlsTrust({
+        certificateAuthorities: configuration.get<string[]>(CERTIFICATE_AUTHORITIES_SETTING),
+        useSystemCertificateAuthorities: configuration.get<boolean>(SYSTEM_CERTIFICATE_AUTHORITIES_SETTING),
+        workspaceRoot: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+    }, log);
+}
+
+/** Re-applies the settings whenever the user edits them, so no window reload is needed. */
+export function registerTlsTrustSettingsWatcher(log: (message: string) => void): vscode.Disposable {
+    return vscode.workspace.onDidChangeConfiguration((event) => {
+        if (!event.affectsConfiguration(TLS_CONFIGURATION_SECTION)) return;
+        applyTlsTrustSettings(log);
+    });
+}

--- a/packages/vscode-extension/src/utils/tls-trust.ts
+++ b/packages/vscode-extension/src/utils/tls-trust.ts
@@ -1,0 +1,47 @@
+import { installExtraCaCertificates, type IExtraCaCertificateInstallation } from 'n8nac';
+
+/**
+ * Extra TLS trust anchors for the extension host.
+ *
+ * The extension host is an Electron process: it ignores `NODE_EXTRA_CA_CERTS` and cannot be
+ * given `--use-system-ca`, so an n8n instance behind a private CA fails to verify even when
+ * the terminal CLI works. Reading the certificates here and appending them to every secure
+ * context restores parity for axios, the global `fetch` the n8n manager uses for health and
+ * project calls, `ws`, and the workflow proxy alike.
+ */
+
+export interface ITlsTrustConfiguration {
+    /** PEM bundle paths, absolute or relative to `workspaceRoot`. */
+    certificateAuthorities?: string[];
+    /** Mirrors Node's `--use-system-ca`. Off by default; see below for why. */
+    useSystemCertificateAuthorities?: boolean;
+    workspaceRoot?: string;
+}
+
+export type TlsTrustInstaller = typeof installExtraCaCertificates;
+
+export function applyTlsTrust(
+    configuration: ITlsTrustConfiguration,
+    log: (message: string) => void,
+    install: TlsTrustInstaller = installExtraCaCertificates,
+): IExtraCaCertificateInstallation {
+    // The OS store holds ~100+ anchors and each one is re-applied to every secure context the
+    // process builds, which costs ~18 ms per TLS handshake against ~0.4 ms without it. Pointing
+    // `certificateAuthorities` at a bundle is both cheaper and more precise, so the store is
+    // opt-in for the rare case where the CA is only reachable from there.
+    const result = install({
+        caFiles: configuration.certificateAuthorities ?? [],
+        useSystemCertificateAuthorities: configuration.useSystemCertificateAuthorities ?? false,
+        baseDir: configuration.workspaceRoot,
+    });
+
+    if (result.certificates.length) {
+        log(`[n8n] Trusting ${result.certificates.length} extra CA certificate(s): ${result.sources.join(', ')}`);
+    }
+    for (const error of result.errors) {
+        // A host without a system trust store API is expected, not fatal: report and carry on.
+        log(`[n8n] TLS trust: ${error}`);
+    }
+
+    return result;
+}

--- a/packages/vscode-extension/tests/unit/tls-trust.test.ts
+++ b/packages/vscode-extension/tests/unit/tls-trust.test.ts
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { applyTlsTrust } from '../../src/utils/tls-trust.js';
+
+type InstallOptions = Parameters<typeof import('n8nac').installExtraCaCertificates>[0];
+
+function createInstaller(result: Partial<ReturnType<typeof import('n8nac').installExtraCaCertificates>> = {}) {
+    const calls: InstallOptions[] = [];
+    const install = ((options: InstallOptions) => {
+        calls.push(options);
+        return {
+            installed: false,
+            certificates: [],
+            sources: [],
+            errors: [],
+            ...result,
+        };
+    }) as typeof import('n8nac').installExtraCaCertificates;
+    return { install, calls };
+}
+
+test('TLS trust: forwards the configured bundles and resolves them against the workspace', () => {
+    const { install, calls } = createInstaller();
+
+    applyTlsTrust({
+        certificateAuthorities: ['certs/root-ca.pem'],
+        useSystemCertificateAuthorities: false,
+        workspaceRoot: '/workspace/project',
+    }, () => {}, install);
+
+    assert.deepStrictEqual(calls, [{
+        caFiles: ['certs/root-ca.pem'],
+        useSystemCertificateAuthorities: false,
+        baseDir: '/workspace/project',
+    }]);
+});
+
+test('TLS trust: leaves the system store opt-in and tolerates an unconfigured workspace', () => {
+    const { install, calls } = createInstaller();
+
+    applyTlsTrust({}, () => {}, install);
+
+    assert.deepStrictEqual(calls, [{
+        caFiles: [],
+        useSystemCertificateAuthorities: false,
+        baseDir: undefined,
+    }]);
+});
+
+test('TLS trust: reports the anchors it installed', () => {
+    const { install } = createInstaller({
+        installed: true,
+        certificates: ['pem-a', 'pem-b'],
+        sources: ['setting: /workspace/project/certs/root-ca.pem (2)'],
+    });
+    const logs: string[] = [];
+
+    const result = applyTlsTrust({ certificateAuthorities: ['certs/root-ca.pem'] }, (message) => logs.push(message), install);
+
+    assert.strictEqual(result.installed, true);
+    assert.deepStrictEqual(logs, ['[n8n] Trusting 2 extra CA certificate(s): setting: /workspace/project/certs/root-ca.pem (2)']);
+});
+
+test('TLS trust: surfaces resolution problems without failing activation', () => {
+    const { install } = createInstaller({
+        errors: [
+            'setting: cannot read "/missing.pem" (ENOENT)',
+            'setting: "/keys.pem" does not contain any PEM certificate',
+        ],
+    });
+    const logs: string[] = [];
+
+    assert.doesNotThrow(() => applyTlsTrust({ certificateAuthorities: ['/missing.pem'] }, (message) => logs.push(message), install));
+
+    assert.deepStrictEqual(logs, [
+        '[n8n] TLS trust: setting: cannot read "/missing.pem" (ENOENT)',
+        '[n8n] TLS trust: setting: "/keys.pem" does not contain any PEM certificate',
+    ]);
+});
+
+test('TLS trust: stays quiet when there is nothing extra to trust', () => {
+    const { install } = createInstaller();
+    const logs: string[] = [];
+
+    applyTlsTrust({}, (message) => logs.push(message), install);
+
+    assert.deepStrictEqual(logs, []);
+});


### PR DESCRIPTION
**What does this PR do?**

Makes the VS Code extension trust self-signed certificates and private CAs when connecting to n8n.

**Root cause**

`N8nApiClient` already passes `rejectUnauthorized: false`, so the axios path was never the one failing. The trust errors come from the code that reaches n8n through the **global `fetch`** — `@n8n-as-code/n8n-manager-core`'s `/healthz` probe, `testN8nApiConnection`, `listN8nProjects`, and the credentials REST client. `fetch` ignores `https.Agent` entirely and uses the process default trust store.

And the extension host is an Electron process: it ignores `NODE_EXTRA_CA_CERTS` and cannot be started with Node's `--use-system-ca`. That is exactly why `n8nac` works from a terminal while the extension's auto-load fails.

**Approach**

`packages/cli/src/core/services/tls-certificates.ts` reads the CA bundles itself and appends them to every secure context the process creates, by wrapping `tls.createSecureContext`. One hook covers axios, `fetch`, `ws` and `http-proxy`. It has to go through the CommonJS `tls` object — the ESM namespace is frozen and assigning to it throws.

Sources, in order: the new `n8n.tls.certificateAuthorities` setting → `N8NAC_EXTRA_CA_CERTS` (accepts several paths) → `NODE_EXTRA_CA_CERTS` → optionally the OS trust store. Installed at CLI startup and at extension activation, re-applied on settings change without a window reload.

Connection failures caused by an untrusted certificate now say so and name the setting, instead of suggesting n8n might not be running.

**Verification**

Against a real HTTPS server with a private CA:

```
before install: fetch FAILED -> UNABLE_TO_VERIFY_LEAF_SIGNATURE
after install:  fetch OK -> 200 {"status":"ok"}
after install:  https.get OK -> 200
```

Same result driving it through `NODE_EXTRA_CA_CERTS` with the runtime having ignored it (the Electron case). 28 new CLI tests and 5 new extension tests; full CLI suite 190/190. Two failures remain in `agent-workbench-html.test.ts`, and they fail identically on an untouched checkout — unrelated to this change.

**Two decisions worth reviewing**

- **The OS trust store is opt-in, not default.** Measured: appending it (115 anchors) costs ~18 ms per secure context against ~0.4 ms baseline, on every handshake including all agent-provider traffic. `n8n.tls.useSystemCertificateAuthorities` therefore defaults to `false`, and pointing `n8n.tls.certificateAuthorities` at a bundle is the documented path.
- **Both settings are `included: false`.** `activation-policy.test.ts` enforces that every `n8n.*` property stays hidden from the Settings UI in favour of the settings webview, so they work via `settings.json` but are not discoverable in the UI. Discovery comes from the error hint, the docs and the env vars. Surfacing them in the configuration webview is the follow-up if you want them visible.

`N8nApiClient`'s `rejectUnauthorized: false` is left alone. It is a real weakness — the API client never validates certificates — but removing it is out of scope here and would break anyone currently relying on it.

**Related issue (if any):** #544
