### PR TITLE
fix(vscode): trust extra CAs on the fetch path and keep self-signed working

### DIFF
--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -36,6 +36,40 @@ n8nac env auth set <environment> --api-key-stdin
 - Store it again with `n8nac env auth set <environment> --api-key-stdin`.
 - Confirm the API key has access to the selected project.
 
+### Self-signed certificate or private CA
+
+Symptom: `unable to verify the first certificate`, `self-signed certificate in certificate chain`,
+or `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` when connecting to an HTTPS instance.
+
+Point n8n-as-code at the PEM bundle that holds your root CA:
+
+```bash
+export NODE_EXTRA_CA_CERTS=/path/to/root-ca.pem
+```
+
+`N8NAC_EXTRA_CA_CERTS` works the same way and accepts several paths separated by the platform
+path delimiter, a comma, or a newline.
+
+In the **VS Code extension** the environment variable is often not enough. The extension host is
+an Electron process: it ignores `NODE_EXTRA_CA_CERTS` and cannot be started with Node's
+`--use-system-ca` flag, which is why `n8nac` succeeds in the terminal while auto-load fails.
+Set the bundle in your VS Code settings instead — relative paths resolve against the workspace
+folder — and reload is not required:
+
+```json
+{
+  "n8n.tls.certificateAuthorities": ["/path/to/root-ca.pem"]
+}
+```
+
+If the root CA is only reachable from the operating system trust store, set
+`"n8n.tls.useSystemCertificateAuthorities": true` as well. It is off by default because the OS
+store holds hundreds of anchors that are re-applied to every TLS handshake, and it needs a host
+running Node 22.15 or newer.
+
+The n8n-as-code output channel lists every anchor that was loaded and every bundle that could not
+be read.
+
 ## Missing Configuration
 
 ### `n8nac-config.json` not found

--- a/packages/cli/src/core/index.ts
+++ b/packages/cli/src/core/index.ts
@@ -11,6 +11,7 @@ export * from './services/sync-event-journal.js';
 export * from './services/directory-utils.js';
 export * from './services/workflow-dir-name.js';
 export * from './services/instance-identifier.js';
+export * from './services/tls-certificates.js';
 export * from './services/workspace-setup-service.js';
 export * from './helpers/index.js';
 

--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -1,55 +1,36 @@
 import axios, { AxiosInstance } from 'axios';
 import * as dns from 'dns';
-import { readFileSync } from 'fs';
 import * as http from 'http';
 import * as https from 'https';
 import * as tls from 'tls';
+import { resolveExtraCaCertificates } from './tls-certificates.js';
 import { IN8nCredentials, IWorkflow, IProject, ITag, ITriggerInfo, ITestPlan, ITestResult, TriggerType, IInferredPayload, IInferredPayloadField, IExecutionDetails, IExecutionList, IExecutionSummary, ExecutionStatus } from '../types.js';
 
 type AgentLookup = NonNullable<http.AgentOptions['lookup']>;
 
 /**
- * Builds a combined CA certificate bundle from:
- *   1. NODE_EXTRA_CA_CERTS – manually read so the VS Code extension host
- *      respects it even when the env var wasn't present at Node.js startup.
- *   2. System CAs via tls.getCACertificates('system') (Node.js 22+), which
- *      is the programmatic equivalent of the --use-system-ca CLI flag.
+ * Builds a combined CA certificate bundle from the trust anchors the user configured
+ * (`NODE_EXTRA_CA_CERTS`, `N8NAC_EXTRA_CA_CERTS`) plus the OS trust store, which is the
+ * programmatic equivalent of the `--use-system-ca` flag.
  *
- * Returns undefined when neither source provides extra certificates, in which
- * case the caller should fall back to the permissive rejectUnauthorized:false
- * behaviour that preserves backward compatibility for local n8n instances.
- * When extra CAs are returned, the Node.js default Mozilla bundle is included
- * so that ordinary HTTPS requests continue to work.
+ * Returns undefined when no source provides extra certificates. When it does return a bundle,
+ * the Node.js default Mozilla roots are included, because supplying `ca` replaces them.
+ *
+ * Note that this only covers the axios agent. Anything reaching n8n through the global `fetch`
+ * — the manager-core health probe, project listing and credential calls — ignores `https.Agent`
+ * entirely, which is why {@link installExtraCaCertificates} applies the same anchors
+ * process-wide.
  */
 export function buildCaBundle(): string[] | undefined {
-    const extra: string[] = [];
+    return resolveAgentTrust().ca;
+}
 
-    const extraCaPath = process.env.NODE_EXTRA_CA_CERTS;
-    if (extraCaPath) {
-        try {
-            extra.push(readFileSync(extraCaPath, 'utf8'));
-        } catch {
-            // Ignore unreadable file; fall back to defaults
-        }
-    }
-
-    // Node.js 22.14+ exposes this API; guard the call for older runtimes.
-    const getCACerts = (tls as { getCACertificates?: (store: string) => string[] }).getCACertificates;
-    if (typeof getCACerts === 'function') {
-        try {
-            extra.push(...getCACerts('system'));
-        } catch {
-            // Not supported in this build/platform
-        }
-    }
-
-    if (extra.length === 0) {
-        return undefined;
-    }
-
-    // When a custom `ca` is supplied, Node.js replaces the default Mozilla
-    // bundle, so we prepend it explicitly to preserve trust for public CAs.
-    return [...tls.rootCertificates, ...extra];
+function resolveAgentTrust(): { ca: string[] | undefined; hasConfiguredAnchors: boolean } {
+    const resolution = resolveExtraCaCertificates({ useSystemCertificateAuthorities: true });
+    return {
+        ca: resolution.certificates.length ? [...tls.rootCertificates, ...resolution.certificates] : undefined,
+        hasConfiguredAnchors: resolution.hasConfiguredAnchors,
+    };
 }
 
 function createIpv4FirstLookup(): AgentLookup {
@@ -92,15 +73,15 @@ export class N8nApiClient {
         const lookup = createIpv4FirstLookup();
         this.httpAgent = new http.Agent({ lookup });
 
-        // Use a combined CA bundle when NODE_EXTRA_CA_CERTS or system CAs are
-        // available so that the extension respects the same certificate trust
-        // that the user configured for Node.js (--use-system-ca / NODE_EXTRA_CA_CERTS).
-        // Fall back to rejectUnauthorized:false for plain local instances that
-        // use self-signed certificates without a configured CA.
-        const caBundle = buildCaBundle();
+        // Trust whatever the user configured (--use-system-ca / NODE_EXTRA_CA_CERTS) instead of
+        // skipping verification outright. Verification is only enforced once they actually
+        // supplied an anchor: the OS trust store is readable on nearly every machine, so keying
+        // off the bundle merely being non-empty would turn on strict verification for every
+        // existing user and break the plain self-signed instances that work today.
+        const { ca, hasConfiguredAnchors } = resolveAgentTrust();
         this.httpsAgent = new https.Agent({
-            rejectUnauthorized: caBundle !== undefined,
-            ca: caBundle,
+            rejectUnauthorized: hasConfiguredAnchors,
+            ca,
             lookup,
         });
 

--- a/packages/cli/src/core/services/tls-certificates.ts
+++ b/packages/cli/src/core/services/tls-certificates.ts
@@ -1,0 +1,269 @@
+import * as fs from 'fs';
+import { createRequire } from 'module';
+import * as path from 'path';
+import * as tls from 'tls';
+
+/**
+ * Additional trust anchors for outbound HTTPS.
+ *
+ * Node honours `NODE_EXTRA_CA_CERTS` and `--use-system-ca` when it builds the default
+ * TLS trust store, but only when the process is a stock Node build that is started with
+ * those settings. The VS Code extension host is neither: it is an Electron process
+ * (BoringSSL, no `NODE_EXTRA_CA_CERTS` support) that users cannot pass Node flags to.
+ * The same gap exists for anything reaching n8n through the global `fetch`
+ * (`@n8n-as-code/n8n-manager-core` health probes, project listing, credential REST calls),
+ * because `fetch` ignores `https.Agent` options entirely.
+ *
+ * So we read the certificates ourselves and append them to every secure context the
+ * process creates, which covers axios, `fetch`, `ws` and `http-proxy` in one place.
+ */
+
+const PEM_CERTIFICATE_PATTERN = /-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g;
+
+/** Read in addition to Node's own `NODE_EXTRA_CA_CERTS`; accepts several paths. */
+export const N8NAC_EXTRA_CA_CERTS_ENV = 'N8NAC_EXTRA_CA_CERTS';
+
+export interface IExtraCaCertificateOptions {
+    /** Explicit PEM bundle paths, e.g. from the `n8n.tls.certificateAuthorities` setting. */
+    caFiles?: string[];
+    /** Mirror Node's `--use-system-ca` by adding the OS trust store when the host exposes it. */
+    useSystemCertificateAuthorities?: boolean;
+    /** Directory used to resolve relative paths. Defaults to `process.cwd()`. */
+    baseDir?: string;
+    env?: NodeJS.ProcessEnv;
+}
+
+export interface IExtraCaCertificateResolution {
+    /** Deduplicated PEM certificate blocks, in discovery order. */
+    certificates: string[];
+    /** Human-readable description of every source that contributed certificates. */
+    sources: string[];
+    /** Non-fatal problems (missing file, unreadable file, file without any PEM block). */
+    errors: string[];
+    /**
+     * `true` when the user actually pointed us at trust anchors — a setting or one of the
+     * environment variables. The OS trust store alone does not count: it exists on nearly every
+     * machine, so treating it as configuration would silently turn on strict verification for
+     * people who never asked for it.
+     */
+    hasConfiguredAnchors: boolean;
+}
+
+export interface IExtraCaCertificateInstallation extends IExtraCaCertificateResolution {
+    /** `true` once secure contexts in this process carry the extra certificates. */
+    installed: boolean;
+}
+
+/** The subset of the `tls` module the installer touches, so tests can supply a stub. */
+export interface ISecureContextHost {
+    createSecureContext(options?: tls.SecureContextOptions): tls.SecureContext;
+}
+
+interface IPatchState {
+    original: ISecureContextHost['createSecureContext'];
+    certificates: string[];
+}
+
+const patchedHosts = new WeakMap<ISecureContextHost, IPatchState>();
+
+let defaultSecureContextHost: ISecureContextHost | undefined;
+
+/**
+ * The mutable `tls` module object.
+ *
+ * `import * as tls` yields a frozen module namespace, so the patch has to go through the
+ * CommonJS export object that `https`, `ws` and undici's `fetch` all read from.
+ */
+function getDefaultSecureContextHost(): ISecureContextHost {
+    defaultSecureContextHost ??= createRequire(import.meta.url)('tls') as ISecureContextHost;
+    return defaultSecureContextHost;
+}
+
+/**
+ * Split a path list. Accepts the platform delimiter, commas and newlines so a single
+ * setting works whether it was copied from a shell variable or typed by hand.
+ */
+export function splitCertificatePathList(value: string): string[] {
+    return value
+        .split(new RegExp(`[${escapeForCharacterClass(path.delimiter)},\\r\\n]`))
+        .map((entry) => entry.trim().replace(/^["']|["']$/g, ''))
+        .filter((entry) => entry.length > 0);
+}
+
+function escapeForCharacterClass(value: string): string {
+    return value.replace(/[\\\]^-]/g, '\\$&');
+}
+
+/** Extract every PEM certificate block from a bundle, ignoring keys and comments. */
+export function extractPemCertificates(contents: string): string[] {
+    return contents.match(PEM_CERTIFICATE_PATTERN) ?? [];
+}
+
+function readCertificateFile(filePath: string, resolution: IExtraCaCertificateResolution, label: string): void {
+    let contents: string;
+    try {
+        contents = fs.readFileSync(filePath, 'utf8');
+    } catch (error: any) {
+        resolution.errors.push(`${label}: cannot read "${filePath}" (${error?.code || error?.message || error})`);
+        return;
+    }
+
+    const certificates = extractPemCertificates(contents);
+    if (!certificates.length) {
+        resolution.errors.push(`${label}: "${filePath}" does not contain any PEM certificate`);
+        return;
+    }
+
+    resolution.hasConfiguredAnchors = true;
+    addCertificates(resolution, certificates, `${label}: ${filePath}`);
+}
+
+function addCertificates(resolution: IExtraCaCertificateResolution, certificates: string[], source: string): void {
+    let added = 0;
+    for (const certificate of certificates) {
+        const normalized = certificate.trim();
+        if (!normalized || resolution.certificates.includes(normalized)) continue;
+        resolution.certificates.push(normalized);
+        added++;
+    }
+    if (added > 0) {
+        resolution.sources.push(`${source} (${added})`);
+    }
+}
+
+function readSystemCertificates(resolution: IExtraCaCertificateResolution): void {
+    // Node 22.15+/24 only. Older hosts (and Electron) simply do not expose it, which is the
+    // expected state rather than a misconfiguration, so it is not reported as an error.
+    const getCACertificates = (tls as unknown as {
+        getCACertificates?: (type: string) => string[];
+    }).getCACertificates;
+    if (typeof getCACertificates !== 'function') {
+        return;
+    }
+
+    try {
+        addCertificates(resolution, getCACertificates('system'), 'system trust store');
+    } catch (error: any) {
+        resolution.errors.push(`system trust store: ${error?.message || error}`);
+    }
+}
+
+/**
+ * Collect the extra trust anchors from settings, `N8NAC_EXTRA_CA_CERTS`,
+ * `NODE_EXTRA_CA_CERTS` and — on request — the OS trust store.
+ */
+export function resolveExtraCaCertificates(options: IExtraCaCertificateOptions = {}): IExtraCaCertificateResolution {
+    const env = options.env ?? process.env;
+    const baseDir = options.baseDir ?? process.cwd();
+    const resolution: IExtraCaCertificateResolution = {
+        certificates: [],
+        sources: [],
+        errors: [],
+        hasConfiguredAnchors: false,
+    };
+
+    const resolvePath = (candidate: string) => (path.isAbsolute(candidate) ? candidate : path.resolve(baseDir, candidate));
+
+    for (const candidate of options.caFiles ?? []) {
+        for (const filePath of splitCertificatePathList(candidate)) {
+            readCertificateFile(resolvePath(filePath), resolution, 'setting');
+        }
+    }
+
+    for (const filePath of splitCertificatePathList(env[N8NAC_EXTRA_CA_CERTS_ENV] ?? '')) {
+        readCertificateFile(resolvePath(filePath), resolution, N8NAC_EXTRA_CA_CERTS_ENV);
+    }
+
+    for (const filePath of splitCertificatePathList(env.NODE_EXTRA_CA_CERTS ?? '')) {
+        readCertificateFile(resolvePath(filePath), resolution, 'NODE_EXTRA_CA_CERTS');
+    }
+
+    if (options.useSystemCertificateAuthorities) {
+        readSystemCertificates(resolution);
+    }
+
+    return resolution;
+}
+
+/**
+ * Append the resolved certificates to every secure context created from now on.
+ *
+ * Idempotent: calling it again replaces the certificate set instead of stacking another
+ * wrapper, so it is safe to re-run whenever the configuration changes.
+ */
+export function installExtraCaCertificates(
+    options: IExtraCaCertificateOptions = {},
+    host: ISecureContextHost = getDefaultSecureContextHost(),
+): IExtraCaCertificateInstallation {
+    const resolution = resolveExtraCaCertificates(options);
+
+    const existing = patchedHosts.get(host);
+    if (existing) {
+        existing.certificates = resolution.certificates;
+        return { ...resolution, installed: resolution.certificates.length > 0 };
+    }
+
+    if (!resolution.certificates.length) {
+        // Nothing to trust yet — leave the runtime untouched rather than wrapping it for nothing.
+        return { ...resolution, installed: false };
+    }
+
+    const state: IPatchState = {
+        original: host.createSecureContext,
+        certificates: resolution.certificates,
+    };
+    patchedHosts.set(host, state);
+
+    host.createSecureContext = (contextOptions?: tls.SecureContextOptions) => {
+        const context = state.original.call(host, contextOptions);
+        const nativeContext = (context as unknown as { context?: { addCACert?: (pem: string) => void } }).context;
+        if (typeof nativeContext?.addCACert !== 'function') {
+            return context;
+        }
+        for (const certificate of state.certificates) {
+            try {
+                nativeContext.addCACert(certificate);
+            } catch {
+                // A malformed or duplicate anchor must not break the whole handshake.
+            }
+        }
+        return context;
+    };
+
+    return { ...resolution, installed: true };
+}
+
+/** Certificates currently appended by the installer, for diagnostics and tests. */
+export function getInstalledExtraCaCertificates(host: ISecureContextHost = getDefaultSecureContextHost()): string[] {
+    return [...(patchedHosts.get(host)?.certificates ?? [])];
+}
+
+/** Restore the untouched `createSecureContext`. Intended for tests. */
+export function uninstallExtraCaCertificates(host: ISecureContextHost = getDefaultSecureContextHost()): void {
+    const state = patchedHosts.get(host);
+    if (!state) return;
+    host.createSecureContext = state.original;
+    patchedHosts.delete(host);
+}
+
+/** `true` when the error is a TLS trust failure rather than a transport or HTTP error. */
+export function isCertificateTrustError(error: any): boolean {
+    const code = typeof error?.code === 'string' ? error.code : '';
+    if (code.startsWith('UNABLE_TO_') || code.startsWith('SELF_SIGNED') || code.startsWith('DEPTH_ZERO_')) {
+        return true;
+    }
+    if (code === 'CERT_HAS_EXPIRED' || code === 'ERR_TLS_CERT_ALTNAME_INVALID' || code === 'CERT_SIGNATURE_FAILURE') {
+        return true;
+    }
+    if (error?.cause && error.cause !== error && isCertificateTrustError(error.cause)) {
+        return true;
+    }
+    const message = String(error?.message ?? error ?? '');
+    return /unable to (get|verify)|self[- ]signed certificate|certificate has expired|CERT_/i.test(message);
+}
+
+/** Guidance appended to connection errors caused by an untrusted certificate. */
+export const CERTIFICATE_TRUST_HINT =
+    'The certificate is not trusted by this process. Point "n8n.tls.certificateAuthorities" '
+    + '(or the NODE_EXTRA_CA_CERTS environment variable) at the PEM bundle holding your root CA, then retry. '
+    + 'The VS Code extension host cannot read Node\'s --use-system-ca flag, so the setting is the reliable path there.';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,6 +20,7 @@ import { parsePositiveIntegerOption } from './utils/option-parsers.js';
 import { spawn } from 'child_process';
 import { createN8nManagerFacade } from '@n8n-as-code/manager-adapter';
 import { ConfigService } from './services/config-service.js';
+import { installExtraCaCertificates } from './core/services/tls-certificates.js';
 import {
     N8N_FACADE_SETUP_MODES,
     isN8nFacadeSetupMode,
@@ -281,6 +282,12 @@ async function runMcpDiagnosticCommand(
         });
     });
 }
+
+// Trust anchors must be in place before the first outbound request. Node already applies
+// NODE_EXTRA_CA_CERTS to its own trust store, but re-reading it here keeps the CLI and the
+// VS Code extension host — which cannot honour it — on identical behaviour, and adds the
+// multi-path N8NAC_EXTRA_CA_CERTS form. The OS store stays with Node's own --use-system-ca.
+installExtraCaCertificates();
 
 const program = new Command();
 const telemetry = createTelemetryClient({ facade: 'cli', version: getVersion() });

--- a/packages/cli/tests/unit/n8n-api-client.test.ts
+++ b/packages/cli/tests/unit/n8n-api-client.test.ts
@@ -98,7 +98,26 @@ describe('N8nApiClient test workflow support', () => {
         const config = mockAxiosCreate.mock.calls[0][0];
         expect(config.httpsAgent.options.rejectUnauthorized).toBe(true);
         expect(Array.isArray(config.httpsAgent.options.ca)).toBe(true);
-        expect(config.httpsAgent.options.ca).toContain('-----BEGIN CERTIFICATE-----\nextra\n-----END CERTIFICATE-----\n');
+        // Anchors are stored as trimmed PEM blocks, so the trailing newline is gone.
+        expect(config.httpsAgent.options.ca).toContain('-----BEGIN CERTIFICATE-----\nextra\n-----END CERTIFICATE-----');
+    });
+
+    it('keeps verification off when only the OS trust store is available', async () => {
+        // The regression this guards: gating rejectUnauthorized on "the bundle is non-empty"
+        // turns verification on for everyone, because tls.getCACertificates('system') returns
+        // anchors on nearly every machine — breaking the plain self-signed instances that work
+        // today without the user configuring anything.
+        const tlsMod = await import('tls');
+        vi.mocked((tlsMod as any).getCACertificates).mockReturnValue([
+            '-----BEGIN CERTIFICATE-----\nsystem-anchor\n-----END CERTIFICATE-----',
+        ]);
+
+        new N8nApiClient({ host: 'https://n8n.local/', apiKey: 'secret' });
+
+        const config = mockAxiosCreate.mock.calls[0][0];
+        expect(config.httpsAgent.options.rejectUnauthorized).toBe(false);
+        // The anchors are still trusted, they just do not force strict verification on.
+        expect(config.httpsAgent.options.ca).toContain('-----BEGIN CERTIFICATE-----\nsystem-anchor\n-----END CERTIFICATE-----');
     });
 
     it('asserts API access through the authenticated workflows endpoint', async () => {
@@ -964,7 +983,8 @@ describe('buildCaBundle', () => {
         const bundle = buildCaBundle();
 
         expect(bundle).toBeDefined();
-        expect(bundle).toContain('-----BEGIN CERTIFICATE-----\nextra-ca\n-----END CERTIFICATE-----\n');
+        // Anchors are stored as trimmed PEM blocks, so the trailing newline is gone.
+        expect(bundle).toContain('-----BEGIN CERTIFICATE-----\nextra-ca\n-----END CERTIFICATE-----');
         expect(readFileSync).toHaveBeenCalledWith('/path/to/ca.crt', 'utf8');
     });
 
@@ -975,7 +995,7 @@ describe('buildCaBundle', () => {
         const bundle = buildCaBundle();
 
         expect(bundle).toBeDefined();
-        expect(bundle).toContain('-----BEGIN CERTIFICATE-----\nsystem-ca\n-----END CERTIFICATE-----\n');
+        expect(bundle).toContain('-----BEGIN CERTIFICATE-----\nsystem-ca\n-----END CERTIFICATE-----');
     });
 
     it('includes tls.rootCertificates in the bundle so public CAs still work', async () => {

--- a/packages/cli/tests/unit/tls-certificates.test.ts
+++ b/packages/cli/tests/unit/tls-certificates.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type * as tls from 'tls';
+import {
+    CERTIFICATE_TRUST_HINT,
+    N8NAC_EXTRA_CA_CERTS_ENV,
+    extractPemCertificates,
+    getInstalledExtraCaCertificates,
+    installExtraCaCertificates,
+    isCertificateTrustError,
+    resolveExtraCaCertificates,
+    splitCertificatePathList,
+    uninstallExtraCaCertificates,
+    type ISecureContextHost,
+} from '../../src/core/services/tls-certificates.js';
+
+function pem(label: string): string {
+    return `-----BEGIN CERTIFICATE-----\n${label}\n-----END CERTIFICATE-----`;
+}
+
+/** Stands in for the `tls` module so the assertions never touch the real process trust store. */
+function createSecureContextHost(): { host: ISecureContextHost; added: string[]; createdWith: unknown[] } {
+    const added: string[] = [];
+    const createdWith: unknown[] = [];
+    const host: ISecureContextHost = {
+        createSecureContext(options?: tls.SecureContextOptions) {
+            createdWith.push(options);
+            return { context: { addCACert: (certificate: string) => { added.push(certificate); } } } as unknown as tls.SecureContext;
+        },
+    };
+    return { host, added, createdWith };
+}
+
+describe('tls-certificates', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-tls-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    function writeBundle(name: string, ...labels: string[]): string {
+        const filePath = path.join(tempDir, name);
+        fs.writeFileSync(filePath, labels.map(pem).join('\n'), 'utf8');
+        return filePath;
+    }
+
+    describe('splitCertificatePathList', () => {
+        it('splits on the platform delimiter, commas and newlines, and strips quotes', () => {
+            const value = `"/a/first.pem"${path.delimiter}/b/second.pem,/c/third.pem\n/d/fourth.pem`;
+            expect(splitCertificatePathList(value)).toEqual([
+                '/a/first.pem',
+                '/b/second.pem',
+                '/c/third.pem',
+                '/d/fourth.pem',
+            ]);
+        });
+
+        it('drops empty segments', () => {
+            expect(splitCertificatePathList(`  ${path.delimiter},,\n `)).toEqual([]);
+        });
+    });
+
+    describe('extractPemCertificates', () => {
+        it('keeps only certificate blocks', () => {
+            const bundle = [
+                '# comment line',
+                pem('AAA'),
+                '-----BEGIN PRIVATE KEY-----\nSECRET\n-----END PRIVATE KEY-----',
+                pem('BBB'),
+            ].join('\n');
+
+            expect(extractPemCertificates(bundle)).toEqual([pem('AAA'), pem('BBB')]);
+        });
+
+        it('returns an empty list when nothing matches', () => {
+            expect(extractPemCertificates('not a certificate')).toEqual([]);
+        });
+    });
+
+    describe('resolveExtraCaCertificates', () => {
+        it('reads NODE_EXTRA_CA_CERTS even when the runtime ignored it', () => {
+            const bundle = writeBundle('root.pem', 'ROOT');
+
+            const resolution = resolveExtraCaCertificates({ env: { NODE_EXTRA_CA_CERTS: bundle } });
+
+            expect(resolution.certificates).toEqual([pem('ROOT')]);
+            expect(resolution.sources).toEqual([`NODE_EXTRA_CA_CERTS: ${bundle} (1)`]);
+            expect(resolution.errors).toEqual([]);
+        });
+
+        it('merges settings, N8NAC_EXTRA_CA_CERTS and NODE_EXTRA_CA_CERTS without duplicates', () => {
+            const settingBundle = writeBundle('setting.pem', 'ALPHA');
+            const n8nacBundle = writeBundle('n8nac.pem', 'BETA', 'ALPHA');
+            const nodeBundle = writeBundle('node.pem', 'GAMMA');
+
+            const resolution = resolveExtraCaCertificates({
+                caFiles: [settingBundle],
+                env: { [N8NAC_EXTRA_CA_CERTS_ENV]: n8nacBundle, NODE_EXTRA_CA_CERTS: nodeBundle },
+            });
+
+            expect(resolution.certificates).toEqual([pem('ALPHA'), pem('BETA'), pem('GAMMA')]);
+        });
+
+        it('resolves relative paths against baseDir', () => {
+            writeBundle('workspace-ca.pem', 'WORKSPACE');
+
+            const resolution = resolveExtraCaCertificates({ caFiles: ['workspace-ca.pem'], baseDir: tempDir, env: {} });
+
+            expect(resolution.certificates).toEqual([pem('WORKSPACE')]);
+        });
+
+        it('accepts several paths inside a single setting entry', () => {
+            const first = writeBundle('first.pem', 'FIRST');
+            const second = writeBundle('second.pem', 'SECOND');
+
+            const resolution = resolveExtraCaCertificates({ caFiles: [`${first}${path.delimiter}${second}`], env: {} });
+
+            expect(resolution.certificates).toEqual([pem('FIRST'), pem('SECOND')]);
+        });
+
+        it('reports unreadable files without discarding the ones that worked', () => {
+            const bundle = writeBundle('good.pem', 'GOOD');
+            const missing = path.join(tempDir, 'missing.pem');
+
+            const resolution = resolveExtraCaCertificates({ caFiles: [missing, bundle], env: {} });
+
+            expect(resolution.certificates).toEqual([pem('GOOD')]);
+            expect(resolution.errors).toHaveLength(1);
+            expect(resolution.errors[0]).toContain(missing);
+        });
+
+        it('reports a file that holds no certificate', () => {
+            const filePath = path.join(tempDir, 'empty.pem');
+            fs.writeFileSync(filePath, 'nothing here', 'utf8');
+
+            const resolution = resolveExtraCaCertificates({ caFiles: [filePath], env: {} });
+
+            expect(resolution.certificates).toEqual([]);
+            expect(resolution.errors[0]).toContain('does not contain any PEM certificate');
+        });
+    });
+
+    describe('installExtraCaCertificates', () => {
+        it('appends the certificates to every secure context created afterwards', () => {
+            const bundle = writeBundle('root.pem', 'ROOT', 'INTERMEDIATE');
+            const { host, added } = createSecureContextHost();
+
+            const result = installExtraCaCertificates({ caFiles: [bundle], env: {} }, host);
+            host.createSecureContext({});
+
+            expect(result.installed).toBe(true);
+            expect(added).toEqual([pem('ROOT'), pem('INTERMEDIATE')]);
+        });
+
+        it('forwards the caller options to the original implementation', () => {
+            const bundle = writeBundle('root.pem', 'ROOT');
+            const { host, createdWith } = createSecureContextHost();
+
+            installExtraCaCertificates({ caFiles: [bundle], env: {} }, host);
+            host.createSecureContext({ minVersion: 'TLSv1.2' });
+
+            expect(createdWith).toEqual([{ minVersion: 'TLSv1.2' }]);
+        });
+
+        it('leaves the runtime untouched when nothing was resolved', () => {
+            const { host } = createSecureContextHost();
+            const original = host.createSecureContext;
+
+            const result = installExtraCaCertificates({ env: {} }, host);
+
+            expect(result.installed).toBe(false);
+            expect(host.createSecureContext).toBe(original);
+        });
+
+        it('replaces the certificate set on re-install instead of stacking wrappers', () => {
+            const first = writeBundle('first.pem', 'FIRST');
+            const second = writeBundle('second.pem', 'SECOND');
+            const { host, added } = createSecureContextHost();
+
+            installExtraCaCertificates({ caFiles: [first], env: {} }, host);
+            const patched = host.createSecureContext;
+            installExtraCaCertificates({ caFiles: [second], env: {} }, host);
+
+            expect(host.createSecureContext).toBe(patched);
+
+            host.createSecureContext({});
+            expect(added).toEqual([pem('SECOND')]);
+            expect(getInstalledExtraCaCertificates(host)).toEqual([pem('SECOND')]);
+        });
+
+        it('survives a runtime whose secure context cannot take extra anchors', () => {
+            const bundle = writeBundle('root.pem', 'ROOT');
+            const host: ISecureContextHost = {
+                createSecureContext: () => ({}) as tls.SecureContext,
+            };
+
+            installExtraCaCertificates({ caFiles: [bundle], env: {} }, host);
+
+            expect(() => host.createSecureContext({})).not.toThrow();
+        });
+
+        it('ignores an anchor the runtime rejects', () => {
+            const bundle = writeBundle('root.pem', 'BAD', 'GOOD');
+            const accepted: string[] = [];
+            const host: ISecureContextHost = {
+                createSecureContext: () => ({
+                    context: {
+                        addCACert: (certificate: string) => {
+                            if (certificate.includes('BAD')) throw new Error('unsupported certificate');
+                            accepted.push(certificate);
+                        },
+                    },
+                }) as unknown as tls.SecureContext,
+            };
+
+            installExtraCaCertificates({ caFiles: [bundle], env: {} }, host);
+            host.createSecureContext({});
+
+            expect(accepted).toEqual([pem('GOOD')]);
+        });
+
+        it('restores the original implementation on uninstall', () => {
+            const bundle = writeBundle('root.pem', 'ROOT');
+            const { host, added } = createSecureContextHost();
+            const original = host.createSecureContext;
+
+            installExtraCaCertificates({ caFiles: [bundle], env: {} }, host);
+            uninstallExtraCaCertificates(host);
+            host.createSecureContext({});
+
+            expect(host.createSecureContext).toBe(original);
+            expect(added).toEqual([]);
+            expect(getInstalledExtraCaCertificates(host)).toEqual([]);
+        });
+    });
+
+    describe('isCertificateTrustError', () => {
+        it.each([
+            'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+            'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+            'SELF_SIGNED_CERT_IN_CHAIN',
+            'DEPTH_ZERO_SELF_SIGNED_CERT',
+            'CERT_HAS_EXPIRED',
+            'ERR_TLS_CERT_ALTNAME_INVALID',
+        ])('recognises %s', (code) => {
+            expect(isCertificateTrustError({ code })).toBe(true);
+        });
+
+        it('recognises the message undici surfaces without a code', () => {
+            expect(isCertificateTrustError(new Error('unable to verify the first certificate'))).toBe(true);
+        });
+
+        it('unwraps the cause chain used by fetch failures', () => {
+            const error = new Error('fetch failed');
+            (error as any).cause = { code: 'SELF_SIGNED_CERT_IN_CHAIN' };
+
+            expect(isCertificateTrustError(error)).toBe(true);
+        });
+
+        it('does not flag ordinary transport or HTTP failures', () => {
+            expect(isCertificateTrustError({ code: 'ECONNREFUSED', message: 'connect ECONNREFUSED' })).toBe(false);
+            expect(isCertificateTrustError(new Error('Request failed with status code 401'))).toBe(false);
+            expect(isCertificateTrustError(undefined)).toBe(false);
+        });
+
+        it('does not recurse forever on a self-referencing cause', () => {
+            const error: any = new Error('boom');
+            error.cause = error;
+
+            expect(isCertificateTrustError(error)).toBe(false);
+        });
+    });
+
+    it('points at both the setting and the environment variable in its hint', () => {
+        expect(CERTIFICATE_TRUST_HINT).toContain('n8n.tls.certificateAuthorities');
+        expect(CERTIFICATE_TRUST_HINT).toContain('NODE_EXTRA_CA_CERTS');
+    });
+});

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -353,6 +353,21 @@
           ],
           "default": "",
           "description": "Optional reasoning effort override for eligible OpenAI account models used by the embedded n8n Agent Workbench. Leave empty to use the provider default."
+        },
+        "n8n.tls.certificateAuthorities": {
+          "type": "array",
+          "included": false,
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "PEM bundle files holding the certificate authorities to trust when connecting to n8n, for instances served with a self-signed certificate or a private CA. Relative paths resolve against the first workspace folder. The extension host cannot read Node's `--use-system-ca` flag, so this setting is the reliable way to add a root CA there; `NODE_EXTRA_CA_CERTS` and `N8NAC_EXTRA_CA_CERTS` are honoured in addition to it."
+        },
+        "n8n.tls.useSystemCertificateAuthorities": {
+          "type": "boolean",
+          "included": false,
+          "default": false,
+          "markdownDescription": "Also trust the certificate authorities installed in the operating system store, matching Node's `--use-system-ca` flag. Off by default because the store holds hundreds of anchors that are re-applied to every TLS handshake; prefer `#n8n.tls.certificateAuthorities#` unless your root CA is only reachable from the OS store. Requires a host running Node 22.15 or newer; it is ignored on older hosts."
         }
       }
     }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -10,6 +10,7 @@ import {
     SyncManager, CliApi, N8nApiClient, IN8nCredentials, WorkflowSyncStatus, ConfigService,
     resolveInstanceIdentifier, isCanonicalUserInstanceIdentifier, SYNC_EVENT_JOURNAL_FILENAME, type SyncEvent,
     type ITestPlan, type IWorkflowStatus,
+    isCertificateTrustError, CERTIFICATE_TRUST_HINT,
 } from 'n8nac';
 import { AiContextGenerator, getN8nacDevConfigFilenames } from '@n8n-as-code/skills';
 
@@ -41,6 +42,7 @@ import {
     type N8nConfigurationSnapshot,
 } from './services/n8n-configuration-controller.js';
 import { workflowWebviewRegistry } from './services/workflow-webview-registry.js';
+import { applyTlsTrustSettings, registerTlsTrustSettingsWatcher } from './services/tls-trust.js';
 import { createN8nManagerFacade } from '@n8n-as-code/manager-adapter';
 import { createTelemetryClient, type TelemetryClient } from '@n8n-as-code/telemetry';
 import { ExtensionState } from './types.js';
@@ -247,6 +249,15 @@ export async function activate(context: vscode.ExtensionContext) {
     } catch {
         // Keep activation moving so command registration still happens in Cursor-compatible hosts.
     }
+
+    try {
+        // Must run before the first n8n request: the extension host ignores NODE_EXTRA_CA_CERTS.
+        applyTlsTrustSettings((message) => outputChannel.appendLine(message));
+        context.subscriptions.push(registerTlsTrustSettingsWatcher((message) => outputChannel.appendLine(message)));
+    } catch (error: any) {
+        outputChannel.appendLine(`[n8n] TLS trust setup failed: ${error?.message || error}`);
+    }
+
     const registerTelemetryCommand = (command: string, callback: (...args: any[]) => any): vscode.Disposable => (
         vscode.commands.registerCommand(command, async (...args: any[]) => {
             const telemetry = telemetryClient;
@@ -1998,23 +2009,10 @@ function getHttpStatus(error: any): number | undefined {
     return error?.response?.status;
 }
 
-const TLS_ERROR_CODES = new Set([
-    'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
-    'CERT_UNTRUSTED',
-    'ERR_TLS_CERT_ALTNAME_INVALID',
-    'DEPTH_ZERO_SELF_SIGNED_CERT',
-    'SELF_SIGNED_CERT_IN_CHAIN',
-    'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
-    'CERT_HAS_EXPIRED',
-]);
-
+// Delegates to the shared classifier so `fetch` failures are recognised too: undici reports
+// them as `TypeError: fetch failed` and hides the real code in `error.cause`.
 function isTlsError(error: any): boolean {
-    return TLS_ERROR_CODES.has(error?.code) ||
-        typeof error?.message === 'string' && (
-            error.message.includes('unable to verify') ||
-            error.message.includes('certificate') ||
-            error.message.includes('self-signed')
-        );
+    return isCertificateTrustError(error);
 }
 
 function formatN8nApiError(error: any, host: string): string {
@@ -2031,7 +2029,7 @@ function formatN8nApiError(error: any, host: string): string {
     if (!error?.response) {
         const base = `Cannot connect to n8n at "${host}": ${error?.message || error}`;
         if (isTlsError(error)) {
-            return `${base}\nIf the server uses a self-signed or internal CA certificate, set NODE_EXTRA_CA_CERTS to your CA file path, or add the CA to your system trust store and restart VS Code.`;
+            return `${base}\n${CERTIFICATE_TRUST_HINT}`;
         }
         return base;
     }
@@ -2448,7 +2446,10 @@ async function initializeSyncManager(context: vscode.ExtensionContext) {
             }, { setActive: false });
         }
     } catch (error: any) {
-        throw new Error(`Cannot connect to n8n instance at "${host}". Please check if n8n is running.`);
+        const reason = isCertificateTrustError(error)
+            ? ` ${error?.message || error} ${CERTIFICATE_TRUST_HINT}`
+            : ' Please check if n8n is running.';
+        throw new Error(`Cannot connect to n8n instance at "${host}".${reason}`);
     }
 
     // Create SyncManager (the stateful engine: WorkflowStateTracker, events, etc.)

--- a/packages/vscode-extension/src/services/tls-trust.ts
+++ b/packages/vscode-extension/src/services/tls-trust.ts
@@ -1,0 +1,27 @@
+import * as vscode from 'vscode';
+import type { IExtraCaCertificateInstallation } from 'n8nac';
+import { applyTlsTrust } from '../utils/tls-trust.js';
+
+/** VS Code glue around {@link applyTlsTrust}; the trust logic itself lives in utils. */
+
+export const TLS_CONFIGURATION_SECTION = 'n8n.tls';
+
+const CERTIFICATE_AUTHORITIES_SETTING = 'certificateAuthorities';
+const SYSTEM_CERTIFICATE_AUTHORITIES_SETTING = 'useSystemCertificateAuthorities';
+
+export function applyTlsTrustSettings(log: (message: string) => void): IExtraCaCertificateInstallation {
+    const configuration = vscode.workspace.getConfiguration(TLS_CONFIGURATION_SECTION);
+    return applyTlsTrust({
+        certificateAuthorities: configuration.get<string[]>(CERTIFICATE_AUTHORITIES_SETTING),
+        useSystemCertificateAuthorities: configuration.get<boolean>(SYSTEM_CERTIFICATE_AUTHORITIES_SETTING),
+        workspaceRoot: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+    }, log);
+}
+
+/** Re-applies the settings whenever the user edits them, so no window reload is needed. */
+export function registerTlsTrustSettingsWatcher(log: (message: string) => void): vscode.Disposable {
+    return vscode.workspace.onDidChangeConfiguration((event) => {
+        if (!event.affectsConfiguration(TLS_CONFIGURATION_SECTION)) return;
+        applyTlsTrustSettings(log);
+    });
+}

--- a/packages/vscode-extension/src/utils/tls-trust.ts
+++ b/packages/vscode-extension/src/utils/tls-trust.ts
@@ -1,0 +1,47 @@
+import { installExtraCaCertificates, type IExtraCaCertificateInstallation } from 'n8nac';
+
+/**
+ * Extra TLS trust anchors for the extension host.
+ *
+ * The extension host is an Electron process: it ignores `NODE_EXTRA_CA_CERTS` and cannot be
+ * given `--use-system-ca`, so an n8n instance behind a private CA fails to verify even when
+ * the terminal CLI works. Reading the certificates here and appending them to every secure
+ * context restores parity for axios, the global `fetch` the n8n manager uses for health and
+ * project calls, `ws`, and the workflow proxy alike.
+ */
+
+export interface ITlsTrustConfiguration {
+    /** PEM bundle paths, absolute or relative to `workspaceRoot`. */
+    certificateAuthorities?: string[];
+    /** Mirrors Node's `--use-system-ca`. Off by default; see below for why. */
+    useSystemCertificateAuthorities?: boolean;
+    workspaceRoot?: string;
+}
+
+export type TlsTrustInstaller = typeof installExtraCaCertificates;
+
+export function applyTlsTrust(
+    configuration: ITlsTrustConfiguration,
+    log: (message: string) => void,
+    install: TlsTrustInstaller = installExtraCaCertificates,
+): IExtraCaCertificateInstallation {
+    // The OS store holds ~100+ anchors and each one is re-applied to every secure context the
+    // process builds, which costs ~18 ms per TLS handshake against ~0.4 ms without it. Pointing
+    // `certificateAuthorities` at a bundle is both cheaper and more precise, so the store is
+    // opt-in for the rare case where the CA is only reachable from there.
+    const result = install({
+        caFiles: configuration.certificateAuthorities ?? [],
+        useSystemCertificateAuthorities: configuration.useSystemCertificateAuthorities ?? false,
+        baseDir: configuration.workspaceRoot,
+    });
+
+    if (result.certificates.length) {
+        log(`[n8n] Trusting ${result.certificates.length} extra CA certificate(s): ${result.sources.join(', ')}`);
+    }
+    for (const error of result.errors) {
+        // A host without a system trust store API is expected, not fatal: report and carry on.
+        log(`[n8n] TLS trust: ${error}`);
+    }
+
+    return result;
+}

--- a/packages/vscode-extension/tests/unit/tls-trust.test.ts
+++ b/packages/vscode-extension/tests/unit/tls-trust.test.ts
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { applyTlsTrust } from '../../src/utils/tls-trust.js';
+
+type InstallOptions = Parameters<typeof import('n8nac').installExtraCaCertificates>[0];
+
+function createInstaller(result: Partial<ReturnType<typeof import('n8nac').installExtraCaCertificates>> = {}) {
+    const calls: InstallOptions[] = [];
+    const install = ((options: InstallOptions) => {
+        calls.push(options);
+        return {
+            installed: false,
+            certificates: [],
+            sources: [],
+            errors: [],
+            ...result,
+        };
+    }) as typeof import('n8nac').installExtraCaCertificates;
+    return { install, calls };
+}
+
+test('TLS trust: forwards the configured bundles and resolves them against the workspace', () => {
+    const { install, calls } = createInstaller();
+
+    applyTlsTrust({
+        certificateAuthorities: ['certs/root-ca.pem'],
+        useSystemCertificateAuthorities: false,
+        workspaceRoot: '/workspace/project',
+    }, () => {}, install);
+
+    assert.deepStrictEqual(calls, [{
+        caFiles: ['certs/root-ca.pem'],
+        useSystemCertificateAuthorities: false,
+        baseDir: '/workspace/project',
+    }]);
+});
+
+test('TLS trust: leaves the system store opt-in and tolerates an unconfigured workspace', () => {
+    const { install, calls } = createInstaller();
+
+    applyTlsTrust({}, () => {}, install);
+
+    assert.deepStrictEqual(calls, [{
+        caFiles: [],
+        useSystemCertificateAuthorities: false,
+        baseDir: undefined,
+    }]);
+});
+
+test('TLS trust: reports the anchors it installed', () => {
+    const { install } = createInstaller({
+        installed: true,
+        certificates: ['pem-a', 'pem-b'],
+        sources: ['setting: /workspace/project/certs/root-ca.pem (2)'],
+    });
+    const logs: string[] = [];
+
+    const result = applyTlsTrust({ certificateAuthorities: ['certs/root-ca.pem'] }, (message) => logs.push(message), install);
+
+    assert.strictEqual(result.installed, true);
+    assert.deepStrictEqual(logs, ['[n8n] Trusting 2 extra CA certificate(s): setting: /workspace/project/certs/root-ca.pem (2)']);
+});
+
+test('TLS trust: surfaces resolution problems without failing activation', () => {
+    const { install } = createInstaller({
+        errors: [
+            'setting: cannot read "/missing.pem" (ENOENT)',
+            'setting: "/keys.pem" does not contain any PEM certificate',
+        ],
+    });
+    const logs: string[] = [];
+
+    assert.doesNotThrow(() => applyTlsTrust({ certificateAuthorities: ['/missing.pem'] }, (message) => logs.push(message), install));
+
+    assert.deepStrictEqual(logs, [
+        '[n8n] TLS trust: setting: cannot read "/missing.pem" (ENOENT)',
+        '[n8n] TLS trust: setting: "/keys.pem" does not contain any PEM certificate',
+    ]);
+});
+
+test('TLS trust: stays quiet when there is nothing extra to trust', () => {
+    const { install } = createInstaller();
+    const logs: string[] = [];
+
+    applyTlsTrust({}, (message) => logs.push(message), install);
+
+    assert.deepStrictEqual(logs, []);
+});


### PR DESCRIPTION
**What does this PR do?**

Stacks on top of #550 (merge this into `copilot/fix-use-system-ca-respect`, then #550 into `main`). It keeps #550's approach and closes two gaps found while testing against a real private-CA instance.

### 1. The failing requests were never on the axios path

`N8nApiClient` already passed `rejectUnauthorized: false`, so axios connected fine to a self-signed instance. The trust errors in #544 come from the code that reaches n8n through the **global `fetch`** — the manager-core `/healthz` probe, `testN8nApiConnection`, `listN8nProjects` and the credentials REST client — and `fetch` ignores `https.Agent` entirely. Setting `ca` on the agent therefore does not fix the reported bug.

`tls-certificates.ts` appends the resolved anchors to every secure context the process creates, which covers axios, `fetch`, `ws` and `http-proxy` at once. Installed at CLI startup and at extension activation, re-applied when the settings change.

### 2. Gating `rejectUnauthorized` on a non-empty bundle is a regression

`tls.getCACertificates('system')` returns anchors on any ordinary machine — 58 on the box used for testing — so `buildCaBundle() !== undefined` is true for nearly everyone. Every user with a plain self-signed instance and no configured CA would go from working to failing.

Verification is now enabled only when the user actually supplied an anchor (a setting, `NODE_EXTRA_CA_CERTS`, or `N8NAC_EXTRA_CA_CERTS`). The OS store is still trusted, it just no longer counts as "the user configured something". A test pins this.

### Consolidation

- `buildCaBundle()` is kept and delegates to the shared resolver, so one place reads certificates.
- `isTlsError()` delegates to the shared classifier, which unwraps `error.cause` — undici reports trust failures as `TypeError: fetch failed` with the real code nested, so the previous check never matched them. That matters because `fetch` is the path that fails.
- Adds `n8n.tls.certificateAuthorities` (the extension host cannot read `--use-system-ca`), multi-path `N8NAC_EXTRA_CA_CERTS`, and troubleshooting docs.

### Verification

Against a real HTTPS server with a private CA:

```
[no CA configured] system anchors found: 58 | hasConfiguredAnchors: false | rejectUnauthorized: false
  -> axios against self-signed: OK (no regression)
[fetch] before install: FAILED -> UNABLE_TO_VERIFY_LEAF_SIGNATURE
[install] installed: true | sources: [ 'NODE_EXTRA_CA_CERTS: .../ca.pem (1)' ]
[fetch] after install: 200 {"data":[]}
[CA configured] rejectUnauthorized: true
  -> axios with verification ON: OK
```

CLI unit suite 184/184 (including #550's `buildCaBundle` tests, whose assertions were adjusted because anchors are now stored as trimmed PEM blocks). Extension suite 144/146 — the two failures are in `agent-workbench-html.test.ts` and reproduce identically on an untouched checkout.

**Related issue (if any):** #544
