### PR TITLE
fix(scripts): correct doc index lookup, slug safety and cache validation

### DIFF
--- a/scripts/build-knowledge-index.cjs
+++ b/scripts/build-knowledge-index.cjs
@@ -216,7 +216,7 @@ function buildCategoryIndex(entries) {
 /**
  * Build quick lookup index
  */
-function buildQuickLookup(nodes, docs) {
+function buildQuickLookup(nodes, docs, pages) {
     const lookup = {
         nodeByName: {},
         docById: {},
@@ -228,17 +228,26 @@ function buildQuickLookup(nodes, docs) {
         lookup.nodeByName[entry.name] = entry;
     }
 
+    // buildDocSearchEntry() does not carry nodeName over, so resolve it from the
+    // source pages. Looking it up in `docs` only ever found the entry itself, which
+    // left docByNodeName permanently empty.
+    const nodeNameByPageId = new Map(
+        (pages || [])
+            .filter(page => page.nodeName)
+            .map(page => [page.id, page.nodeName])
+    );
+
     // Index docs
     for (const entry of docs) {
         lookup.docById[entry.id] = entry;
 
         // Index by node name if applicable
-        const page = docs.find(d => d.id === entry.id);
-        if (page && page.nodeName) {
-            if (!lookup.docByNodeName[page.nodeName]) {
-                lookup.docByNodeName[page.nodeName] = [];
+        const nodeName = nodeNameByPageId.get(entry.id);
+        if (nodeName) {
+            if (!lookup.docByNodeName[nodeName]) {
+                lookup.docByNodeName[nodeName] = [];
             }
-            lookup.docByNodeName[page.nodeName].push(entry.id);
+            lookup.docByNodeName[nodeName].push(entry.id);
         }
     }
 
@@ -412,7 +421,7 @@ async function main() {
 
         // Build quick lookup
         console.log('\n⚡ Building quick lookup index...');
-        const quickLookup = buildQuickLookup(nodeEntries, docEntries);
+        const quickLookup = buildQuickLookup(nodeEntries, docEntries, docsComplete.pages);
 
         // Build suggestions
         console.log('\n💡 Building suggestions...');

--- a/scripts/download-complete-docs.cjs
+++ b/scripts/download-complete-docs.cjs
@@ -33,8 +33,16 @@ const DELAY_BETWEEN_REQUESTS = 100; // ms
 const MAX_CONCURRENT_DOWNLOADS = 10;
 
 // Slug a section heading from llms.txt into a stable kebab-case id.
+// The result is used as a directory name under PAGES_DIR, so every character
+// outside [a-z0-9-] is replaced rather than passed through to path.join().
+// Without this a heading containing a path separator or '..' would escape the
+// cache directory. All nine section headings currently published in llms.txt
+// slug identically under this rule, so it is a hardening, not a rename.
 function slugifySection(name) {
-    return name.toLowerCase().replace(/\s+/g, '-');
+    return name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '') || 'uncategorized';
 }
 
 // Fallback category detection by URL prefix. Order matters — most specific first.
@@ -249,12 +257,23 @@ async function downloadAllPages(links, llmsHash) {
     if (fs.existsSync(METADATA_FILE)) {
         try {
             const metadata = JSON.parse(fs.readFileSync(METADATA_FILE, 'utf-8'));
-            if (metadata.llmsHash === llmsHash && metadata.totalPages > 0 && fs.existsSync(PAGES_DIR)) {
+            const cachedPages = Object.values(metadata.pages || {});
+            // A run that hit download errors still writes metadata, so the hash alone
+            // does not mean the cache is complete. Require a clean run and confirm every
+            // referenced file is still on disk before skipping the download.
+            const cacheIsComplete = metadata.llmsHash === llmsHash
+                && metadata.totalPages > 0
+                && metadata.errors === 0
+                && fs.existsSync(PAGES_DIR)
+                && cachedPages.length === metadata.totalPages
+                && cachedPages.every(page => page.filePath && fs.existsSync(path.join(OUTPUT_DIR, page.filePath)));
+
+            if (cacheIsComplete) {
                 console.log(`\n✅ Cache found with ${metadata.totalPages} pages. Skipping all downloads.`);
-                return { results: Object.values(metadata.pages), errors: [] };
+                return { results: cachedPages, errors: [] };
             }
 
-            console.log('\n🔄 llms.txt changed since the last snapshot. Refreshing documentation pages...');
+            console.log('\n🔄 Cached documentation is stale or incomplete. Refreshing documentation pages...');
             removeDirectoryIfExists(PAGES_DIR);
             await mkdir(PAGES_DIR, { recursive: true });
         } catch (e) {
@@ -283,7 +302,6 @@ async function downloadAllPages(links, llmsHash) {
 
                 // Save page to disk
                 const pageId = `page-${String(results.length + 1).padStart(4, '0')}`;
-                const safePath = link.urlPath.replace(/[^a-zA-Z0-9\/\-_.]/g, '-');
                 const pagePath = path.join(PAGES_DIR, category, `${pageId}.md`);
 
                 await mkdir(path.dirname(pagePath), { recursive: true });


### PR DESCRIPTION
Three defects CodeRabbit surfaced while reviewing #569. They are in code that PR does not change — it only renormalizes those files from CRLF to LF, which re-renders every line and made the whole file eligible for review — so they are fixed separately here.

Base is `main`. Independent of #569.

---

### 1. `docByNodeName` was always empty

`buildQuickLookup()` resolved a page with:

```js
const page = docs.find(d => d.id === entry.id);
if (page && page.nodeName) { ... }
```

`docs.find(d => d.id === entry.id)` can only ever return the entry currently being iterated, and `buildDocSearchEntry()` does not copy `nodeName` onto its result. So `page.nodeName` was always `undefined` and the map was never populated — every consumer of `quickLookup.docByNodeName` has been reading `{}`.

Fixed by resolving `nodeName` from the source pages, which carry it (`build-complete-index.cjs:279`). That file already builds its own `byNodeName` this way, so the corrected code matches the existing working pattern.

### 2. `slugifySection()` produced unsafe path segments

```js
return name.toLowerCase().replace(/\s+/g, '-');
```

The result is used directly as a directory name:

```js
const pagePath = path.join(PAGES_DIR, category, `${pageId}.md`);
```

Only whitespace was replaced, so a section heading in the upstream `llms.txt` containing a path separator or `..` would have written outside the cache directory. Now everything outside `[a-z0-9-]` is replaced.

I fetched the live `llms.txt` and checked all nine published section headings — `Get started`, `Deploy`, `Build`, `Nodes`, `Connect`, `Administer`, `Contribute`, `Privacy and security`, `Changelog` — and every one slugs identically under the new rule. This is hardening, not a rename; no category ids change.

The adjacent `safePath` variable was computed and never used, so the sanitizing it implied never actually happened. Removed.

### 3. A partially-downloaded docs cache was treated as complete

```js
if (metadata.llmsHash === llmsHash && metadata.totalPages > 0 && fs.existsSync(PAGES_DIR)) {
```

`generateMetadata()` writes metadata even when downloads failed — it records `errors: errors.length` — so a run that lost pages to network errors still produced a cache that matched this condition and was reused indefinitely on every later build.

Now also requires `metadata.errors === 0`, that the page count agrees with `totalPages`, and that every referenced `filePath` still exists on disk. The refresh log line no longer claims `llms.txt` changed, since that is now only one of several reasons to refetch.

---

### Verification

These scripts have no test coverage and export only `main()`, so I verified by extracting the patched helpers from the files and exercising them directly:

- `slugifySection` — path-safe for `../../etc`, `a/b`, `a\b`, `..`, `.`, `Nodes & Triggers`, `!!!`; `path.join` cannot escape for any of them; identical output for all nine real headings.
- `buildQuickLookup` — `docByNodeName` correctly groups multiple pages per node and omits pages without one; `docById` still indexes everything; degrades to the old empty map when `pages` is not supplied.
- Cache validation — accepts a clean complete cache; rejects non-zero errors, a missing referenced file, a count mismatch, and a stale hash.

Worth noting as follow-up: nothing under `scripts/` is covered by `scripts/unified-test-report.mjs`, which only walks workspace packages. Adding coverage there would need a new runner entry and exporting these helpers, which felt out of scope for a bugfix.
