### PR TITLE
test(skills): drop docs-provider mock that collides with main's categorization fix

### DIFF
--- a/packages/skills/tests/docs-provider.test.ts
+++ b/packages/skills/tests/docs-provider.test.ts
@@ -1,134 +1,11 @@
 import { DocsProvider } from '../src/services/docs-provider';
 import { describe, it, expect, beforeAll } from '@jest/globals';
-import fs from 'fs';
-import { jest } from '@jest/globals';
 
 describe('DocsProvider', () => {
     let provider: DocsProvider;
-    const docsPath = '/tmp/mock-n8n-docs-complete.json';
-
-    const mockDocs = {
-        generatedAt: '2026-01-01T00:00:00.000Z',
-        version: '1.0.0',
-        sourceUrl: 'https://docs.n8n.io/llms.txt',
-        totalPages: 3,
-        statistics: {
-            byCategory: {
-                workflows: 1,
-                tutorials: 1,
-                integrations: 1
-            },
-            withNodeNames: 1,
-            withUseCases: 2,
-            withCodeExamples: 1
-        },
-        categories: {
-            workflows: {
-                description: 'Workflow examples',
-                totalPages: 1,
-                pages: ['doc-1']
-            },
-            tutorials: {
-                description: 'Step-by-step tutorials',
-                totalPages: 1,
-                pages: ['doc-2']
-            },
-            integrations: {
-                description: 'Integrations docs',
-                totalPages: 1,
-                pages: ['doc-3']
-            }
-        },
-        pages: [
-            {
-                id: 'doc-1',
-                title: 'Webhook workflow example',
-                url: 'https://docs.n8n.io/workflows/webhook/',
-                urlPath: 'workflows/webhook/',
-                category: 'workflows',
-                subcategory: 'examples',
-                nodeName: null,
-                nodeType: null,
-                content: {
-                    markdown: 'Build a webhook workflow using n8n and trigger nodes.',
-                    excerpt: 'Webhook workflow guide',
-                    sections: []
-                },
-                metadata: {
-                    keywords: ['webhook', 'workflow'],
-                    useCases: ['Process inbound events'],
-                    operations: [],
-                    codeExamples: 1,
-                    complexity: 'beginner',
-                    readingTime: '2 min',
-                    contentLength: 200
-                }
-            },
-            {
-                id: 'doc-2',
-                title: 'Google Sheets tutorial',
-                url: 'https://docs.n8n.io/tutorials/google-sheets/',
-                urlPath: 'tutorials/google-sheets/',
-                category: 'tutorials',
-                subcategory: null,
-                nodeName: 'googleSheets',
-                nodeType: 'n8n-nodes-base.googleSheets',
-                content: {
-                    markdown: 'Learn how to automate Google Sheets in n8n.',
-                    excerpt: 'Google Sheets automation',
-                    sections: []
-                },
-                metadata: {
-                    keywords: ['google', 'sheets'],
-                    useCases: ['Spreadsheet automation'],
-                    operations: [],
-                    codeExamples: 0,
-                    complexity: 'beginner',
-                    readingTime: '3 min',
-                    contentLength: 220
-                }
-            },
-            {
-                id: 'doc-3',
-                title: 'Slack node reference',
-                url: 'https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.slack/',
-                urlPath: 'integrations/builtin/app-nodes/n8n-nodes-base.slack/',
-                category: 'integrations',
-                subcategory: 'app-nodes',
-                nodeName: 'slack',
-                nodeType: 'n8n-nodes-base.slack',
-                content: {
-                    markdown: 'Slack integration reference for messaging operations.',
-                    excerpt: 'Slack integration',
-                    sections: []
-                },
-                metadata: {
-                    keywords: ['slack', 'messaging'],
-                    useCases: ['Team notifications'],
-                    operations: [],
-                    codeExamples: 0,
-                    complexity: 'intermediate',
-                    readingTime: '4 min',
-                    contentLength: 240
-                }
-            }
-        ],
-        searchIndex: {
-            byKeyword: {},
-            byCategory: {},
-            byNodeName: {}
-        }
-    };
 
     beforeAll(() => {
-        jest.spyOn(fs, 'existsSync').mockImplementation((filePath) => String(filePath) === docsPath);
-        jest.spyOn(fs, 'readFileSync').mockImplementation((filePath) => {
-            if (String(filePath) === docsPath) {
-                return JSON.stringify(mockDocs);
-            }
-            throw new Error(`Unexpected file read: ${String(filePath)}`);
-        });
-        provider = new DocsProvider(docsPath);
+        provider = new DocsProvider();
     });
 
     it('should search documentation', () => {
@@ -153,20 +30,17 @@ describe('DocsProvider', () => {
         expect(categories[0]).toHaveProperty('name');
         expect(categories[0]).toHaveProperty('description');
 
-        const workflowCategory = categories.find(c => c.name === 'workflows');
-        expect(workflowCategory).toBeDefined();
+        const nodesCategory = categories.find(c => c.name === 'nodes');
+        expect(nodesCategory).toBeDefined();
     });
 
     it('should get guides with fuzzy search', () => {
-        // "webhooc" misspelled to test fuzzy/search capability is slightly better than simple inclusion
-        // Note: Our fuzzy search isn't typo-tolerant yet, but it searches keywords/content
-
         const results = provider.getGuides('webhook', 5);
         expect(Array.isArray(results)).toBe(true);
         expect(results.length).toBeGreaterThan(0);
 
-        // Verify we get results from the expected categories
-        const allowedCategories = ['tutorials', 'advanced-ai', 'workflows'];
+        // Verify we get results from the expected sections on docs.n8n.io
+        const allowedCategories = ['build', 'nodes'];
         const allValid = results.every(r =>
             allowedCategories.includes(r.category) || r.subcategory === 'examples'
         );


### PR DESCRIPTION
**What does this PR do?**

Stacks on top of #550 (merge into `copilot/fix-use-system-ca-respect`), fixing the `build-and-test` CI failure currently seen there.

**Root cause**

#550 carries an unrelated commit, `9df3dde test(skills): stabilize docs-provider tests with mocked docs dataset`, touching only `packages/skills/tests/docs-provider.test.ts`. Meanwhile `main` picked up `409dc65 fix(skills): restore docs categorization against current docs.n8n.io llms.txt`, which edits the same file.

The merge is textually clean but semantically contradictory: it keeps #550's mocked dataset (only `workflows`/`tutorials`/`integrations` categories) alongside `main`'s assertions, one of which expects a `nodes` category. Result:

```
FAIL tests/docs-provider.test.ts
  ✕ should get categories
    Received: undefined
    at tests/docs-provider.test.ts:157:31
```

That's the exact failure in #550's CI run (https://github.com/EtienneLescot/n8n-as-code/actions/runs/29995469816/job/89167997040).

**Fix**

`main` already solved the drift `9df3dde` was working around, and the change has nothing to do with certificate trust, so this restores `docs-provider.test.ts` to `main`'s version. One file, +5/-131.

**Related issue (if any):** #544
