### PR TITLE
fix(scripts): pass CI through the environment so builds work on Windows

### DIFF
--- a/scripts/ensure-n8n-cache.cjs
+++ b/scripts/ensure-n8n-cache.cjs
@@ -154,10 +154,14 @@ async function resolveStableTag() {
     throw new Error('Could not resolve n8n stable tag (API failed and no cache metadata found).');
 }
 
-function run(command, cwd = ROOT_DIR) {
+function run(command, cwd = ROOT_DIR, extraEnv = undefined) {
     console.log(`> ${command}`);
     try {
-        execSync(command, { cwd, stdio: 'inherit' });
+        execSync(command, {
+            cwd,
+            stdio: 'inherit',
+            env: extraEnv ? { ...process.env, ...extraEnv } : process.env,
+        });
     } catch (error) {
         console.error(`❌ Command failed: ${command}`);
         process.exit(1);
@@ -266,8 +270,11 @@ async function main() {
         console.log('🏗 Preparing n8n nodes (this may take a while)...');
 
         console.log('📦 Installing dependencies (root)...');
-        // Set CI=true to skip prepare scripts (lefthook install) which can fail
-        run('CI=true pnpm install', CACHE_DIR);
+        // CI=true skips prepare scripts (lefthook install) which can fail. It is passed
+        // through the environment rather than as a `CI=true ...` command prefix, which is
+        // POSIX shell syntax that cmd.exe cannot parse — on Windows it fails with
+        // "'CI' is not recognized as an internal or external command".
+        run('pnpm install', CACHE_DIR, { CI: 'true' });
 
         console.log('🔨 Building n8n-nodes-base (with dependencies)...');
         run('pnpm build --filter n8n-nodes-base...', CACHE_DIR);


### PR DESCRIPTION
Reported by @Hope-IT-Works on #569 while trying to build a VSIX to verify that fix. `npm run build` fails on Windows before it reaches any package:

```
📦 Installing dependencies (root)...
> CI=true pnpm install
Der Befehl "CI" ist entweder falsch geschrieben oder
konnte nicht gefunden werden.
❌ Command failed: CI=true pnpm install
```

### Cause

`scripts/ensure-n8n-cache.cjs` ran:

```js
run('CI=true pnpm install', CACHE_DIR);
```

`VAR=value command` is POSIX shell syntax. `execSync()` spawns `cmd.exe` on win32, which parses `CI=true` as the program name and aborts — so `generate:nodes` could never get past the n8n dependency install, and the whole monorepo build was unreachable on Windows.

It only ever worked for contributors running the build through Git Bash or WSL, which is why CI (ubuntu) never caught it.

### Fix

Pass `CI` through `execSync`'s `env` option, which behaves identically on every platform, and keep the command string shell-agnostic. `run()` takes an optional third `extraEnv` argument.

```js
run('pnpm install', CACHE_DIR, { CI: 'true' });
```

This was the only remaining POSIX env-prefix across the repo's `scripts/` and all `package.json` manifests.

### Verification

Reproduced and verified on Windows against the patched `run()` helper extracted from the file:

- `CI=true node -e "..."` under `execSync` → fails with `'CI' n'est pas reconnu en tant que commande interne` (same error as the report, different locale). Failure reproduced.
- Same command with `env: { ...process.env, CI: 'true' }` → child reads `process.env.CI === 'true'`.
- The patched `run()` forwards `extraEnv` to the child process.
- The shipped call site no longer contains the prefix.

Full `npm run build` on Windows still needs the n8n clone and a complete pnpm build of `n8n-nodes-base`, which I did not run end to end — but this was the first and only hard blocker, and the mechanism it depended on is verified above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency installation during node rebuilds across environments, including Windows command prompts.
  * Ensured the CI environment setting is applied consistently when running installation commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->