### PR TITLE
test(cli): make CLI integration suites runnable on Windows

### DIFF
--- a/packages/cli/tests/integration/instance-cli.integration.test.ts
+++ b/packages/cli/tests/integration/instance-cli.integration.test.ts
@@ -4,6 +4,19 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+/**
+ * Each test spawns the built CLI, and node process startup on Windows makes that take
+ * seconds — no headroom under vitest's 5s default. Applied per test because vitest 1.x
+ * silently ignores a suite-level `timeout` option on `describe`.
+ */
+const INTEGRATION_TIMEOUT = 30_000;
+
+/**
+ * `tsc -b` walks the whole project-reference graph, so on a clean checkout this builds
+ * every upstream package, not just the CLI — far past vitest's 10s default hookTimeout.
+ */
+const BUILD_TIMEOUT = 180_000;
+
 const tempDirs: string[] = [];
 const repoRoot = path.resolve(import.meta.dirname, '../../../..');
 const cliEntry = path.join(repoRoot, 'packages/cli/dist/index.js');
@@ -49,12 +62,14 @@ function runCliWithInput(cwd: string, homeDir: string, args: string[], input: st
 }
 
 beforeAll(() => {
+    // `npm` is a .cmd shim on Windows, which execFileSync cannot spawn without a shell.
     execFileSync('npm', ['run', 'build', '--workspace=packages/cli'], {
         cwd: repoRoot,
         stdio: 'pipe',
         encoding: 'utf8',
+        shell: process.platform === 'win32',
     });
-});
+}, BUILD_TIMEOUT);
 
 afterAll(() => {
     for (const dir of tempDirs) {
@@ -80,7 +95,7 @@ describe('CLI workspace integration', () => {
 
         expect(stripAnsi(output)).toContain('search [options] <query>');
         expect(stripAnsi(output)).toContain('examples');
-    });
+    }, INTEGRATION_TIMEOUT);
 
     it('does not expose legacy instance management commands and resolves workspace context non-interactively', () => {
         const workspaceDir = createTempDir('n8nac-cli-instance-workspace-');
@@ -148,7 +163,7 @@ describe('CLI workspace integration', () => {
         const workspaceConfig = JSON.parse(fs.readFileSync(configPath, 'utf8'));
         expect(workspaceConfig.activeInstanceId).toBe('test');
         expect(workspaceConfig.projectId).toBe('project-test');
-    });
+    }, INTEGRATION_TIMEOUT);
 
     it('creates remote environments directly without exposing low-level targets', () => {
         const workspaceDir = createTempDir('n8nac-cli-env-workspace-');
@@ -184,7 +199,7 @@ describe('CLI workspace integration', () => {
 
         const migration = runCliExpectFailure(workspaceDir, homeDir, ['workspace', 'migrate', '--json']);
         expect(stripAnsi(migration)).toContain("unknown command 'migrate'");
-    });
+    }, INTEGRATION_TIMEOUT);
 
     it('stores env auth locally for external workspace targets', () => {
         const workspaceDir = createTempDir('n8nac-cli-external-auth-workspace-');
@@ -216,7 +231,7 @@ describe('CLI workspace integration', () => {
             apiKeySource: 'workspace-local',
         });
         expect(authOutput).not.toContain('dev-key');
-    });
+    }, INTEGRATION_TIMEOUT);
 
     it('configures native MCP assist per environment without committing the token', () => {
         const workspaceDir = createTempDir('n8nac-cli-native-mcp-workspace-');
@@ -253,7 +268,7 @@ describe('CLI workspace integration', () => {
 
         const disabled = JSON.parse(runCli(workspaceDir, homeDir, ['native-mcp', 'disable', 'Dev', '--json']));
         expect(disabled.nativeMcp).toMatchObject({ enabled: false, tokenConfigured: false });
-    });
+    }, INTEGRATION_TIMEOUT);
 
     it('rejects env auth set for managed environments', () => {
         const workspaceDir = createTempDir('n8nac-cli-managed-auth-workspace-');
@@ -293,5 +308,5 @@ describe('CLI workspace integration', () => {
 
         const stdinOutput = runCliExpectFailure(workspaceDir, homeDir, ['env', 'auth', 'set', 'Dev', '--api-key-stdin']);
         expect(stripAnsi(stdinOutput)).toContain('uses managed instance "managed-dev"');
-    });
+    }, INTEGRATION_TIMEOUT);
 });

--- a/packages/cli/tests/integration/update-ai.integration.test.ts
+++ b/packages/cli/tests/integration/update-ai.integration.test.ts
@@ -5,6 +5,20 @@ import { execFileSync } from 'node:child_process';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 
+/**
+ * Every test here either spawns the built CLI (`node dist/index.js`) or loads its dist
+ * module graph in-process. Node process startup on Windows makes each one take seconds,
+ * which leaves no headroom under vitest's 5s default. Applied per test because vitest 1.x
+ * silently ignores a suite-level `timeout` option on `describe`.
+ */
+const INTEGRATION_TIMEOUT = 30_000;
+
+/**
+ * `tsc -b` walks the whole project-reference graph, so on a clean checkout this builds
+ * every upstream package, not just the CLI — far past vitest's 10s default hookTimeout.
+ */
+const BUILD_TIMEOUT = 180_000;
+
 const tempDirs: string[] = [];
 const repoRoot = path.resolve(import.meta.dirname, '../../../..');
 const cliEntry = path.join(repoRoot, 'packages/cli/dist/index.js');
@@ -102,12 +116,14 @@ function expectNativeMcpRoutingPolicy(content: string, cliCmd: string, skillsCmd
 }
 
 beforeAll(() => {
+    // `npm` is a .cmd shim on Windows, which execFileSync cannot spawn without a shell.
     execFileSync('npm', ['run', 'build', '--workspace=packages/cli'], {
         cwd: repoRoot,
         stdio: 'pipe',
         encoding: 'utf8',
+        shell: process.platform === 'win32',
     });
-});
+}, BUILD_TIMEOUT);
 
 afterAll(() => {
     for (const dir of tempDirs) {
@@ -148,7 +164,7 @@ describe('CLI update-ai integration', () => {
         expect(architectSkill).toContain('Managed Local Runtime');
         expect(architectSkill).toContain('--api-key-stdin');
         expect(agentsContent).not.toContain('saved instance configs');
-    });
+    }, INTEGRATION_TIMEOUT);
 
     it('generates native MCP routing guidance that uses live assist only when needed', () => {
         const workspaceDir = createTempDir('n8nac-update-ai-native-mcp-routing-');
@@ -157,7 +173,7 @@ describe('CLI update-ai integration', () => {
         const architectSkill = fs.readFileSync(path.join(workspaceDir, '.agents/skills/n8n-architect/SKILL.md'), 'utf8');
 
         expectNativeMcpRoutingPolicy(architectSkill, `node ${cliEntry}`, `node ${cliEntry} skills`);
-    });
+    }, INTEGRATION_TIMEOUT);
 
     it('embeds the n8nac CLI version stamp in AGENTS.md', () => {
         const workspaceDir = createTempDir('n8nac-update-ai-stamp-');
@@ -165,7 +181,7 @@ describe('CLI update-ai integration', () => {
 
         const agentsContent = fs.readFileSync(path.join(workspaceDir, 'AGENTS.md'), 'utf8');
         expect(agentsContent).toContain(`<!-- n8nac-version: ${cliVersion} -->`);
-    });
+    }, INTEGRATION_TIMEOUT);
 
     it('reports unsupported config versions from workspace status for legacy configs', () => {
         const workspaceDir = createTempDir('n8nac-status-legacy-workspace-');
@@ -186,7 +202,7 @@ describe('CLI update-ai integration', () => {
         expect(result.stderr).toContain('Unsupported n8nac workspace config version: 2');
         expect(result.stderr).toContain('n8nac env add <name> --base-url <url> --workflows-path workflows/<name>');
         expect(result.stderr).not.toContain('workspace migrate');
-    });
+    }, INTEGRATION_TIMEOUT);
 
     it('reports unsupported config versions from environment commands', () => {
         const workspaceDir = createTempDir('n8nac-env-blocked-legacy-workspace-');
@@ -206,7 +222,7 @@ describe('CLI update-ai integration', () => {
         expect(result.stdout).toBe('');
         expect(result.stderr).toContain('Unsupported n8nac workspace config version: 2');
         expect(result.stderr).not.toContain('workspace migrate');
-    });
+    }, INTEGRATION_TIMEOUT);
 
     it('uses n8nac workflow presentation and keeps n8n-manager guidance limited', () => {
         const workspaceDir = createTempDir('n8nac-update-ai-manager-tools-');
@@ -223,7 +239,7 @@ describe('CLI update-ai integration', () => {
         expect(architectSkill).toContain(`Do not call \`${managerCmd} presentWorkflowResult\``);
         expect(fs.existsSync(path.join(workspaceDir, '.github/agents/n8n-manager.agent.md'))).toBe(false);
         expect(fs.existsSync(path.join(workspaceDir, '.agents/skills/n8n-manager/SKILL.md'))).toBe(false);
-    });
+    }, INTEGRATION_TIMEOUT);
 
     it('checkAndRefreshIfStale silently refreshes AGENTS.md when the version stamp is stale', async () => {
         const workspaceDir = createTempDir('n8nac-update-ai-stale-');
@@ -253,7 +269,7 @@ describe('CLI update-ai integration', () => {
         expect(refreshed).not.toContain('workspace migrate --json');
         expect(fs.existsSync(path.join(workspaceDir, '.github/agents/n8n-architect.agent.md'))).toBe(true);
         expect(fs.existsSync(path.join(workspaceDir, '.agents/skills/n8n-architect/SKILL.md'))).toBe(true);
-    });
+    }, INTEGRATION_TIMEOUT);
 
     it('refreshes n8n-workflows.d.ts for all configured environment directories', () => {
         const workspaceDir = createTempDir('n8nac-update-ai-dts-');
@@ -299,5 +315,5 @@ describe('CLI update-ai integration', () => {
         const dtsContent = fs.readFileSync(dtsPath, 'utf8');
         expect(dtsContent).not.toBe('// stale');
         expect(dtsContent.length).toBeGreaterThan(100);
-    });
+    }, INTEGRATION_TIMEOUT);
 });

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -5,6 +5,13 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/**/*.test.ts'],
+    server: {
+      deps: {
+        // Built artifacts are plain JS — load them with native node ESM instead of
+        // pushing the whole CLI dist graph through Vite's transform pipeline.
+        external: [/[\\/]dist[\\/]/],
+      },
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
**What does this PR do?**

The two CLI integration suites could not run on Windows **at all**. `npm` is a `.cmd` shim, which `execFileSync` cannot spawn without a shell, so both `beforeAll` hooks died with `spawnSync npm ENOENT` before a single test executed. Passing `shell` on Windows fixes that — and surfaced three separate timeout problems underneath.

### 1. The stale-refresh test was 2.5x slower than it needed to be

`checkAndRefreshIfStale silently refreshes AGENTS.md when the version stamp is stale` timed out at the 5s default. Unlike its neighbours it does not spawn the CLI — it imports the dist module graph in-process. Profiling isolated the cost:

| | |
|---|---|
| `import(dist/commands/update-ai.js)` | 1685 ms |
| `checkAndRefreshIfStale()` actual work | 78 ms |
| Same test body under vitest | ~5040 ms |

The work is trivial; the gap was vitest routing that dynamic `import()` through Vite''s transform pipeline instead of native node ESM, forcing a transform of the whole CLI dist graph. Externalizing `dist/` in `vitest.config.ts` takes it from **5042 ms to 2007 ms**. Nothing was hanging — no network call is ever made, since `dotenv` injects 0 vars and no API client is constructed.

### 2. Every test in both files sat too close to the 5s default

The stale test was the one that tipped over, but it was not alone: the remaining tests run 3–5s on Windows because each spawns `node dist/index.js`. Measured 4406 ms and 4761 ms on one run — a timeout on only the failing test would have left the rest ~0.2s from the edge. `INTEGRATION_TIMEOUT` (30s) is applied per test.

> Applied per test, not on `describe`, because **vitest 1.x silently ignores a suite-level `timeout` option**. Verified by probing with `{ timeout: 100 }`, under which all 8 tests still passed. Noted in a comment so nobody retries it.

### 3. The build hook would fail on any clean checkout

`build` is `tsc -b`, which walks the whole project-reference graph — on a fresh worktree it builds every upstream package, measured at **~30s** against vitest''s 10s default `hookTimeout`. This passes today only because `dist` is usually warm locally. `BUILD_TIMEOUT` (180s) covers it.

**Verification**

Run on Windows with all `dist/` directories and `tsconfig.tsbuildinfo` files deleted, so the cold-build path is actually exercised:

- `npx vitest run tests/integration/update-ai.integration.test.ts` (no flag overrides) — 8/8 passing
- Full package suite — 25 files, 189 tests passing

Test-only change; no production code touched.

**Related issue (if any):** #

---

> Note: the PR template asks for `next` as base. Targeting `main` here deliberately — `next` is currently 14 commits *behind* `main`, so a `next`-based PR would carry 15 commits instead of 1 and would pull those 14 back into `next`. Happy to retarget if that is wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI integration test reliability by allowing longer execution times for builds and test cases.
  * Added Windows compatibility for CLI build steps.
  * Improved test handling of built CLI modules to reduce transformation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->