### PR TITLE
feat(cli): optional /rest session folder-source for folderSync pull

### DIFF
--- a/docs/docs/usage/folder-sync.md
+++ b/docs/docs/usage/folder-sync.md
@@ -9,9 +9,9 @@ title: Folder Sync
 folder on the instance, creating the folders if they do not exist yet.
 
 Out of the box it is **push-only** over n8n's public API — that direction is a
-property of the API, not a choice we made. An **optional session-auth source** can
+property of the API, not a choice we made. An **optional, experimental session-auth source** can
 additionally reconstruct the nested layout on `pull` (see
-[Reading folders on pull](#reading-folders-on-pull-optional)). Read the sections
+[Reading folders on pull](#reading-folders-on-pull-experimental)). Read the sections
 below before enabling it, because they determine what you can expect from `pull`.
 
 ## What works, and what cannot
@@ -37,7 +37,7 @@ Consequences:
   inside a folder is pulled to the root of your workflows directory. Move it where
   you want it once, and the next push pins that placement on n8n. (With the optional
   session source configured, pull instead reconstructs the nested layout — see
-  [Reading folders on pull](#reading-folders-on-pull-optional).)
+  [Reading folders on pull](#reading-folders-on-pull-experimental).)
 - Workflows already tracked in `.n8n-state.json` keep their local path across pulls,
   so an existing nested layout is never flattened.
 - `n8nac status` cannot report "someone moved this workflow in the UI". Drift in that
@@ -55,7 +55,7 @@ Consequences:
 - **An API key only, to push.** No session login is required to push folders. The
   project id is read from a workflow's `shared[]` payload, so the Enterprise-gated
   `GET /api/v1/projects` endpoint is never called. Reconstructing folders on *pull*
-  is the one thing that needs more — see [Reading folders on pull](#reading-folders-on-pull-optional).
+  is the one thing that needs more — see [Reading folders on pull](#reading-folders-on-pull-experimental).
 
 ## Configuration
 
@@ -85,7 +85,10 @@ for organisation. With it off, a push only ever places workflows the repository 
 an opinion about, and never undoes a folder someone created in the n8n UI. With it
 on, the repository layout wins outright: local root means project root.
 
-## Reading folders on pull (optional)
+## Reading folders on pull (Experimental)
+
+> [!NOTE]
+> **Experimental workaround**: In n8n, `parentFolderId` is write-only in the public API. Pulling the folder hierarchy requires communicating with n8n's internal `/rest` session API (the same endpoints used by the n8n web app). This feature is opt-in and experimental. If n8n eventually adds folder reading to its public API, this session mechanism may be deprecated in favor of the public API.
 
 Because the public API never returns a workflow's folder (the table above), `pull`
 normally lays workflows out flat. If you want `pull` to **reconstruct the nested
@@ -113,6 +116,22 @@ n8nac env auth folder-logout prod
 The stored cookie is a bearer credential. It lives in the same local secret store as
 your API keys (honouring `N8N_MANAGER_HOME`), `n8nac env auth clear` removes it along
 with the API key, and it is redacted from command output.
+
+### SSO / SAML / 2FA (MFA) Workaround
+
+`n8nac env auth folder-login` performs a direct username/password login against n8n's `/rest/login`. If your n8n instance uses **Single Sign-On (Google, Okta, SAML)** or has **Two-Factor Authentication (2FA / MFA)** enabled on your account:
+- Direct email/password login will be rejected.
+- You can obtain a valid session cookie directly from your browser:
+  1. Log into your n8n web interface in your browser.
+  2. Open Developer Tools (`F12`) → **Application** (Chrome/Edge) or **Storage** (Firefox) → **Cookies**.
+  3. Find and copy the value of the `n8n-auth` cookie (the JWT string).
+  4. Pass it via the environment variable:
+     ```bash
+     export N8NAC_FOLDER_LOGIN_TOKEN="n8n-auth=<jwt>"
+     # or per-environment:
+     export N8NAC_ENV_PROD_FOLDER_TOKEN="n8n-auth=<jwt>"
+     ```
+This token will remain valid until the cookie expires in n8n (typically ~7 days).
 
 ### Credentials via environment (CI)
 

--- a/docs/docs/usage/folder-sync.md
+++ b/docs/docs/usage/folder-sync.md
@@ -8,9 +8,11 @@ title: Folder Sync
 `Reports/Weekly/summary.workflow.ts` is created — or moved — into the `Reports/Weekly`
 folder on the instance, creating the folders if they do not exist yet.
 
-It is **push-only**, and that is a property of n8n's public API rather than a choice
-we made. Read the section below before enabling it, because it determines what you
-can expect from `pull`.
+Out of the box it is **push-only** over n8n's public API — that direction is a
+property of the API, not a choice we made. An **optional session-auth source** can
+additionally reconstruct the nested layout on `pull` (see
+[Reading folders on pull](#reading-folders-on-pull-optional)). Read the sections
+below before enabling it, because they determine what you can expect from `pull`.
 
 ## What works, and what cannot
 
@@ -31,9 +33,11 @@ not a licence gate.
 Consequences:
 
 - **Push** carries your folder layout to n8n. This direction is complete.
-- **Pull** cannot restore it. A workflow created in the n8n UI inside a folder is
-  pulled to the root of your workflows directory. Move it where you want it once,
-  and the next push pins that placement on n8n.
+- **Pull** cannot restore it over the public API: a workflow created in the n8n UI
+  inside a folder is pulled to the root of your workflows directory. Move it where
+  you want it once, and the next push pins that placement on n8n. (With the optional
+  session source configured, pull instead reconstructs the nested layout — see
+  [Reading folders on pull](#reading-folders-on-pull-optional).)
 - Workflows already tracked in `.n8n-state.json` keep their local path across pulls,
   so an existing nested layout is never flattened.
 - `n8nac status` cannot report "someone moved this workflow in the UI". Drift in that
@@ -48,9 +52,10 @@ Consequences:
   Community edition (free, email registration) and are present on all paid plans. On
   an unregistered instance the folder endpoints answer `403` and n8nac degrades to a
   flat push with a warning.
-- **An API key only.** No session login is required. The project id is read from a
-  workflow's `shared[]` payload, so the Enterprise-gated `GET /api/v1/projects`
-  endpoint is never called.
+- **An API key only, to push.** No session login is required to push folders. The
+  project id is read from a workflow's `shared[]` payload, so the Enterprise-gated
+  `GET /api/v1/projects` endpoint is never called. Reconstructing folders on *pull*
+  is the one thing that needs more — see [Reading folders on pull](#reading-folders-on-pull-optional).
 
 ## Configuration
 
@@ -79,6 +84,70 @@ Leave `folderSyncMoveToRoot` off unless the repository is the sole source of tru
 for organisation. With it off, a push only ever places workflows the repository has
 an opinion about, and never undoes a folder someone created in the n8n UI. With it
 on, the repository layout wins outright: local root means project root.
+
+## Reading folders on pull (optional)
+
+Because the public API never returns a workflow's folder (the table above), `pull`
+normally lays workflows out flat. If you want `pull` to **reconstruct the nested
+layout** — to seed a fresh checkout, or to place new and remote-only workflows into
+their folders — n8nac can read the folder tree over n8n's internal `/rest` API,
+which the editor itself uses and which works on every edition.
+
+As on the public path, workflows already tracked in `.n8n-state.json` keep their
+local path across pulls: this reconstructs folders for workflows not yet tracked
+locally; it does not relocate a tracked workflow that was moved between folders in
+the n8n UI.
+
+This path uses **session (cookie) auth**, so it is opt-in. Log in once and n8nac
+stores the resulting session cookie locally — kept until its server-issued expiry
+(n8n's default is ~7 days), and never the password:
+
+```bash
+# read the password from stdin (keeps it out of process listings / shell history)
+n8nac env auth folder-login prod --user you@example.com --password-stdin
+
+# remove the stored session again
+n8nac env auth folder-logout prod
+```
+
+The stored cookie is a bearer credential. It lives in the same local secret store as
+your API keys (honouring `N8N_MANAGER_HOME`), `n8nac env auth clear` removes it along
+with the API key, and it is redacted from command output.
+
+### Credentials via environment (CI)
+
+Instead of a stored cookie you can supply credentials or a token through the
+environment — never committed:
+
+| Variable | Purpose |
+| --- | --- |
+| `N8NAC_ENV_<ENV>_FOLDER_USER` / `_FOLDER_PASS` | Per-environment login credentials |
+| `N8NAC_ENV_<ENV>_FOLDER_TOKEN` | Per-environment session cookie / JWT |
+| `N8NAC_FOLDER_LOGIN_USER` / `_PASS` / `_TOKEN` | Generic fallback |
+
+`<ENV>` is the environment name upper-cased with non-alphanumerics turned into `_`
+(e.g. `prod` → `PROD`). A stored cookie is tried first, then the env token; if both
+are rejected and credentials are present, n8nac logs in again automatically.
+
+### Failure behaviour
+
+If a session source **is** configured but the load fails (revoked cookie, wrong
+credentials, unreachable `/rest`), `pull` **fails closed** with an actionable error
+rather than silently falling back to a flat layout — a silent flat pull would
+produce a large, misleading diff when reconciling. To allow the flat fallback
+instead (warn and continue), set `N8NAC_FOLDER_ALLOW_FLAT_FALLBACK=1` (or the
+per-environment `N8NAC_ENV_<ENV>_FOLDER_ALLOW_FLAT`).
+
+### Security
+
+The password is used only to mint the cookie and is never stored. Prefer
+`--password-stdin` over `--password`, which can be visible in process listings and
+shell history. When the host is a non-loopback `http://` URL, n8nac warns that the
+password and cookie travel in cleartext — use HTTPS.
+
+`/rest` is an **internal, unsupported** n8n API: it is not covered by n8n's public
+API stability guarantees and may change between versions. n8nac uses it only to read
+folder membership; every write still goes through the public API.
 
 ## Naming
 

--- a/packages/cli/src/commands/base.ts
+++ b/packages/cli/src/commands/base.ts
@@ -228,12 +228,20 @@ export class BaseCommand {
         let pass = '';
         let envToken = '';
         for (const slug of slugs) {
-            user = user || clean(process.env[`N8NAC_ENV_${slug}_FOLDER_USER`]);
-            pass = pass || clean(process.env[`N8NAC_ENV_${slug}_FOLDER_PASS`]);
+            const scopedUser = clean(process.env[`N8NAC_ENV_${slug}_FOLDER_USER`]);
+            const scopedPass = clean(process.env[`N8NAC_ENV_${slug}_FOLDER_PASS`]);
+            if (!user && !pass && scopedUser && scopedPass) {
+                user = scopedUser;
+                pass = scopedPass;
+            }
             envToken = envToken || clean(process.env[`N8NAC_ENV_${slug}_FOLDER_TOKEN`]);
         }
-        user = user || clean(process.env.N8NAC_FOLDER_LOGIN_USER);
-        pass = pass || clean(process.env.N8NAC_FOLDER_LOGIN_PASS);
+        const genericUser = clean(process.env.N8NAC_FOLDER_LOGIN_USER);
+        const genericPass = clean(process.env.N8NAC_FOLDER_LOGIN_PASS);
+        if (!user && !pass && genericUser && genericPass) {
+            user = genericUser;
+            pass = genericPass;
+        }
         envToken = envToken || clean(process.env.N8NAC_FOLDER_LOGIN_TOKEN);
 
         // Accept a bare JWT by adding the cookie name.

--- a/packages/cli/src/commands/base.ts
+++ b/packages/cli/src/commands/base.ts
@@ -202,6 +202,85 @@ export class BaseCommand {
     }
 
     /**
+     * Resolve optional session auth for reading n8n folders over the internal
+     * `/rest` API. folderSync needs it wherever the public workflow API omits a
+     * workflow's folder ownership — which is every edition today — so `pull` can
+     * rebuild the nested layout. Entirely opt-in: with nothing configured this
+     * returns undefined and the public (flat) path is used, unchanged.
+     *
+     * Candidate cookies are tried in order — the stored per-target token (from
+     * `n8nac env auth folder-login`) first, then an env token — and `user`/`pass`
+     * mint a fresh cookie when none works. Env vars are never committed:
+     *   N8NAC_ENV_<ENV>_FOLDER_USER / _FOLDER_PASS   (per-environment creds)
+     *   N8NAC_ENV_<ENV>_FOLDER_TOKEN                 (per-environment cookie/jwt)
+     *   N8NAC_FOLDER_LOGIN_USER / _PASS / _TOKEN     (generic fallback)
+     */
+    protected resolveFolderAuth(): { cookies?: string[]; user?: string; pass?: string } | undefined {
+        const clean = (v?: string) => v?.trim().replace(/^['"]|['"]$/g, '') || '';
+        const slugify = (v?: string) =>
+            (v || '').toUpperCase().replace(/[^A-Z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+        const slugs = [
+            this.activeEnvironment?.environmentName,
+            this.activeEnvironment?.environmentId,
+        ].map(slugify).filter(Boolean);
+
+        let user = '';
+        let pass = '';
+        let envToken = '';
+        for (const slug of slugs) {
+            user = user || clean(process.env[`N8NAC_ENV_${slug}_FOLDER_USER`]);
+            pass = pass || clean(process.env[`N8NAC_ENV_${slug}_FOLDER_PASS`]);
+            envToken = envToken || clean(process.env[`N8NAC_ENV_${slug}_FOLDER_TOKEN`]);
+        }
+        user = user || clean(process.env.N8NAC_FOLDER_LOGIN_USER);
+        pass = pass || clean(process.env.N8NAC_FOLDER_LOGIN_PASS);
+        envToken = envToken || clean(process.env.N8NAC_FOLDER_LOGIN_TOKEN);
+
+        // Accept a bare JWT by adding the cookie name.
+        const asCookie = (v: string) => (v && !v.includes('=') ? `n8n-auth=${v}` : v);
+
+        const cookies: string[] = [];
+        // Stored per-target token first (skips a login round-trip), if unexpired.
+        const targetId = this.activeEnvironment?.environmentTargetId;
+        if (targetId) {
+            const session = this.configService.getFolderSession(targetId);
+            if (session?.cookie && (!session.expiresAt || Date.parse(session.expiresAt) > Date.now())) {
+                cookies.push(asCookie(session.cookie));
+            }
+        }
+        // Env token as a fallback candidate — used if the stored cookie is revoked.
+        if (envToken) cookies.push(asCookie(envToken));
+        const uniqueCookies = cookies.filter((c, i) => c && cookies.indexOf(c) === i);
+
+        if (uniqueCookies.length === 0 && !(user && pass)) return undefined;
+        return {
+            cookies: uniqueCookies.length ? uniqueCookies : undefined,
+            user: user || undefined,
+            pass: pass || undefined,
+        };
+    }
+
+    /**
+     * Whether a configured session folder source that fails to load may degrade to
+     * a flat pull (with a warning) instead of failing closed. Off by default; opt in
+     * with N8NAC_ENV_<ENV>_FOLDER_ALLOW_FLAT or N8NAC_FOLDER_ALLOW_FLAT_FALLBACK.
+     */
+    protected resolveFolderSessionAllowFlatFallback(): boolean {
+        const truthy = (v?: string) => /^(1|true|yes|on)$/i.test((v || '').trim());
+        const slugify = (v?: string) =>
+            (v || '').toUpperCase().replace(/[^A-Z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+        const slugs = [
+            this.activeEnvironment?.environmentName,
+            this.activeEnvironment?.environmentId,
+        ].map(slugify).filter(Boolean);
+        for (const slug of slugs) {
+            const perEnv = process.env[`N8NAC_ENV_${slug}_FOLDER_ALLOW_FLAT`];
+            if (perEnv !== undefined) return truthy(perEnv);
+        }
+        return truthy(process.env.N8NAC_FOLDER_ALLOW_FLAT_FALLBACK);
+    }
+
+    /**
      * Get sync config with instance identifier.
      * Validates that required project fields are present; exits with a clear error if not.
      */
@@ -238,6 +317,9 @@ export class BaseCommand {
             projectName: localConfig.projectName,
             folderSync: localConfig.folderSync ?? false,
             folderSyncMoveToRoot: localConfig.folderSyncMoveToRoot ?? false,
+            host: this.config.host,
+            folderAuth: this.resolveFolderAuth(),
+            folderSessionAllowFlatFallback: this.resolveFolderSessionAllowFlatFallback(),
             environmentId: this.activeEnvironment?.environmentId,
             environmentName: this.activeEnvironment?.environmentName,
             environmentTargetId: this.activeEnvironment?.environmentTargetId,

--- a/packages/cli/src/core/services/rest-folder-source.ts
+++ b/packages/cli/src/core/services/rest-folder-source.ts
@@ -62,7 +62,7 @@ function parseCookieExpiry(setCookie: string[] | undefined, now: number): string
 const warnedInsecureHosts = new Set<string>();
 
 /** True for loopback hosts, where plain HTTP does not leave the machine. */
-function isLoopbackHost(hostname: string): boolean {
+export function isLoopbackHost(hostname: string): boolean {
     return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]';
 }
 

--- a/packages/cli/src/core/services/rest-folder-source.ts
+++ b/packages/cli/src/core/services/rest-folder-source.ts
@@ -29,6 +29,8 @@ export interface RestFolderData {
     folders: IFolder[];
     /** `workflowId -> parentFolderId` for every foldered workflow. */
     workflowParentFolderId: Map<string, string>;
+    /** Set when the folders endpoint returns 403 (unregistered Community) or 404 (predates folders). */
+    licenseUnavailableReason?: string;
 }
 
 /** n8n's placeholder id for the current user's personal project. */
@@ -90,11 +92,9 @@ function warnIfInsecureHost(host: string): void {
  *
  * Rationale: n8n's public workflow API omits a workflow's folder ownership on
  * every edition (`parentFolderId` is `writeOnly` in the spec and no endpoint maps
- * workflows to folders), and `GET /api/v1/projects/{id}/folders` is license-gated
- * on Community (403). So the public folder path cannot reconstruct a nested layout
- * on `pull`. The n8n UI itself uses these `/rest` endpoints with a login cookie,
- * which work on every edition. This source replicates that path so `folderSync`
- * can mirror the real folder tree.
+ * workflows to folders). The n8n UI itself uses these `/rest` endpoints with a login cookie,
+ * which work whenever folders are licensed on the instance (registered Community edition or paid plans).
+ * This source replicates that path so `folderSync` can mirror the real folder tree.
  *
  * It only fetches data; folder→path resolution is delegated to the existing
  * {@link FolderPathResolver} so behavior matches the public-API code path.
@@ -188,7 +188,24 @@ export class RestFolderSource {
         // editor, avoids paginating every workflow visible to the account, and keeps
         // the map to this project's workflows (never a team project's).
         const workflows = await this.getAll<any>('/rest/workflows', { filter: JSON.stringify({ projectId: resolvedProjectId }) });
-        const folders = await this.getAll<IFolder>(`/rest/projects/${encodeURIComponent(resolvedProjectId)}/folders`);
+        let folders: IFolder[] = [];
+        let licenseUnavailableReason: string | undefined;
+        try {
+            folders = await this.getAll<IFolder>(`/rest/projects/${encodeURIComponent(resolvedProjectId)}/folders`);
+        } catch (error: any) {
+            // 403 on /folders indicates that the instance lacks the `feat:folders` license
+            // (e.g. an unregistered Community instance); 404 indicates an older n8n version without folders.
+            // Scoping this degrade specifically to the /folders endpoint: a 403 on workflows or other endpoints
+            // remains a real auth error that fails closed, whereas folders license absence degrades to a flat pull
+            // with a warning, matching the push path.
+            if ([403, 404].includes(error?.response?.status)) {
+                licenseUnavailableReason = error?.response?.status === 403
+                    ? 'the n8n instance reports no folder support (register the Community instance to unlock folders)'
+                    : 'this n8n version has no folder API (needs n8n 2.19+, and 2.32+ to place workflows)';
+            } else {
+                throw error;
+            }
+        }
 
         const workflowParentFolderId = new Map<string, string>();
         for (const wf of workflows) {
@@ -197,7 +214,7 @@ export class RestFolderSource {
             if (folderId) workflowParentFolderId.set(wf.id, folderId);
         }
 
-        return { folders, workflowParentFolderId };
+        return { folders, workflowParentFolderId, licenseUnavailableReason };
     }
 
     /** The user's personal project id from `/rest/projects` (type === 'personal'); undefined if unavailable. */

--- a/packages/cli/src/core/services/rest-folder-source.ts
+++ b/packages/cli/src/core/services/rest-folder-source.ts
@@ -135,7 +135,7 @@ export class RestFolderSource {
         const res = await axios.post(
             `${host.replace(/\/+$/, '')}/rest/login`,
             { emailOrLdapLoginId: user, password: pass },
-            { headers: { 'Content-Type': 'application/json' }, timeout: 30000 },
+            { headers: { 'Content-Type': 'application/json' }, timeout: 30000, maxRedirects: 0 },
         );
         const setCookie: string[] | undefined = res.headers?.['set-cookie'];
         const cookie = extractAuthCookie(setCookie);

--- a/packages/cli/src/core/services/rest-folder-source.ts
+++ b/packages/cli/src/core/services/rest-folder-source.ts
@@ -1,0 +1,300 @@
+import axios, { AxiosInstance } from 'axios';
+import { IFolder } from '../types.js';
+
+/**
+ * Folder-auth material for the internal `/rest` API. Provide one or more
+ * previously-stored session cookies (`n8n-auth=<jwt>`, valid until their server-issued expiry) and/or raw
+ * `user`/`pass` to log in with. Cookies are tried in order; `user`/`pass` are
+ * used to mint a fresh cookie when none is present, and to silently re-login once
+ * if every supplied cookie is rejected (401).
+ */
+export interface RestFolderAuth {
+    /** Single cookie (convenience). Merged after {@link cookies}. */
+    cookie?: string;
+    /** Ordered candidate cookies, tried in turn on 401 before re-login. */
+    cookies?: string[];
+    user?: string;
+    pass?: string;
+}
+
+export interface RestFolderLoginResult {
+    /** Cookie header value, e.g. `n8n-auth=<jwt>`. */
+    cookie: string;
+    /** ISO expiry parsed from the Set-Cookie (Max-Age/Expires), if available. */
+    expiresAt?: string;
+}
+
+export interface RestFolderData {
+    /** Raw folder tree (feeds {@link FolderPathResolver}). */
+    folders: IFolder[];
+    /** `workflowId -> parentFolderId` for every foldered workflow. */
+    workflowParentFolderId: Map<string, string>;
+}
+
+/** n8n's placeholder id for the current user's personal project. */
+const PERSONAL_PROJECT_PLACEHOLDER = 'personal';
+
+/** Reduce a Set-Cookie array to the `n8n-auth=<value>` cookie pair (only). */
+function extractAuthCookie(setCookie: string[] | undefined): string | undefined {
+    if (!setCookie?.length) return undefined;
+    // Require the actual auth cookie: an unrelated CSRF/routing cookie is not a session.
+    const auth = setCookie.find((c) => c.startsWith('n8n-auth='));
+    return auth ? auth.split(';')[0] : undefined;
+}
+
+/** Parse an absolute expiry from the `n8n-auth` Set-Cookie entry's Max-Age/Expires. */
+function parseCookieExpiry(setCookie: string[] | undefined, now: number): string | undefined {
+    const auth = setCookie?.find((c) => c.startsWith('n8n-auth='));
+    if (!auth) return undefined;
+    const maxAge = /max-age=(\d+)/i.exec(auth)?.[1];
+    if (maxAge) return new Date(now + Number(maxAge) * 1000).toISOString();
+    const expires = /expires=([^;]+)/i.exec(auth)?.[1];
+    if (expires) {
+        const ts = Date.parse(expires);
+        if (!Number.isNaN(ts)) return new Date(ts).toISOString();
+    }
+    return undefined;
+}
+
+/** Hosts we've already warned about sending credentials over cleartext (warn once each). */
+const warnedInsecureHosts = new Set<string>();
+
+/** True for loopback hosts, where plain HTTP does not leave the machine. */
+function isLoopbackHost(hostname: string): boolean {
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]';
+}
+
+/**
+ * Warn (once per host) when session credentials — the password on login and the
+ * cookie on every request — would travel over non-loopback cleartext HTTP.
+ */
+function warnIfInsecureHost(host: string): void {
+    let url: URL;
+    try {
+        url = new URL(host);
+    } catch {
+        return;
+    }
+    if (url.protocol !== 'http:' || isLoopbackHost(url.hostname)) return;
+    if (warnedInsecureHosts.has(url.host)) return;
+    warnedInsecureHosts.add(url.host);
+    console.warn(
+        `[RestFolderSource] Sending folder-login credentials and session cookie over plain HTTP to ${url.host}. ` +
+        `Use HTTPS for any non-loopback host so they are not exposed on the network.`,
+    );
+}
+
+/**
+ * Reads the n8n folder hierarchy over the INTERNAL `/rest` API using session
+ * (cookie) authentication.
+ *
+ * Rationale: n8n's public workflow API omits a workflow's folder ownership on
+ * every edition (`parentFolderId` is `writeOnly` in the spec and no endpoint maps
+ * workflows to folders), and `GET /api/v1/projects/{id}/folders` is license-gated
+ * on Community (403). So the public folder path cannot reconstruct a nested layout
+ * on `pull`. The n8n UI itself uses these `/rest` endpoints with a login cookie,
+ * which work on every edition. This source replicates that path so `folderSync`
+ * can mirror the real folder tree.
+ *
+ * It only fetches data; folder→path resolution is delegated to the existing
+ * {@link FolderPathResolver} so behavior matches the public-API code path.
+ */
+export class RestFolderSource {
+    private readonly client: AxiosInstance;
+    private readonly cookieCandidates: string[];
+    private cookieIndex = 0;
+    private cookie?: string;
+    private reloggedIn = false;
+    private loadChain: Promise<unknown> = Promise.resolve();
+
+    constructor(
+        private readonly host: string,
+        private readonly projectId: string,
+        private readonly auth: RestFolderAuth,
+    ) {
+        this.client = axios.create({
+            baseURL: host.replace(/\/+$/, ''),
+            timeout: 30000,
+        });
+        // De-duplicated, ordered candidate cookies: explicit list first, then the
+        // single-cookie convenience field. A stale-but-unexpired stored cookie can
+        // then fall through to an env-provided token instead of masking it.
+        this.cookieCandidates = [...(auth.cookies ?? []), ...(auth.cookie ? [auth.cookie] : [])]
+            .filter((c, i, arr) => c && arr.indexOf(c) === i);
+        this.cookie = this.cookieCandidates[0];
+        warnIfInsecureHost(host);
+    }
+
+    /**
+     * Log in once and return the session cookie + its expiry. Used by the
+     * `env auth folder-login` command to mint a token to store, and internally
+     * to refresh an expired one.
+     */
+    static async login(host: string, user: string, pass: string, now = Date.now()): Promise<RestFolderLoginResult> {
+        warnIfInsecureHost(host);
+        const res = await axios.post(
+            `${host.replace(/\/+$/, '')}/rest/login`,
+            { emailOrLdapLoginId: user, password: pass },
+            { headers: { 'Content-Type': 'application/json' }, timeout: 30000 },
+        );
+        const setCookie: string[] | undefined = res.headers?.['set-cookie'];
+        const cookie = extractAuthCookie(setCookie);
+        if (!cookie) throw new Error('session login returned no cookie');
+        return { cookie, expiresAt: parseCookieExpiry(setCookie, now) };
+    }
+
+    /** Fetch the folder tree and the workflow→folder mapping in one shot. */
+    async load(): Promise<RestFolderData> {
+        // Serialize loads on this source: two loads must never run concurrently, or
+        // they would race on the mutable auth state (cookie index / one-shot re-login).
+        // Chaining (rather than sharing one in-flight promise) also means a later
+        // caller runs its OWN doLoad after the earlier one finishes, so it reads a
+        // fresh snapshot instead of inheriting the earlier load's result.
+        const run = this.loadChain.then(() => this.doLoad(), () => this.doLoad());
+        // Keep the chain alive regardless of this run's outcome, so the next load waits.
+        this.loadChain = run.then(() => undefined, () => undefined);
+        return run;
+    }
+
+    private async doLoad(): Promise<RestFolderData> {
+        this.reloggedIn = false; // allow one fresh re-login per load, not once per lifetime
+        let projectId: string | undefined = this.projectId;
+
+        if (!projectId || projectId === PERSONAL_PROJECT_PLACEHOLDER) {
+            // The folders endpoint won't accept the `personal` alias, so resolve a real
+            // id. Prefer the project list (unambiguous: pick type === 'personal') and
+            // only fall back to inferring the personal project from workflows.
+            projectId = await this.resolvePersonalProjectId();
+            if (!projectId) {
+                // Unscoped read used ONLY to infer the personal project id; the workflow
+                // list is (re)fetched scoped below, so the map can never include another
+                // project's workflows.
+                const sample = await this.getAll<any>('/rest/workflows');
+                projectId = this.personalProjectIdFromWorkflows(sample);
+            }
+            if (!projectId) {
+                // Do NOT guess a team project — fail with an actionable error so the
+                // caller's fail-closed policy applies instead of pulling the wrong tree.
+                throw new Error(
+                    'could not resolve the personal project id over /rest (the configured ' +
+                    'projectId is the "personal" placeholder). Set a concrete projectId on the ' +
+                    'environment, or ensure the folder-login account can list its projects.',
+                );
+            }
+        }
+
+        const resolvedProjectId = projectId as string;
+        // Always scope the workflow read to the resolved project — matches the n8n
+        // editor, avoids paginating every workflow visible to the account, and keeps
+        // the map to this project's workflows (never a team project's).
+        const workflows = await this.getAll<any>('/rest/workflows', { filter: JSON.stringify({ projectId: resolvedProjectId }) });
+        const folders = await this.getAll<IFolder>(`/rest/projects/${encodeURIComponent(resolvedProjectId)}/folders`);
+
+        const workflowParentFolderId = new Map<string, string>();
+        for (const wf of workflows) {
+            if (!wf?.id) continue;
+            const folderId = wf.parentFolder?.id ?? wf.parentFolderId ?? null;
+            if (folderId) workflowParentFolderId.set(wf.id, folderId);
+        }
+
+        return { folders, workflowParentFolderId };
+    }
+
+    /** The user's personal project id from `/rest/projects` (type === 'personal'); undefined if unavailable. */
+    private async resolvePersonalProjectId(): Promise<string | undefined> {
+        try {
+            const projects = await this.getAll<any>('/rest/projects');
+            const personal = projects.find((p) => p?.type === 'personal');
+            return personal?.id ?? undefined;
+        } catch {
+            return undefined;
+        }
+    }
+
+    /**
+     * The personal project id inferred from workflows, for the `personal` placeholder
+     * when the project list is unavailable. Returns ONLY a project whose workflow home
+     * project is typed `personal` — never an arbitrary (possibly team) project, so a
+     * misresolved `personal` fails closed rather than pulling the wrong folder tree.
+     */
+    private personalProjectIdFromWorkflows(workflows: any[]): string | undefined {
+        for (const wf of workflows) {
+            const home = wf?.homeProject;
+            if (home?.type === 'personal' && home.id) return home.id;
+        }
+        return undefined;
+    }
+
+    private async ensureCookie(): Promise<void> {
+        if (this.cookie) return;
+        if (this.auth.user && this.auth.pass) {
+            this.reloggedIn = true;
+            this.cookie = (await RestFolderSource.login(this.host, this.auth.user, this.auth.pass)).cookie;
+            return;
+        }
+        throw new Error('no folder-login cookie or credentials available');
+    }
+
+    /**
+     * On 401: advance to the next candidate cookie, or (once) mint a fresh cookie
+     * from credentials. Returns false when there is nothing left to try.
+     */
+    private async advanceAuth(): Promise<boolean> {
+        if (this.cookieIndex + 1 < this.cookieCandidates.length) {
+            this.cookieIndex += 1;
+            this.cookie = this.cookieCandidates[this.cookieIndex];
+            return true;
+        }
+        if (this.auth.user && this.auth.pass && !this.reloggedIn) {
+            this.reloggedIn = true;
+            this.cookie = (await RestFolderSource.login(this.host, this.auth.user, this.auth.pass)).cookie;
+            return true;
+        }
+        return false;
+    }
+
+    /** Paginated GET that retries on 401 with the next candidate cookie / a re-login. */
+    private async getAll<T>(pathname: string, extraParams: Record<string, unknown> = {}): Promise<T[]> {
+        for (;;) {
+            try {
+                return await this.fetchAllPages<T>(pathname, extraParams);
+            } catch (error: any) {
+                if (error?.response?.status !== 401) throw error;
+                if (await this.advanceAuth()) continue;
+                throw error;
+            }
+        }
+    }
+
+    private async fetchAllPages<T>(pathname: string, extraParams: Record<string, unknown>): Promise<T[]> {
+        await this.ensureCookie();
+        const all: T[] = [];
+        const take = 100;
+        let skip = 0;
+        for (;;) {
+            const res = await this.client.get(pathname, {
+                params: { ...extraParams, take, skip },
+                headers: { Cookie: this.cookie ?? '' },
+            });
+            const body = res.data;
+            const data: T[] = Array.isArray(body?.data)
+                ? body.data
+                : Array.isArray(body)
+                ? body
+                : [];
+            all.push(...data);
+            const count: number | undefined =
+                typeof body?.count === 'number' ? body.count : undefined;
+            if (data.length === 0) break;
+            if (count !== undefined && all.length >= count) break;
+            // Advance by what the server actually returned: n8n's /rest endpoints
+            // cap page size (100) regardless of the requested `take`, so neither
+            // `skip += take` nor a `data.length < take` stop are safe — they'd
+            // skip pages or stop after the first short page.
+            skip += data.length;
+            // Last-resort stop only when the server gives no count to page against.
+            if (count === undefined && data.length < take) break;
+        }
+        return all;
+    }
+}

--- a/packages/cli/src/core/services/sync-manager.ts
+++ b/packages/cli/src/core/services/sync-manager.ts
@@ -253,6 +253,9 @@ export class SyncManager extends EventEmitter {
             this.emit('log', `[SyncManager] Fetched remote state for workflow ${workflowId}.`);
             return true;
         } catch (error) {
+            if ((error as any)?.folderSessionFailClosed) {
+                throw error;
+            }
             this.emit('error', new Error(`Failed to fetch workflow ${workflowId}: ${error}`));
             return false;
         }

--- a/packages/cli/src/core/services/sync-manager.ts
+++ b/packages/cli/src/core/services/sync-manager.ts
@@ -66,6 +66,9 @@ export class SyncManager extends EventEmitter {
             ignoredTags: [],
             projectId: this.config.projectId,
             folderSync: this.config.folderSync ?? false,
+            host: this.config.host,
+            folderAuth: this.config.folderAuth,
+            folderSessionAllowFlatFallback: this.config.folderSessionAllowFlatFallback ?? false,
         });
 
         this.syncEventJournal = new SyncEventJournal(instanceDir);

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -328,6 +328,8 @@ export class WorkflowStateTracker extends EventEmitter {
             const remoteWorkflows = await this.client.getAllWorkflows(this.projectId);
             this.isConnected = true;
 
+            const folderResolver = await this.createFolderResolver(remoteWorkflows);
+
             // Update remoteIds and names (ID is the unique key; name is for display only)
             this.remoteIds.clear();
             this.remoteNames.clear();
@@ -336,7 +338,6 @@ export class WorkflowStateTracker extends EventEmitter {
             this.remoteParentFolderIds.clear();
             this.remoteFolderPaths.clear();
 
-            const folderResolver = await this.createFolderResolver(remoteWorkflows);
             const state = this.loadState();
             let stateChanged = false;
 

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -71,7 +71,7 @@ export class WorkflowStateTracker extends EventEmitter {
      * the next read. A failed load clears the entry (only if still current) so it
      * stays retryable rather than being cached as a permanent miss.
      */
-    private sessionFolders?: { generation: number; promise: Promise<{ resolver: FolderPathResolver; parentMap: Map<string, string> }> };
+    private sessionFolders?: { generation: number; promise: Promise<{ resolver: FolderPathResolver; parentMap: Map<string, string> } | undefined> };
     private folderGeneration = 0;
     /**
      * When true, a configured session source that fails to load degrades to a flat
@@ -110,8 +110,8 @@ export class WorkflowStateTracker extends EventEmitter {
             ignoredTags: string[];
             projectId: string;      // Project scope filter
             folderSync?: boolean;
-            host?: string;          // n8n base URL (for the session-auth folder source)
-            folderAuth?: RestFolderAuth; // Session token or creds for /rest folder reads
+            host?: string;          // Target instance URL (needed for session folderSync)
+            folderAuth?: RestFolderAuth; // Session credentials/token (opt-in; pull uses public API without them)
             folderSessionAllowFlatFallback?: boolean; // degrade to flat pull if the session source fails
         }
     ) {
@@ -124,8 +124,7 @@ export class WorkflowStateTracker extends EventEmitter {
         this.folderSync = options.folderSync ?? false;
         this.folderSessionAllowFlatFallback = options.folderSessionAllowFlatFallback ?? false;
         // When folderSync is on and session creds are provided, prefer reading
-        // folders over /rest — it works on every edition, including instances
-        // where the public folder API is license-gated.
+        // folders over /rest when folders are licensed on the instance.
         if (this.folderSync && options.host && options.folderAuth && this.projectId) {
             this.folderSource = new RestFolderSource(options.host, this.projectId, options.folderAuth);
         }
@@ -820,8 +819,12 @@ export class WorkflowStateTracker extends EventEmitter {
         }
     }
 
-    private async loadSessionFolders(): Promise<{ resolver: FolderPathResolver; parentMap: Map<string, string> }> {
-        const { folders, workflowParentFolderId } = await this.folderSource!.load();
+    private async loadSessionFolders(): Promise<{ resolver: FolderPathResolver; parentMap: Map<string, string> } | undefined> {
+        const { folders, workflowParentFolderId, licenseUnavailableReason } = await this.folderSource!.load();
+        if (licenseUnavailableReason) {
+            this.warnFolderMetadataUnavailable(licenseUnavailableReason);
+            return undefined;
+        }
         return { resolver: new FolderPathResolver(folders), parentMap: workflowParentFolderId };
     }
 
@@ -876,6 +879,13 @@ export class WorkflowStateTracker extends EventEmitter {
     private warnFolderMetadataUnavailable(reason?: string): void {
         if (this.warnedFolderMetadataUnavailable) return;
         this.warnedFolderMetadataUnavailable = true;
+        if (reason?.includes('reports no folder support') || reason?.includes('no folder API')) {
+            console.warn(
+                `[WorkflowStateTracker] folderSync is enabled but ${reason}. ` +
+                `Workflows will be pulled flat without folder assignment.`,
+            );
+            return;
+        }
         console.warn(
             `[WorkflowStateTracker] folderSync is enabled, but n8n's public API does not report which folder a workflow is in${reason ? ` (${reason})` : ''}. ` +
             `Pull keeps workflows flat; push still mirrors your local folders onto n8n.`,

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -8,7 +8,7 @@ import { WorkflowSyncStatus, IWorkflowStatus, IWorkflow, IWorkflowDrift } from '
 import { IWorkflowState, IInstanceState } from './state-manager.js';
 import { FolderPathResolver, sanitizePathSegment } from './folder-path-resolver.js';
 import { listWorkflowFilesRecursive, normalizeWorkflowRelativePath, workflowRelativePathToAbsolute } from './workflow-path-utils.js';
-import { RestFolderSource, RestFolderAuth } from './rest-folder-source.js';
+import { RestFolderSource, RestFolderAuth, isLoopbackHost } from './rest-folder-source.js';
 
 const WINDOWS_RESERVED_FILENAMES = new Set([
     'CON',
@@ -125,8 +125,25 @@ export class WorkflowStateTracker extends EventEmitter {
         this.folderSessionAllowFlatFallback = options.folderSessionAllowFlatFallback ?? false;
         // When folderSync is on and session creds are provided, prefer reading
         // folders over /rest when folders are licensed on the instance.
+        // Plain HTTP over non-loopback hosts is blocked to prevent credential leaks,
+        // unless explicitly opted into with N8NAC_ALLOW_INSECURE_HTTP=1.
         if (this.folderSync && options.host && options.folderAuth && this.projectId) {
-            this.folderSource = new RestFolderSource(options.host, this.projectId, options.folderAuth);
+            let isInsecureHttp = false;
+            try {
+                const parsedUrl = new URL(options.host);
+                isInsecureHttp = parsedUrl.protocol === 'http:' && !isLoopbackHost(parsedUrl.hostname);
+            } catch {
+                isInsecureHttp = true;
+            }
+
+            if (isInsecureHttp && process.env.N8NAC_ALLOW_INSECURE_HTTP !== '1') {
+                console.warn(
+                    `[WorkflowStateTracker] Refusing to pass folderAuth to RestFolderSource over non-loopback plain HTTP (${options.host}). ` +
+                    `Use HTTPS or loopback, or set N8NAC_ALLOW_INSECURE_HTTP=1 to allow cleartext transmission.`,
+                );
+            } else {
+                this.folderSource = new RestFolderSource(options.host, this.projectId, options.folderAuth);
+            }
         }
         this.stateFilePath = path.join(this.directory, '.n8n-state.json');
 

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -8,6 +8,7 @@ import { WorkflowSyncStatus, IWorkflowStatus, IWorkflow, IWorkflowDrift } from '
 import { IWorkflowState, IInstanceState } from './state-manager.js';
 import { FolderPathResolver, sanitizePathSegment } from './folder-path-resolver.js';
 import { listWorkflowFilesRecursive, normalizeWorkflowRelativePath, workflowRelativePathToAbsolute } from './workflow-path-utils.js';
+import { RestFolderSource, RestFolderAuth } from './rest-folder-source.js';
 
 const WINDOWS_RESERVED_FILENAMES = new Set([
     'CON',
@@ -57,6 +58,27 @@ export class WorkflowStateTracker extends EventEmitter {
     private stateFilePath: string;
     private folderSync: boolean;
     private warnedFolderMetadataUnavailable = false;
+    /**
+     * Optional session-auth source for the folder hierarchy, used because n8n's
+     * public workflow API never reports which folder a workflow is in. Present only
+     * when folderSync is on and host + a folder-login token/creds are configured.
+     */
+    private folderSource?: RestFolderSource;
+    /**
+     * Memoised session folder load, tagged with the generation it was started for.
+     * Callers within one generation share the request; each refreshRemoteState()
+     * bumps {@link folderGeneration} so folder moves and new folders are observed on
+     * the next read. A failed load clears the entry (only if still current) so it
+     * stays retryable rather than being cached as a permanent miss.
+     */
+    private sessionFolders?: { generation: number; promise: Promise<{ resolver: FolderPathResolver; parentMap: Map<string, string> }> };
+    private folderGeneration = 0;
+    /**
+     * When true, a configured session source that fails to load degrades to a flat
+     * pull with a warning instead of failing the folder-aware pull. Off by default
+     * (fail closed): opt in with N8NAC_FOLDER_ALLOW_FLAT_FALLBACK.
+     */
+    private folderSessionAllowFlatFallback = false;
     private isConnected: boolean = true;
     /** True during the first refreshRemoteState() call — suppresses status broadcasts */
     private isInitialRemoteLoad: boolean = false;
@@ -88,6 +110,9 @@ export class WorkflowStateTracker extends EventEmitter {
             ignoredTags: string[];
             projectId: string;      // Project scope filter
             folderSync?: boolean;
+            host?: string;          // n8n base URL (for the session-auth folder source)
+            folderAuth?: RestFolderAuth; // Session token or creds for /rest folder reads
+            folderSessionAllowFlatFallback?: boolean; // degrade to flat pull if the session source fails
         }
     ) {
         super();
@@ -97,6 +122,13 @@ export class WorkflowStateTracker extends EventEmitter {
         this.ignoredTags = options.ignoredTags;
         this.projectId = options.projectId;
         this.folderSync = options.folderSync ?? false;
+        this.folderSessionAllowFlatFallback = options.folderSessionAllowFlatFallback ?? false;
+        // When folderSync is on and session creds are provided, prefer reading
+        // folders over /rest — it works on every edition, including instances
+        // where the public folder API is license-gated.
+        if (this.folderSync && options.host && options.folderAuth && this.projectId) {
+            this.folderSource = new RestFolderSource(options.host, this.projectId, options.folderAuth);
+        }
         this.stateFilePath = path.join(this.directory, '.n8n-state.json');
 
         // Restore persisted mappings immediately so 'pull' and other commands can find workflows
@@ -284,6 +316,10 @@ export class WorkflowStateTracker extends EventEmitter {
      * spurious "Change detected" messages in the VSCode extension and CLI output.
      */
     public async refreshRemoteState() {
+        // Bump the generation so the session folder tree is re-read on this refresh
+        // (folder moves and new folders are observed); an in-flight load from a
+        // previous generation is superseded rather than discarded mid-flight.
+        this.folderGeneration += 1;
         // Suppress broadcasts during the very first remote load (populating cache from scratch).
         // Subsequent calls (user-triggered fetch/refresh) will still broadcast normally.
         const isFirstLoad = this.remoteIds.size === 0;
@@ -745,13 +781,59 @@ export class WorkflowStateTracker extends EventEmitter {
     }
 
     /**
+     * Lazily load (and cache) the folder hierarchy over the session-auth `/rest`
+     * source. Returns undefined when no source is configured or the load fails,
+     * so callers fall back to the public-API path. The workflow→parentFolderId
+     * map fills the gap the public workflows API leaves (it omits that field).
+     */
+    private async ensureSessionFolders(): Promise<{ resolver: FolderPathResolver; parentMap: Map<string, string> } | undefined> {
+        if (!this.folderSource) return undefined;
+        const generation = this.folderGeneration;
+        if (!this.sessionFolders || this.sessionFolders.generation !== generation) {
+            this.sessionFolders = { generation, promise: this.loadSessionFolders() };
+        }
+        const entry = this.sessionFolders;
+        try {
+            return await entry.promise;
+        } catch (error: any) {
+            // Clear only if still the current entry, so a newer generation's in-flight
+            // load isn't discarded; a later read then retries rather than caching the miss.
+            if (this.sessionFolders === entry) this.sessionFolders = undefined;
+            const reason = error?.message || String(error);
+            if (this.folderSessionAllowFlatFallback) {
+                this.warnFolderMetadataUnavailable(
+                    `session folder source failed (${reason}); pulling flat because N8NAC_FOLDER_ALLOW_FLAT_FALLBACK is set`,
+                );
+                return undefined;
+            }
+            // Fail closed: the user explicitly configured a session source, so a
+            // silent flat pull (which would produce a large, wrong diff on reconcile)
+            // is worse than stopping with a clear, actionable error. The tag lets the
+            // resilient single-workflow path (updateSingleRemoteState) re-raise it too.
+            const failClosed: any = new Error(
+                `folderSync session folder source failed: ${reason}. ` +
+                `Re-run \`n8nac env auth folder-login <env>\`, or set ` +
+                `N8NAC_FOLDER_ALLOW_FLAT_FALLBACK=1 to allow a flat pull.`,
+            );
+            failClosed.folderSessionFailClosed = true;
+            throw failClosed;
+        }
+    }
+
+    private async loadSessionFolders(): Promise<{ resolver: FolderPathResolver; parentMap: Map<string, string> }> {
+        const { folders, workflowParentFolderId } = await this.folderSource!.load();
+        return { resolver: new FolderPathResolver(folders), parentMap: workflowParentFolderId };
+    }
+
+    /**
      * Builds the resolver that turns a remote workflow's folder into local path
      * segments — when n8n tells us what that folder is.
      *
-     * As of n8n 2.32 it does not: `parentFolderId` is declared `writeOnly` in the
+     * As of n8n 2.32 the public API does not, so pull falls back to this path and
+     * lays workflows out flat: `parentFolderId` is declared `writeOnly` in the
      * public API spec, the read handlers never load the `parentFolder` relation,
-     * and no endpoint maps workflows to folders. This holds on every edition,
-     * Enterprise included, so pull lays workflows out flat and this returns null.
+     * and no endpoint maps workflows to folders. (The session-auth `/rest` source
+     * above, when configured, sidesteps this and reconstructs nested paths.)
      *
      * The detection is deliberately based on the payload rather than a version
      * check: the day a workflow read carries folder fields, nested pulls start
@@ -759,6 +841,23 @@ export class WorkflowStateTracker extends EventEmitter {
      */
     private async createFolderResolver(remoteWorkflows: IWorkflow[]): Promise<FolderPathResolver | null> {
         if (!this.folderSync) return null;
+
+        // Creds-first: when a session folder source is configured, use it. It
+        // supplies the workflow→folder link the public API omits, so we backfill
+        // parentFolderId onto the workflow objects before path resolution.
+        const session = await this.ensureSessionFolders();
+        if (session) {
+            for (const wf of remoteWorkflows) {
+                const folderId = session.parentMap.get(wf.id);
+                if (folderId) wf.parentFolderId = folderId;
+            }
+            return session.resolver;
+        }
+
+        // Public-API path (no login): only works if a workflow read happens to
+        // carry folder fields. Current n8n omits them on every edition, so this
+        // normally yields a flat layout — kept for forward-compat and any
+        // deployment where workflow reads do expose folder metadata.
         const hasWorkflowFolderFields = remoteWorkflows.some((workflow) =>
             workflow.parentFolderId !== undefined || workflow.parentFolder?.id,
         );
@@ -1358,6 +1457,39 @@ export class WorkflowStateTracker extends EventEmitter {
             });
             const hash = await WorkflowTransformerAdapter.hashWorkflow(tsCode);
 
+            // Resolve folder placement BEFORE mutating any cache: if a session source
+            // is configured and fails, ensureSessionFolders() throws the fail-closed
+            // error, and this workflow's cache must be left untouched (all-or-nothing)
+            // rather than half-applied (known-remote + fresh hash but no folder data).
+            let parentFolderId = remoteWf.parentFolderId ?? remoteWf.parentFolder?.id ?? null;
+            let folderPath: string[] = [];
+            if (this.folderSync) {
+                // Creds-first: backfill the folder link from the session source
+                // (the public workflow API omits parentFolderId).
+                const session = await this.ensureSessionFolders();
+                if (session) {
+                    const folderId = session.parentMap.get(remoteWf.id) ?? null;
+                    if (folderId) {
+                        remoteWf.parentFolderId = folderId;
+                        parentFolderId = folderId;
+                    }
+                    folderPath = session.resolver.getPathForWorkflow(remoteWf);
+                } else if (parentFolderId && typeof this.client.getFolders === 'function') {
+                    try {
+                        // Same project-id caveat as the push path: the folder list endpoint
+                        // needs a real id, not the `personal` placeholder.
+                        const folderProjectId = typeof this.client.resolveFolderProjectId === 'function'
+                            ? await this.client.resolveFolderProjectId(this.projectId)
+                            : this.projectId;
+                        const resolver = new FolderPathResolver(await this.client.getFolders(folderProjectId ?? this.projectId));
+                        folderPath = resolver.getPathForWorkflow(remoteWf);
+                    } catch (error: any) {
+                        this.warnFolderMetadataUnavailable(error?.message);
+                    }
+                }
+            }
+
+            // All cache mutations happen together, after the fallible reads above.
             this.remoteHashes.set(remoteWf.id, hash);
             if (remoteWf.updatedAt) {
                 this.remoteTimestamps.set(remoteWf.id, remoteWf.updatedAt);
@@ -1371,21 +1503,6 @@ export class WorkflowStateTracker extends EventEmitter {
             // Store active and archived flags
             this.remoteActive.set(remoteWf.id, remoteWf.active === true);
             this.remoteArchived.set(remoteWf.id, remoteWf.isArchived === true);
-            const parentFolderId = remoteWf.parentFolderId ?? remoteWf.parentFolder?.id ?? null;
-            let folderPath: string[] = [];
-            if (this.folderSync && parentFolderId && typeof this.client.getFolders === 'function') {
-                try {
-                    // Same project-id caveat as the push path: the folder list endpoint
-                    // needs a real id, not the `personal` placeholder.
-                    const folderProjectId = typeof this.client.resolveFolderProjectId === 'function'
-                        ? await this.client.resolveFolderProjectId(this.projectId)
-                        : this.projectId;
-                    const resolver = new FolderPathResolver(await this.client.getFolders(folderProjectId ?? this.projectId));
-                    folderPath = resolver.getPathForWorkflow(remoteWf);
-                } catch (error: any) {
-                    this.warnFolderMetadataUnavailable(error?.message);
-                }
-            }
             this.remoteParentFolderIds.set(remoteWf.id, parentFolderId);
             this.remoteFolderPaths.set(remoteWf.id, folderPath);
 
@@ -1415,6 +1532,9 @@ export class WorkflowStateTracker extends EventEmitter {
                 this.broadcastStatus(filename, remoteWf.id);
             }
         } catch (error) {
+            // A configured session folder source that failed must fail the pull, not be
+            // swallowed here — otherwise `pull <id>` would silently lay the workflow out flat.
+            if ((error as any)?.folderSessionFailClosed) throw error;
             console.error(`[WorkflowStateTracker] Failed to update single remote state for ${remoteWf.id}:`, error);
         }
     }

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -82,6 +82,16 @@ export interface IFolder {
     updatedAt?: string;
 }
 
+/** A stored n8n `/rest` session cookie for folder reads (per target). */
+export interface IFolderSession {
+    /** Cookie header value, e.g. `n8n-auth=<jwt>`. */
+    cookie: string;
+    /** ISO expiry parsed from the server's Set-Cookie, if provided (n8n's default is ~7 days). */
+    expiresAt?: string;
+    /** Login identifier used to mint it (for display / re-login hints; never the password). */
+    user?: string;
+}
+
 export interface ITag {
     id: string;
     name: string;
@@ -180,8 +190,9 @@ export interface ISyncConfig {
      * at `Some Folder/foo.workflow.ts` is created/moved into `Some Folder` on the
      * instance, creating the folder if needed.
      *
-     * Push-only. n8n's public API never returns a workflow's folder, so pull
-     * cannot restore the remote layout — see docs/guides/folder-sync.md.
+     * Push works over the public API. Pull cannot restore folders over the public
+     * API (it never returns a workflow's folder); an optional session-auth source
+     * can reconstruct them — see docs/usage/folder-sync.md.
      */
     folderSync?: boolean;
     /**
@@ -193,6 +204,11 @@ export interface ISyncConfig {
      * about. Turn this on when the repository is the sole source of truth.
      */
     folderSyncMoveToRoot?: boolean;
+    host?: string;               // n8n base URL (used by the session-auth folder source)
+    /** Optional session auth (stored cookie(s) or creds) for reading folders over /rest when folderSync is on. */
+    folderAuth?: { cookie?: string; cookies?: string[]; user?: string; pass?: string };
+    /** Degrade to a flat pull (with a warning) if a configured session folder source fails, instead of failing closed. */
+    folderSessionAllowFlatFallback?: boolean;
     environmentId?: string;
     environmentName?: string;
     environmentTargetId?: string;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,7 @@ import { parsePositiveIntegerOption } from './utils/option-parsers.js';
 import { spawn } from 'child_process';
 import { createN8nManagerFacade } from '@n8n-as-code/manager-adapter';
 import { ConfigService } from './services/config-service.js';
+import { RestFolderSource } from './core/services/rest-folder-source.js';
 import { installExtraCaCertificates } from './core/services/tls-certificates.js';
 import {
     N8N_FACADE_SETUP_MODES,
@@ -697,7 +698,7 @@ environmentAuthProgram.command('set')
     });
 
 environmentAuthProgram.command('clear')
-    .description('Remove the API key stored for a single environment')
+    .description("Remove the API key for an environment, plus the folder-login session for its instance target (shared by any environment on that target)")
     .argument('<name-or-id>', 'Environment name or ID')
     .option('--json', 'Output resolved environment as JSON')
     .action((nameOrId, options) => {
@@ -705,10 +706,72 @@ environmentAuthProgram.command('clear')
         const environment = configService.getEnvironment(nameOrId);
         configService.deleteWorkspaceEnvironmentApiKey(environment.id);
         const resolved = configService.resolveEnvironment(environment.id);
+        // A folder-login cookie is a bearer credential; clear it alongside the API key.
+        // It is stored per instance target, so this also clears it for any sibling
+        // environment pointing at the same target — the message says so.
+        configService.clearFolderSession(resolved.environmentTargetId);
         printJsonOrText(
             options,
             redactResolvedEnvironment(resolved),
-            chalk.green(`✔ Local API key cleared for environment: ${resolved.environmentName}`),
+            chalk.green(
+                `✔ Cleared the local API key for environment "${resolved.environmentName}" and the ` +
+                `folder-login session for its instance target "${resolved.environmentTargetName}".`,
+            ),
+        );
+    });
+
+environmentAuthProgram.command('folder-login')
+    .description("Store a session token so folderSync's pull can reconstruct nested folders — n8n's public workflow API never reports a workflow's folder. Logs in once via /rest and saves the session cookie locally until its server-issued expiry (never the password). Clear it with `folder-logout`.")
+    .argument('<name-or-id>', 'Environment name or ID')
+    .option('--user <email>', 'Login email / identifier')
+    .option('--password <password>', 'Login password (prefer --password-stdin; --password can be exposed in process listings)')
+    .option('--password-stdin', 'Read the login password from stdin')
+    .option('--json', 'Output result as JSON')
+    .action(async (nameOrId, options) => {
+        const configService = new ConfigService();
+        const environment = configService.resolveEnvironment(nameOrId);
+        if (environment.sourceKind === 'managed-instance') {
+            throw new Error(`Environment "${environment.environmentName}" uses a managed instance; folder-login is for remote n8n environments.`);
+        }
+        if (!environment.host) {
+            throw new Error(`Environment "${environment.environmentName}" has no host URL to log in against.`);
+        }
+        const user = (options.user || '').trim();
+        if (!user) throw new Error('Provide --user <email>.');
+        // Warn whenever --password was passed on argv, even alongside --password-stdin.
+        if (options.password) {
+            console.warn(chalk.yellow('⚠ Passing --password on the command line can expose it in process listings and shell history. Prefer --password-stdin.'));
+        }
+        if (options.passwordStdin) {
+            options.password = await readSecretFromStdin();
+        }
+        const password = options.password || '';
+        if (!password) throw new Error('Provide --password or --password-stdin.');
+
+        const { cookie, expiresAt } = await RestFolderSource.login(environment.host, user, password);
+        configService.saveFolderSession(environment.environmentTargetId, { cookie, expiresAt, user });
+        printJsonOrText(
+            options,
+            { environment: environment.environmentName, user, expiresAt: expiresAt ?? null },
+            chalk.green(
+                `✔ Folder-login session stored for "${environment.environmentName}"` +
+                (expiresAt ? ` (expires ${expiresAt}).` : '.'),
+            ),
+        );
+    });
+
+environmentAuthProgram.command('folder-logout')
+    .description('Remove the stored folderSync session token for an environment (paired with folder-login).')
+    .argument('<name-or-id>', 'Environment name or ID')
+    .option('--json', 'Output result as JSON')
+    .action((nameOrId, options) => {
+        const configService = new ConfigService();
+        const environment = configService.resolveEnvironment(nameOrId);
+        configService.clearFolderSession(environment.environmentTargetId);
+        printJsonOrText(
+            options,
+            { environment: environment.environmentName },
+            chalk.green(`✔ Folder-login session cleared for "${environment.environmentName}".`),
         );
     });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -721,7 +721,7 @@ environmentAuthProgram.command('clear')
     });
 
 environmentAuthProgram.command('folder-login')
-    .description("Store a session token so folderSync's pull can reconstruct nested folders — n8n's public workflow API never reports a workflow's folder. Logs in once via /rest and saves the session cookie locally until its server-issued expiry (never the password). Clear it with `folder-logout`.")
+    .description("[Experimental] Store a session token so folderSync's pull can reconstruct nested folders — n8n's public workflow API never reports a workflow's folder. Logs in once via /rest and saves the session cookie locally until its server-issued expiry (never the password). Clear it with `folder-logout`.")
     .argument('<name-or-id>', 'Environment name or ID')
     .option('--user <email>', 'Login email / identifier')
     .option('--password <password>', 'Login password (prefer --password-stdin; --password can be exposed in process listings)')
@@ -748,20 +748,24 @@ environmentAuthProgram.command('folder-login')
         const password = options.password || '';
         if (!password) throw new Error('Provide --password or --password-stdin.');
 
+        if (!options.json) {
+            console.log(chalk.dim('[Experimental] Authenticating via n8n internal /rest session API. For instances with SSO or 2FA, pass N8NAC_FOLDER_LOGIN_TOKEN instead.'));
+        }
+
         const { cookie, expiresAt } = await RestFolderSource.login(environment.host, user, password);
         configService.saveFolderSession(environment.environmentTargetId, { cookie, expiresAt, user });
         printJsonOrText(
             options,
             { environment: environment.environmentName, user, expiresAt: expiresAt ?? null },
             chalk.green(
-                `✔ Folder-login session stored for "${environment.environmentName}"` +
+                `✔ [Experimental] Folder-login session stored for "${environment.environmentName}"` +
                 (expiresAt ? ` (expires ${expiresAt}).` : '.'),
             ),
         );
     });
 
 environmentAuthProgram.command('folder-logout')
-    .description('Remove the stored folderSync session token for an environment (paired with folder-login).')
+    .description('[Experimental] Remove the stored folderSync session token for an environment (paired with folder-login).')
     .argument('<name-or-id>', 'Environment name or ID')
     .option('--json', 'Output result as JSON')
     .action((nameOrId, options) => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -738,6 +738,9 @@ environmentAuthProgram.command('folder-login')
         }
         const user = (options.user || '').trim();
         if (!user) throw new Error('Provide --user <email>.');
+        if (options.password && options.passwordStdin) {
+            throw new Error('Provide either --password or --password-stdin, not both.');
+        }
         // Warn whenever --password was passed on argv, even alongside --password-stdin.
         if (options.password) {
             console.warn(chalk.yellow('⚠ Passing --password on the command line can expose it in process listings and shell history. Prefer --password-stdin.'));

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import type { IFolderSession } from '../core/types.js';
 import {
     N8nConfigurationService,
     N8nRuntimeOrchestrator,
@@ -1035,6 +1036,57 @@ export class ConfigService {
             this.manager.deleteApiKey(this.nativeMcpSecretKey(environment.id));
         } catch {
             this.manager.deleteApiKey(this.nativeMcpSecretKey(environmentNameOrId));
+        }
+    }
+
+    // ── Folder-sync session tokens ────────────────────────────────────────────
+    // Folder reads over the internal /rest API need session (cookie) auth. The
+    // resulting cookie is stored per target through the SAME secret store as API
+    // keys and MCP tokens (it honours N8N_MANAGER_HOME, so it is isolated in tests
+    // and lives with the other secrets rather than in a separate file). The
+    // password is never persisted.
+
+    /** Canonical target id (accepts a name or id); falls back to the input if unresolvable. */
+    private resolveFolderSessionKey(targetId: string): string {
+        try {
+            return this.getInstanceTarget(targetId).id;
+        } catch {
+            return targetId;
+        }
+    }
+
+    private folderSessionSecretKey(targetId: string): string {
+        return `folder-session:${targetId}`;
+    }
+
+    saveFolderSession(targetId: string, session: IFolderSession): void {
+        const key = this.resolveFolderSessionKey(targetId);
+        this.manager.saveApiKey(this.folderSessionSecretKey(key), JSON.stringify(session));
+    }
+
+    getFolderSession(targetId: string): IFolderSession | undefined {
+        const key = this.resolveFolderSessionKey(targetId);
+        const raw = this.manager.getApiKey(this.folderSessionSecretKey(key));
+        if (!raw) return undefined;
+        try {
+            const parsed = JSON.parse(raw);
+            // Validate the shape: a tampered/wrong value must not reach callers that
+            // assume `cookie` is a string (e.g. resolveFolderAuth's cookie normaliser).
+            if (parsed && typeof parsed === 'object' && typeof parsed.cookie === 'string') {
+                return parsed as IFolderSession;
+            }
+        } catch {
+            // fall through to undefined
+        }
+        return undefined;
+    }
+
+    clearFolderSession(targetId: string): void {
+        const key = this.resolveFolderSessionKey(targetId);
+        try {
+            this.manager.deleteApiKey(this.folderSessionSecretKey(key));
+        } catch {
+            // best-effort: nothing stored, or the secret store is unavailable
         }
     }
 

--- a/packages/cli/tests/unit/folder-session-store.test.ts
+++ b/packages/cli/tests/unit/folder-session-store.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { ConfigService } from '../../src/services/config-service.js';
+
+/**
+ * The folder-login cookie is stored through the same secret store as API keys, so
+ * it honours N8N_MANAGER_HOME. These tests confirm round-trip, clear, and — most
+ * importantly — that a session never leaks across manager homes (so the unit suite
+ * can't read a developer's real folder session).
+ */
+describe('ConfigService folder-login session store', () => {
+    let prevManagerHome: string | undefined;
+    let prevXdg: string | undefined;
+    let managerHome: string;
+    let workspaceRoot: string;
+    let config: ConfigService;
+    let targetId: string;
+
+    function makeConfigWithEnv(root: string): { config: ConfigService; targetId: string } {
+        const svc = new ConfigService(root);
+        const env = svc.addEnvironment({
+            name: 'Prod',
+            environmentTarget: svc.ensureEmbeddedInstanceTarget({ name: 'Prod', url: 'https://n8n.example.test' }).id,
+            projectId: 'personal',
+            projectName: 'Personal',
+            workflowsPath: 'workflows/prod',
+        });
+        return { config: svc, targetId: svc.resolveEnvironment(env.id).environmentTargetId };
+    }
+
+    beforeEach(() => {
+        prevManagerHome = process.env.N8N_MANAGER_HOME;
+        prevXdg = process.env.XDG_CONFIG_HOME;
+        managerHome = mkdtempSync(path.join(tmpdir(), 'n8nac-fs-home-'));
+        workspaceRoot = mkdtempSync(path.join(tmpdir(), 'n8nac-fs-ws-'));
+        process.env.N8N_MANAGER_HOME = managerHome;
+        process.env.XDG_CONFIG_HOME = managerHome;
+        ({ config, targetId } = makeConfigWithEnv(workspaceRoot));
+    });
+
+    afterEach(() => {
+        if (prevManagerHome === undefined) delete process.env.N8N_MANAGER_HOME;
+        else process.env.N8N_MANAGER_HOME = prevManagerHome;
+        if (prevXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+        else process.env.XDG_CONFIG_HOME = prevXdg;
+    });
+
+    it('round-trips a stored session', () => {
+        const session = { cookie: 'n8n-auth=jwt', expiresAt: '2999-01-01T00:00:00.000Z', user: 'you@example.com' };
+        config.saveFolderSession(targetId, session);
+        expect(config.getFolderSession(targetId)).toEqual(session);
+    });
+
+    it('returns undefined when nothing is stored', () => {
+        expect(config.getFolderSession(targetId)).toBeUndefined();
+    });
+
+    it('clears a stored session', () => {
+        config.saveFolderSession(targetId, { cookie: 'n8n-auth=jwt' });
+        config.clearFolderSession(targetId);
+        expect(config.getFolderSession(targetId)).toBeUndefined();
+    });
+
+    it('ignores a stored value with the wrong shape', () => {
+        // Simulate a tampered/corrupt secret-store entry (valid JSON, wrong type).
+        (config as unknown as { manager: { saveApiKey(k: string, v: string): void } })
+            .manager.saveApiKey(`folder-session:${targetId}`, JSON.stringify({ cookie: 123 }));
+        expect(config.getFolderSession(targetId)).toBeUndefined();
+    });
+
+    it('does not leak a session across manager homes', () => {
+        config.saveFolderSession(targetId, { cookie: 'n8n-auth=jwt' });
+
+        // Point at a fresh, empty manager home — a new service must not see it.
+        const otherHome = mkdtempSync(path.join(tmpdir(), 'n8nac-fs-home2-'));
+        process.env.N8N_MANAGER_HOME = otherHome;
+        process.env.XDG_CONFIG_HOME = otherHome;
+        const otherWorkspace = mkdtempSync(path.join(tmpdir(), 'n8nac-fs-ws2-'));
+        const { config: other, targetId: otherTargetId } = makeConfigWithEnv(otherWorkspace);
+
+        expect(other.getFolderSession(otherTargetId)).toBeUndefined();
+        expect(other.getFolderSession(targetId)).toBeUndefined();
+    });
+});

--- a/packages/cli/tests/unit/rest-folder-source.test.ts
+++ b/packages/cli/tests/unit/rest-folder-source.test.ts
@@ -1,0 +1,330 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RestFolderSource } from '../../src/core/services/rest-folder-source.js';
+
+const { mockAxiosGet, mockAxiosPost, mockAxiosCreate } = vi.hoisted(() => ({
+    mockAxiosGet: vi.fn(),
+    mockAxiosPost: vi.fn(),
+    mockAxiosCreate: vi.fn(),
+}));
+
+vi.mock('axios', () => {
+    mockAxiosCreate.mockImplementation(() => ({ get: mockAxiosGet }));
+    return {
+        default: Object.assign(vi.fn(), { create: mockAxiosCreate, post: mockAxiosPost }),
+    };
+});
+
+const HOST = 'https://n8n.local';
+const PROJECT = 'proj-1';
+
+/**
+ * Simulate n8n's `/rest/workflows`, which caps a page at 100 items regardless of
+ * the requested `take` and reports the grand total in `count`. This is the exact
+ * shape that broke the original pagination (`skip += take` + `data.length < take`
+ * stop): only the first 100 workflows were ever read.
+ */
+function makeCappedWorkflowsEndpoint(total: number, pageCap = 100) {
+    return (params: { take: number; skip: number }) => {
+        const { skip } = params;
+        const pageSize = Math.min(pageCap, Math.max(0, total - skip));
+        const data = Array.from({ length: pageSize }, (_, i) => {
+            const n = skip + i;
+            return { id: `wf-${n}`, parentFolder: { id: `folder-${n % 5}` } };
+        });
+        return { data: { data, count: total } };
+    };
+}
+
+describe('RestFolderSource pagination', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockAxiosCreate.mockImplementation(() => ({ get: mockAxiosGet }));
+    });
+
+    it('reads every workflow across pages when the server caps page size below `take`', async () => {
+        const total = 229; // > 2 pages of 100, with a short final page
+        const workflowsEndpoint = makeCappedWorkflowsEndpoint(total);
+
+        mockAxiosGet.mockImplementation((pathname: string, config: { params: { take: number; skip: number } }) => {
+            if (pathname.includes('/folders')) {
+                return Promise.resolve({ data: { data: [{ id: 'folder-0', name: 'F0' }], count: 1 } });
+            }
+            return Promise.resolve(workflowsEndpoint(config.params));
+        });
+
+        const source = new RestFolderSource(HOST, PROJECT, { cookie: 'n8n-auth=token' });
+        const { workflowParentFolderId } = await source.load();
+
+        // The bug stopped after the first 100; the fix must map all 229.
+        expect(workflowParentFolderId.size).toBe(total);
+        expect(workflowParentFolderId.get('wf-0')).toBe('folder-0');
+        expect(workflowParentFolderId.get('wf-150')).toBeDefined();
+        expect(workflowParentFolderId.get('wf-228')).toBeDefined();
+
+        // skip must advance by the items actually returned (100), not by `take`,
+        // so no page is skipped: skips seen should be 0, 100, 200.
+        const workflowSkips = mockAxiosGet.mock.calls
+            .filter(([p]) => String(p).includes('/workflows'))
+            .map(([, c]) => c.params.skip);
+        expect(workflowSkips).toEqual([0, 100, 200]);
+    });
+});
+
+describe('RestFolderSource.login', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockAxiosCreate.mockImplementation(() => ({ get: mockAxiosGet }));
+    });
+
+    it('selects the n8n-auth cookie and parses Max-Age into an absolute expiry', async () => {
+        const NOW = 1_700_000_000_000;
+        mockAxiosPost.mockResolvedValue({
+            headers: { 'set-cookie': ['unrelated=x; Path=/', 'n8n-auth=JWT; Max-Age=604800; HttpOnly'] },
+        });
+
+        const result = await RestFolderSource.login(HOST, 'you@example.com', 'secret', NOW);
+
+        expect(result.cookie).toBe('n8n-auth=JWT');
+        expect(result.expiresAt).toBe(new Date(NOW + 604800 * 1000).toISOString());
+        // The password must reach the login body, but nothing persists it here.
+        expect(mockAxiosPost).toHaveBeenCalledWith(
+            `${HOST}/rest/login`,
+            expect.objectContaining({ emailOrLdapLoginId: 'you@example.com', password: 'secret' }),
+            expect.anything(),
+        );
+    });
+
+    it('throws when the login response carries no cookie', async () => {
+        mockAxiosPost.mockResolvedValue({ headers: {} });
+        await expect(RestFolderSource.login(HOST, 'you@example.com', 'secret')).rejects.toThrow(/no cookie/i);
+    });
+
+    it('throws when the response has cookies but none is the n8n-auth session', async () => {
+        // A CSRF/routing cookie must not be accepted as a valid folder session.
+        mockAxiosPost.mockResolvedValue({ headers: { 'set-cookie': ['n8n-csrf=abc; Path=/', 'route=x'] } });
+        await expect(RestFolderSource.login(HOST, 'you@example.com', 'secret')).rejects.toThrow(/no cookie/i);
+    });
+});
+
+describe('RestFolderSource.load auth + scoping', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockAxiosCreate.mockImplementation(() => ({ get: mockAxiosGet }));
+    });
+
+    it('scopes /rest/workflows by the configured project id', async () => {
+        mockAxiosGet.mockImplementation((pathname: string) => {
+            if (pathname.includes('/folders')) {
+                return Promise.resolve({ data: { data: [{ id: 'f1', name: 'Reports' }], count: 1 } });
+            }
+            return Promise.resolve({ data: { data: [{ id: 'wf-1', parentFolder: { id: 'f1' } }], count: 1 } });
+        });
+
+        await new RestFolderSource(HOST, PROJECT, { cookie: 'n8n-auth=t' }).load();
+
+        const workflowsCall = mockAxiosGet.mock.calls.find(([p]) => String(p).includes('/workflows'));
+        expect(workflowsCall?.[1]?.params?.filter).toBe(JSON.stringify({ projectId: PROJECT }));
+        // Folders are read under the same project id.
+        expect(mockAxiosGet.mock.calls.some(([p]) => String(p) === `/rest/projects/${PROJECT}/folders`)).toBe(true);
+    });
+
+    it('resolves the `personal` placeholder via /rest/projects, preferring the personal project', async () => {
+        mockAxiosGet.mockImplementation((pathname: string) => {
+            if (pathname === '/rest/projects') {
+                return Promise.resolve({ data: { data: [{ id: 'team-1', type: 'team' }, { id: 'personal-1', type: 'personal' }], count: 2 } });
+            }
+            if (pathname.includes('/folders')) {
+                return Promise.resolve({ data: { data: [{ id: 'f1', name: 'Reports' }], count: 1 } });
+            }
+            return Promise.resolve({ data: { data: [{ id: 'wf-1', parentFolder: { id: 'f1' } }], count: 1 } });
+        });
+
+        const { workflowParentFolderId } = await new RestFolderSource(HOST, 'personal', { cookie: 'n8n-auth=t' }).load();
+
+        // Folders + workflows must use the resolved PERSONAL id, never `personal` or the team id.
+        expect(mockAxiosGet.mock.calls.some(([p]) => String(p) === '/rest/projects/personal-1/folders')).toBe(true);
+        expect(mockAxiosGet.mock.calls.some(([p]) => String(p) === '/rest/projects/team-1/folders')).toBe(false);
+        expect(mockAxiosGet.mock.calls.some(([p]) => String(p).includes('/projects/personal/'))).toBe(false);
+        const workflowsCall = mockAxiosGet.mock.calls.find(([p]) => String(p) === '/rest/workflows');
+        expect(workflowsCall?.[1]?.params?.filter).toBe(JSON.stringify({ projectId: 'personal-1' }));
+        expect(workflowParentFolderId.get('wf-1')).toBe('f1');
+    });
+
+    it('falls back to the personal home-project when the project list is unavailable', async () => {
+        mockAxiosGet.mockImplementation((pathname: string) => {
+            if (pathname === '/rest/projects') return Promise.reject({ response: { status: 403 } });
+            if (pathname.includes('/folders')) return Promise.resolve({ data: { data: [], count: 0 } });
+            // The first workflow belongs to a TEAM project; the personal one must still win.
+            return Promise.resolve({ data: { data: [
+                { id: 'wf-team', homeProject: { id: 'team-1', type: 'team' }, parentFolder: { id: 'ft' } },
+                { id: 'wf-me', homeProject: { id: 'personal-1', type: 'personal' }, parentFolder: { id: 'fp' } },
+            ], count: 2 } });
+        });
+
+        await new RestFolderSource(HOST, 'personal', { cookie: 'n8n-auth=t' }).load();
+
+        expect(mockAxiosGet.mock.calls.some(([p]) => String(p) === '/rest/projects/personal-1/folders')).toBe(true);
+        expect(mockAxiosGet.mock.calls.some(([p]) => String(p) === '/rest/projects/team-1/folders')).toBe(false);
+    });
+
+    it('refetches workflows scoped after inferring personal, so the map excludes other projects', async () => {
+        mockAxiosGet.mockImplementation((pathname: string, config: any) => {
+            if (pathname === '/rest/projects') return Promise.reject({ response: { status: 403 } });
+            if (pathname.includes('/folders')) return Promise.resolve({ data: { data: [{ id: 'fp', name: 'P' }], count: 1 } });
+            // Unscoped read (id resolution) returns team + personal; the scoped read returns only personal.
+            const filter = config?.params?.filter;
+            if (!filter) {
+                return Promise.resolve({ data: { data: [
+                    { id: 'wf-team', homeProject: { id: 'team-1', type: 'team' }, parentFolder: { id: 'ft' } },
+                    { id: 'wf-me', homeProject: { id: 'personal-1', type: 'personal' }, parentFolder: { id: 'fp' } },
+                ], count: 2 } });
+            }
+            return Promise.resolve({ data: { data: [{ id: 'wf-me', parentFolder: { id: 'fp' } }], count: 1 } });
+        });
+
+        const { workflowParentFolderId } = await new RestFolderSource(HOST, 'personal', { cookie: 'n8n-auth=t' }).load();
+
+        expect(workflowParentFolderId.get('wf-me')).toBe('fp');
+        expect(workflowParentFolderId.has('wf-team')).toBe(false); // excluded by the scoped refetch
+        const scoped = mockAxiosGet.mock.calls.find(
+            ([p, c]) => String(p) === '/rest/workflows' && c?.params?.filter === JSON.stringify({ projectId: 'personal-1' }),
+        );
+        expect(scoped).toBeTruthy();
+    });
+
+    it('fails closed instead of picking a team project when `personal` cannot be resolved', async () => {
+        mockAxiosGet.mockImplementation((pathname: string) => {
+            if (pathname === '/rest/projects') return Promise.resolve({ data: { data: [{ id: 'team-1', type: 'team' }], count: 1 } });
+            if (pathname.includes('/folders')) return Promise.resolve({ data: { data: [], count: 0 } });
+            // Only a team workflow is visible — no personal evidence at all.
+            return Promise.resolve({ data: { data: [{ id: 'wf-team', homeProject: { id: 'team-1', type: 'team' } }], count: 1 } });
+        });
+
+        await expect(new RestFolderSource(HOST, 'personal', { cookie: 'n8n-auth=t' }).load())
+            .rejects.toThrow(/could not resolve the personal project id/i);
+        // The team project's folders must never be read as a consolation prize.
+        expect(mockAxiosGet.mock.calls.some(([p]) => String(p) === '/rest/projects/team-1/folders')).toBe(false);
+    });
+
+    it('serializes concurrent loads so they never race on auth state', async () => {
+        let mintCount = 0;
+        let validCookie: string | null = null;
+        mockAxiosPost.mockImplementation(() => {
+            mintCount += 1;
+            validCookie = `n8n-auth=fresh-${mintCount}`;
+            return Promise.resolve({ headers: { 'set-cookie': [`${validCookie}; Max-Age=604800`] } });
+        });
+        mockAxiosGet.mockImplementation((pathname: string, config: any) => {
+            if (config?.headers?.Cookie !== validCookie) return Promise.reject({ response: { status: 401 } });
+            return Promise.resolve({ data: { data: [], count: 0 } });
+        });
+
+        const source = new RestFolderSource(HOST, PROJECT, { cookie: 'n8n-auth=stale', user: 'u', pass: 'p' });
+        const [a, b] = await Promise.allSettled([source.load(), source.load()]);
+
+        // Both succeed (neither loses the single re-login to a concurrent peer); the
+        // second reuses the cookie the first minted, so exactly one login happens.
+        expect(a.status).toBe('fulfilled');
+        expect(b.status).toBe('fulfilled');
+        expect(mintCount).toBe(1);
+    });
+
+    it('a later concurrent load runs its own fresh doLoad (not a shared/stale result)', async () => {
+        let foldersCall = 0;
+        mockAxiosGet.mockImplementation((pathname: string) => {
+            if (pathname.includes('/folders')) {
+                foldersCall += 1;
+                const id = `f-${foldersCall}`;
+                return Promise.resolve({ data: { data: [{ id, name: id }], count: 1 } });
+            }
+            return Promise.resolve({ data: { data: [], count: 0 } });
+        });
+
+        const source = new RestFolderSource(HOST, PROJECT, { cookie: 'n8n-auth=t' });
+        const [r1, r2] = await Promise.all([source.load(), source.load()]);
+
+        // Serialized, each ran its own execution: the second sees a fresh snapshot
+        // rather than inheriting the first load's folders (the dedupe-staleness bug).
+        expect(r1.folders[0].id).toBe('f-1');
+        expect(r2.folders[0].id).toBe('f-2');
+        expect(foldersCall).toBe(2);
+    });
+
+    it('re-logs in again on a later load (relogin allowance resets per load)', async () => {
+        let mintCount = 0;
+        let validCookie: string | null = null; // nothing valid at first -> the stored cookie 401s
+        mockAxiosPost.mockImplementation(() => {
+            mintCount += 1;
+            validCookie = `n8n-auth=fresh-${mintCount}`;
+            return Promise.resolve({ headers: { 'set-cookie': [`${validCookie}; Max-Age=604800`] } });
+        });
+        mockAxiosGet.mockImplementation((pathname: string, config: any) => {
+            if (config?.headers?.Cookie !== validCookie) return Promise.reject({ response: { status: 401 } });
+            return Promise.resolve({ data: { data: [], count: 0 } });
+        });
+
+        const source = new RestFolderSource(HOST, PROJECT, { cookie: 'n8n-auth=stale', user: 'u', pass: 'p' });
+        await source.load();
+        expect(mintCount).toBe(1);
+
+        validCookie = null; // simulate the freshly-minted cookie expiring before the next load
+        await source.load();
+        expect(mintCount).toBe(2); // a second load can re-login again, not just once per lifetime
+    });
+
+    it('re-logs in once on 401 when a stored cookie is rejected and creds are present', async () => {
+        let getCalls = 0;
+        mockAxiosGet.mockImplementation((pathname: string) => {
+            getCalls += 1;
+            if (getCalls === 1) return Promise.reject({ response: { status: 401 } });
+            if (pathname.includes('/folders')) {
+                return Promise.resolve({ data: { data: [], count: 0 } });
+            }
+            return Promise.resolve({ data: { data: [{ id: 'wf-1', parentFolder: { id: 'f1' } }], count: 1 } });
+        });
+        mockAxiosPost.mockResolvedValue({ headers: { 'set-cookie': ['n8n-auth=fresh; Max-Age=604800'] } });
+
+        const source = new RestFolderSource(HOST, PROJECT, { cookie: 'n8n-auth=stale', user: 'u', pass: 'p' });
+        const { workflowParentFolderId } = await source.load();
+
+        expect(mockAxiosPost).toHaveBeenCalledTimes(1); // exactly one re-login
+        expect(workflowParentFolderId.get('wf-1')).toBe('f1');
+    });
+
+    it('falls through to the next candidate cookie on 401 without re-logging in', async () => {
+        let getCalls = 0;
+        const cookiesUsed: string[] = [];
+        mockAxiosGet.mockImplementation((pathname: string, config: any) => {
+            getCalls += 1;
+            cookiesUsed.push(config?.headers?.Cookie);
+            if (getCalls === 1) return Promise.reject({ response: { status: 401 } });
+            if (pathname.includes('/folders')) return Promise.resolve({ data: { data: [], count: 0 } });
+            return Promise.resolve({ data: { data: [{ id: 'wf-1', parentFolder: { id: 'f1' } }], count: 1 } });
+        });
+
+        const source = new RestFolderSource(HOST, PROJECT, { cookies: ['n8n-auth=bad', 'n8n-auth=good'] });
+        await source.load();
+
+        expect(mockAxiosPost).not.toHaveBeenCalled();
+        expect(cookiesUsed[0]).toBe('n8n-auth=bad');
+        expect(cookiesUsed).toContain('n8n-auth=good');
+    });
+
+    it('throws on 401 when no other cookie or credentials remain', async () => {
+        mockAxiosGet.mockRejectedValue({ response: { status: 401 } });
+        const source = new RestFolderSource(HOST, PROJECT, { cookie: 'n8n-auth=bad' });
+        await expect(source.load()).rejects.toMatchObject({ response: { status: 401 } });
+        expect(mockAxiosPost).not.toHaveBeenCalled();
+    });
+
+    it('warns when credentials would travel over non-loopback plain HTTP', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            // Unique host so the module-level "warn once per host" set does not suppress it.
+            new RestFolderSource('http://insecure.example.test', PROJECT, { cookie: 'n8n-auth=t' });
+            expect(warn).toHaveBeenCalledWith(expect.stringMatching(/plain HTTP/i));
+        } finally {
+            warn.mockRestore();
+        }
+    });
+});

--- a/packages/cli/tests/unit/rest-folder-source.test.ts
+++ b/packages/cli/tests/unit/rest-folder-source.test.ts
@@ -327,4 +327,31 @@ describe('RestFolderSource.load auth + scoping', () => {
             warn.mockRestore();
         }
     });
+
+    it('degrades with licenseUnavailableReason when the folders endpoint returns 403 (unregistered instance)', async () => {
+        mockAxiosGet.mockImplementation((pathname: string) => {
+            if (pathname.includes('/folders')) {
+                return Promise.reject({ response: { status: 403, data: { message: 'Plan lacks license for this feature' } } });
+            }
+            return Promise.resolve({ data: { data: [{ id: 'wf-1', name: 'W1' }], count: 1 } });
+        });
+
+        const source = new RestFolderSource(HOST, PROJECT, { cookie: 'n8n-auth=t' });
+        const result = await source.load();
+
+        expect(result.folders).toEqual([]);
+        expect(result.licenseUnavailableReason).toMatch(/register the Community instance/i);
+    });
+
+    it('throws when /rest/workflows returns 403 (real auth/permissions failure)', async () => {
+        mockAxiosGet.mockImplementation((pathname: string) => {
+            if (String(pathname).includes('/workflows')) {
+                return Promise.reject({ response: { status: 403 } });
+            }
+            return Promise.resolve({ data: { data: [], count: 0 } });
+        });
+
+        const source = new RestFolderSource(HOST, PROJECT, { cookie: 'n8n-auth=t' });
+        await expect(source.load()).rejects.toMatchObject({ response: { status: 403 } });
+    });
 });

--- a/packages/cli/tests/unit/workflow-state-tracker-session.test.ts
+++ b/packages/cli/tests/unit/workflow-state-tracker-session.test.ts
@@ -234,4 +234,52 @@ describe('WorkflowStateTracker session folder source', () => {
         expect(mockLoad).not.toHaveBeenCalled();
         expect(tracker.getFilenameForId('wf-foldered')).toBe('Normalize Attachments.workflow.ts');
     });
+
+    it('refuses to pass folderAuth to RestFolderSource over non-loopback plain HTTP without opt-in', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            const tracker = new WorkflowStateTracker(makeClient(), {
+                directory: tempDir,
+                syncInactive: false,
+                ignoredTags: [],
+                projectId: 'project-1',
+                folderSync: true,
+                host: 'http://insecure.example.test',
+                folderAuth: { cookies: ['n8n-auth=t'] },
+            });
+
+            await tracker.refreshRemoteState();
+
+            expect(mockLoad).not.toHaveBeenCalled();
+            expect(warn).toHaveBeenCalledWith(expect.stringMatching(/Refusing to pass folderAuth/i));
+            expect(tracker.getFilenameForId('wf-foldered')).toBe('Normalize Attachments.workflow.ts');
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    it('allows RestFolderSource over non-loopback plain HTTP when N8NAC_ALLOW_INSECURE_HTTP is set', async () => {
+        const prevEnv = process.env.N8NAC_ALLOW_INSECURE_HTTP;
+        process.env.N8NAC_ALLOW_INSECURE_HTTP = '1';
+        mockLoad.mockResolvedValue(sessionData());
+        try {
+            const tracker = new WorkflowStateTracker(makeClient(), {
+                directory: tempDir,
+                syncInactive: false,
+                ignoredTags: [],
+                projectId: 'project-1',
+                folderSync: true,
+                host: 'http://insecure.example.test',
+                folderAuth: { cookies: ['n8n-auth=t'] },
+            });
+
+            await tracker.refreshRemoteState();
+
+            expect(mockLoad).toHaveBeenCalledTimes(1);
+            expect(tracker.getFilenameForId('wf-foldered')).toBe('Ai Chat/File Processing/Normalize Attachments.workflow.ts');
+        } finally {
+            if (prevEnv === undefined) delete process.env.N8NAC_ALLOW_INSECURE_HTTP;
+            else process.env.N8NAC_ALLOW_INSECURE_HTTP = prevEnv;
+        }
+    });
 });

--- a/packages/cli/tests/unit/workflow-state-tracker-session.test.ts
+++ b/packages/cli/tests/unit/workflow-state-tracker-session.test.ts
@@ -132,6 +132,20 @@ describe('WorkflowStateTracker session folder source', () => {
         await expect(tracker.refreshRemoteState()).rejects.toThrow(/session folder source failed/i);
     });
 
+    it('preserves prior remote state when a subsequent refreshRemoteState fails closed', async () => {
+        mockLoad.mockResolvedValue(sessionData());
+        const tracker = makeTracker();
+        await tracker.refreshRemoteState();
+        expect(tracker.getFilenameForId('wf-foldered')).toBe('Ai Chat/File Processing/Normalize Attachments.workflow.ts');
+
+        // Subsequent refresh fails closed
+        mockLoad.mockRejectedValue(new Error('401 Unauthorized'));
+        await expect(tracker.refreshRemoteState()).rejects.toThrow(/session folder source failed/i);
+
+        // Prior state must still be intact
+        expect(tracker.getFilenameForId('wf-foldered')).toBe('Ai Chat/File Processing/Normalize Attachments.workflow.ts');
+    });
+
     it('degrades to a flat pull when the flat fallback is opted in', async () => {
         mockLoad.mockRejectedValue(new Error('401 Unauthorized'));
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/cli/tests/unit/workflow-state-tracker-session.test.ts
+++ b/packages/cli/tests/unit/workflow-state-tracker-session.test.ts
@@ -144,6 +144,23 @@ describe('WorkflowStateTracker session folder source', () => {
         }
     });
 
+    it('degrades to flat pull with a warning when the instance reports no folder support (403 license)', async () => {
+        mockLoad.mockResolvedValue({
+            folders: [],
+            workflowParentFolderId: new Map(),
+            licenseUnavailableReason: 'the n8n instance reports no folder support (register the Community instance to unlock folders)',
+        });
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            const tracker = makeTracker();
+            await tracker.refreshRemoteState();
+            expect(tracker.getFilenameForId('wf-foldered')).toBe('Normalize Attachments.workflow.ts');
+            expect(warn).toHaveBeenCalledWith(expect.stringMatching(/register the Community instance to unlock folders/i));
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
     it('re-reads the folder tree on every refresh (failures stay retryable, moves are seen)', async () => {
         mockLoad.mockResolvedValue(sessionData());
         const tracker = makeTracker();

--- a/packages/cli/tests/unit/workflow-state-tracker-session.test.ts
+++ b/packages/cli/tests/unit/workflow-state-tracker-session.test.ts
@@ -1,0 +1,206 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The tracker constructs RestFolderSource internally; mock it so these tests drive
+// its load() result without any network.
+const { mockLoad } = vi.hoisted(() => ({ mockLoad: vi.fn() }));
+
+vi.mock('../../src/core/services/rest-folder-source.js', () => ({
+    RestFolderSource: class {
+        load = mockLoad;
+        static login = vi.fn();
+    },
+}));
+
+// updateSingleRemoteState serialises the workflow before the folder step; stub the
+// transformer so minimal fixtures reach the folder logic under test.
+vi.mock('../../src/core/services/workflow-transformer-adapter.js', () => ({
+    WorkflowTransformerAdapter: {
+        convertToTypeScript: vi.fn().mockResolvedValue('// stubbed workflow code'),
+        hashWorkflow: vi.fn().mockResolvedValue('stub-hash'),
+    },
+}));
+
+import { WorkflowStateTracker } from '../../src/core/services/workflow-state-tracker.js';
+import { IWorkflow } from '../../src/core/types.js';
+
+const FOLDERS = [
+    { id: 'folder-ai-chat', name: 'Ai Chat', parentFolderId: null },
+    { id: 'folder-fp', name: 'File Processing', parentFolderId: 'folder-ai-chat' },
+];
+
+/** The session source supplies the workflow→folder link the public API omits. */
+function sessionData() {
+    return { folders: FOLDERS, workflowParentFolderId: new Map([['wf-foldered', 'folder-fp']]) };
+}
+
+/** A public client whose workflow read carries NO folder metadata (the real n8n case). */
+function makeClient() {
+    return {
+        getAllWorkflows: vi.fn().mockResolvedValue([
+            { id: 'wf-foldered', name: 'Normalize Attachments', active: true, isArchived: false } as IWorkflow,
+        ]),
+    } as any;
+}
+
+describe('WorkflowStateTracker session folder source', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-tracker-session-'));
+    });
+
+    afterEach(() => {
+        if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    function makeTracker(extra: Record<string, unknown> = {}) {
+        return new WorkflowStateTracker(makeClient(), {
+            directory: tempDir,
+            syncInactive: false,
+            ignoredTags: [],
+            projectId: 'project-1',
+            folderSync: true,
+            host: 'https://n8n.example.test',
+            folderAuth: { cookies: ['n8n-auth=t'] },
+            ...extra,
+        });
+    }
+
+    it('backfills parentFolderId from the session source and builds the nested path', async () => {
+        mockLoad.mockResolvedValue(sessionData());
+        const tracker = makeTracker();
+
+        await tracker.refreshRemoteState();
+
+        expect(tracker.getFilenameForId('wf-foldered')).toBe(
+            'Ai Chat/File Processing/Normalize Attachments.workflow.ts',
+        );
+        expect(mockLoad).toHaveBeenCalledTimes(1);
+    });
+
+    it('places multiple workflows into their reconstructed folders on the initial pull', async () => {
+        // Mirrors the shape of a real instance: a deep branch plus a sibling and a root flow.
+        mockLoad.mockResolvedValue({
+            folders: [
+                { id: 'timeless', name: 'Timeless', parentFolderId: null },
+                { id: 'ap', name: 'ai-action-plan', parentFolderId: 'timeless' },
+                { id: 'pi', name: 'patient-info', parentFolderId: 'ap' },
+                { id: 'common', name: 'Common', parentFolderId: null },
+            ],
+            // Only foldered workflows appear here; a root workflow is absent from the map.
+            workflowParentFolderId: new Map([
+                ['wf-tl', 'timeless'],
+                ['wf-pi', 'pi'],
+                ['wf-common', 'common'],
+            ]),
+        });
+        const client = {
+            getAllWorkflows: vi.fn().mockResolvedValue([
+                { id: 'wf-root', name: 'Root Flow', active: true, isArchived: false },
+                { id: 'wf-tl', name: 'TL Flow', active: true, isArchived: false },
+                { id: 'wf-pi', name: 'PI Flow', active: true, isArchived: false },
+                { id: 'wf-common', name: 'Common Flow', active: true, isArchived: false },
+            ]),
+        } as any;
+        const tracker = new WorkflowStateTracker(client, {
+            directory: tempDir,
+            syncInactive: false,
+            ignoredTags: [],
+            projectId: 'project-1',
+            folderSync: true,
+            host: 'https://n8n.example.test',
+            folderAuth: { cookies: ['n8n-auth=t'] },
+        });
+
+        await tracker.refreshRemoteState();
+
+        expect(tracker.getFilenameForId('wf-root')).toBe('Root Flow.workflow.ts');
+        expect(tracker.getFilenameForId('wf-tl')).toBe('Timeless/TL Flow.workflow.ts');
+        expect(tracker.getFilenameForId('wf-pi')).toBe('Timeless/ai-action-plan/patient-info/PI Flow.workflow.ts');
+        expect(tracker.getFilenameForId('wf-common')).toBe('Common/Common Flow.workflow.ts');
+    });
+
+    it('fails closed when a configured session source cannot load', async () => {
+        mockLoad.mockRejectedValue(new Error('401 Unauthorized'));
+        const tracker = makeTracker();
+        tracker.on('error', () => {}); // swallow the emitter re-raise; we assert on the rejection
+
+        await expect(tracker.refreshRemoteState()).rejects.toThrow(/session folder source failed/i);
+    });
+
+    it('degrades to a flat pull when the flat fallback is opted in', async () => {
+        mockLoad.mockRejectedValue(new Error('401 Unauthorized'));
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            const tracker = makeTracker({ folderSessionAllowFlatFallback: true });
+            await tracker.refreshRemoteState();
+            expect(tracker.getFilenameForId('wf-foldered')).toBe('Normalize Attachments.workflow.ts');
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    it('re-reads the folder tree on every refresh (failures stay retryable, moves are seen)', async () => {
+        mockLoad.mockResolvedValue(sessionData());
+        const tracker = makeTracker();
+
+        await tracker.refreshRemoteState();
+        await tracker.refreshRemoteState();
+
+        expect(mockLoad).toHaveBeenCalledTimes(2);
+    });
+
+    it('fails closed on the single-workflow pull path (updateSingleRemoteState)', async () => {
+        mockLoad.mockRejectedValue(new Error('401 Unauthorized'));
+        const tracker = makeTracker();
+
+        await expect(
+            tracker.updateSingleRemoteState(
+                { id: 'wf-foldered', name: 'Normalize Attachments', active: true, isArchived: false } as IWorkflow,
+            ),
+        ).rejects.toThrow(/session folder source failed/i);
+    });
+
+    it('leaves the workflow cache untouched (all-or-nothing) when the single-workflow pull fails closed', async () => {
+        mockLoad.mockRejectedValue(new Error('401 Unauthorized'));
+        const tracker = makeTracker();
+
+        await expect(
+            tracker.updateSingleRemoteState({ id: 'wf-x', name: 'X', active: true, isArchived: false } as IWorkflow),
+        ).rejects.toThrow(/session folder source failed/i);
+
+        // Fail-closed happens before any cache write -> the workflow is not half-recorded.
+        expect(tracker.isRemoteKnown('wf-x')).toBe(false);
+        expect(tracker.getFilenameForId('wf-x')).toBeUndefined();
+    });
+
+    it('shares one session load across single-workflow updates within a generation', async () => {
+        mockLoad.mockResolvedValue(sessionData());
+        const tracker = makeTracker();
+
+        await tracker.updateSingleRemoteState({ id: 'wf-foldered', name: 'A', active: true, isArchived: false } as IWorkflow);
+        await tracker.updateSingleRemoteState({ id: 'wf-foldered', name: 'A', active: true, isArchived: false } as IWorkflow);
+
+        expect(mockLoad).toHaveBeenCalledTimes(1); // memoised within the same generation
+    });
+
+    it('never touches /rest when folderSync is on but no host/auth is configured', async () => {
+        const tracker = new WorkflowStateTracker(makeClient(), {
+            directory: tempDir,
+            syncInactive: false,
+            ignoredTags: [],
+            projectId: 'project-1',
+            folderSync: true,
+            // no host, no folderAuth -> no session source is constructed
+        });
+
+        await tracker.refreshRemoteState();
+
+        expect(mockLoad).not.toHaveBeenCalled();
+        expect(tracker.getFilenameForId('wf-foldered')).toBe('Normalize Attachments.workflow.ts');
+    });
+});


### PR DESCRIPTION
**What does this PR do?**

Adds an **optional, opt-in** way for `folderSync` **pull** to reconstruct the nested folder layout, by reading folder membership over n8n's internal `/rest` API with session auth.

### Why

The merged folder-sync is push-only because n8n's **public** workflow API never returns a workflow's folder — `parentFolderId` is `writeOnly` and no endpoint maps workflows to folders, on every edition. So `pull` lays workflows out flat. The n8n editor reads folders over `/rest` with a login cookie, which works on every edition; this replicates that path so `pull` can rebuild the tree. This is the session-auth pull path discussed around #527.

### What it adds (all opt-in — with nothing configured, behavior is unchanged)

- **`RestFolderSource`** — logs in via `/rest/login`, reads `/rest/projects/{id}/folders` and the project-scoped, paginated `/rest/workflows`, and builds a workflow→`parentFolderId` map. Resolves the `personal` project placeholder via `/rest/projects` (fails closed rather than guessing a team project), serializes concurrent loads, and re-logs in with credentials when a cookie is rejected (401).
- **`n8nac env auth folder-login <env>`** — logs in once and stores the ~7-day cookie in the same local secret store as API keys (honours `N8N_MANAGER_HOME`; the password is never stored). `folder-logout` and `env auth clear` remove it. Credentials/token may also come from `N8NAC_ENV_<ENV>_FOLDER_*` / `N8NAC_FOLDER_LOGIN_*` env vars.
- **`WorkflowStateTracker`** — backfills `parentFolderId` from the session source, re-reading it on each refresh. When a configured source fails, pull **fails closed** with an actionable error instead of silently flattening (`N8NAC_FOLDER_ALLOW_FLAT_FALLBACK=1` opts into a flat pull).

### Security / caveats

- `/rest` is an **internal, unsupported** n8n API and may change between versions; it is used only to *read* folder membership — every write still goes through the public API.
- The stored cookie is a bearer credential; prefer `--password-stdin` over `--password`, and a warning is emitted when credentials would cross a non-loopback plain-HTTP host.
- Validated end-to-end against a live self-hosted Community instance (folders licensed, n8n 2.25.6): `folder-login` followed by a folder-aware read reconstructed the full nested folder tree.

### Tests / docs

Documented in `docs/usage/folder-sync.md`. Unit tests cover login + cookie/expiry parsing, project scoping + `personal` resolution (incl. team-project fail-closed), 401 re-login / candidate cookies, fail-closed vs opt-in flat fallback, the session-folder cache lifecycle, and the secret-store round-trip/clear/isolation.

_Base branch: targeting `main` because the merged folder-sync this builds on lives on `main` (not `next`)._

**Related issue (if any):** #527 (follow-up)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pull operations can optionally reconstruct nested n8n folder structures using session authentication.
  - Added `environment auth folder-login` and `folder-logout` commands for managing folder-sync sessions.
  - Added optional flat-folder fallback when authenticated folder loading fails.
  - Push operations support draft workflows and publish-state reporting.

- **Documentation**
  - Clarified push-only behavior and public API limitations for folder placement.
  - Documented authentication setup, CI configuration, fallback behavior, and security considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->