### PR TITLE
Add Atlas Cloud agent provider

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -319,6 +319,7 @@
             "google",
             "mistral",
             "openrouter",
+            "atlascloud",
             "openai-oauth",
             "copilot-proxy",
             "minimax",

--- a/packages/vscode-extension/scripts/run-provider-stream-v3-integrations.mjs
+++ b/packages/vscode-extension/scripts/run-provider-stream-v3-integrations.mjs
@@ -11,6 +11,7 @@ const providers = [
   { id: 'anthropic', envKeys: ['ANTHROPIC_API_KEY', 'ANTHROPIC_LLM_API_KEY', 'ANTHROPIC_KEY', 'CLAUDE_API_KEY'] },
   { id: 'google', envKeys: ['GOOGLE_GENERATIVE_AI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'GEMINI_LLM_API_KEY', 'GOOGLE_LLM_API_KEY'] },
   { id: 'openrouter', envKeys: ['OPENROUTER_API_KEY', 'OPENROUTER_LLM_API_KEY', 'OPEN_ROUTEUR_KEY'] },
+  { id: 'atlascloud', envKeys: ['ATLASCLOUD_API_KEY', 'ATLAS_CLOUD_API_KEY'] },
   { id: 'openai-compatible', envKeys: ['OPENAI_COMPATIBLE_API_KEY', 'OPENAI_API_KEY', 'OPENAI_LLM_API_KEY', 'OPENAI_KEY'] },
 ];
 

--- a/packages/vscode-extension/src/services/agent-provider-capabilities.ts
+++ b/packages/vscode-extension/src/services/agent-provider-capabilities.ts
@@ -50,6 +50,9 @@ export function getReasoningCapability(provider: string, model?: string): Reason
     if (normalizedProvider === 'openrouter' && isOpenRouterReasoningModel(model)) {
         return { supported: true, efforts: OPENROUTER_REASONING_EFFORTS, defaultEffort: 'medium', strategy: 'openrouter-reasoning' };
     }
+    if (normalizedProvider === 'atlascloud' && isAtlasCloudReasoningModel(model)) {
+        return { supported: true, efforts: OPENROUTER_REASONING_EFFORTS, defaultEffort: 'medium', strategy: 'openrouter-reasoning' };
+    }
     if (normalizedProvider === 'google' && isGeminiThinkingModel(model)) {
         return { supported: true, efforts: GOOGLE_REASONING_EFFORTS, defaultEffort: 'medium', strategy: 'google-thinking' };
     }
@@ -140,6 +143,10 @@ function buildAnthropicReasoningOptions(model: string | undefined, effort: Agent
 function isOpenAIReasoningModel(model?: string): boolean {
     const normalized = normalizeModelName(model);
     return /^(o\d|o\d-|o\d\.|gpt-5|gpt-5-|gpt-5\.)/.test(normalized);
+}
+
+function isAtlasCloudReasoningModel(model?: string): boolean {
+    return normalizeModelName(model) === 'deepseek-ai/deepseek-v4-pro';
 }
 
 function isAnthropicReasoningModel(model?: string): boolean {

--- a/packages/vscode-extension/src/services/agent-provider-capabilities.ts
+++ b/packages/vscode-extension/src/services/agent-provider-capabilities.ts
@@ -4,6 +4,7 @@ export type AgentCapabilityProvider =
     | 'google'
     | 'mistral'
     | 'openrouter'
+    | 'atlascloud'
     | 'openai-oauth'
     | 'copilot-proxy'
     | 'minimax'

--- a/packages/vscode-extension/src/services/agent-provider-service.ts
+++ b/packages/vscode-extension/src/services/agent-provider-service.ts
@@ -12,6 +12,7 @@ export type AgentModelProvider =
     | 'google'
     | 'mistral'
     | 'openrouter'
+    | 'atlascloud'
     | 'openai-oauth'
     | 'copilot-proxy'
     | 'minimax'
@@ -28,6 +29,7 @@ export interface AgentProviderDefinition {
     description: string;
     defaultModel: string;
     defaultBaseUrl?: string;
+    baseUrlEnvKeys?: string[];
     requiresApiKey: boolean;
     authKind: ProviderAuthKind;
     envKeys: string[];
@@ -63,6 +65,8 @@ type DeviceChallenge = {
 const OPENAI_CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 const OPENAI_CODEX_DEVICE_REDIRECT_URI = 'https://auth.openai.com/deviceauth/callback';
 const DISABLED_PROVIDERS_STATE_KEY = 'n8n.agent.disabledProviders';
+const ATLAS_CLOUD_DEFAULT_BASE_URL = 'https://api.atlascloud.ai/v1';
+const ATLAS_CLOUD_MODEL_CATALOG_URL = 'https://api.atlascloud.ai/api/v1/models';
 const MINIMAX_DISCOVERY_CANDIDATE_MODELS = [
     'MiniMax-M2.7',
     'MiniMax-M2.7-highspeed',
@@ -136,6 +140,18 @@ export const AGENT_PROVIDER_DEFINITIONS: Record<AgentModelProvider, AgentProvide
         envKeys: ['OPENROUTER_API_KEY', 'OPENROUTER_LLM_API_KEY'],
         canDiscoverModels: true,
     },
+    atlascloud: {
+        id: 'atlascloud',
+        label: 'Atlas Cloud',
+        description: 'ATLASCLOUD_API_KEY',
+        defaultModel: 'deepseek-ai/deepseek-v4-pro',
+        defaultBaseUrl: ATLAS_CLOUD_DEFAULT_BASE_URL,
+        baseUrlEnvKeys: ['ATLASCLOUD_BASE_URL', 'ATLAS_CLOUD_BASE_URL', 'ATLASCLOUD_API_BASE', 'ATLAS_CLOUD_API_BASE'],
+        requiresApiKey: true,
+        authKind: 'api-key',
+        envKeys: ['ATLASCLOUD_API_KEY', 'ATLAS_CLOUD_API_KEY'],
+        canDiscoverModels: true,
+    },
     'openai-oauth': {
         id: 'openai-oauth',
         label: 'OpenAI ChatGPT OAuth',
@@ -200,6 +216,7 @@ export function normalizeAgentProviderId(provider?: string): AgentModelProvider 
     if (normalized === 'claude') return 'anthropic';
     if (normalized === 'anthropic-proxy') return 'anthropic';
     if (normalized === 'gemini') return 'google';
+    if (normalized === 'atlas' || normalized === 'atlas-cloud') return 'atlascloud';
     return normalized in AGENT_PROVIDER_DEFINITIONS ? normalized as AgentModelProvider : undefined;
 }
 
@@ -247,7 +264,7 @@ export class AgentProviderService {
                 credentialSource: hasStoredCredential ? 'secret' as const : hasEnvironmentCredential ? 'environment' as const : undefined,
                 selected: provider === selectedProvider,
                 model: provider === selectedProvider ? selectedModel : undefined,
-                baseUrl: provider === 'openai-compatible' ? configuredBaseUrl : definition.defaultBaseUrl,
+                baseUrl: provider === 'openai-compatible' ? configuredBaseUrl : this.readEnvironmentBaseUrl(provider) || definition.defaultBaseUrl,
                 supportsReasoningEffort: providerSupportsReasoningEffort(provider, provider === selectedProvider ? selectedModel : definition.defaultModel),
                 reasoningEffort: provider === selectedProvider && providerSupportsReasoningEffort(provider, selectedModel) ? selectedReasoningEffort : undefined,
             };
@@ -396,9 +413,9 @@ export class AgentProviderService {
         if (!definition.canDiscoverModels) return [];
         const apiKey = await this.getStoredCredential(provider) || this.readEnvironmentCredential(provider);
         const configuredBaseUrl = readAgentProviderSettings(this.context.globalState).baseUrl || '';
-        const baseUrl = provider === 'openai-compatible' ? configuredBaseUrl : definition.defaultBaseUrl;
+        const baseUrl = provider === 'openai-compatible' ? configuredBaseUrl : this.readEnvironmentBaseUrl(provider) || definition.defaultBaseUrl;
 
-        if ((definition.requiresApiKey || provider !== 'openai-compatible') && !apiKey && definition.authKind !== 'none') {
+        if (provider !== 'atlascloud' && (definition.requiresApiKey || provider !== 'openai-compatible') && !apiKey && definition.authKind !== 'none') {
             return [];
         }
 
@@ -419,6 +436,9 @@ export class AgentProviderService {
         if (provider === 'minimax' || provider === 'minimax-token-plan') {
             return this.probeMiniMaxModels(apiKey || '', baseUrl || definition.defaultBaseUrl);
         }
+        if (provider === 'atlascloud') {
+            return this.fetchAtlasCloudModels();
+        }
 
         const modelsUrl = provider === 'openai-compatible'
             ? (baseUrl ? `${baseUrl.replace(/\/$/, '')}/models` : undefined)
@@ -427,11 +447,32 @@ export class AgentProviderService {
         return this.fetchJsonModels(modelsUrl, apiKey ? { Authorization: `Bearer ${apiKey}` } : {});
     }
 
+    private async fetchAtlasCloudModels(): Promise<string[]> {
+        const response = await fetch(ATLAS_CLOUD_MODEL_CATALOG_URL, { headers: { Accept: 'application/json' } });
+        if (!response.ok) return [];
+        const payload = await response.json() as Record<string, unknown>;
+        const data = Array.isArray(payload.data) ? payload.data : [];
+        return [...new Set(data
+            .filter((entry) => entry && typeof entry === 'object')
+            .filter((entry) => String((entry as Record<string, unknown>).type || '').toLowerCase() === 'text')
+            .map((entry) => String((entry as Record<string, unknown>).model || (entry as Record<string, unknown>).id || '').trim())
+            .filter(Boolean))]
+            .sort((left, right) => left.localeCompare(right));
+    }
+
     private readEnvironmentCredential(provider: AgentModelProvider): string | undefined {
         if (this.getDisabledProviders().has(provider)) return undefined;
         for (const key of AGENT_PROVIDER_DEFINITIONS[provider].envKeys) {
             const value = process.env[key]?.trim();
             if (value) return value;
+        }
+        return undefined;
+    }
+
+    private readEnvironmentBaseUrl(provider: AgentModelProvider): string | undefined {
+        for (const key of AGENT_PROVIDER_DEFINITIONS[provider].baseUrlEnvKeys ?? []) {
+            const value = process.env[key]?.trim();
+            if (value) return value.replace(/\/$/, '');
         }
         return undefined;
     }

--- a/packages/vscode-extension/src/services/agent-provider-service.ts
+++ b/packages/vscode-extension/src/services/agent-provider-service.ts
@@ -8,6 +8,7 @@ import {
     DISABLED_PROVIDERS_STATE_KEY,
     getAtlasCloudModelCatalogUrl,
     mapAtlasCloudTextModels,
+    readAgentProviderEnvironmentSecret,
     readAgentProviderSettings,
     readFirstEnvironmentValue,
     updateAgentProviderSettings,
@@ -469,12 +470,7 @@ export class AgentProviderService {
     }
 
     private readEnvironmentCredential(provider: AgentModelProvider): string | undefined {
-        if (this.getDisabledProviders().has(provider)) return undefined;
-        for (const key of AGENT_PROVIDER_DEFINITIONS[provider].envKeys) {
-            const value = process.env[key]?.trim();
-            if (value) return value;
-        }
-        return undefined;
+        return readAgentProviderEnvironmentSecret(this.context.globalState, provider);
     }
 
     private readEnvironmentBaseUrl(provider: AgentModelProvider): string | undefined {

--- a/packages/vscode-extension/src/services/agent-provider-service.ts
+++ b/packages/vscode-extension/src/services/agent-provider-service.ts
@@ -1,7 +1,17 @@
 import * as vscode from 'vscode';
 import { getAgentProviderSecretKey } from './agent-runtime-controller.js';
 import { fetchGitHubCopilotModels } from './agent-provider-runtime/copilot-account.js';
-import { readAgentProviderSettings, updateAgentProviderSettings } from './agent-provider-settings.js';
+import {
+    AGENT_PROVIDER_BASE_URL_ENV_KEYS,
+    AGENT_PROVIDER_ENV_KEYS,
+    ATLAS_CLOUD_DEFAULT_BASE_URL,
+    DISABLED_PROVIDERS_STATE_KEY,
+    getAtlasCloudModelCatalogUrl,
+    mapAtlasCloudTextModels,
+    readAgentProviderSettings,
+    readFirstEnvironmentValue,
+    updateAgentProviderSettings,
+} from './agent-provider-settings.js';
 import { getReasoningCapability, normalizeReasoningEffortForCapability, type AgentReasoningEffort } from './agent-provider-capabilities.js';
 
 export { AGENT_REASONING_EFFORTS } from './agent-provider-capabilities.js';
@@ -64,9 +74,6 @@ type DeviceChallenge = {
 
 const OPENAI_CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 const OPENAI_CODEX_DEVICE_REDIRECT_URI = 'https://auth.openai.com/deviceauth/callback';
-const DISABLED_PROVIDERS_STATE_KEY = 'n8n.agent.disabledProviders';
-const ATLAS_CLOUD_DEFAULT_BASE_URL = 'https://api.atlascloud.ai/v1';
-const ATLAS_CLOUD_MODEL_CATALOG_URL = 'https://api.atlascloud.ai/api/v1/models';
 const MINIMAX_DISCOVERY_CANDIDATE_MODELS = [
     'MiniMax-M2.7',
     'MiniMax-M2.7-highspeed',
@@ -76,6 +83,7 @@ const MINIMAX_DISCOVERY_CANDIDATE_MODELS = [
     'MiniMax-M2.1-highspeed',
     'MiniMax-M2',
 ] as const;
+const PROVIDERS_WITH_PUBLIC_MODEL_CATALOG = new Set<AgentModelProvider>(['atlascloud']);
 
 const MODEL_LIST_MAPPER = (payload: Record<string, unknown>): string[] => {
     const data = Array.isArray(payload.data) ? payload.data : [];
@@ -93,7 +101,7 @@ export const AGENT_PROVIDER_DEFINITIONS: Record<AgentModelProvider, AgentProvide
         defaultModel: 'claude-haiku-4-5',
         requiresApiKey: true,
         authKind: 'api-key',
-        envKeys: ['ANTHROPIC_LLM_API_KEY', 'ANTHROPIC_API_KEY'],
+        envKeys: [...AGENT_PROVIDER_ENV_KEYS.anthropic],
         canDiscoverModels: true,
     },
     openai: {
@@ -104,7 +112,7 @@ export const AGENT_PROVIDER_DEFINITIONS: Record<AgentModelProvider, AgentProvide
         defaultBaseUrl: 'https://api.openai.com/v1',
         requiresApiKey: true,
         authKind: 'api-key',
-        envKeys: ['OPENAI_LLM_API_KEY', 'OPENAI_API_KEY'],
+        envKeys: [...AGENT_PROVIDER_ENV_KEYS.openai],
         canDiscoverModels: true,
     },
     google: {
@@ -115,7 +123,7 @@ export const AGENT_PROVIDER_DEFINITIONS: Record<AgentModelProvider, AgentProvide
         defaultBaseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
         requiresApiKey: true,
         authKind: 'api-key',
-        envKeys: ['GOOGLE_GENERATIVE_AI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'GEMINI_LLM_API_KEY', 'GOOGLE_LLM_API_KEY'],
+        envKeys: [...AGENT_PROVIDER_ENV_KEYS.google],
         canDiscoverModels: true,
     },
     mistral: {
@@ -126,7 +134,7 @@ export const AGENT_PROVIDER_DEFINITIONS: Record<AgentModelProvider, AgentProvide
         defaultBaseUrl: 'https://api.mistral.ai/v1',
         requiresApiKey: true,
         authKind: 'api-key',
-        envKeys: ['MISTRAL_API_KEY', 'MISTRAL_LLM_API_KEY'],
+        envKeys: [...AGENT_PROVIDER_ENV_KEYS.mistral],
         canDiscoverModels: true,
     },
     openrouter: {
@@ -137,7 +145,7 @@ export const AGENT_PROVIDER_DEFINITIONS: Record<AgentModelProvider, AgentProvide
         defaultBaseUrl: 'https://openrouter.ai/api/v1',
         requiresApiKey: true,
         authKind: 'api-key',
-        envKeys: ['OPENROUTER_API_KEY', 'OPENROUTER_LLM_API_KEY'],
+        envKeys: [...AGENT_PROVIDER_ENV_KEYS.openrouter],
         canDiscoverModels: true,
     },
     atlascloud: {
@@ -146,10 +154,10 @@ export const AGENT_PROVIDER_DEFINITIONS: Record<AgentModelProvider, AgentProvide
         description: 'ATLASCLOUD_API_KEY',
         defaultModel: 'deepseek-ai/deepseek-v4-pro',
         defaultBaseUrl: ATLAS_CLOUD_DEFAULT_BASE_URL,
-        baseUrlEnvKeys: ['ATLASCLOUD_BASE_URL', 'ATLAS_CLOUD_BASE_URL', 'ATLASCLOUD_API_BASE', 'ATLAS_CLOUD_API_BASE'],
+        baseUrlEnvKeys: [...(AGENT_PROVIDER_BASE_URL_ENV_KEYS.atlascloud ?? [])],
         requiresApiKey: true,
         authKind: 'api-key',
-        envKeys: ['ATLASCLOUD_API_KEY', 'ATLAS_CLOUD_API_KEY'],
+        envKeys: [...AGENT_PROVIDER_ENV_KEYS.atlascloud],
         canDiscoverModels: true,
     },
     'openai-oauth': {
@@ -160,7 +168,7 @@ export const AGENT_PROVIDER_DEFINITIONS: Record<AgentModelProvider, AgentProvide
         defaultBaseUrl: 'https://chatgpt.com/backend-api',
         requiresApiKey: false,
         authKind: 'oauth-device',
-        envKeys: [],
+        envKeys: [...AGENT_PROVIDER_ENV_KEYS['openai-oauth']],
         canDiscoverModels: true,
     },
     'copilot-proxy': {
@@ -171,7 +179,7 @@ export const AGENT_PROVIDER_DEFINITIONS: Record<AgentModelProvider, AgentProvide
         defaultBaseUrl: 'https://api.individual.githubcopilot.com',
         requiresApiKey: false,
         authKind: 'oauth-device',
-        envKeys: ['COPILOT_GITHUB_TOKEN', 'GH_TOKEN', 'GITHUB_TOKEN'],
+        envKeys: [...AGENT_PROVIDER_ENV_KEYS['copilot-proxy']],
         canDiscoverModels: true,
     },
     minimax: {
@@ -182,7 +190,7 @@ export const AGENT_PROVIDER_DEFINITIONS: Record<AgentModelProvider, AgentProvide
         defaultBaseUrl: 'https://api.minimax.io/anthropic',
         requiresApiKey: true,
         authKind: 'api-key',
-        envKeys: ['MINIMAX_API_KEY'],
+        envKeys: [...AGENT_PROVIDER_ENV_KEYS.minimax],
         canDiscoverModels: true,
     },
     'minimax-token-plan': {
@@ -193,7 +201,7 @@ export const AGENT_PROVIDER_DEFINITIONS: Record<AgentModelProvider, AgentProvide
         defaultBaseUrl: 'https://api.minimax.io/anthropic',
         requiresApiKey: true,
         authKind: 'api-key',
-        envKeys: ['MINIMAX_TOKEN_PLAN_API_KEY'],
+        envKeys: [...AGENT_PROVIDER_ENV_KEYS['minimax-token-plan']],
         canDiscoverModels: true,
     },
     'openai-compatible': {
@@ -203,7 +211,7 @@ export const AGENT_PROVIDER_DEFINITIONS: Record<AgentModelProvider, AgentProvide
         defaultModel: '',
         requiresApiKey: false,
         authKind: 'api-key',
-        envKeys: ['OPENAI_COMPATIBLE_API_KEY'],
+        envKeys: [...AGENT_PROVIDER_ENV_KEYS['openai-compatible']],
         canDiscoverModels: true,
     },
 };
@@ -411,11 +419,12 @@ export class AgentProviderService {
     async fetchAvailableModels(provider: AgentModelProvider): Promise<string[]> {
         const definition = AGENT_PROVIDER_DEFINITIONS[provider];
         if (!definition.canDiscoverModels) return [];
+        if (this.getDisabledProviders().has(provider)) return [];
         const apiKey = await this.getStoredCredential(provider) || this.readEnvironmentCredential(provider);
         const configuredBaseUrl = readAgentProviderSettings(this.context.globalState).baseUrl || '';
-        const baseUrl = provider === 'openai-compatible' ? configuredBaseUrl : this.readEnvironmentBaseUrl(provider) || definition.defaultBaseUrl;
+        const baseUrl = this.resolveProviderBaseUrl(provider, configuredBaseUrl);
 
-        if (provider !== 'atlascloud' && (definition.requiresApiKey || provider !== 'openai-compatible') && !apiKey && definition.authKind !== 'none') {
+        if (!PROVIDERS_WITH_PUBLIC_MODEL_CATALOG.has(provider) && (definition.requiresApiKey || provider !== 'openai-compatible') && !apiKey && definition.authKind !== 'none') {
             return [];
         }
 
@@ -437,7 +446,7 @@ export class AgentProviderService {
             return this.probeMiniMaxModels(apiKey || '', baseUrl || definition.defaultBaseUrl);
         }
         if (provider === 'atlascloud') {
-            return this.fetchAtlasCloudModels();
+            return this.fetchAtlasCloudModels(baseUrl, apiKey);
         }
 
         const modelsUrl = provider === 'openai-compatible'
@@ -447,17 +456,16 @@ export class AgentProviderService {
         return this.fetchJsonModels(modelsUrl, apiKey ? { Authorization: `Bearer ${apiKey}` } : {});
     }
 
-    private async fetchAtlasCloudModels(): Promise<string[]> {
-        const response = await fetch(ATLAS_CLOUD_MODEL_CATALOG_URL, { headers: { Accept: 'application/json' } });
+    private async fetchAtlasCloudModels(baseUrl?: string, apiKey?: string): Promise<string[]> {
+        const response = await fetch(getAtlasCloudModelCatalogUrl(baseUrl), {
+            headers: {
+                Accept: 'application/json',
+                ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+            },
+        });
         if (!response.ok) return [];
         const payload = await response.json() as Record<string, unknown>;
-        const data = Array.isArray(payload.data) ? payload.data : [];
-        return [...new Set(data
-            .filter((entry) => entry && typeof entry === 'object')
-            .filter((entry) => String((entry as Record<string, unknown>).type || '').toLowerCase() === 'text')
-            .map((entry) => String((entry as Record<string, unknown>).model || (entry as Record<string, unknown>).id || '').trim())
-            .filter(Boolean))]
-            .sort((left, right) => left.localeCompare(right));
+        return mapAtlasCloudTextModels(payload);
     }
 
     private readEnvironmentCredential(provider: AgentModelProvider): string | undefined {
@@ -470,11 +478,14 @@ export class AgentProviderService {
     }
 
     private readEnvironmentBaseUrl(provider: AgentModelProvider): string | undefined {
-        for (const key of AGENT_PROVIDER_DEFINITIONS[provider].baseUrlEnvKeys ?? []) {
-            const value = process.env[key]?.trim();
-            if (value) return value.replace(/\/$/, '');
-        }
-        return undefined;
+        return readFirstEnvironmentValue(AGENT_PROVIDER_BASE_URL_ENV_KEYS[provider] ?? []);
+    }
+
+    private resolveProviderBaseUrl(provider: AgentModelProvider, configuredBaseUrl?: string): string | undefined {
+        const configured = configuredBaseUrl?.trim().replace(/\/$/, '') || undefined;
+        if (provider === 'openai-compatible') return configured;
+        if (provider === 'atlascloud') return configured || this.readEnvironmentBaseUrl(provider) || AGENT_PROVIDER_DEFINITIONS[provider].defaultBaseUrl;
+        return this.readEnvironmentBaseUrl(provider) || AGENT_PROVIDER_DEFINITIONS[provider].defaultBaseUrl;
     }
 
     private async probeMiniMaxModels(apiKey: string, baseUrl?: string): Promise<string[]> {

--- a/packages/vscode-extension/src/services/agent-provider-settings.ts
+++ b/packages/vscode-extension/src/services/agent-provider-settings.ts
@@ -140,6 +140,19 @@ export function readFirstEnvironmentValue(keys: readonly string[]): string | und
     return undefined;
 }
 
+export function readAgentProviderEnvironmentSecret(state: vscode.Memento, provider: string): string | undefined {
+    const normalizedProvider = normalizeAgentProviderId(provider);
+    if (!normalizedProvider) return undefined;
+    const disabledProviders = state.get<string[]>(DISABLED_PROVIDERS_STATE_KEY, [])
+        .map((disabledProvider) => normalizeAgentProviderId(disabledProvider));
+    if (disabledProviders.includes(normalizedProvider)) return undefined;
+    for (const key of AGENT_PROVIDER_ENV_KEYS[normalizedProvider]) {
+        const value = process.env[key]?.trim();
+        if (value) return value;
+    }
+    return undefined;
+}
+
 export function getAtlasCloudModelCatalogUrl(baseUrl?: string): string {
     try {
         const parsed = new URL(baseUrl || ATLAS_CLOUD_DEFAULT_BASE_URL);

--- a/packages/vscode-extension/src/services/agent-provider-settings.ts
+++ b/packages/vscode-extension/src/services/agent-provider-settings.ts
@@ -6,6 +6,7 @@ export type AgentProviderId =
     | 'google'
     | 'mistral'
     | 'openrouter'
+    | 'atlascloud'
     | 'openai-oauth'
     | 'copilot-proxy'
     | 'minimax'
@@ -20,6 +21,7 @@ const AGENT_PROVIDER_IDS = new Set<AgentProviderId>([
     'google',
     'mistral',
     'openrouter',
+    'atlascloud',
     'openai-oauth',
     'copilot-proxy',
     'minimax',
@@ -88,6 +90,7 @@ function normalizeAgentProviderId(provider?: string): AgentProviderId | undefine
     if (normalized === 'claude') return 'anthropic';
     if (normalized === 'anthropic-proxy') return 'anthropic';
     if (normalized === 'gemini') return 'google';
+    if (normalized === 'atlas' || normalized === 'atlas-cloud') return 'atlascloud';
     return AGENT_PROVIDER_IDS.has(normalized as AgentProviderId) ? normalized as AgentProviderId : undefined;
 }
 

--- a/packages/vscode-extension/src/services/agent-provider-settings.ts
+++ b/packages/vscode-extension/src/services/agent-provider-settings.ts
@@ -35,6 +35,27 @@ const SELECTED_MODEL_STATE_KEY = 'n8n.agent.model';
 const BASE_URL_STATE_KEY = 'n8n.agent.baseUrl';
 const REASONING_EFFORT_STATE_KEY = 'n8n.agent.reasoningEffort';
 const MANAGED_SETTINGS_STATE_KEY = 'n8n.agent.settingsManaged';
+export const DISABLED_PROVIDERS_STATE_KEY = 'n8n.agent.disabledProviders';
+export const ATLAS_CLOUD_DEFAULT_BASE_URL = 'https://api.atlascloud.ai/v1';
+export const ATLAS_CLOUD_MODEL_CATALOG_URL = 'https://api.atlascloud.ai/api/v1/models';
+
+export const AGENT_PROVIDER_ENV_KEYS: Record<AgentProviderId, readonly string[]> = {
+    anthropic: ['ANTHROPIC_LLM_API_KEY', 'ANTHROPIC_API_KEY'],
+    openai: ['OPENAI_LLM_API_KEY', 'OPENAI_API_KEY'],
+    google: ['GOOGLE_GENERATIVE_AI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'GEMINI_LLM_API_KEY', 'GOOGLE_LLM_API_KEY'],
+    mistral: ['MISTRAL_API_KEY', 'MISTRAL_LLM_API_KEY'],
+    openrouter: ['OPENROUTER_API_KEY', 'OPENROUTER_LLM_API_KEY'],
+    atlascloud: ['ATLASCLOUD_API_KEY', 'ATLAS_CLOUD_API_KEY'],
+    'openai-oauth': [],
+    'copilot-proxy': ['COPILOT_GITHUB_TOKEN', 'GH_TOKEN', 'GITHUB_TOKEN'],
+    minimax: ['MINIMAX_API_KEY'],
+    'minimax-token-plan': ['MINIMAX_TOKEN_PLAN_API_KEY'],
+    'openai-compatible': ['OPENAI_COMPATIBLE_API_KEY'],
+};
+
+export const AGENT_PROVIDER_BASE_URL_ENV_KEYS: Partial<Record<AgentProviderId, readonly string[]>> = {
+    atlascloud: ['ATLASCLOUD_BASE_URL', 'ATLAS_CLOUD_BASE_URL', 'ATLASCLOUD_API_BASE', 'ATLAS_CLOUD_API_BASE'],
+};
 
 export interface AgentProviderSettings {
     provider: AgentProviderId;
@@ -84,7 +105,7 @@ function getLegacyAgentConfiguration(): LegacyConfiguration {
     }
 }
 
-function normalizeAgentProviderId(provider?: string): AgentProviderId | undefined {
+export function normalizeAgentProviderId(provider?: string): AgentProviderId | undefined {
     const normalized = provider?.trim().toLowerCase();
     if (!normalized) return undefined;
     if (normalized === 'claude') return 'anthropic';
@@ -109,4 +130,31 @@ function readPersistedString(state: vscode.Memento, key: string, legacyValue: un
 
 function readOptionalString(value: unknown): string {
     return String(value ?? '').trim();
+}
+
+export function readFirstEnvironmentValue(keys: readonly string[]): string | undefined {
+    for (const key of keys) {
+        const value = process.env[key]?.trim();
+        if (value) return value.replace(/\/$/, '');
+    }
+    return undefined;
+}
+
+export function getAtlasCloudModelCatalogUrl(baseUrl?: string): string {
+    try {
+        const parsed = new URL(baseUrl || ATLAS_CLOUD_DEFAULT_BASE_URL);
+        return `${parsed.origin}/api/v1/models`;
+    } catch {
+        return ATLAS_CLOUD_MODEL_CATALOG_URL;
+    }
+}
+
+export function mapAtlasCloudTextModels(payload: Record<string, unknown>): string[] {
+    const data = Array.isArray(payload.data) ? payload.data : [];
+    return [...new Set(data
+        .filter((entry) => entry && typeof entry === 'object')
+        .filter((entry) => String((entry as Record<string, unknown>).type || '').toLowerCase() === 'text')
+        .map((entry) => String((entry as Record<string, unknown>).model || (entry as Record<string, unknown>).id || '').trim())
+        .filter(Boolean))]
+        .sort((left, right) => left.localeCompare(right));
 }

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -4,7 +4,16 @@ import * as path from 'path';
 import { randomUUID } from 'crypto';
 import { WorkspaceSnapshotService } from './workspace-snapshot-service.js';
 import { createLocalProviderLangChainModel } from './agent-provider-runtime/create-langchain-model.js';
-import { readAgentProviderSettings } from './agent-provider-settings.js';
+import {
+    AGENT_PROVIDER_BASE_URL_ENV_KEYS,
+    AGENT_PROVIDER_ENV_KEYS,
+    ATLAS_CLOUD_DEFAULT_BASE_URL,
+    DISABLED_PROVIDERS_STATE_KEY,
+    normalizeAgentProviderId as normalizeManagedAgentProviderId,
+    readAgentProviderSettings,
+    readFirstEnvironmentValue,
+    type AgentProviderId,
+} from './agent-provider-settings.js';
 import { buildLangChainReasoningOptions, getReasoningCapability, getReasoningOptions, normalizeReasoningEffortForCapability, shouldDisableModelStreamingForToolCalling, type AgentReasoningEffort as AgentProviderReasoningEffort } from './agent-provider-capabilities.js';
 import type { WorktreeInfo } from './worktree-service.js';
 
@@ -31,7 +40,6 @@ const NON_FINAL_ASSISTANT_PHASE_RECOVERY_MARKER = 'N8N_NON_FINAL_ASSISTANT_PHASE
 const NON_FINAL_ASSISTANT_PHASE_MAX_RECOVERY_ATTEMPTS = 12;
 const STREAM_TEXT_FLUSH_INTERVAL_MS = 33;
 const STREAM_TEXT_FLUSH_CHAR_THRESHOLD = 512;
-const ATLAS_CLOUD_DEFAULT_BASE_URL = 'https://api.atlascloud.ai/v1';
 
 type ActiveWorktreePathsBySession = Record<string, string | null>;
 
@@ -3428,36 +3436,25 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     private readProviderEnvironmentSecret(provider: string): string | undefined {
-        const envKeys: Record<string, string[]> = {
-            anthropic: ['ANTHROPIC_LLM_API_KEY', 'ANTHROPIC_API_KEY'],
-            openai: ['OPENAI_LLM_API_KEY', 'OPENAI_API_KEY'],
-            google: ['GOOGLE_GENERATIVE_AI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'GEMINI_LLM_API_KEY', 'GOOGLE_LLM_API_KEY'],
-            mistral: ['MISTRAL_API_KEY', 'MISTRAL_LLM_API_KEY'],
-            openrouter: ['OPENROUTER_API_KEY', 'OPENROUTER_LLM_API_KEY'],
-            atlascloud: ['ATLASCLOUD_API_KEY', 'ATLAS_CLOUD_API_KEY'],
-            'openai-compatible': ['OPENAI_COMPATIBLE_API_KEY'],
-        };
-        for (const key of envKeys[provider] ?? []) {
-            const value = process.env[key]?.trim();
-            if (value) return value;
-        }
-        return undefined;
+        const normalizedProvider = normalizeManagedAgentProviderId(provider);
+        if (!normalizedProvider || this.getDisabledProviders().has(normalizedProvider)) return undefined;
+        return readFirstEnvironmentValue(AGENT_PROVIDER_ENV_KEYS[normalizedProvider] ?? []);
     }
 
     private resolveProviderRuntimeBaseUrl(provider: string, configuredBaseUrl?: string): string | undefined {
-        if (provider === 'atlascloud') {
-            return this.readFirstEnvironmentValue(['ATLASCLOUD_BASE_URL', 'ATLAS_CLOUD_BASE_URL', 'ATLASCLOUD_API_BASE', 'ATLAS_CLOUD_API_BASE'])
-                || ATLAS_CLOUD_DEFAULT_BASE_URL;
-        }
-        return configuredBaseUrl;
+        const configured = configuredBaseUrl?.trim().replace(/\/$/, '') || undefined;
+        if (configured) return configured;
+        const normalizedProvider = normalizeManagedAgentProviderId(provider);
+        const environmentBaseUrl = normalizedProvider
+            ? readFirstEnvironmentValue(AGENT_PROVIDER_BASE_URL_ENV_KEYS[normalizedProvider] ?? [])
+            : undefined;
+        if (environmentBaseUrl) return environmentBaseUrl;
+        return normalizedProvider === 'atlascloud' ? ATLAS_CLOUD_DEFAULT_BASE_URL : undefined;
     }
 
-    private readFirstEnvironmentValue(keys: readonly string[]): string | undefined {
-        for (const key of keys) {
-            const value = process.env[key]?.trim();
-            if (value) return value.replace(/\/$/, '');
-        }
-        return undefined;
+    private getDisabledProviders(): Set<AgentProviderId> {
+        const disabled = this._context.globalState.get<string[]>(DISABLED_PROVIDERS_STATE_KEY, []);
+        return new Set(disabled.map((provider) => normalizeManagedAgentProviderId(provider)).filter((provider): provider is AgentProviderId => Boolean(provider)));
     }
 
     private async buildScaffoldResponse(input: AgentPromptInput, runtimeError?: string): Promise<string> {

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -4266,9 +4266,7 @@ export class AgentRuntimeController implements vscode.Disposable {
             ? providerConfig.baseUrl || 'https://openrouter.ai/api/v1'
             : provider === 'google'
                 ? providerConfig.baseUrl || 'https://generativelanguage.googleapis.com/v1beta/openai'
-                : provider === 'atlascloud'
-                    ? providerConfig.baseUrl || ATLAS_CLOUD_DEFAULT_BASE_URL
-                    : providerConfig.baseUrl;
+                : providerConfig.baseUrl;
         const modelKwargs = reasoningOptions.modelKwargs;
         return new ChatOpenAI({
             ...(providerConfig.apiKey ? { apiKey: providerConfig.apiKey } : {}),

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -31,6 +31,7 @@ const NON_FINAL_ASSISTANT_PHASE_RECOVERY_MARKER = 'N8N_NON_FINAL_ASSISTANT_PHASE
 const NON_FINAL_ASSISTANT_PHASE_MAX_RECOVERY_ATTEMPTS = 12;
 const STREAM_TEXT_FLUSH_INTERVAL_MS = 33;
 const STREAM_TEXT_FLUSH_CHAR_THRESHOLD = 512;
+const ATLAS_CLOUD_DEFAULT_BASE_URL = 'https://api.atlascloud.ai/v1';
 
 type ActiveWorktreePathsBySession = Record<string, string | null>;
 
@@ -361,6 +362,7 @@ const AGENT_MODEL_PROVIDERS = Object.freeze([
     'google',
     'mistral',
     'openrouter',
+    'atlascloud',
     'openai-oauth',
     'copilot-proxy',
     'minimax',
@@ -374,6 +376,7 @@ const AGENT_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
     google: 'Gemini API',
     mistral: 'Mistral API',
     openrouter: 'OpenRouter API',
+    atlascloud: 'Atlas Cloud',
     'openai-oauth': 'OpenAI ChatGPT OAuth',
     'copilot-proxy': 'GitHub Copilot OAuth',
     minimax: 'MiniMax API',
@@ -381,7 +384,7 @@ const AGENT_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
     'openai-compatible': 'OpenAI Compatible',
 };
 
-const AGENT_API_KEY_PROVIDERS = new Set(['anthropic', 'openai', 'google', 'mistral', 'openrouter', 'minimax', 'minimax-token-plan']);
+const AGENT_API_KEY_PROVIDERS = new Set(['anthropic', 'openai', 'google', 'mistral', 'openrouter', 'atlascloud', 'minimax', 'minimax-token-plan']);
 
 function normalizeAgentProviderId(provider: string | undefined): string | undefined {
     const normalized = provider?.trim().toLowerCase();
@@ -389,6 +392,7 @@ function normalizeAgentProviderId(provider: string | undefined): string | undefi
     if (normalized === 'claude') return 'anthropic';
     if (normalized === 'anthropic-proxy') return 'anthropic';
     if (normalized === 'gemini') return 'google';
+    if (normalized === 'atlas' || normalized === 'atlas-cloud') return 'atlascloud';
     return AGENT_MODEL_PROVIDERS.includes(normalized) ? normalized : undefined;
 }
 
@@ -2179,8 +2183,9 @@ export class AgentRuntimeController implements vscode.Disposable {
             };
         }
         const model = settings.model;
-        const baseUrl = settings.baseUrl;
-        const apiKey = await this._context.secrets.get(getAgentProviderSecretKey(normalizedProvider));
+        const baseUrl = this.resolveProviderRuntimeBaseUrl(normalizedProvider, settings.baseUrl);
+        const apiKey = await this._context.secrets.get(getAgentProviderSecretKey(normalizedProvider))
+            || this.readProviderEnvironmentSecret(normalizedProvider);
         if (normalizedProvider === 'openai-oauth' && !apiKey) {
             return {
                 ready: false,
@@ -3413,7 +3418,7 @@ export class AgentRuntimeController implements vscode.Disposable {
         const baseUrl = settings.baseUrl || '';
         const reasoningEffort = settings.reasoningEffort;
         const storedSecret = await this._context.secrets.get(getAgentProviderSecretKey(provider));
-        const hasEnvSecret = this.hasProviderEnvironmentSecret(provider);
+        const hasEnvSecret = Boolean(this.readProviderEnvironmentSecret(provider));
         const secretState = storedSecret
             ? 'API key stored in VS Code Secret Storage'
             : hasEnvSecret
@@ -3422,16 +3427,37 @@ export class AgentRuntimeController implements vscode.Disposable {
         return `Agent provider: ${provider}${model ? ` / ${model}` : ''}${reasoningEffort ? ` / reasoning ${reasoningEffort}` : ''}${baseUrl ? ` / ${baseUrl}` : ''}. ${secretState}.`;
     }
 
-    private hasProviderEnvironmentSecret(provider: string): boolean {
+    private readProviderEnvironmentSecret(provider: string): string | undefined {
         const envKeys: Record<string, string[]> = {
-            anthropic: ['ANTHROPIC_API_KEY'],
-            openai: ['OPENAI_API_KEY'],
-            google: ['GOOGLE_GENERATIVE_AI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY'],
-            mistral: ['MISTRAL_API_KEY'],
-            openrouter: ['OPENROUTER_API_KEY'],
+            anthropic: ['ANTHROPIC_LLM_API_KEY', 'ANTHROPIC_API_KEY'],
+            openai: ['OPENAI_LLM_API_KEY', 'OPENAI_API_KEY'],
+            google: ['GOOGLE_GENERATIVE_AI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'GEMINI_LLM_API_KEY', 'GOOGLE_LLM_API_KEY'],
+            mistral: ['MISTRAL_API_KEY', 'MISTRAL_LLM_API_KEY'],
+            openrouter: ['OPENROUTER_API_KEY', 'OPENROUTER_LLM_API_KEY'],
+            atlascloud: ['ATLASCLOUD_API_KEY', 'ATLAS_CLOUD_API_KEY'],
             'openai-compatible': ['OPENAI_COMPATIBLE_API_KEY'],
         };
-        return (envKeys[provider] ?? []).some((key) => Boolean(process.env[key]?.trim()));
+        for (const key of envKeys[provider] ?? []) {
+            const value = process.env[key]?.trim();
+            if (value) return value;
+        }
+        return undefined;
+    }
+
+    private resolveProviderRuntimeBaseUrl(provider: string, configuredBaseUrl?: string): string | undefined {
+        if (provider === 'atlascloud') {
+            return this.readFirstEnvironmentValue(['ATLASCLOUD_BASE_URL', 'ATLAS_CLOUD_BASE_URL', 'ATLASCLOUD_API_BASE', 'ATLAS_CLOUD_API_BASE'])
+                || ATLAS_CLOUD_DEFAULT_BASE_URL;
+        }
+        return configuredBaseUrl;
+    }
+
+    private readFirstEnvironmentValue(keys: readonly string[]): string | undefined {
+        for (const key of keys) {
+            const value = process.env[key]?.trim();
+            if (value) return value.replace(/\/$/, '');
+        }
+        return undefined;
     }
 
     private async buildScaffoldResponse(input: AgentPromptInput, runtimeError?: string): Promise<string> {
@@ -4252,7 +4278,9 @@ export class AgentRuntimeController implements vscode.Disposable {
             ? providerConfig.baseUrl || 'https://openrouter.ai/api/v1'
             : provider === 'google'
                 ? providerConfig.baseUrl || 'https://generativelanguage.googleapis.com/v1beta/openai'
-                : providerConfig.baseUrl;
+                : provider === 'atlascloud'
+                    ? providerConfig.baseUrl || ATLAS_CLOUD_DEFAULT_BASE_URL
+                    : providerConfig.baseUrl;
         const modelKwargs = reasoningOptions.modelKwargs;
         return new ChatOpenAI({
             ...(providerConfig.apiKey ? { apiKey: providerConfig.apiKey } : {}),
@@ -4272,6 +4300,7 @@ export class AgentRuntimeController implements vscode.Disposable {
             google: 'gemini-3-flash-preview',
             mistral: 'mistral-large-latest',
             openrouter: 'anthropic/claude-3.5-sonnet',
+            atlascloud: 'deepseek-ai/deepseek-v4-pro',
             'openai-oauth': 'gpt-5.4',
             'copilot-proxy': 'gpt-4.1',
             minimax: 'MiniMax-M2.7',

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -6,13 +6,11 @@ import { WorkspaceSnapshotService } from './workspace-snapshot-service.js';
 import { createLocalProviderLangChainModel } from './agent-provider-runtime/create-langchain-model.js';
 import {
     AGENT_PROVIDER_BASE_URL_ENV_KEYS,
-    AGENT_PROVIDER_ENV_KEYS,
     ATLAS_CLOUD_DEFAULT_BASE_URL,
-    DISABLED_PROVIDERS_STATE_KEY,
     normalizeAgentProviderId as normalizeManagedAgentProviderId,
+    readAgentProviderEnvironmentSecret,
     readAgentProviderSettings,
     readFirstEnvironmentValue,
-    type AgentProviderId,
 } from './agent-provider-settings.js';
 import { buildLangChainReasoningOptions, getReasoningCapability, getReasoningOptions, normalizeReasoningEffortForCapability, shouldDisableModelStreamingForToolCalling, type AgentReasoningEffort as AgentProviderReasoningEffort } from './agent-provider-capabilities.js';
 import type { WorktreeInfo } from './worktree-service.js';
@@ -3436,9 +3434,7 @@ export class AgentRuntimeController implements vscode.Disposable {
     }
 
     private readProviderEnvironmentSecret(provider: string): string | undefined {
-        const normalizedProvider = normalizeManagedAgentProviderId(provider);
-        if (!normalizedProvider || this.getDisabledProviders().has(normalizedProvider)) return undefined;
-        return readFirstEnvironmentValue(AGENT_PROVIDER_ENV_KEYS[normalizedProvider] ?? []);
+        return readAgentProviderEnvironmentSecret(this._context.globalState, provider);
     }
 
     private resolveProviderRuntimeBaseUrl(provider: string, configuredBaseUrl?: string): string | undefined {
@@ -3450,11 +3446,6 @@ export class AgentRuntimeController implements vscode.Disposable {
             : undefined;
         if (environmentBaseUrl) return environmentBaseUrl;
         return normalizedProvider === 'atlascloud' ? ATLAS_CLOUD_DEFAULT_BASE_URL : undefined;
-    }
-
-    private getDisabledProviders(): Set<AgentProviderId> {
-        const disabled = this._context.globalState.get<string[]>(DISABLED_PROVIDERS_STATE_KEY, []);
-        return new Set(disabled.map((provider) => normalizeManagedAgentProviderId(provider)).filter((provider): provider is AgentProviderId => Boolean(provider)));
     }
 
     private async buildScaffoldResponse(input: AgentPromptInput, runtimeError?: string): Promise<string> {

--- a/packages/vscode-extension/tests/integration/native-mcp-agent-benchmark.integration.test.ts
+++ b/packages/vscode-extension/tests/integration/native-mcp-agent-benchmark.integration.test.ts
@@ -13,7 +13,7 @@ import { shouldDisableModelStreamingForToolCalling } from '../../src/services/ag
 import { N8nAsCodeMcpService } from '../../../mcp/src/services/mcp-service.js';
 import { NATIVE_MCP_READ_ONLY_TOOL_MAP } from '../../../mcp/src/services/native-mcp-tools.js';
 
-type ProviderId = 'openai' | 'mistral' | 'anthropic' | 'google' | 'openrouter' | 'openai-compatible';
+type ProviderId = 'openai' | 'mistral' | 'anthropic' | 'google' | 'openrouter' | 'atlascloud' | 'openai-compatible';
 type BenchmarkMode = 'mcp-off' | 'mcp-on';
 
 interface ProviderCase {
@@ -134,6 +134,13 @@ const providerCases: ProviderCase[] = [
     envKeys: ['OPENROUTER_API_KEY', 'OPENROUTER_LLM_API_KEY', 'OPEN_ROUTEUR_KEY'],
     model: process.env.OPENROUTER_MODEL || process.env.N8N_NATIVE_MCP_AGENT_BENCHMARK_OPENROUTER_MODEL || process.env.N8N_AGENT_TEST_OPENROUTER_MODEL || 'openai/gpt-4o-mini',
     baseUrl: process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1',
+    createModel: ({ apiKey, model, baseUrl }) => new ChatOpenAI({ apiKey, model, temperature: 0, configuration: { baseURL: baseUrl } }),
+  },
+  {
+    id: 'atlascloud',
+    envKeys: ['ATLASCLOUD_API_KEY', 'ATLAS_CLOUD_API_KEY'],
+    model: process.env.ATLASCLOUD_MODEL || process.env.ATLAS_CLOUD_MODEL || process.env.N8N_NATIVE_MCP_AGENT_BENCHMARK_ATLASCLOUD_MODEL || process.env.N8N_AGENT_TEST_ATLASCLOUD_MODEL || 'deepseek-ai/deepseek-v4-pro',
+    baseUrl: process.env.ATLASCLOUD_BASE_URL || process.env.ATLAS_CLOUD_BASE_URL || 'https://api.atlascloud.ai/v1',
     createModel: ({ apiKey, model, baseUrl }) => new ChatOpenAI({ apiKey, model, temperature: 0, configuration: { baseURL: baseUrl } }),
   },
   {

--- a/packages/vscode-extension/tests/integration/native-mcp-agent-routing.integration.test.ts
+++ b/packages/vscode-extension/tests/integration/native-mcp-agent-routing.integration.test.ts
@@ -11,7 +11,7 @@ import { shouldDisableModelStreamingForToolCalling } from '../../src/services/ag
 import { N8nAsCodeMcpService } from '../../../mcp/src/services/mcp-service.js';
 import { NATIVE_MCP_READ_ONLY_TOOL_MAP } from '../../../mcp/src/services/native-mcp-tools.js';
 
-type ProviderId = 'openai' | 'mistral' | 'anthropic' | 'google' | 'openrouter' | 'openai-compatible';
+type ProviderId = 'openai' | 'mistral' | 'anthropic' | 'google' | 'openrouter' | 'atlascloud' | 'openai-compatible';
 
 interface ProviderCase {
   id: ProviderId;
@@ -87,6 +87,13 @@ const providerCases: ProviderCase[] = [
     envKeys: ['OPENROUTER_API_KEY', 'OPENROUTER_LLM_API_KEY', 'OPEN_ROUTEUR_KEY'],
     model: process.env.OPENROUTER_MODEL || process.env.N8N_NATIVE_MCP_AGENT_TEST_OPENROUTER_MODEL || process.env.N8N_AGENT_TEST_OPENROUTER_MODEL || 'openai/gpt-4o-mini',
     baseUrl: process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1',
+    createModel: ({ apiKey, model, baseUrl }) => new ChatOpenAI({ apiKey, model, temperature: 0, configuration: { baseURL: baseUrl } }),
+  },
+  {
+    id: 'atlascloud',
+    envKeys: ['ATLASCLOUD_API_KEY', 'ATLAS_CLOUD_API_KEY'],
+    model: process.env.ATLASCLOUD_MODEL || process.env.ATLAS_CLOUD_MODEL || process.env.N8N_NATIVE_MCP_AGENT_TEST_ATLASCLOUD_MODEL || process.env.N8N_AGENT_TEST_ATLASCLOUD_MODEL || 'deepseek-ai/deepseek-v4-pro',
+    baseUrl: process.env.ATLASCLOUD_BASE_URL || process.env.ATLAS_CLOUD_BASE_URL || 'https://api.atlascloud.ai/v1',
     createModel: ({ apiKey, model, baseUrl }) => new ChatOpenAI({ apiKey, model, temperature: 0, configuration: { baseURL: baseUrl } }),
   },
   {

--- a/packages/vscode-extension/tests/integration/provider-stream-v3.integration.test.ts
+++ b/packages/vscode-extension/tests/integration/provider-stream-v3.integration.test.ts
@@ -12,7 +12,7 @@ import { createMiddleware } from 'langchain';
 import { LocalShellBackend, createDeepAgent } from 'deepagents';
 import { shouldDisableModelStreamingForToolCalling } from '../../src/services/agent-provider-capabilities.js';
 
-type ProviderId = 'openai' | 'mistral' | 'anthropic' | 'google' | 'openrouter' | 'openai-compatible';
+type ProviderId = 'openai' | 'mistral' | 'anthropic' | 'google' | 'openrouter' | 'atlascloud' | 'openai-compatible';
 
 interface ProviderCase {
   id: ProviderId;
@@ -87,6 +87,14 @@ const providerCases: ProviderCase[] = [
     envKeys: ['OPENROUTER_API_KEY', 'OPENROUTER_LLM_API_KEY', 'OPEN_ROUTEUR_KEY'],
     model: process.env.OPENROUTER_MODEL || process.env.N8N_AGENT_TEST_OPENROUTER_MODEL || 'openai/gpt-4o-mini',
     baseUrl: process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1',
+    createModel: ({ apiKey, model, baseUrl }) => new ChatOpenAI({ apiKey, model, temperature: 0, configuration: { baseURL: baseUrl } }),
+  },
+  {
+    id: 'atlascloud',
+    label: 'Atlas Cloud',
+    envKeys: ['ATLASCLOUD_API_KEY', 'ATLAS_CLOUD_API_KEY'],
+    model: process.env.ATLASCLOUD_MODEL || process.env.ATLAS_CLOUD_MODEL || process.env.N8N_AGENT_TEST_ATLASCLOUD_MODEL || 'deepseek-ai/deepseek-v4-pro',
+    baseUrl: process.env.ATLASCLOUD_BASE_URL || process.env.ATLAS_CLOUD_BASE_URL || 'https://api.atlascloud.ai/v1',
     createModel: ({ apiKey, model, baseUrl }) => new ChatOpenAI({ apiKey, model, temperature: 0, configuration: { baseURL: baseUrl } }),
   },
   {

--- a/packages/vscode-extension/tests/integration/tool-usage-workflow-authoring.integration.test.ts
+++ b/packages/vscode-extension/tests/integration/tool-usage-workflow-authoring.integration.test.ts
@@ -12,7 +12,7 @@ import { createMiddleware } from 'langchain';
 import { LocalShellBackend, createDeepAgent } from 'deepagents';
 import { shouldDisableModelStreamingForToolCalling } from '../../src/services/agent-provider-capabilities.js';
 
-type ProviderId = 'openai' | 'mistral' | 'anthropic' | 'google' | 'openrouter' | 'openai-compatible';
+type ProviderId = 'openai' | 'mistral' | 'anthropic' | 'google' | 'openrouter' | 'atlascloud' | 'openai-compatible';
 
 interface ProviderCase {
   id: ProviderId;
@@ -62,6 +62,13 @@ const providerCases: ProviderCase[] = [
     envKeys: ['OPENROUTER_API_KEY', 'OPENROUTER_LLM_API_KEY', 'OPEN_ROUTEUR_KEY'],
     model: process.env.OPENROUTER_MODEL || process.env.N8N_AGENT_TEST_OPENROUTER_MODEL || 'openai/gpt-4o-mini',
     baseUrl: process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1',
+    createModel: ({ apiKey, model, baseUrl }) => new ChatOpenAI({ apiKey, model, temperature: 0, configuration: { baseURL: baseUrl } }),
+  },
+  {
+    id: 'atlascloud',
+    envKeys: ['ATLASCLOUD_API_KEY', 'ATLAS_CLOUD_API_KEY'],
+    model: process.env.ATLASCLOUD_MODEL || process.env.ATLAS_CLOUD_MODEL || process.env.N8N_AGENT_TEST_ATLASCLOUD_MODEL || 'deepseek-ai/deepseek-v4-pro',
+    baseUrl: process.env.ATLASCLOUD_BASE_URL || process.env.ATLAS_CLOUD_BASE_URL || 'https://api.atlascloud.ai/v1',
     createModel: ({ apiKey, model, baseUrl }) => new ChatOpenAI({ apiKey, model, temperature: 0, configuration: { baseURL: baseUrl } }),
   },
   {

--- a/packages/vscode-extension/tests/integration/workbench-runtime-authoring.integration.test.ts
+++ b/packages/vscode-extension/tests/integration/workbench-runtime-authoring.integration.test.ts
@@ -881,6 +881,7 @@ function liveProviderEnvKeys(provider: string): string[] {
     case 'mistral': return ['MISTRAL_API_KEY', 'MISTRAL_LLM_API_KEY'];
     case 'google': return ['GOOGLE_GENERATIVE_AI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY'];
     case 'openrouter': return ['OPENROUTER_API_KEY', 'OPENROUTER_LLM_API_KEY'];
+    case 'atlascloud': return ['ATLASCLOUD_API_KEY', 'ATLAS_CLOUD_API_KEY'];
     case 'openai-oauth': return ['N8N_AGENT_WORKBENCH_LIVE_OPENAI_OAUTH_TOKEN', 'N8N_AGENT_WORKBENCH_OPENAI_OAUTH_TOKEN', 'OPENAI_OAUTH_ACCESS_TOKEN', 'OPENAI_CODEX_ACCESS_TOKEN'];
     case 'openai-compatible': return ['OPENAI_COMPATIBLE_API_KEY', 'OPENAI_API_KEY'];
     default: return ['OPENAI_API_KEY', 'OPENAI_LLM_API_KEY', 'OPENAI_KEY'];
@@ -890,7 +891,7 @@ function liveProviderEnvKeys(provider: string): string[] {
 function chooseLiveProvider(): string {
   const configured = process.env.N8N_AGENT_WORKBENCH_LIVE_PROVIDER?.trim();
   if (configured) return configured;
-  const candidates = ['google', 'openai', 'anthropic', 'mistral', 'openrouter', 'openai-compatible', 'openai-oauth'];
+  const candidates = ['google', 'openai', 'anthropic', 'mistral', 'openrouter', 'atlascloud', 'openai-compatible', 'openai-oauth'];
   return candidates.find((provider) => Boolean(readFirstEnv(liveProviderEnvKeys(provider)))) || 'openai';
 }
 

--- a/packages/vscode-extension/tests/unit/agent-provider-atlascloud.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-provider-atlascloud.test.ts
@@ -69,7 +69,7 @@ test('agent provider source registers Atlas Cloud on OpenAI-compatible runtime p
     assert.ok(providerService.includes("normalized === 'atlas' || normalized === 'atlas-cloud'"), 'Provider service must normalize Atlas aliases');
 
     assert.ok(runtimeController.includes("atlascloud: 'Atlas Cloud'"), 'Runtime registry must expose the Atlas display name');
-    assert.ok(runtimeController.includes("provider === 'atlascloud'"), 'Runtime factory must special-case the Atlas default endpoint');
+    assert.ok(runtimeController.includes("normalizedProvider === 'atlascloud' ? ATLAS_CLOUD_DEFAULT_BASE_URL : undefined"), 'Runtime base URL resolver must apply the Atlas default endpoint');
     assert.ok(runtimeController.includes('readAgentProviderEnvironmentSecret(this._context.globalState, provider)'), 'Runtime env fallback must use the shared credential helper');
 });
 

--- a/packages/vscode-extension/tests/unit/agent-provider-atlascloud.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-provider-atlascloud.test.ts
@@ -4,7 +4,15 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { getReasoningCapability } from '../../src/services/agent-provider-capabilities.js';
-import { readAgentProviderSettings, updateAgentProviderSettings } from '../../src/services/agent-provider-settings.js';
+import {
+    AGENT_PROVIDER_BASE_URL_ENV_KEYS,
+    AGENT_PROVIDER_ENV_KEYS,
+    ATLAS_CLOUD_DEFAULT_BASE_URL,
+    getAtlasCloudModelCatalogUrl,
+    mapAtlasCloudTextModels,
+    readAgentProviderSettings,
+    updateAgentProviderSettings,
+} from '../../src/services/agent-provider-settings.js';
 
 class MemoryMemento {
     private readonly values = new Map<string, unknown>();
@@ -53,16 +61,33 @@ test('agent provider source registers Atlas Cloud on OpenAI-compatible runtime p
     assert.ok(providerService.includes("label: 'Atlas Cloud'"), 'Provider service must expose the Atlas Cloud label');
     assert.ok(providerService.includes("defaultModel: 'deepseek-ai/deepseek-v4-pro'"), 'Provider service must set the Atlas Cloud default model');
     assert.ok(providerService.includes("defaultBaseUrl: ATLAS_CLOUD_DEFAULT_BASE_URL"), 'Provider service must set the Atlas Cloud default base URL');
-    assert.ok(providerService.includes("ATLAS_CLOUD_MODEL_CATALOG_URL = 'https://api.atlascloud.ai/api/v1/models'"), 'Provider service must use the Atlas model catalog for discovery');
-    assert.ok(providerService.includes("'ATLASCLOUD_API_KEY', 'ATLAS_CLOUD_API_KEY'"), 'Provider service must support both Atlas API key env names');
+    assert.deepEqual(AGENT_PROVIDER_ENV_KEYS.atlascloud, ['ATLASCLOUD_API_KEY', 'ATLAS_CLOUD_API_KEY']);
+    assert.deepEqual(AGENT_PROVIDER_BASE_URL_ENV_KEYS.atlascloud, ['ATLASCLOUD_BASE_URL', 'ATLAS_CLOUD_BASE_URL', 'ATLASCLOUD_API_BASE', 'ATLAS_CLOUD_API_BASE']);
     assert.ok(providerService.includes("normalized === 'atlas' || normalized === 'atlas-cloud'"), 'Provider service must normalize Atlas aliases');
 
     assert.ok(runtimeController.includes("'atlascloud'"), 'Runtime registry must include the Atlas provider id');
     assert.ok(runtimeController.includes("atlascloud: 'Atlas Cloud'"), 'Runtime registry must expose the Atlas display name');
     assert.ok(runtimeController.includes("provider === 'atlascloud'"), 'Runtime factory must special-case the Atlas default endpoint');
-    assert.ok(runtimeController.includes("ATLASCLOUD_BASE_URL', 'ATLAS_CLOUD_BASE_URL'"), 'Runtime must support Atlas base URL environment aliases');
+    assert.ok(runtimeController.includes('DISABLED_PROVIDERS_STATE_KEY'), 'Runtime env fallback must honor disabled providers');
 });
 
 test('Atlas Cloud provider does not opt into provider-specific reasoning knobs', () => {
     assert.equal(getReasoningCapability('atlascloud', 'deepseek-ai/deepseek-v4-pro').supported, false);
+});
+
+test('Atlas Cloud catalog helper derives resolved catalog endpoint', () => {
+    assert.equal(getAtlasCloudModelCatalogUrl('https://regional.atlas.example/v1/'), 'https://regional.atlas.example/api/v1/models');
+    assert.equal(getAtlasCloudModelCatalogUrl(ATLAS_CLOUD_DEFAULT_BASE_URL), 'https://api.atlascloud.ai/api/v1/models');
+    assert.equal(getAtlasCloudModelCatalogUrl('not a url'), 'https://api.atlascloud.ai/api/v1/models');
+});
+
+test('Atlas Cloud catalog helper keeps text models, model ids, dedupe, and sorted order', () => {
+    assert.deepEqual(mapAtlasCloudTextModels({
+        data: [
+            { id: 'z-by-id', type: 'Text' },
+            { id: 'duplicate-id', model: 'a-model-over-id', type: 'text' },
+            { id: 'a-model-over-id', model: 'a-model-over-id', type: 'text' },
+            { id: 'image-model', model: 'image-model', type: 'image' },
+        ],
+    }), ['a-model-over-id', 'z-by-id']);
 });

--- a/packages/vscode-extension/tests/unit/agent-provider-atlascloud.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-provider-atlascloud.test.ts
@@ -11,6 +11,7 @@ import {
     getAtlasCloudModelCatalogUrl,
     mapAtlasCloudTextModels,
     readAgentProviderSettings,
+    readFirstEnvironmentValue,
     updateAgentProviderSettings,
 } from '../../src/services/agent-provider-settings.js';
 
@@ -65,10 +66,10 @@ test('agent provider source registers Atlas Cloud on OpenAI-compatible runtime p
     assert.deepEqual(AGENT_PROVIDER_BASE_URL_ENV_KEYS.atlascloud, ['ATLASCLOUD_BASE_URL', 'ATLAS_CLOUD_BASE_URL', 'ATLASCLOUD_API_BASE', 'ATLAS_CLOUD_API_BASE']);
     assert.ok(providerService.includes("normalized === 'atlas' || normalized === 'atlas-cloud'"), 'Provider service must normalize Atlas aliases');
 
-    assert.ok(runtimeController.includes("'atlascloud'"), 'Runtime registry must include the Atlas provider id');
     assert.ok(runtimeController.includes("atlascloud: 'Atlas Cloud'"), 'Runtime registry must expose the Atlas display name');
     assert.ok(runtimeController.includes("provider === 'atlascloud'"), 'Runtime factory must special-case the Atlas default endpoint');
-    assert.ok(runtimeController.includes('DISABLED_PROVIDERS_STATE_KEY'), 'Runtime env fallback must honor disabled providers');
+    assert.ok(runtimeController.includes('this.getDisabledProviders().has(normalizedProvider)'), 'Runtime env fallback must honor disabled providers');
+    assert.ok(runtimeController.includes('AGENT_PROVIDER_ENV_KEYS[normalizedProvider]'), 'Runtime env fallback must use shared provider env keys');
 });
 
 test('Atlas Cloud provider does not opt into provider-specific reasoning knobs', () => {
@@ -79,6 +80,22 @@ test('Atlas Cloud catalog helper derives resolved catalog endpoint', () => {
     assert.equal(getAtlasCloudModelCatalogUrl('https://regional.atlas.example/v1/'), 'https://regional.atlas.example/api/v1/models');
     assert.equal(getAtlasCloudModelCatalogUrl(ATLAS_CLOUD_DEFAULT_BASE_URL), 'https://api.atlascloud.ai/api/v1/models');
     assert.equal(getAtlasCloudModelCatalogUrl('not a url'), 'https://api.atlascloud.ai/api/v1/models');
+});
+
+test('provider environment helper prefers the first configured value and trims trailing slash', () => {
+    const previousPrimary = process.env.ATLASCLOUD_BASE_URL;
+    const previousFallback = process.env.ATLAS_CLOUD_BASE_URL;
+    process.env.ATLASCLOUD_BASE_URL = 'https://primary.atlas.example/v1/';
+    process.env.ATLAS_CLOUD_BASE_URL = 'https://fallback.atlas.example/v1/';
+
+    try {
+        assert.equal(readFirstEnvironmentValue(AGENT_PROVIDER_BASE_URL_ENV_KEYS.atlascloud ?? []), 'https://primary.atlas.example/v1');
+    } finally {
+        if (previousPrimary === undefined) delete process.env.ATLASCLOUD_BASE_URL;
+        else process.env.ATLASCLOUD_BASE_URL = previousPrimary;
+        if (previousFallback === undefined) delete process.env.ATLAS_CLOUD_BASE_URL;
+        else process.env.ATLAS_CLOUD_BASE_URL = previousFallback;
+    }
 });
 
 test('Atlas Cloud catalog helper keeps text models, model ids, dedupe, and sorted order', () => {

--- a/packages/vscode-extension/tests/unit/agent-provider-atlascloud.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-provider-atlascloud.test.ts
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { getReasoningCapability } from '../../src/services/agent-provider-capabilities.js';
+import { readAgentProviderSettings, updateAgentProviderSettings } from '../../src/services/agent-provider-settings.js';
+
+class MemoryMemento {
+    private readonly values = new Map<string, unknown>();
+
+    constructor(initial: Record<string, unknown> = {}) {
+        for (const [key, value] of Object.entries(initial)) {
+            this.values.set(key, value);
+        }
+    }
+
+    get<T>(key: string, defaultValue?: T): T | undefined {
+        return this.values.has(key) ? this.values.get(key) as T : defaultValue;
+    }
+
+    async update(key: string, value: unknown): Promise<void> {
+        if (value === undefined) {
+            this.values.delete(key);
+            return;
+        }
+        this.values.set(key, value);
+    }
+}
+
+test('agent provider settings normalize Atlas Cloud aliases', async () => {
+    const state = new MemoryMemento({ 'n8n.agent.provider': 'atlas-cloud' });
+    assert.equal(readAgentProviderSettings(state as any).provider, 'atlascloud');
+
+    await updateAgentProviderSettings(state as any, {
+        provider: 'atlascloud',
+        model: 'deepseek-ai/deepseek-v4-pro',
+    });
+
+    assert.deepEqual(readAgentProviderSettings(state as any), {
+        provider: 'atlascloud',
+        model: 'deepseek-ai/deepseek-v4-pro',
+        baseUrl: undefined,
+        reasoningEffort: undefined,
+    });
+});
+
+test('agent provider source registers Atlas Cloud on OpenAI-compatible runtime paths', () => {
+    const root = path.join(__dirname, '../../src/services');
+    const providerService = fs.readFileSync(path.join(root, 'agent-provider-service.ts'), 'utf8');
+    const runtimeController = fs.readFileSync(path.join(root, 'agent-runtime-controller.ts'), 'utf8');
+
+    assert.ok(providerService.includes("label: 'Atlas Cloud'"), 'Provider service must expose the Atlas Cloud label');
+    assert.ok(providerService.includes("defaultModel: 'deepseek-ai/deepseek-v4-pro'"), 'Provider service must set the Atlas Cloud default model');
+    assert.ok(providerService.includes("defaultBaseUrl: ATLAS_CLOUD_DEFAULT_BASE_URL"), 'Provider service must set the Atlas Cloud default base URL');
+    assert.ok(providerService.includes("ATLAS_CLOUD_MODEL_CATALOG_URL = 'https://api.atlascloud.ai/api/v1/models'"), 'Provider service must use the Atlas model catalog for discovery');
+    assert.ok(providerService.includes("'ATLASCLOUD_API_KEY', 'ATLAS_CLOUD_API_KEY'"), 'Provider service must support both Atlas API key env names');
+    assert.ok(providerService.includes("normalized === 'atlas' || normalized === 'atlas-cloud'"), 'Provider service must normalize Atlas aliases');
+
+    assert.ok(runtimeController.includes("'atlascloud'"), 'Runtime registry must include the Atlas provider id');
+    assert.ok(runtimeController.includes("atlascloud: 'Atlas Cloud'"), 'Runtime registry must expose the Atlas display name');
+    assert.ok(runtimeController.includes("provider === 'atlascloud'"), 'Runtime factory must special-case the Atlas default endpoint');
+    assert.ok(runtimeController.includes("ATLASCLOUD_BASE_URL', 'ATLAS_CLOUD_BASE_URL'"), 'Runtime must support Atlas base URL environment aliases');
+});
+
+test('Atlas Cloud provider does not opt into provider-specific reasoning knobs', () => {
+    assert.equal(getReasoningCapability('atlascloud', 'deepseek-ai/deepseek-v4-pro').supported, false);
+});

--- a/packages/vscode-extension/tests/unit/agent-provider-atlascloud.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-provider-atlascloud.test.ts
@@ -3,13 +3,15 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { getReasoningCapability } from '../../src/services/agent-provider-capabilities.js';
+import { buildLangChainReasoningOptions, getReasoningCapability } from '../../src/services/agent-provider-capabilities.js';
 import {
     AGENT_PROVIDER_BASE_URL_ENV_KEYS,
     AGENT_PROVIDER_ENV_KEYS,
     ATLAS_CLOUD_DEFAULT_BASE_URL,
+    DISABLED_PROVIDERS_STATE_KEY,
     getAtlasCloudModelCatalogUrl,
     mapAtlasCloudTextModels,
+    readAgentProviderEnvironmentSecret,
     readAgentProviderSettings,
     readFirstEnvironmentValue,
     updateAgentProviderSettings,
@@ -68,12 +70,40 @@ test('agent provider source registers Atlas Cloud on OpenAI-compatible runtime p
 
     assert.ok(runtimeController.includes("atlascloud: 'Atlas Cloud'"), 'Runtime registry must expose the Atlas display name');
     assert.ok(runtimeController.includes("provider === 'atlascloud'"), 'Runtime factory must special-case the Atlas default endpoint');
-    assert.ok(runtimeController.includes('this.getDisabledProviders().has(normalizedProvider)'), 'Runtime env fallback must honor disabled providers');
-    assert.ok(runtimeController.includes('AGENT_PROVIDER_ENV_KEYS[normalizedProvider]'), 'Runtime env fallback must use shared provider env keys');
+    assert.ok(runtimeController.includes('readAgentProviderEnvironmentSecret(this._context.globalState, provider)'), 'Runtime env fallback must use the shared credential helper');
 });
 
-test('Atlas Cloud provider does not opt into provider-specific reasoning knobs', () => {
-    assert.equal(getReasoningCapability('atlascloud', 'deepseek-ai/deepseek-v4-pro').supported, false);
+test('Atlas Cloud DeepSeek V4 Pro uses OpenAI-compatible reasoning options', () => {
+    assert.deepEqual(getReasoningCapability('atlascloud', 'deepseek-ai/deepseek-v4-pro'), {
+        supported: true,
+        efforts: ['none', 'low', 'medium', 'high'],
+        defaultEffort: 'medium',
+        strategy: 'openrouter-reasoning',
+    });
+    assert.deepEqual(buildLangChainReasoningOptions('atlascloud', 'deepseek-ai/deepseek-v4-pro', 'low'), {
+        modelKwargs: {
+            reasoning: { effort: 'low' },
+            include_reasoning: true,
+        },
+    });
+});
+
+test('disabled providers do not read environment credentials', () => {
+    const previousApiKey = process.env.ATLASCLOUD_API_KEY;
+    process.env.ATLASCLOUD_API_KEY = 'test-atlas-key';
+
+    try {
+        const enabledState = new MemoryMemento();
+        assert.equal(readAgentProviderEnvironmentSecret(enabledState as any, 'atlascloud'), 'test-atlas-key');
+
+        const disabledState = new MemoryMemento({
+            [DISABLED_PROVIDERS_STATE_KEY]: ['atlas-cloud'],
+        });
+        assert.equal(readAgentProviderEnvironmentSecret(disabledState as any, 'atlascloud'), undefined);
+    } finally {
+        if (previousApiKey === undefined) delete process.env.ATLASCLOUD_API_KEY;
+        else process.env.ATLASCLOUD_API_KEY = previousApiKey;
+    }
 });
 
 test('Atlas Cloud catalog helper derives resolved catalog endpoint', () => {


### PR DESCRIPTION
**What does this PR do?**

Adds Atlas Cloud as an Agent Workbench LLM provider using the existing OpenAI-compatible ChatOpenAI runtime path.

- registers the `atlascloud` provider with `atlas` / `atlas-cloud` aliases
- uses `https://api.atlascloud.ai/v1` and `deepseek-ai/deepseek-v4-pro` defaults
- supports `ATLASCLOUD_API_KEY` / `ATLAS_CLOUD_API_KEY` and Atlas base URL aliases
- discovers Text models from the Atlas Cloud model catalog
- keeps disconnected providers disabled for environment fallback at runtime
- adds offline provider registration/catalog tests and Atlas entries to live provider integration matrices

**Follow-up after review**

- moved provider env/base URL keys and Atlas constants into shared provider settings helpers
- made runtime env fallback honor disabled providers
- made Atlas Cloud runtime/discovery base URL resolution use explicit config first, then env aliases, then the default Atlas endpoint
- sends Authorization to Atlas model discovery when an API key is available, while still supporting the public catalog path
- added Atlas Cloud to the VS Code `n8n.agent.provider` enum and provider stream integration runner
- strengthened Atlas provider unit coverage for catalog URL derivation, text model filtering, `model` over `id`, dedupe/sort, env precedence, and trailing-slash trimming

**Related issue (if any):** #

Validation:
- `npm test` from `packages/vscode-extension` (147 passed)
- `npm run build` from `packages/vscode-extension`
- `N8N_AGENT_TEST_PROVIDERS=atlascloud npx tsx --test packages/vscode-extension/tests/integration/provider-stream-v3.integration.test.ts` (`PROVIDER_STREAM_OK`)
- `npm run docs:api -- --dry-run`
- `npm run typecheck` from `docs` after installing docs dependencies locally
- `git diff --check`

Notes:
- root `npm run build` still stops before project compilation at the upstream lockfile supply-chain policy check: `xlsx@0.20.2` has no tarball integrity entry. I did not modify `pnpm-lock.yaml`.
- local `docs` build still fails on existing Docusaurus/Mermaid SSR pages with `useColorMode is called outside the <ColorModeProvider>` for contribution docs paths; this is unrelated to the Atlas provider files changed here.
- Atlas Cloud reasoning controls are left disabled for now because changing `include_reasoning`/reasoning payloads would alter the runtime request contract and should be handled as a separate provider capability follow-up once the endpoint contract is confirmed.