### PR TITLE
feat(cli): warn that push releases published workflows, add --draft

### DIFF
--- a/docs/docs/usage/cli.md
+++ b/docs/docs/usage/cli.md
@@ -250,7 +250,7 @@ does two different things depending on a state you cannot see from the terminal:
 
 That is the default, and push announces it before the update lands:
 
-```
+```text
 ⚠  "my-workflow.workflow.ts" is published — this push releases it to production.
 ✔ Pushed workflow my-workflow.workflow.ts.
 ```
@@ -265,7 +265,7 @@ firing against it:
 n8nac push workflows/dev/my-workflow.workflow.ts --draft
 ```
 
-```
+```text
 ✔ Pushed workflow my-workflow.workflow.ts.
 📝 Draft updated — production still runs version 8f3c1e2a.
    Release it by pushing again without --draft.

--- a/docs/docs/usage/cli.md
+++ b/docs/docs/usage/cli.md
@@ -227,9 +227,65 @@ Pull downloads one workflow and refuses to overwrite when a conflict is detected
 ```bash
 n8nac push workflows/dev/my-workflow.workflow.ts
 n8nac push workflows/dev/my-workflow.workflow.ts --verify
+n8nac push workflows/dev/my-workflow.workflow.ts --draft
 ```
 
 Push uploads one local workflow and uses optimistic concurrency checks.
+
+#### On a published workflow, push also releases
+
+On n8n 2.x a workflow is two things at once:
+
+- a **draft** — its content, rewritten by every save and by every push;
+- a **published version** — a pointer to the version production actually runs.
+
+`PUT /workflows/:id` writes the draft *and* moves the pointer when the workflow
+is published, and the public API offers no opt-out. So the same `n8nac push`
+does two different things depending on a state you cannot see from the terminal:
+
+| Workflow state | What `push` does |
+|---|---|
+| not published | writes the draft; nothing runs in production |
+| published | writes the draft **and** releases it — the UI equivalent of Save + Publish |
+
+That is the default, and push announces it before the update lands:
+
+```
+⚠  "my-workflow.workflow.ts" is published — this push releases it to production.
+✔ Pushed workflow my-workflow.workflow.ts.
+```
+
+#### `--draft`: keep production on the version it already ran
+
+`--draft` is for checking a change in n8n before it goes live — open the
+workflow, hit *Execute workflow*, look at the result — without real triggers
+firing against it:
+
+```bash
+n8nac push workflows/dev/my-workflow.workflow.ts --draft
+```
+
+```
+✔ Pushed workflow my-workflow.workflow.ts.
+📝 Draft updated — production still runs version 8f3c1e2a.
+   Release it by pushing again without --draft.
+```
+
+**It is a rollback, not a no-op.** Since the API always re-publishes, `--draft`
+pushes and then re-pins the previous version. Two consequences:
+
+- there is a brief window between the update and the re-pin in which the pushed
+  content is live, so a webhook or schedule firing at that instant can run it;
+- each `--draft` push against a published workflow leaves two entries in n8n's
+  version history.
+
+If the re-pin fails, the push fails with the version id to re-publish manually —
+it never reports success while leaving unreleased content in production.
+
+`--draft` refuses rather than pretending when it cannot keep its promise: on n8n
+1.x, which has no version pointer (an active workflow runs the content it
+holds), and when the published version cannot be read before the push. In both
+cases nothing has been sent yet, so the refusal costs nothing.
 
 ### `promote`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -97,6 +97,7 @@ Use `env status --json` as the source of truth for active environment readiness.
 n8nac list
 n8nac pull <workflow-id>
 n8nac push workflows/dev/my-workflow.workflow.ts --verify
+n8nac push workflows/dev/my-workflow.workflow.ts --draft
 n8nac promote workflows/dev/my-workflow.workflow.ts --from Dev --to Prod --dry-run
 n8nac promote --from Dev --to Prod --dry-run
 n8nac resolve <workflow-id> --mode keep-current
@@ -104,6 +105,12 @@ n8nac resolve <workflow-id> --mode keep-incoming
 ```
 
 Sync is Git-like and explicit. `pull` and `push` block on conflicts instead of silently overwriting work.
+
+On n8n 2.x, pushing to a **published** workflow also releases it — the API
+re-publishes on update and offers no opt-out. `push` announces that before the
+update lands, and `--draft` re-pins the previously published version so a change
+can be checked in n8n first. See
+[On a published workflow, push also releases](https://n8nascode.dev/docs/usage/cli/#on-a-published-workflow-push-also-releases).
 
 ### Promote Between Environments
 

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1,5 +1,5 @@
 import { BaseCommand, captureEmittedErrors, formatConnectionError } from './base.js';
-import { SyncManager, WorkflowSyncStatus } from '../core/index.js';
+import { SyncManager, WorkflowSyncStatus, type IPushPublishReport } from '../core/index.js';
 import { WorkflowValidator } from '@n8n-as-code/skills';
 import chalk from 'chalk';
 import ora from 'ora';
@@ -53,7 +53,7 @@ export class SyncCommand extends BaseCommand {
         }
     }
 
-    async pushOne(filename: string): Promise<string | undefined> {
+    async pushOne(filename: string, options?: { draft?: boolean }): Promise<string | undefined> {
         const syncConfig = await this.getSyncConfig();
         const syncManager = new SyncManager(this.client, syncConfig);
         const lastEmittedError = captureEmittedErrors(syncManager);
@@ -93,9 +93,21 @@ export class SyncCommand extends BaseCommand {
         }
 
         const spinner = ora(`Pushing workflow ${filename}...`).start();
+
+        // The engine emits this before the update lands, so the "this goes live"
+        // notice is printed while it is still news rather than after the fact.
+        let publishReport: IPushPublishReport | undefined;
+        syncManager.on('publishState', (report: IPushPublishReport) => {
+            publishReport = report;
+            if (report.outcome !== 'goes-live') return;
+            spinner.info(chalk.yellow(`⚠  "${filename}" is published — this push releases it to production.`));
+            spinner.start(`Pushing workflow ${filename}...`);
+        });
+
         try {
-            const finalWorkflowId = await syncManager.push(filename);
+            const finalWorkflowId = await syncManager.push(filename, { draft: options?.draft === true });
             spinner.succeed(chalk.green(`✔ Pushed workflow ${filename}.`));
+            this.reportPublishState(publishReport, finalWorkflowId);
             return finalWorkflowId;
         } catch (e: any) {
             if (e.message.includes('modified in the n8n UI')) {
@@ -116,6 +128,29 @@ export class SyncCommand extends BaseCommand {
             }
             spinner.fail(formatConnectionError('Push failed', lastEmittedError() ?? e));
             process.exit(1);
+        }
+    }
+
+    /**
+     * States what the push did to production, once it is done.
+     *
+     * `goes-live` is absent on purpose: it was already announced before the
+     * update, which is the only moment where saying it is useful.
+     */
+    private reportPublishState(report: IPushPublishReport | undefined, workflowId: string | undefined): void {
+        switch (report?.outcome) {
+            case 'restores':
+                console.log(chalk.dim(`📝 Draft updated — production still runs version ${report.versionId}.`));
+                console.log(chalk.dim(`   Release it by pushing again without --draft.`));
+                break;
+            case 'not-published':
+                console.log(chalk.dim(`📝 This workflow is not published, so nothing changed in production.`));
+                break;
+            case 'unknown':
+                console.log(chalk.yellow(`⚠  Could not read the published version before pushing.`));
+                console.log(chalk.yellow(`   If this workflow was published, production now runs the pushed content.`));
+                if (workflowId) console.log(chalk.dim(`   Check its version history in the n8n UI (workflow ${workflowId}).`));
+                break;
         }
     }
 

--- a/packages/cli/src/core/services/cli-api.ts
+++ b/packages/cli/src/core/services/cli-api.ts
@@ -85,10 +85,15 @@ export class CliApi {
      *  • Local-only with ID (remote deleted) → re-creates on remote
      *  • Both sides exist                    → updates remote (with OCC check)
      *
+    * On n8n 2.x, pushing to a published workflow also releases the pushed
+    * content. Set `options.draft` to restore the previously published version
+    * afterwards, mirroring `n8nac push --draft`.
+    *
     * @param filename - Workflow path or basename inside the active sync scope
+    * @param options.draft - Keep production on the version it already ran
      */
-    async push(filename: string): Promise<string> {
-        return this.syncManager.push(filename);
+    async push(filename: string, options?: { draft?: boolean }): Promise<string> {
+        return this.syncManager.push(filename, options);
     }
 
     // ── conflict resolution (extension-only, no CLI equivalent) ──────────────

--- a/packages/cli/src/core/services/n8n-api-client.ts
+++ b/packages/cli/src/core/services/n8n-api-client.ts
@@ -4,7 +4,7 @@ import * as http from 'http';
 import * as https from 'https';
 import * as tls from 'tls';
 import { resolveExtraCaCertificates, shouldVerifyServerCertificate } from './tls-certificates.js';
-import { IN8nCredentials, IWorkflow, IProject, ITag, ITriggerInfo, ITestPlan, ITestResult, TriggerType, IInferredPayload, IInferredPayloadField, IExecutionDetails, IExecutionList, IExecutionSummary, ExecutionStatus, IFolder } from '../types.js';
+import { IN8nCredentials, IWorkflow, IProject, ITag, ITriggerInfo, ITestPlan, ITestResult, TriggerType, IInferredPayload, IInferredPayloadField, IExecutionDetails, IExecutionList, IExecutionSummary, ExecutionStatus, IFolder, IPublishedVersion } from '../types.js';
 
 type AgentLookup = NonNullable<http.AgentOptions['lookup']>;
 
@@ -908,6 +908,45 @@ export class N8nApiClient {
             console.error(`Failed to delete workflow ${id}:`, error);
             return false;
         }
+    }
+
+    /**
+     * Reads which version of a workflow currently runs in production.
+     *
+     * Deliberately a bare GET: this runs on the push hot path, and the project
+     * and tag enrichment `getWorkflow` performs is irrelevant here.
+     *
+     * Throws on transport failures — the caller decides whether an unreadable
+     * pointer should block a push or only warn.
+     */
+    async getPublishedVersion(id: string): Promise<IPublishedVersion> {
+        const res = await this.client.get(`/api/v1/workflows/${id}`);
+        const workflow = (res.data ?? {}) as IWorkflow;
+
+        // n8n has exposed the pointer under both names across 2.x releases, and
+        // neither exists on 1.x. Absent means "nothing to restore", not an error.
+        const versionId = workflow.activeVersionId ?? workflow.activeVersion?.id;
+
+        return {
+            published: workflow.active === true,
+            versionId: typeof versionId === 'string' && versionId.length > 0 ? versionId : undefined,
+        };
+    }
+
+    /**
+     * Publishes a specific version of a workflow, i.e. points production at it.
+     *
+     * Without `versionId` n8n publishes the latest version — which is what
+     * `workflow activate` wants, and never what publish-restoration wants.
+     *
+     * Unlike {@link activateWorkflow} this throws: callers use it to undo an
+     * unwanted publish, and a silent failure there leaves production running
+     * content the user never released.
+     */
+    async publishWorkflowVersion(id: string, versionId?: string): Promise<IWorkflow | null> {
+        const body = versionId ? { versionId } : {};
+        const res = await this.client.post(`/api/v1/workflows/${id}/activate`, body);
+        return res.data && typeof res.data === 'object' ? (res.data as IWorkflow) : null;
     }
 
     async activateWorkflow(id: string, active: boolean): Promise<IWorkflow | null> {

--- a/packages/cli/src/core/services/sync-engine.ts
+++ b/packages/cli/src/core/services/sync-engine.ts
@@ -307,13 +307,10 @@ export class SyncEngine {
             );
         }
 
-        const remoteUpdatedAt = outcome === 'restores'
-            ? await this.restorePublishedVersion(workflowId, filename, published!.versionId!, updatedWf)
-            : updatedWf.updatedAt;
-
         // CRITICAL: Write the API response back to local file to ensure consistency
-        // This ensures local and remote have identical content after push
-        // Convert the updated workflow back to TypeScript
+        // This ensures local and remote have identical content after push.
+        // It happens BEFORE the restore attempt below: the PUT already changed
+        // the remote, so local must reflect it even when the re-pin fails.
         const tsCode = await WorkflowTransformerAdapter.convertToTypeScript(updatedWf, {
             format: true,
             commentStyle: 'verbose'
@@ -325,7 +322,19 @@ export class SyncEngine {
         const hash = await WorkflowTransformerAdapter.hashWorkflow(tsCode);
         this.watcher.setRemoteHash(workflowId, hash);
 
-        return remoteUpdatedAt;
+        if (outcome !== 'restores') {
+            return updatedWf.updatedAt;
+        }
+
+        try {
+            return await this.restorePublishedVersion(workflowId, filename, published!.versionId!, updatedWf);
+        } catch (error) {
+            // The loud failure above stops the regular finalize path, yet the
+            // remote did move (our own PUT). Advance the sync base here so the
+            // next push does not false-conflict against its own update.
+            await this.watcher.finalizeSync(workflowId, updatedWf.updatedAt);
+            throw error;
+        }
     }
 
     /**

--- a/packages/cli/src/core/services/sync-engine.ts
+++ b/packages/cli/src/core/services/sync-engine.ts
@@ -5,7 +5,7 @@ import { WorkflowTransformerAdapter } from './workflow-transformer-adapter.js';
 import { HashUtils } from './hash-utils.js';
 import { WorkflowStateTracker } from './workflow-state-tracker.js';
 import { SyncEventJournal } from './sync-event-journal.js';
-import { WorkflowSyncStatus, IWorkflow, IFolder } from '../types.js';
+import { WorkflowSyncStatus, IWorkflow, IFolder, IPublishedVersion, IPushPublishReport } from '../types.js';
 import { ensureParentDirectory, normalizeWorkflowRelativePath, workflowRelativePathToAbsolute } from './workflow-path-utils.js';
 
 /**
@@ -39,6 +39,8 @@ export class SyncEngine {
     private folderSyncMoveToRoot: boolean;
     /** Guards the "folders unavailable" warning so a bulk push logs it once. */
     private folderUnavailableWarned = false;
+    /** Reports what each update did to the published version, for the CLI to surface. */
+    private onPublishState: ((report: IPushPublishReport) => void) | undefined;
 
     constructor(
         client: N8nApiClient,
@@ -46,7 +48,11 @@ export class SyncEngine {
         directory: string,
         projectId: string,
         syncEventJournal?: SyncEventJournal,
-        options?: { folderSync?: boolean; folderSyncMoveToRoot?: boolean },
+        options?: {
+            folderSync?: boolean;
+            folderSyncMoveToRoot?: boolean;
+            onPublishState?: (report: IPushPublishReport) => void;
+        },
     ) {
         this.client = client;
         this.watcher = watcher;
@@ -55,6 +61,7 @@ export class SyncEngine {
         this.syncEventJournal = syncEventJournal;
         this.folderSync = options?.folderSync ?? false;
         this.folderSyncMoveToRoot = options?.folderSyncMoveToRoot ?? false;
+        this.onPublishState = options?.onPublishState;
     }
 
     /**
@@ -89,14 +96,19 @@ export class SyncEngine {
      * PUSH Strategy: Local -> Remote
      * Based on spec 5.3 PUSH Strategy table
      */
-    public async push(filename: string, workflowId?: string, status?: WorkflowSyncStatus): Promise<string> {
+    public async push(
+        filename: string,
+        workflowId?: string,
+        status?: WorkflowSyncStatus,
+        options?: { draft?: boolean },
+    ): Promise<string> {
         // If we have an ID, we ALWAYS try to update first (robustness for git-like sync)
             if (workflowId) {
                 try {
                     // PUT to API (Update)
                     // We bypass OCC check if the status is EXIST_ONLY_LOCALLY (meaning we think it's new but it might not be)
                     const skipOcc = status === WorkflowSyncStatus.EXIST_ONLY_LOCALLY;
-                    const updateUpdatedAt = await this.executeUpdate(workflowId, filename, skipOcc);
+                    const updateUpdatedAt = await this.executeUpdate(workflowId, filename, skipOcc, options?.draft === true);
                     
                     // Update lastSyncedHash via finalizeSync
                     await this.watcher.finalizeSync(workflowId, updateUpdatedAt);
@@ -113,8 +125,10 @@ export class SyncEngine {
             }
 
             // No ID or Update failed with 404 -> POST to API (Create)
+            // n8n creates workflows unpublished, so a create never touches
+            // production and `--draft` has nothing to protect here.
             const { id: newWorkflowId, updatedAt } = await this.executeCreate(filename);
-            
+
             // Initialize lastSyncedHash via finalizeSync
             await this.watcher.finalizeSync(newWorkflowId, updatedAt);
             this.recordPushSuccess(newWorkflowId, filename, updatedAt);
@@ -196,7 +210,24 @@ export class SyncEngine {
         return fullWf.updatedAt;
     }
 
-    private async executeUpdate(workflowId: string, filename: string, skipOcc = false): Promise<string | undefined> {
+    /**
+     * PUT the local workflow to n8n.
+     *
+     * On n8n 2.x a workflow is a draft (the content) plus a pointer to the
+     * version production runs. `PUT /workflows/:id` rewrites the draft *and*
+     * moves the pointer when the workflow is published, with no opt-out — so on
+     * a published workflow a push is a save *and* a publish.
+     *
+     * That stays the default: `push` is a deploy command, and the API is not
+     * worked around behind the user's back. It is announced before the update
+     * lands, through `onPublishState`.
+     *
+     * `draft` opts into the workaround: capture the pointer, PUT, re-pin. It is
+     * a compensating call, not an atomic one — between the two the pushed
+     * content is briefly live — which is why it is opt-in rather than the path
+     * everyone silently depends on.
+     */
+    private async executeUpdate(workflowId: string, filename: string, skipOcc = false, draft = false): Promise<string | undefined> {
         const filePath = workflowRelativePathToAbsolute(this.directory, filename);
         const tsContent = this.readTypeScriptFile(filePath);
         if (!tsContent) {
@@ -242,6 +273,12 @@ export class SyncEngine {
             localWf.parentFolderId = inferredParentFolderId;
         }
 
+        // Read the published version *before* the PUT — afterwards it already
+        // points at the content we are about to send, and the warning would come
+        // too late to be one.
+        const published = await this.capturePublishedVersion(workflowId);
+        const outcome = this.announcePublishIntent(workflowId, filename, draft, published);
+
         let updatedWf: IWorkflow;
         try {
             updatedWf = await this.client.updateWorkflow(workflowId, localWf);
@@ -270,6 +307,10 @@ export class SyncEngine {
             );
         }
 
+        const remoteUpdatedAt = outcome === 'restores'
+            ? await this.restorePublishedVersion(workflowId, filename, published!.versionId!, updatedWf)
+            : updatedWf.updatedAt;
+
         // CRITICAL: Write the API response back to local file to ensure consistency
         // This ensures local and remote have identical content after push
         // Convert the updated workflow back to TypeScript
@@ -283,8 +324,114 @@ export class SyncEngine {
         // Update Watcher's remote hash cache with the updated workflow
         const hash = await WorkflowTransformerAdapter.hashWorkflow(tsCode);
         this.watcher.setRemoteHash(workflowId, hash);
-        
-        return updatedWf.updatedAt;
+
+        return remoteUpdatedAt;
+    }
+
+    /**
+     * Says what this push is about to do to production, before it does it.
+     *
+     * `--draft` on a workflow whose published version cannot be read or re-pinned
+     * throws here rather than pushing: the user asked for a guarantee, nothing
+     * has happened yet, and silently doing the opposite is the worst option.
+     */
+    private announcePublishIntent(
+        workflowId: string,
+        filename: string,
+        draft: boolean,
+        published: IPublishedVersion | undefined,
+    ): IPushPublishReport['outcome'] {
+        const outcome = ((): IPushPublishReport['outcome'] => {
+            if (!published) {
+                if (draft) {
+                    throw new Error(
+                        `Refusing to push "${filename}" with --draft: the published version could not be read, ` +
+                        `so it could not be restored either. Retry, or push without --draft to release the change.`
+                    );
+                }
+                return 'unknown';
+            }
+
+            // Nothing runs in production, so the update releases nothing.
+            if (!published.published) return 'not-published';
+
+            if (!draft) return 'goes-live';
+
+            // n8n 1.x: no version pointer, the workflow content *is* what runs.
+            if (!published.versionId) {
+                throw new Error(
+                    `Refusing to push "${filename}" with --draft: this n8n instance exposes no published-version ` +
+                    `pointer (n8n 1.x), where an active workflow runs the content it holds. There is nothing to ` +
+                    `restore, so the push would go live. Unpublish the workflow first, or push without --draft.`
+                );
+            }
+            return 'restores';
+        })();
+
+        try {
+            this.onPublishState?.({ workflowId, filename, outcome, versionId: published?.versionId });
+        } catch (error: any) {
+            console.warn(`[SyncEngine] Publish-state listener threw: ${error?.message || error}`);
+        }
+        return outcome;
+    }
+
+    /**
+     * Reads the published version before an update, tolerating failure.
+     *
+     * A pointer we cannot read is a pointer we cannot restore, but refusing the
+     * push over a failed GET helps nobody — the PUT that follows would fail on
+     * the same transport. The push proceeds and reports `unknown` instead.
+     */
+    private async capturePublishedVersion(workflowId: string): Promise<IPublishedVersion | undefined> {
+        try {
+            return await this.client.getPublishedVersion(workflowId);
+        } catch (error: any) {
+            console.warn(
+                `[SyncEngine] Could not read the published version of ${workflowId} ` +
+                `(${error?.message || error}). This push may change what runs in production.`
+            );
+            return undefined;
+        }
+    }
+
+    /**
+     * Puts the published version back where the PUT moved it from.
+     *
+     * Returns the `updatedAt` to record as the sync base. Re-pinning a version
+     * touches the workflow again, so the timestamp from the PUT response is
+     * already stale by then — keeping it would make the next push think someone
+     * edited the workflow in the n8n UI.
+     */
+    private async restorePublishedVersion(
+        workflowId: string,
+        filename: string,
+        versionId: string,
+        updatedWf: IWorkflow,
+    ): Promise<string | undefined> {
+        try {
+            const restored = await this.client.publishWorkflowVersion(workflowId, versionId);
+            return restored?.updatedAt ?? (await this.readRemoteUpdatedAt(workflowId)) ?? updatedWf.updatedAt;
+        } catch (error: any) {
+            throw new Error(
+                `Pushed "${filename}", but failed to restore the published version ${versionId}: ` +
+                `${error?.message || error}. n8n re-publishes on update, so the content you just pushed is ` +
+                `now live in production. Re-publish version ${versionId} from the n8n UI to roll back, ` +
+                `or drop --draft if the new version is what you want live.`
+            );
+        }
+    }
+
+    /** Best-effort re-read of `updatedAt` when the activate response omits it. */
+    private async readRemoteUpdatedAt(workflowId: string): Promise<string | undefined> {
+        try {
+            const wf = await this.client.getWorkflow(workflowId);
+            return wf?.updatedAt;
+        } catch {
+            // The sync base stays on the PUT timestamp; the next push falls back
+            // to the normal conflict prompt rather than failing here.
+            return undefined;
+        }
     }
 
     private recordPushSuccess(workflowId: string, filename: string, remoteUpdatedAt?: string): void {

--- a/packages/cli/src/core/services/sync-manager.ts
+++ b/packages/cli/src/core/services/sync-manager.ts
@@ -7,7 +7,7 @@ import { WorkflowStateTracker } from './workflow-state-tracker.js';
 import { SyncEngine } from './sync-engine.js';
 import { SyncEventJournal } from './sync-event-journal.js';
 import { ResolutionManager } from './resolution-manager.js';
-import { ISyncConfig, IWorkflow, WorkflowSyncStatus, IWorkflowStatus } from '../types.js';
+import { ISyncConfig, IWorkflow, WorkflowSyncStatus, IWorkflowStatus, IPushPublishReport } from '../types.js';
 import { createProjectSlug } from './directory-utils.js';
 import { WorkspaceSetupService } from './workspace-setup-service.js';
 import { normalizeWorkflowRelativePath, relativePathFromAbsolute, workflowRelativePathToAbsolute } from './workflow-path-utils.js';
@@ -72,6 +72,7 @@ export class SyncManager extends EventEmitter {
         this.syncEngine = new SyncEngine(this.client, this.watcher, instanceDir, this.config.projectId, this.syncEventJournal, {
             folderSync: this.config.folderSync ?? false,
             folderSyncMoveToRoot: this.config.folderSyncMoveToRoot ?? false,
+            onPublishState: (report) => this.emit('publishState', report),
         });
         this.resolutionManager = new ResolutionManager(this.syncEngine, this.watcher, this.client);
 
@@ -280,9 +281,14 @@ export class SyncManager extends EventEmitter {
      *  2. EXIST_ONLY_LOCALLY with an ID     → CREATE on remote (POST) — e.g. remote was deleted
      *  3. Known on both sides               → UPDATE on remote (PUT, with OCC check)
      *
+     * On n8n 2.x, pushing to a published workflow also releases the pushed
+     * content — see `SyncEngine.executeUpdate`. That is announced before the
+     * update lands, as a `publishState` event ({@link IPushPublishReport}).
+     *
      * @param filename - Filename inside the active sync scope
+     * @param options.draft - Restore the previously published version afterwards.
      */
-    public async push(filename: string): Promise<string> {
+    public async push(filename: string, options?: { draft?: boolean }): Promise<string> {
         await this.ensureInitialized();
 
         let targetFilename: string | undefined;
@@ -309,7 +315,7 @@ export class SyncManager extends EventEmitter {
 
             if (!effectiveId) {
                 // Case 1: brand-new workflow (no ID mapping yet) — let SyncEngine create it
-                return await this.syncEngine!.push(targetFilename, undefined, undefined);
+                return await this.syncEngine!.push(targetFilename, undefined, undefined, options);
             }
 
             // Case 2 & 3: workflow has an ID locally
@@ -320,11 +326,11 @@ export class SyncManager extends EventEmitter {
 
             if (!this.watcher!.isRemoteKnown(effectiveId)) {
                 // Truly doesn't exist on remote → create
-                return await this.syncEngine!.push(targetFilename, effectiveId, WorkflowSyncStatus.EXIST_ONLY_LOCALLY);
+                return await this.syncEngine!.push(targetFilename, effectiveId, WorkflowSyncStatus.EXIST_ONLY_LOCALLY, options);
             }
 
             // Known on both sides → update (with OCC check)
-            return await this.syncEngine!.push(targetFilename, effectiveId, WorkflowSyncStatus.TRACKED);
+            return await this.syncEngine!.push(targetFilename, effectiveId, WorkflowSyncStatus.TRACKED, options);
         } catch (error: any) {
             this.recordWorkflowPushFailure(targetFilename || path.basename(filename), effectiveId, error);
             throw error;

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -25,6 +25,52 @@ export interface IWorkflow {
     parentFolder?: { id: string; name: string } | null;
     folderPath?: string[];
     folderPathString?: string;
+
+    // n8n 2.x publishing model. `active` says whether *a* version runs in
+    // production; these say *which* one. Absent on 1.x, where the workflow
+    // content and the running content are the same thing.
+    activeVersionId?: string;
+    activeVersion?: { id?: string } | null;
+}
+
+/**
+ * Which version of a workflow n8n runs in production, read before a push.
+ *
+ * n8n 2.x splits a workflow in two: the draft (the content, rewritten by every
+ * save) and the published version (a pointer to the version production runs).
+ * `PUT /workflows/:id` moves the pointer to the new content when the workflow
+ * is published, with no opt-out — so a push has to put the pointer back itself.
+ */
+export interface IPublishedVersion {
+    /** `true` when a version of this workflow currently runs in production. */
+    published: boolean;
+    /**
+     * The published version's id, when the instance exposes one.
+     *
+     * Undefined on n8n 1.x, which has no version pointer to restore: there the
+     * workflow content *is* what runs, and a push necessarily changes it.
+     */
+    versionId?: string;
+}
+
+/**
+ * What a push is about to do to the published version.
+ *
+ * Emitted *before* the update lands, on purpose: "your push just changed
+ * production" arrives too late to be a warning.
+ */
+export interface IPushPublishReport {
+    workflowId: string;
+    filename: string;
+    /**
+     * - `goes-live`     — the workflow is published, so this push releases the pushed content.
+     * - `restores`      — `--draft`: the previously published version is re-pinned after the update.
+     * - `not-published` — nothing runs in production, so the push changes no live behaviour.
+     * - `unknown`       — the published version could not be read.
+     */
+    outcome: 'goes-live' | 'restores' | 'not-published' | 'unknown';
+    /** The version re-pinned on `restores`. */
+    versionId?: string;
 }
 
 export interface IFolder {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -999,12 +999,13 @@ program.command('pull')
 
 // push - Upload a single local workflow file to n8n
 program.command('push')
-    .description('Upload a single local workflow to n8n')
+    .description('Upload a single local workflow to n8n (on a published workflow, this also releases it)')
     .argument('<path>', 'Path to a local workflow file inside the active sync scope (absolute or relative)')
     .option('--verify', 'After pushing, fetch the workflow from n8n and validate it against the local schema')
+    .option('--draft', 'Keep production on the version it already ran, so the change can be checked in n8n first')
     .action(async (pathArg, options) => {
         const cmd = new SyncCommand();
-        const workflowId = await cmd.pushOne(pathArg);
+        const workflowId = await cmd.pushOne(pathArg, { draft: options.draft === true });
         if (options.verify && workflowId) {
             console.log(chalk.dim('\n── Post-push verification ──────────────────────────────'));
             const ok = await cmd.verifyRemote(workflowId);

--- a/packages/cli/tests/unit/n8n-api-client.test.ts
+++ b/packages/cli/tests/unit/n8n-api-client.test.ts
@@ -1159,3 +1159,73 @@ describe('buildCaBundle', () => {
         expect(buildCaBundle()).toBeUndefined();
     });
 });
+
+describe('N8nApiClient published version', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockAxiosGet.mockReset();
+        mockAxiosPost.mockReset();
+        mockAxiosCreate.mockReset();
+        mockAxiosCreate.mockImplementation((config?: MockAxiosCreateConfig) => ({
+            defaults: { baseURL: config?.baseURL ?? '' },
+            get: mockAxiosGet,
+            post: mockAxiosPost,
+            put: mockAxiosPut,
+            delete: mockAxiosDelete,
+        }));
+    });
+
+    const client = () => new N8nApiClient({ host: 'https://n8n.local/', apiKey: 'secret' });
+
+    it('reads the pointer from the nested activeVersion object', async () => {
+        mockAxiosGet.mockResolvedValue({ data: { id: 'wf-1', active: true, activeVersion: { id: 'v-9' } } });
+
+        await expect(client().getPublishedVersion('wf-1')).resolves.toEqual({ published: true, versionId: 'v-9' });
+    });
+
+    // n8n has exposed the same pointer flat across 2.x releases, so both shapes
+    // have to resolve rather than one silently reporting "nothing to restore".
+    it('reads the pointer from the flat activeVersionId field', async () => {
+        mockAxiosGet.mockResolvedValue({ data: { id: 'wf-1', active: true, activeVersionId: 'v-9' } });
+
+        await expect(client().getPublishedVersion('wf-1')).resolves.toEqual({ published: true, versionId: 'v-9' });
+    });
+
+    it('reports an inactive workflow as not published', async () => {
+        mockAxiosGet.mockResolvedValue({ data: { id: 'wf-1', active: false, activeVersion: null } });
+
+        await expect(client().getPublishedVersion('wf-1')).resolves.toEqual({ published: false, versionId: undefined });
+    });
+
+    // n8n 1.x payloads carry `active` but no version pointer at all.
+    it('reports no version id when the instance exposes none', async () => {
+        mockAxiosGet.mockResolvedValue({ data: { id: 'wf-1', active: true } });
+
+        await expect(client().getPublishedVersion('wf-1')).resolves.toEqual({ published: true, versionId: undefined });
+    });
+
+    it('publishes a specific version by id', async () => {
+        mockAxiosPost.mockResolvedValue({ data: { id: 'wf-1' } });
+
+        await client().publishWorkflowVersion('wf-1', 'v-9');
+
+        expect(mockAxiosPost).toHaveBeenCalledWith('/api/v1/workflows/wf-1/activate', { versionId: 'v-9' });
+    });
+
+    it('publishes the latest version when no id is given', async () => {
+        mockAxiosPost.mockResolvedValue({ data: { id: 'wf-1' } });
+
+        await client().publishWorkflowVersion('wf-1');
+
+        expect(mockAxiosPost).toHaveBeenCalledWith('/api/v1/workflows/wf-1/activate', {});
+    });
+
+    // Unlike `activateWorkflow`, this one must not swallow: callers use it to
+    // undo an unwanted publish, and a silent failure leaves production running
+    // content the user never released.
+    it('propagates failures instead of returning null', async () => {
+        mockAxiosPost.mockRejectedValue(new Error('403 Forbidden'));
+
+        await expect(client().publishWorkflowVersion('wf-1', 'v-9')).rejects.toThrow('403 Forbidden');
+    });
+});

--- a/packages/cli/tests/unit/sync-engine.test.ts
+++ b/packages/cli/tests/unit/sync-engine.test.ts
@@ -1017,7 +1017,11 @@ describe('SyncEngine publish handling on push', () => {
         const push = () => engine.push(filename, workflowId, undefined, { draft: true });
         await expect(push()).rejects.toThrow(/now live in production/);
         await expect(push()).rejects.toThrow(/v-live/);
-        expect(watcher.finalizeSync).not.toHaveBeenCalled();
+        // The PUT already moved the remote, so local state is reconciled and the
+        // sync base advances even though the push fails — otherwise the next
+        // push false-conflicts against its own update.
+        expect(watcher.setRemoteHash).toHaveBeenCalled();
+        expect(watcher.finalizeSync).toHaveBeenCalledWith(workflowId, '2026-07-01T00:00:00.000Z');
     });
 
     // n8n creates workflows unpublished, so a create never touches production

--- a/packages/cli/tests/unit/sync-engine.test.ts
+++ b/packages/cli/tests/unit/sync-engine.test.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+﻿import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -14,6 +14,8 @@ function createEngine(params: {
     getFolders?: ReturnType<typeof vi.fn>;
     createFolder?: ReturnType<typeof vi.fn>;
     resolveFolderProjectId?: ReturnType<typeof vi.fn>;
+    publishWorkflowVersion?: ReturnType<typeof vi.fn>;
+    onPublishState?: (report: any) => void;
 }) {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-sync-engine-'));
     const filename = params.filename ?? 'new.workflow.ts';
@@ -29,14 +31,16 @@ function createEngine(params: {
         getFolders: params.getFolders,
         createFolder: params.createFolder,
         resolveFolderProjectId: params.resolveFolderProjectId,
+        publishWorkflowVersion: params.publishWorkflowVersion ?? vi.fn(async () => null),
     } as any;
 
     const engine = new SyncEngine(client, watcher, directory, params.projectId, undefined, {
         folderSync: params.folderSync,
         folderSyncMoveToRoot: params.folderSyncMoveToRoot,
+        onPublishState: params.onPublishState,
     });
 
-    return { engine, directory, filename, watcher };
+    return { engine, directory, filename, watcher, client };
 }
 
 describe('SyncEngine create payload projectId behavior', () => {
@@ -234,7 +238,7 @@ describe('SyncEngine create payload projectId behavior', () => {
         vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
 
         // A 400 whose body mentions "folder" but not "parentFolderId" / "parentFolder" must NOT be
-        // misclassified as "unsupported parentFolderId" — that would silently drop the folder assignment
+        // misclassified as "unsupported parentFolderId" â€” that would silently drop the folder assignment
         // on n8n instances that DO support it.
         const genericFolderError: any = new Error('Request failed with status code 400');
         genericFolderError.response = {
@@ -318,7 +322,7 @@ describe('SyncEngine create payload projectId behavior', () => {
 // ---------------------------------------------------------------------------
 //
 // Mirrors the create-path folderSync tests but for executeUpdate(). The update
-// path used to drop `parentFolderId` on the floor — both because
+// path used to drop `parentFolderId` on the floor â€” both because
 // `inferParentFolderIdFromFilename` was only called from executeCreate(), and
 // because `N8nApiClient.cleanWorkflowUpdatePayload()` did not include
 // `parentFolderId` in its allowedKeys set. Both are fixed; these tests guard
@@ -335,6 +339,9 @@ function updateEngine(params: {
     createFolder?: ReturnType<typeof vi.fn>;
     resolveFolderProjectId?: ReturnType<typeof vi.fn>;
     workflowId?: string;
+    getPublishedVersion?: ReturnType<typeof vi.fn>;
+    publishWorkflowVersion?: ReturnType<typeof vi.fn>;
+    onPublishState?: (report: any) => void;
 }) {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-sync-engine-update-'));
     const filename = params.filename ?? 'existing.workflow.ts';
@@ -344,6 +351,9 @@ function updateEngine(params: {
     const watcher = {
         finalizeSync: vi.fn(async () => undefined),
         setRemoteHash: vi.fn(),
+        // No sync base recorded, so the OCC check passes whatever `getWorkflow`
+        // returns — tests that stub it for other reasons stay unaffected.
+        getLastSyncedAt: vi.fn(() => undefined),
     } as any;
 
     // Return undefined from getWorkflow to bypass OCC; tests don't exercise OCC.
@@ -353,11 +363,16 @@ function updateEngine(params: {
         getFolders: params.getFolders,
         createFolder: params.createFolder,
         resolveFolderProjectId: params.resolveFolderProjectId,
+        // Unpublished by default: most update tests are about the payload, and an
+        // unpublished workflow is the case where the push touches nothing else.
+        getPublishedVersion: params.getPublishedVersion ?? vi.fn(async () => ({ published: false })),
+        publishWorkflowVersion: params.publishWorkflowVersion ?? vi.fn(async () => null),
     } as any;
 
     const engine = new SyncEngine(client, watcher, directory, params.projectId, undefined, {
         folderSync: params.folderSync,
         folderSyncMoveToRoot: params.folderSyncMoveToRoot,
+        onPublishState: params.onPublishState,
     });
 
     return {
@@ -514,7 +529,7 @@ describe('SyncEngine update payload folderSync behavior', () => {
         // Snapshot each call's payload at call time. Vitest's vi.fn() records
         // arguments by live reference, and SyncEngine mutates the same localWf
         // between the two updateWorkflow calls (sets parentFolderId, then
-        // deletes it in the catch block) — so the recorded `calls` would
+        // deletes it in the catch block) â€” so the recorded `calls` would
         // reflect the post-mutation object by the time the assertion runs.
         // Capturing { ...payload } at each call preserves call-time state.
         // Same pattern as the create-side fix in commit c801ff43.
@@ -746,3 +761,286 @@ describe('SyncEngine folder placement without session auth', () => {
         expect(payloads[0]).toHaveProperty('parentFolderId', 'folder-reports');
     });
 });
+
+/**
+ * n8n 2.x publishing model.
+ *
+ * A workflow is a draft (its content) plus a pointer to the version production
+ * runs. `PUT /workflows/:id` rewrites the draft and, when the workflow is
+ * published, drags the pointer along with no opt-out — so a push to a published
+ * workflow is a save *and* a publish. That stays the default; it is announced
+ * up front, and `--draft` opts into putting the pointer back (#563).
+ */
+describe('SyncEngine publish handling on push', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    function mockTransformer() {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'Existing Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+    }
+
+    const updateOk = () => vi.fn(async (id, payload) => ({
+        ...payload,
+        id,
+        updatedAt: '2026-07-01T00:00:00.000Z',
+    }));
+
+    const publishedAt = (versionId?: string) => vi.fn(async () => ({ published: true, versionId }));
+
+    it('releases the pushed content by default on a published workflow', async () => {
+        mockTransformer();
+
+        const publishWorkflowVersion = vi.fn(async () => null);
+        const reports: any[] = [];
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow: updateOk(),
+            getPublishedVersion: publishedAt('v-live'),
+            publishWorkflowVersion,
+            onPublishState: (r) => reports.push(r),
+        });
+
+        await expect(engine.push(filename, workflowId)).resolves.toBe(workflowId);
+
+        // The PUT already published; nothing is undone behind the user's back.
+        expect(publishWorkflowVersion).not.toHaveBeenCalled();
+        expect(reports).toEqual([expect.objectContaining({ outcome: 'goes-live', workflowId })]);
+    });
+
+    // "Your push changed production" after the fact is a notification, not a
+    // warning. The whole point of the default path is that it is announced.
+    it('announces going live before the update lands', async () => {
+        mockTransformer();
+
+        const updateWorkflow = updateOk();
+        let updatesAtAnnounce: number | undefined;
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow,
+            getPublishedVersion: publishedAt('v-live'),
+            onPublishState: () => { updatesAtAnnounce = updateWorkflow.mock.calls.length; },
+        });
+
+        await engine.push(filename, workflowId);
+
+        expect(updatesAtAnnounce).toBe(0);
+        expect(updateWorkflow).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-pins the previously published version with --draft', async () => {
+        mockTransformer();
+
+        const publishWorkflowVersion = vi.fn(async () => ({ id: 'wf-existing', updatedAt: '2026-07-01T00:00:05.000Z' }));
+        const reports: any[] = [];
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow: updateOk(),
+            getPublishedVersion: publishedAt('v-live'),
+            publishWorkflowVersion,
+            onPublishState: (r) => reports.push(r),
+        });
+
+        await expect(engine.push(filename, workflowId, undefined, { draft: true })).resolves.toBe(workflowId);
+
+        expect(publishWorkflowVersion).toHaveBeenCalledWith(workflowId, 'v-live');
+        expect(reports).toEqual([
+            expect.objectContaining({ outcome: 'restores', versionId: 'v-live', workflowId }),
+        ]);
+    });
+
+    // The pointer has to be read before the PUT — afterwards it already names
+    // the version we just uploaded, so restoring it would be a no-op.
+    it('reads the published version before updating', async () => {
+        mockTransformer();
+
+        const updateWorkflow = updateOk();
+        const getPublishedVersion = publishedAt('v-live');
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow,
+            getPublishedVersion,
+            publishWorkflowVersion: vi.fn(async () => null),
+        });
+
+        await engine.push(filename, workflowId, undefined, { draft: true });
+
+        expect(getPublishedVersion.mock.invocationCallOrder[0])
+            .toBeLessThan(updateWorkflow.mock.invocationCallOrder[0]);
+    });
+
+    // Re-pinning touches the workflow again, so the PUT's timestamp is stale by
+    // the time the push ends. Recording it would make the next push believe the
+    // workflow had been edited in the n8n UI.
+    it('records the post-restore updatedAt as the sync base', async () => {
+        mockTransformer();
+
+        const { engine, filename, workflowId, watcher } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow: updateOk(),
+            getPublishedVersion: publishedAt('v-live'),
+            publishWorkflowVersion: vi.fn(async () => ({ id: 'wf-existing', updatedAt: '2026-07-01T00:00:05.000Z' })),
+        });
+
+        await engine.push(filename, workflowId, undefined, { draft: true });
+
+        expect(watcher.finalizeSync).toHaveBeenCalledWith(workflowId, '2026-07-01T00:00:05.000Z');
+    });
+
+    it('falls back to a fresh read when the activate response carries no timestamp', async () => {
+        mockTransformer();
+
+        const { engine, filename, workflowId, watcher, client } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow: updateOk(),
+            getPublishedVersion: publishedAt('v-live'),
+            publishWorkflowVersion: vi.fn(async () => null),
+        });
+        client.getWorkflow = vi.fn(async () => ({ id: workflowId, updatedAt: '2026-07-01T00:00:09.000Z' }));
+
+        await engine.push(filename, workflowId, undefined, { draft: true });
+
+        expect(watcher.finalizeSync).toHaveBeenCalledWith(workflowId, '2026-07-01T00:00:09.000Z');
+    });
+
+    it('leaves an unpublished workflow alone', async () => {
+        mockTransformer();
+
+        const publishWorkflowVersion = vi.fn(async () => null);
+        const reports: any[] = [];
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow: updateOk(),
+            getPublishedVersion: vi.fn(async () => ({ published: false })),
+            publishWorkflowVersion,
+            onPublishState: (r) => reports.push(r),
+        });
+
+        await engine.push(filename, workflowId);
+
+        expect(publishWorkflowVersion).not.toHaveBeenCalled();
+        expect(reports).toEqual([expect.objectContaining({ outcome: 'not-published' })]);
+    });
+
+    it('reports unknown when the published version cannot be read', async () => {
+        mockTransformer();
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        const updateWorkflow = updateOk();
+        const reports: any[] = [];
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow,
+            getPublishedVersion: vi.fn(async () => { throw new Error('ECONNRESET'); }),
+            onPublishState: (r) => reports.push(r),
+        });
+
+        // A failed pre-read must not block a default push: the PUT that follows
+        // would fail on the same transport if the instance were unreachable.
+        await expect(engine.push(filename, workflowId)).resolves.toBe(workflowId);
+
+        expect(updateWorkflow).toHaveBeenCalledTimes(1);
+        expect(reports).toEqual([expect.objectContaining({ outcome: 'unknown' })]);
+    });
+
+    // `--draft` is a promise about production. When it cannot be kept, refusing
+    // costs nothing (the PUT has not happened) and silently doing the opposite
+    // is the worst available option.
+    it('refuses --draft when the published version cannot be read', async () => {
+        mockTransformer();
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        const updateWorkflow = updateOk();
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow,
+            getPublishedVersion: vi.fn(async () => { throw new Error('ECONNRESET'); }),
+        });
+
+        await expect(engine.push(filename, workflowId, undefined, { draft: true }))
+            .rejects.toThrow(/could not be read/);
+        expect(updateWorkflow).not.toHaveBeenCalled();
+    });
+
+    // n8n 1.x has no version pointer: an active workflow runs the content it
+    // holds, so there is nothing to restore and `--draft` cannot be honoured.
+    it('refuses --draft on an instance without a version pointer', async () => {
+        mockTransformer();
+
+        const updateWorkflow = updateOk();
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow,
+            getPublishedVersion: publishedAt(undefined),
+        });
+
+        await expect(engine.push(filename, workflowId, undefined, { draft: true }))
+            .rejects.toThrow(/n8n 1\.x/);
+        expect(updateWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('still pushes to an unversioned instance without --draft', async () => {
+        mockTransformer();
+
+        const updateWorkflow = updateOk();
+        const reports: any[] = [];
+        const { engine, filename, workflowId } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow,
+            getPublishedVersion: publishedAt(undefined),
+            onPublishState: (r) => reports.push(r),
+        });
+
+        await expect(engine.push(filename, workflowId)).resolves.toBe(workflowId);
+
+        expect(updateWorkflow).toHaveBeenCalledTimes(1);
+        expect(reports).toEqual([expect.objectContaining({ outcome: 'goes-live' })]);
+    });
+
+    // Restoration is a compensating call, not an atomic one. When it fails the
+    // pushed content stays live, so the push must not report success.
+    it('fails loudly when the published version cannot be restored', async () => {
+        mockTransformer();
+
+        const { engine, filename, workflowId, watcher } = updateEngine({
+            projectId: 'project-1',
+            updateWorkflow: updateOk(),
+            getPublishedVersion: publishedAt('v-live'),
+            publishWorkflowVersion: vi.fn(async () => { throw new Error('403 Forbidden'); }),
+        });
+
+        const push = () => engine.push(filename, workflowId, undefined, { draft: true });
+        await expect(push()).rejects.toThrow(/now live in production/);
+        await expect(push()).rejects.toThrow(/v-live/);
+        expect(watcher.finalizeSync).not.toHaveBeenCalled();
+    });
+
+    // n8n creates workflows unpublished, so a create never touches production
+    // and neither mode has anything to publish or restore.
+    it('never publishes a newly created workflow', async () => {
+        vi.spyOn(WorkflowTransformerAdapter, 'compileToJson').mockResolvedValue({
+            name: 'New Workflow',
+            nodes: [{ id: 'n1' }],
+            connections: {},
+        } as any);
+        vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
+
+        const publishWorkflowVersion = vi.fn(async () => null);
+        const { engine, filename } = createEngine({
+            projectId: 'personal',
+            createWorkflow: vi.fn(async (payload) => ({ ...payload, id: 'wf-new' })),
+            publishWorkflowVersion,
+        });
+
+        await expect(engine.push(filename)).resolves.toBe('wf-new');
+        await expect(engine.push(filename, undefined, undefined, { draft: true })).resolves.toBe('wf-new');
+
+        expect(publishWorkflowVersion).not.toHaveBeenCalled();
+    });
+});
+

--- a/packages/cli/tests/unit/sync-engine.test.ts
+++ b/packages/cli/tests/unit/sync-engine.test.ts
@@ -1,4 +1,4 @@
-﻿import fs from 'fs';
+import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -238,7 +238,7 @@ describe('SyncEngine create payload projectId behavior', () => {
         vi.spyOn(WorkflowTransformerAdapter, 'convertToTypeScript').mockResolvedValue('// generated');
 
         // A 400 whose body mentions "folder" but not "parentFolderId" / "parentFolder" must NOT be
-        // misclassified as "unsupported parentFolderId" â€” that would silently drop the folder assignment
+        // misclassified as "unsupported parentFolderId" — that would silently drop the folder assignment
         // on n8n instances that DO support it.
         const genericFolderError: any = new Error('Request failed with status code 400');
         genericFolderError.response = {
@@ -322,7 +322,7 @@ describe('SyncEngine create payload projectId behavior', () => {
 // ---------------------------------------------------------------------------
 //
 // Mirrors the create-path folderSync tests but for executeUpdate(). The update
-// path used to drop `parentFolderId` on the floor â€” both because
+// path used to drop `parentFolderId` on the floor — both because
 // `inferParentFolderIdFromFilename` was only called from executeCreate(), and
 // because `N8nApiClient.cleanWorkflowUpdatePayload()` did not include
 // `parentFolderId` in its allowedKeys set. Both are fixed; these tests guard
@@ -529,7 +529,7 @@ describe('SyncEngine update payload folderSync behavior', () => {
         // Snapshot each call's payload at call time. Vitest's vi.fn() records
         // arguments by live reference, and SyncEngine mutates the same localWf
         // between the two updateWorkflow calls (sets parentFolderId, then
-        // deletes it in the catch block) â€” so the recorded `calls` would
+        // deletes it in the catch block) — so the recorded `calls` would
         // reflect the post-mutation object by the time the assertion runs.
         // Capturing { ...payload } at each call preserves call-time state.
         // Same pattern as the create-side fix in commit c801ff43.

--- a/packages/cli/tests/unit/sync-manager.test.ts
+++ b/packages/cli/tests/unit/sync-manager.test.ts
@@ -170,7 +170,36 @@ describe('SyncManager push filename contract', () => {
         expect(refreshLocalState).toHaveBeenCalledOnce();
         expect(getWorkflowIdForFilename).toHaveBeenCalledWith(workflowFilename);
         expect(refreshLocalState.mock.invocationCallOrder[0]).toBeLessThan(getWorkflowIdForFilename.mock.invocationCallOrder[0]);
-        expect(push).toHaveBeenCalledWith(workflowFilename, 'wf-123', expect.any(String));
+        expect(push).toHaveBeenCalledWith(workflowFilename, 'wf-123', expect.any(String), undefined);
+    });
+
+    // Dropping this argument would silently turn every `--draft` push into a
+    // release, which is the one thing the flag exists to prevent.
+    it('forwards draft intent to the sync engine', async () => {
+        const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-sync-manager-'));
+        const manager = new SyncManager(new MockN8nApiClient() as any, {
+            directory: workspaceDir,
+            workflowsPath: workspaceDir,
+            projectId: 'personal',
+            projectName: 'Personal',
+        } as any);
+
+        const workflowFilename = 'draftable.workflow.ts';
+        fs.writeFileSync(path.join(workspaceDir, workflowFilename), '// workflow placeholder', 'utf-8');
+
+        const push = vi.fn(async () => 'wf-123');
+        (manager as any).ensureInitialized = vi.fn(async () => undefined);
+        (manager as any).watcher = {
+            getDirectory: () => workspaceDir,
+            refreshLocalState: vi.fn(async () => undefined),
+            getWorkflowIdForFilename: vi.fn(() => 'wf-123'),
+            isRemoteKnown: vi.fn(() => true),
+        };
+        (manager as any).syncEngine = { push };
+
+        await manager.push(path.join(workspaceDir, workflowFilename), { draft: true });
+
+        expect(push).toHaveBeenCalledWith(workflowFilename, 'wf-123', expect.any(String), { draft: true });
     });
 
     it('uses an explicit workflowsPath as the active sync scope', async () => {

--- a/packages/skills/src/agent-skills/n8n-architect/SKILL.md
+++ b/packages/skills/src/agent-skills/n8n-architect/SKILL.md
@@ -168,6 +168,7 @@ Instance and tunnel operations are per managed local instance:
 ```
 
 - `push` requires the full workflow file path, either absolute or context-root-relative. Do not pass a bare filename.
+- On n8n 2.x, pushing to a **published** workflow also releases it to production — the API re-publishes on update. Treat every push to a published workflow as a deploy. Use `push --draft` when the user wants to check the change in n8n first: it re-pins the previously published version so production keeps running what it already ran.
 - For a new workflow, create the file inside the `workflowsPath` returned by `env status --json`, then confirm it with `{{N8NAC_CMD}} list --local`.
 - If push/pull reports a conflict, use explicit resolution commands. Do not overwrite remote changes blindly.
 - `pull` and conflict resolution operate on a single workflow ID.

--- a/plugins/claude/n8n-as-code/skills/n8n-architect/SKILL.md
+++ b/plugins/claude/n8n-as-code/skills/n8n-architect/SKILL.md
@@ -168,6 +168,7 @@ npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
 ```
 
 - `push` requires the full workflow file path, either absolute or context-root-relative. Do not pass a bare filename.
+- On n8n 2.x, pushing to a **published** workflow also releases it to production — the API re-publishes on update. Treat every push to a published workflow as a deploy. Use `push --draft` when the user wants to check the change in n8n first: it re-pins the previously published version so production keeps running what it already ran.
 - For a new workflow, create the file inside the `workflowsPath` returned by `env status --json`, then confirm it with `npx --yes n8nac list --local`.
 - If push/pull reports a conflict, use explicit resolution commands. Do not overwrite remote changes blindly.
 - `pull` and conflict resolution operate on a single workflow ID.

--- a/plugins/cursor/n8n-as-code/skills/n8n-architect/SKILL.md
+++ b/plugins/cursor/n8n-as-code/skills/n8n-architect/SKILL.md
@@ -168,6 +168,7 @@ npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
 ```
 
 - `push` requires the full workflow file path, either absolute or context-root-relative. Do not pass a bare filename.
+- On n8n 2.x, pushing to a **published** workflow also releases it to production — the API re-publishes on update. Treat every push to a published workflow as a deploy. Use `push --draft` when the user wants to check the change in n8n first: it re-pins the previously published version so production keeps running what it already ran.
 - For a new workflow, create the file inside the `workflowsPath` returned by `env status --json`, then confirm it with `npx --yes n8nac list --local`.
 - If push/pull reports a conflict, use explicit resolution commands. Do not overwrite remote changes blindly.
 - `pull` and conflict resolution operate on a single workflow ID.

--- a/plugins/openclaw/n8n-as-code/skills/n8n-architect/SKILL.md
+++ b/plugins/openclaw/n8n-as-code/skills/n8n-architect/SKILL.md
@@ -168,6 +168,7 @@ npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
 ```
 
 - `push` requires the full workflow file path, either absolute or context-root-relative. Do not pass a bare filename.
+- On n8n 2.x, pushing to a **published** workflow also releases it to production — the API re-publishes on update. Treat every push to a published workflow as a deploy. Use `push --draft` when the user wants to check the change in n8n first: it re-pins the previously published version so production keeps running what it already ran.
 - For a new workflow, create the file inside the `workflowsPath` returned by `env status --json`, then confirm it with `npx --yes n8nac list --local`.
 - If push/pull reports a conflict, use explicit resolution commands. Do not overwrite remote changes blindly.
 - `pull` and conflict resolution operate on a single workflow ID.

--- a/skills/n8n-architect/SKILL.md
+++ b/skills/n8n-architect/SKILL.md
@@ -168,6 +168,7 @@ npx --yes n8nac push <path-to-workflow.workflow.ts> --verify
 ```
 
 - `push` requires the full workflow file path, either absolute or context-root-relative. Do not pass a bare filename.
+- On n8n 2.x, pushing to a **published** workflow also releases it to production — the API re-publishes on update. Treat every push to a published workflow as a deploy. Use `push --draft` when the user wants to check the change in n8n first: it re-pins the previously published version so production keeps running what it already ran.
 - For a new workflow, create the file inside the `workflowsPath` returned by `env status --json`, then confirm it with `npx --yes n8nac list --local`.
 - If push/pull reports a conflict, use explicit resolution commands. Do not overwrite remote changes blindly.
 - `pull` and conflict resolution operate on a single workflow ID.


### PR DESCRIPTION
Closes #563.

## The problem

On n8n 2.x a workflow is a **draft** (its content) plus a **published version** (a pointer to what production runs). `PUT /workflows/:id` writes the draft and, when the workflow is published, moves the pointer with it — the public API offers no opt-out.

So the same `n8nac push` does two different things depending on a state you cannot see from the terminal:

| Workflow state | What `push` does |
|---|---|
| not published | writes the draft; nothing runs in production |
| published | writes the draft **and** releases it — the UI equivalent of Save + Publish |

The second case was never announced. That is the actual defect.

## What this does

**The default stays a release.** `push` is a deploy command, and working around the API for everyone would make every user depend on a non-atomic rollback they never asked for. What changes is that push now says what it is about to do, *before* the update lands — after the fact it would be a notification, not a warning:

```
⚠  "my-workflow.workflow.ts" is published — this push releases it to production.
✔ Pushed workflow my-workflow.workflow.ts.
```

**`--draft` opts into the workaround** for the case in the issue — no separate staging instance, and a change to eyeball in n8n before real triggers fire against it:

```
✔ Pushed workflow my-workflow.workflow.ts.
📝 Draft updated — production still runs version 8f3c1e2a.
   Release it by pushing again without --draft.
```

It captures the published version, pushes, and re-pins it.

**No behaviour change for existing users.** The default push is what it has always been, and creates stay unpublished as n8n makes them. Nothing to migrate, no semver question.

## What `--draft` does and does not guarantee

- **It is a rollback, not a no-op.** The pushed content is briefly live between the PUT and the re-pin, so a webhook or schedule firing at that instant can run it.
- **Version history gets two entries** per `--draft` push against a published workflow.
- **If the re-pin fails, the push fails**, naming the version id to re-publish manually. It never reports success while leaving unreleased content in production.
- **It refuses rather than pretending** when it cannot keep the promise: on n8n 1.x (no version pointer — an active workflow runs the content it holds), and when the published version cannot be read. In both cases nothing has been sent yet, so refusing costs nothing.

A default push with an unreadable published version still goes through — the PUT would fail on the same transport if the instance were truly unreachable — and reports that it could not tell.

## Notes for review

**Why not draft-by-default.** That was the first version of this PR, and @TheSmartMonkey's [comment](https://github.com/EtienneLescot/n8n-as-code/issues/563#issuecomment-5078914174) plus a second look changed it. Making the safe path the default sounds better until you notice it puts *everyone* on an emulated, non-atomic publish-then-rollback — including the majority who only ever wanted a deploy. Opt-in keeps the impurity where someone asked for it.

**`workflow activate` is untouched.** No second "publish"-named flag, so the collision raised in the issue discussion never arises. Deciding what `workflow activate` should mean under n8n 2.0 stays a separate question.

**`updatedAt` bookkeeping.** Re-pinning touches the workflow again, so the post-restore timestamp is recorded as the sync base; keeping the PUT's would make the next push report a phantom "modified in the n8n UI" conflict. Covered by a test.

**Scope.** The `--draft` path is only on `push`. `forcePush` (conflict resolution, `resolve --mode keep-current`) behaves exactly as before.

**Pre-existing Windows issue.** `packages/skills/scripts/build-skill-adapters.js` fails on Windows, so the four generated `SKILL.md` copies were patched by hand to match what the generator emits. Fixed separately in #583; CI on Linux confirms they are in sync.

## Testing

`vitest run tests/unit tests/scenarios tests/integration/*.test.ts` in `packages/cli` — 326 passed. New coverage:

- a default push on a published workflow releases it and calls no activate;
- the announcement fires while `updateWorkflow` has not been called yet;
- `--draft` re-pins the previously published version, reading the pointer before the PUT;
- the post-restore `updatedAt` is the sync base, with a fresh-read fallback when the activate response omits it;
- unpublished workflows are left alone;
- `--draft` refuses on an unreadable pointer and on n8n 1.x, without sending the PUT;
- a default push still goes through in both those situations;
- a failed re-pin rejects with the version id and does not finalize the sync;
- creates are never published, in either mode;
- both API payload shapes (`activeVersion.id` and `activeVersionId`) resolve, and `publishWorkflowVersion` propagates failures instead of swallowing them like `activateWorkflow` does.

Not exercised against a live n8n 2.x instance — worth a manual pass on a published workflow before merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--draft` option to update published workflows while keeping the previously published version running.
  * Pushes now report whether changes go live, remain unpublished, or restore a prior published version.
  * Added draft-push support to the programmatic API.
  * Added safeguards for unavailable published-version information and restoration failures.

* **Documentation**
  * Clarified n8n 2.x publishing behavior, draft workflows, restoration, and n8n 1.x limitations.
  * Updated CLI and assistant guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->