### PR TITLE
chore(build): make the skill-adapter chain work and fail loudly on Windows

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -25,7 +25,12 @@ pre-commit:
         - "packages/skills/src/services/ai-context-generator.ts"
         - "packages/skills/src/agent-skills/**"
         - "packages/skills/scripts/build-skill-adapters.js"
+      # `set -e` is load-bearing. Without it this block reported success with a
+      # failing `postbuild` and a failing generator — the commit went through
+      # carrying stale SKILL.md files, which is exactly what the hook exists to
+      # prevent. Verified both ways against a deliberately broken generator.
       run: |
+        set -e
         npx tsc -b packages/skills
         npm run postbuild --workspace=packages/skills
         node packages/skills/scripts/build-skill-adapters.js

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -9,7 +9,7 @@
     "scripts": {
         "prebuild": "node ../../scripts/ensure-n8n-cache.cjs && node ../../scripts/stamp-n8n-version.cjs && node ../../scripts/generate-n8n-index.cjs && node ../../scripts/generate-credential-ontology.cjs && node ../../scripts/download-complete-docs.cjs && node ../../scripts/build-complete-index.cjs && node ../../scripts/enrich-nodes-technical.cjs && node ../../scripts/build-knowledge-index.cjs && node ../../scripts/build-workflow-index.cjs",
         "build": "tsc -b",
-        "postbuild": "rm -rf dist/agent-skills && mkdir -p dist/assets dist/agent-skills && cp src/assets/*.json dist/assets/ && cp -R src/agent-skills/* dist/agent-skills/",
+        "postbuild": "node scripts/postbuild.mjs",
         "clean": "rm -rf dist tsconfig.tsbuildinfo",
         "test": "node --experimental-vm-modules ../../node_modules/.bin/jest",
         "build:adapters": "node scripts/build-skill-adapters.js",

--- a/packages/skills/scripts/build-skill-adapters.js
+++ b/packages/skills/scripts/build-skill-adapters.js
@@ -7,7 +7,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { execFileSync } from 'child_process';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -47,7 +47,10 @@ async function getAiContextGenerator() {
   if (!fs.existsSync(distPath)) {
     throw new Error('AiContextGenerator not found in dist/. Please run "npm run build --workspace=packages/skills" first.');
   }
-  const mod = await import(distPath);
+  // A bare absolute path is a valid ESM specifier only on POSIX. On Windows the
+  // loader reads `C:\...` as a URL with the scheme `c:` and refuses it, so the
+  // path has to become a file:// URL first.
+  const mod = await import(pathToFileURL(distPath).href);
   return new mod.AiContextGenerator();
 }
 

--- a/packages/skills/scripts/postbuild.mjs
+++ b/packages/skills/scripts/postbuild.mjs
@@ -1,0 +1,41 @@
+/**
+ * Stages the non-TypeScript build outputs: JSON assets and the canonical agent
+ * skill sources that `build-skill-adapters.js` reads from `dist/`.
+ *
+ * This used to be an inline `rm -rf && mkdir -p && cp` chain in package.json.
+ * npm runs lifecycle scripts through cmd.exe on Windows, where `mkdir -p` hits
+ * the shell builtin and fails, so the whole pre-commit adapter chain died there.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const distDir = path.join(packageDir, 'dist');
+const agentSkillsDist = path.join(distDir, 'agent-skills');
+const assetsDist = path.join(distDir, 'assets');
+
+// Rebuilt from scratch so a renamed or deleted skill does not linger in dist.
+fs.rmSync(agentSkillsDist, { recursive: true, force: true });
+fs.mkdirSync(agentSkillsDist, { recursive: true });
+fs.mkdirSync(assetsDist, { recursive: true });
+
+// `src/assets` is gitignored and produced by `prebuild`, so it is absent on a
+// checkout that has never run a full build. The agent-skill staging below is
+// what the pre-commit adapter chain needs, and it must not be held hostage to
+// the multi-minute node/docs indexing — warn and carry on instead.
+const assetsSrc = path.join(packageDir, 'src', 'assets');
+if (fs.existsSync(assetsSrc)) {
+  for (const entry of fs.readdirSync(assetsSrc)) {
+    if (!entry.endsWith('.json')) continue;
+    fs.copyFileSync(path.join(assetsSrc, entry), path.join(assetsDist, entry));
+  }
+} else {
+  console.warn(
+    '[skills postbuild] src/assets is missing, so no JSON assets were staged into dist/assets. ' +
+    'Run "npm run prebuild --workspace=packages/skills" to generate them before publishing.'
+  );
+}
+
+fs.cpSync(path.join(packageDir, 'src', 'agent-skills'), agentSkillsDist, { recursive: true });

--- a/packages/skills/scripts/postbuild.mjs
+++ b/packages/skills/scripts/postbuild.mjs
@@ -16,8 +16,10 @@ const distDir = path.join(packageDir, 'dist');
 const agentSkillsDist = path.join(distDir, 'agent-skills');
 const assetsDist = path.join(distDir, 'assets');
 
-// Rebuilt from scratch so a renamed or deleted skill does not linger in dist.
+// Both are rebuilt from scratch so a renamed or deleted skill or asset does
+// not linger in dist on incremental builds.
 fs.rmSync(agentSkillsDist, { recursive: true, force: true });
+fs.rmSync(assetsDist, { recursive: true, force: true });
 fs.mkdirSync(agentSkillsDist, { recursive: true });
 fs.mkdirSync(assetsDist, { recursive: true });
 


### PR DESCRIPTION
The pre-commit chain that regenerates the committed `SKILL.md` mirrors was broken on Windows in three separate places. The last one is the reason it went unnoticed.

## 1. `build-skill-adapters.js` — `ERR_UNSUPPORTED_ESM_URL_SCHEME`

```
cd packages/skills && node scripts/build-skill-adapters.js
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: … Received protocol 'c:'
```

`getAiContextGenerator()` passed a raw absolute path to `await import()`. That is a valid ESM specifier only on POSIX; on Windows the loader parses `C:\...` as a URL with the scheme `c:` and refuses it. Wrapped in `pathToFileURL()`, which is already how `scripts/generate-n8n-index.cjs`, `scripts/generate-credential-ontology.cjs` and `smoke-vsix-runtime.mjs` import computed paths.

## 2. `packages/skills` postbuild — `mkdir -p` under cmd.exe

```
npm run postbuild --workspace=packages/skills
> rm -rf dist/agent-skills && mkdir -p dist/assets dist/agent-skills && cp …
La syntaxe de la commande n'est pas correcte.
npm error code 1
```

npm runs lifecycle scripts through `cmd.exe` on Windows, where `mkdir -p` hits the shell builtin and fails. Moved to `scripts/postbuild.mjs`, mirroring the existing `packages/cli/scripts/postbuild.mjs`.

One behaviour change: the JSON asset copy now warns and continues when `src/assets` is missing. That directory is gitignored and generated by `prebuild`, and the adapter chain does not read it — a contributor editing a skill should not have to run the multi-minute node/docs indexing first. CI runs `prebuild`, so the copy still happens there.

## 3. The hook reported success anyway — this is the important one

With both of the above failing, `regen-skill-adapters` printed a green check and the commit went through carrying stale `SKILL.md` files. That is precisely what the hook exists to prevent, and it is why #1 and #2 could sit there unnoticed.

`set -e` fixes it. Verified both directions against a deliberately broken generator, same staged files each time:

| Block | Result |
|---|---|
| without `set -e`, broken generator | `✓ regen-skill-adapters`, exit 0 — commit allowed |
| with `set -e`, broken generator | `✗ regen-skill-adapters`, exit 1 — commit blocked |
| with `set -e`, fixed generator | `✓ regen-skill-adapters`, exit 0 |

## Verification

```
node packages/skills/scripts/build-skill-adapters.js --check   → exit 0
npx lefthook run pre-commit                                    → both commands ✓
```

The generator reproduces the committed mirrors byte-for-byte on Windows: after running it, `git diff` on `skills/` and `plugins/*/n8n-as-code/skills/` is empty.

## Note on the commit type

Tagged `chore(build)`, not `fix`. release-please maps commits to packages by path, so a `fix` touching `packages/skills/**` would cut a patch release of `@n8n-as-code/skills` and put a user-facing changelog entry on a change that ships no code — `dist/` output is unchanged and only build scripts moved. Retitle if you would rather it release.

Found while working on #563: the hook silently no-oped, so the generated `SKILL.md` copies in #582 had to be patched by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for building skill adapters on Windows.
  * Build hooks now stop immediately when a command fails, preventing incomplete outputs.
  * Prevented outdated or removed skills and assets from remaining in distribution packages.

* **Chores**
  * Updated the post-build process to reliably package agent skills and asset files.
  * Added clearer handling when expected asset files are unavailable during packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->