### PR TITLE
test(scripts): run the mcp suite in npm test, and scope ci.yml permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, next ]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/scripts/unified-test-report.mjs
+++ b/scripts/unified-test-report.mjs
@@ -15,6 +15,7 @@ const testSuites = [
     { section: 'Unit Tests', name: 'cli', pkg: 'n8nac', cmd: 'npm', args: ['test', '--workspace=n8nac'] },
     { section: 'Unit Tests', name: 'openclaw', pkg: '@n8n-as-code/n8nac', cmd: 'npm', args: ['test', '--workspace=@n8n-as-code/n8nac'] },
     { section: 'Unit Tests', name: 'vscode-unit', pkg: 'n8n-as-code', cmd: 'npm', args: ['run', 'test', '--workspace=packages/vscode-extension'] },
+    { section: 'Unit Tests', name: 'mcp', pkg: '@n8n-as-code/mcp', cmd: 'npm', args: ['test', '--workspace=@n8n-as-code/mcp'] },
     { section: 'Integration Tests', name: 'cli-live', pkg: 'n8nac', cmd: 'npm', args: ['run', 'test:integration', '--workspace=n8nac'] }
 ];
 
@@ -66,7 +67,9 @@ async function runTest(suite) {
             }
 
             // Parse counts (even if it failed, we want the stats if available)
-            if (scenarioMatches.length === 0 && (suite.name === 'transformer' || suite.name === 'skills' || suite.name === 'cli' || suite.name === 'openclaw' || suite.name === 'vscode-unit')) {
+            // Derived from the section rather than a second hand-maintained name list, so a new
+            // unit suite only has to be added to testSuites above.
+            if (scenarioMatches.length === 0 && suite.section === 'Unit Tests') {
                 // Support both Vitest and Jest formats:
                 // Vitest: "Tests  53 passed (53)"
                 // Jest: "Tests:       29 passed, 29 total"


### PR DESCRIPTION
Picks up two of the smaller findings in #585. The packaging fix is already covered by #586; this is scoped to the test-runner and CI items only.

## `packages/mcp` tests never ran

`scripts/unified-test-report.mjs` listed six suites — transformer, skills, cli, openclaw, vscode-unit, cli-live — but not `@n8n-as-code/mcp`, so its four test files never executed under `npm test`.

Running the suite standalone confirms it is healthy and safe to wire in:

```
Test Suites: 4 passed, 4 total
Tests:       3 skipped, 23 passed, 26 total
```

The three skips are `native-mcp-live.integration.test.ts`, which already self-skips via `describeLive` when no live config is present — so adding the suite does not make `npm test` require a live n8n.

The count parser kept a **second** hand-maintained list of suite names (`suite.name === 'transformer' || ... || 'vscode-unit'`). That is the same failure mode as the original bug: adding `mcp` to only one of the two lists would have run the suite but silently mis-parsed its totals. Since that list was exactly the `Unit Tests` section, it is now derived from `suite.section`, so a new unit suite only has to be added in one place.

Verified the derived set is identical to the old hardcoded one plus `mcp`, and that the parser returns `passed=23 failed=0` against the real jest output above (and `failed=2` against a failing-run summary).

## `ci.yml` had no `permissions:` block

It inherited the repository default on a job that runs a full build with `N8N_API_KEY` in env, while every other workflow scopes its own. Added a top-level `permissions: contents: read`, matching `claude-plugin.yml`.

`read` is sufficient — nothing in the job writes to the repository; the generated-skills verification step is `git diff --quiet` only. All seven workflow files still parse.

## Not included: the pnpm step is not vestigial

#585 also suggests removing the `pnpm/action-setup@v2` step from `ci.yml` since the next step is `npm install`. **That one is a false positive and I have deliberately left it alone.**

`npm run build` → `generate:nodes` → `scripts/ensure-n8n-cache.cjs`, which shells out to pnpm inside the cloned n8n repo:

```js
run('pnpm install', CACHE_DIR, { CI: 'true' });
run('pnpm build --filter n8n-nodes-base...', CACHE_DIR);
run('pnpm build --filter @n8n/n8n-nodes-langchain', CACHE_DIR);
```

Removing the setup step would break the build. That is also why every other workflow that builds installs pnpm first.
