### PR TITLE
fix(transformer): persist disabled, notes and notesInFlow through workflow round-trip

### DIFF
--- a/packages/cli/src/core/assets/n8n-workflows.d.ts
+++ b/packages/cli/src/core/assets/n8n-workflows.d.ts
@@ -116,6 +116,12 @@ declare module '@n8n-as-code/transformer' {
         maxTries?: number;
         /** Milliseconds to wait between retries (used with retryOnFail) */
         waitBetweenTries?: number;
+        /** Whether the node is disabled */
+        disabled?: boolean;
+        /** Notes/documentation for this node */
+        notes?: string;
+        /** Display notes directly on the workflow canvas */
+        notesInFlow?: boolean;
     }
 
     // =========================================================================

--- a/packages/transformer/src/compiler/typescript-parser.ts
+++ b/packages/transformer/src/compiler/typescript-parser.ts
@@ -180,6 +180,9 @@ export class TypeScriptParser {
                 ...(metadata.retryOnFail !== undefined && { retryOnFail: metadata.retryOnFail }),
                 ...(metadata.maxTries !== undefined && { maxTries: metadata.maxTries }),
                 ...(metadata.waitBetweenTries !== undefined && { waitBetweenTries: metadata.waitBetweenTries }),
+                ...(metadata.disabled !== undefined && { disabled: metadata.disabled }),
+                ...(metadata.notes !== undefined && { notes: metadata.notes }),
+                ...(metadata.notesInFlow !== undefined && { notesInFlow: metadata.notesInFlow }),
                 parameters
                 // aiDependencies will be added by extractAIDependencies()
             });

--- a/packages/transformer/src/compiler/workflow-builder.ts
+++ b/packages/transformer/src/compiler/workflow-builder.ts
@@ -103,6 +103,15 @@ export class WorkflowBuilder {
             if (node.waitBetweenTries !== undefined) {
                 n8nNode.waitBetweenTries = node.waitBetweenTries;
             }
+            if (node.disabled !== undefined) {
+                n8nNode.disabled = node.disabled;
+            }
+            if (node.notes !== undefined) {
+                n8nNode.notes = node.notes;
+            }
+            if (node.notesInFlow !== undefined) {
+                n8nNode.notesInFlow = node.notesInFlow;
+            }
             
             return n8nNode;
         });

--- a/packages/transformer/src/decorators/index.ts
+++ b/packages/transformer/src/decorators/index.ts
@@ -12,6 +12,7 @@ export { createNodeProxy, createOutputReference } from './helpers.js';
 export type {
     WorkflowDecoratorMetadata,
     NodeDecoratorMetadata,
+    NodeDecoratorOptions,
     NodeProxy,
     OutputConnection,
     InputConnection,

--- a/packages/transformer/src/decorators/types.ts
+++ b/packages/transformer/src/decorators/types.ts
@@ -71,7 +71,18 @@ export interface NodeDecoratorMetadata {
 
     /** Milliseconds to wait between retries (used with retryOnFail) */
     waitBetweenTries?: number;
+
+    /** Whether the node is disabled */
+    disabled?: boolean;
+
+    /** Notes/documentation for this node */
+    notes?: string;
+
+    /** Display notes directly on the workflow canvas */
+    notesInFlow?: boolean;
 }
+
+export type NodeDecoratorOptions = NodeDecoratorMetadata;
 
 // =====================================================================
 // RUNTIME HELPERS (for .uses(), .out(), .to(), etc.)

--- a/packages/transformer/src/index.ts
+++ b/packages/transformer/src/index.ts
@@ -14,6 +14,7 @@ export {
 export type {
     WorkflowDecoratorMetadata,
     NodeDecoratorMetadata,
+    NodeDecoratorOptions,
     NodeProxy,
     OutputConnection,
     InputConnection,
@@ -30,6 +31,8 @@ export { WorkflowBuilder } from './compiler/index.js';
 export type {
     WorkflowAST,
     NodeAST,
+    IAstNode,
+    INodeMetadata,
     ConnectionAST,
     WorkflowMetadata,
     N8nWorkflow,

--- a/packages/transformer/src/parser/ast-to-typescript.ts
+++ b/packages/transformer/src/parser/ast-to-typescript.ts
@@ -109,6 +109,7 @@ export class AstToTypeScriptGenerator {
             if (n.alwaysOutputData) flags.push('[alwaysOutput]');
             if (n.executeOnce) flags.push('[executeOnce]');
             if (n.retryOnFail) flags.push('[retry]');
+            if (n.disabled) flags.push('[disabled]');
             for (const role of subNodeRoles.get(n.propertyName) ?? []) flags.push(`[${role}]`);
             lines.push(`// ${prop} ${t} ${flags.join(' ')}`);
         }
@@ -350,6 +351,16 @@ export class AstToTypeScriptGenerator {
         }
         if (node.waitBetweenTries !== undefined) {
             parts.push(`waitBetweenTries: ${node.waitBetweenTries}`);
+        }
+        
+        if (node.disabled !== undefined) {
+            parts.push(`disabled: ${node.disabled}`);
+        }
+        if (node.notes !== undefined) {
+            parts.push(`notes: ${JSON.stringify(node.notes)}`);
+        }
+        if (node.notesInFlow !== undefined) {
+            parts.push(`notesInFlow: ${node.notesInFlow}`);
         }
         
         return `{\n        ${parts.join(',\n        ')}\n    }`;

--- a/packages/transformer/src/parser/json-to-ast.ts
+++ b/packages/transformer/src/parser/json-to-ast.ts
@@ -96,6 +96,9 @@ export class JsonToAstParser {
             ...(node.retryOnFail !== undefined && { retryOnFail: node.retryOnFail }),
             ...(node.maxTries !== undefined && { maxTries: node.maxTries }),
             ...(node.waitBetweenTries !== undefined && { waitBetweenTries: node.waitBetweenTries }),
+            ...(node.disabled !== undefined && { disabled: node.disabled }),
+            ...(node.notes !== undefined && { notes: node.notes }),
+            ...(node.notesInFlow !== undefined && { notesInFlow: node.notesInFlow }),
         };
     }
     

--- a/packages/transformer/src/types.ts
+++ b/packages/transformer/src/types.ts
@@ -82,6 +82,11 @@ export interface NodeAST {
     retryOnFail?: boolean;
     maxTries?: number;
     waitBetweenTries?: number;
+
+    // Node state & documentation
+    disabled?: boolean;
+    notes?: string;
+    notesInFlow?: boolean;
     
     // Node parameters (property value in TypeScript)
     parameters: Record<string, any>;
@@ -190,7 +195,18 @@ export interface N8nNode {
     retryOnFail?: boolean;
     maxTries?: number;
     waitBetweenTries?: number;
+
+    // Node state & documentation
+    disabled?: boolean;
+    notes?: string;
+    notesInFlow?: boolean;
 }
+
+/**
+ * Type aliases for AST / Metadata nodes
+ */
+export type IAstNode = NodeAST;
+export type INodeMetadata = NodeAST;
 
 /**
  * n8n connections structure

--- a/packages/transformer/tests/json-to-typescript.test.ts
+++ b/packages/transformer/tests/json-to-typescript.test.ts
@@ -440,4 +440,137 @@ export class AiTestWorkflow {
         expect(tsCode).toMatch(/AlwaysOutputNode\s+set\s+.*\[alwaysOutput\].*\[retry\]/);
         expect(tsCode).toMatch(/OnceNode\s+set\s+.*\[executeOnce\]/);
     });
+
+    it('should preserve disabled, notes, and notesInFlow through JSON → AST → TypeScript', async () => {
+        const workflowJson = {
+            id: 'wf-disabled-notes-1',
+            name: 'Disabled and Notes Workflow',
+            active: false,
+            nodes: [
+                {
+                    id: 'node-dn-1',
+                    name: 'My Configured Node',
+                    type: 'n8n-nodes-base.set',
+                    typeVersion: 3,
+                    position: [100, 200],
+                    parameters: { mode: 'manual' },
+                    disabled: true,
+                    notes: 'important notes',
+                    notesInFlow: true,
+                },
+            ],
+            connections: {},
+            settings: {},
+        };
+
+        const parser = new JsonToAstParser();
+        const ast = parser.parse(workflowJson as any);
+
+        expect(ast.nodes[0].disabled).toBe(true);
+        expect(ast.nodes[0].notes).toBe('important notes');
+        expect(ast.nodes[0].notesInFlow).toBe(true);
+
+        const generator = new AstToTypeScriptGenerator();
+        const tsCode = await generator.generate(ast, { format: false, commentStyle: 'minimal' });
+
+        expect(tsCode).toContain('disabled: true');
+        expect(tsCode).toContain('notes: "important notes"');
+        expect(tsCode).toContain('notesInFlow: true');
+    });
+
+    it('should preserve disabled, notes, and notesInFlow through full pull→push roundtrip', async () => {
+        const workflowJson = {
+            id: 'wf-roundtrip-disabled-notes',
+            name: 'Roundtrip Disabled Notes Workflow',
+            active: false,
+            nodes: [
+                {
+                    id: 'node-dn-rt-1',
+                    name: 'Special Node',
+                    type: 'n8n-nodes-base.set',
+                    typeVersion: 3,
+                    position: [100, 200],
+                    parameters: { mode: 'manual' },
+                    disabled: true,
+                    notes: 'important notes with "quotes" and \\backslashes\\',
+                    notesInFlow: true,
+                },
+                {
+                    id: 'node-dn-rt-2',
+                    name: 'Normal Node',
+                    type: 'n8n-nodes-base.set',
+                    typeVersion: 3,
+                    position: [300, 200],
+                    parameters: { mode: 'manual' },
+                    disabled: false,
+                },
+            ],
+            connections: {},
+            settings: {},
+        };
+
+        // JSON → AST → TypeScript
+        const jsonParser = new JsonToAstParser();
+        const ast1 = jsonParser.parse(workflowJson as any);
+        const generator = new AstToTypeScriptGenerator();
+        const tsCode = await generator.generate(ast1, { format: false, commentStyle: 'minimal' });
+
+        expect(tsCode).toContain('disabled: true');
+        expect(tsCode).toContain('notesInFlow: true');
+        expect(tsCode).toContain('disabled: false');
+
+        // TypeScript → AST → JSON
+        const tsParser = new TypeScriptParser();
+        const ast2 = await tsParser.parseCode(tsCode);
+
+        // Verify AST2
+        expect(ast2.nodes[0].disabled).toBe(true);
+        expect(ast2.nodes[0].notes).toBe('important notes with "quotes" and \\backslashes\\');
+        expect(ast2.nodes[0].notesInFlow).toBe(true);
+        expect(ast2.nodes[1].disabled).toBe(false);
+        expect(ast2.nodes[1].notes).toBeUndefined();
+        expect(ast2.nodes[1].notesInFlow).toBeUndefined();
+
+        const builder = new WorkflowBuilder();
+        const rebuilt = builder.build(ast2);
+
+        // Verify rebuilt JSON
+        const node1 = rebuilt.nodes[0];
+        expect(node1.disabled).toBe(true);
+        expect(node1.notes).toBe('important notes with "quotes" and \\backslashes\\');
+        expect(node1.notesInFlow).toBe(true);
+
+        const node2 = rebuilt.nodes[1];
+        expect(node2.disabled).toBe(false);
+        expect(node2.notes).toBeUndefined();
+        expect(node2.notesInFlow).toBeUndefined();
+    });
+
+    it('should emit [disabled] flag in workflow-map for disabled nodes', async () => {
+        const workflowJson = {
+            id: 'wf-flags-disabled',
+            name: 'Disabled Flags Workflow',
+            active: false,
+            nodes: [
+                {
+                    id: 'node-disabled-1',
+                    name: 'Inactive Node',
+                    type: 'n8n-nodes-base.set',
+                    typeVersion: 3,
+                    position: [0, 0],
+                    parameters: {},
+                    disabled: true,
+                },
+            ],
+            connections: {},
+            settings: {},
+        };
+
+        const parser = new JsonToAstParser();
+        const ast = parser.parse(workflowJson as any);
+        const generator = new AstToTypeScriptGenerator();
+        const tsCode = await generator.generate(ast, { format: false });
+
+        expect(tsCode).toMatch(/InactiveNode\s+set\s+.*\[disabled\]/);
+    });
 });


### PR DESCRIPTION
## Problem
When converting an n8n workflow JSON to TypeScript and back (pull/push round-trip), node properties \disabled\, \
otes\, and \
otesInFlow\ were silently dropped. This resulted in:
1. Disabled nodes becoming re-enabled after round-trip synchronization.
2. Canvas and node documentation notes being completely lost.
3. Canvas display preferences (\
otesInFlow\) being discarded.

## Solution
- **\packages/transformer/src/types.ts\**:
  - Added \disabled?: boolean;\, \
otes?: string;\, and \
otesInFlow?: boolean;\ to both \NodeAST\ and \N8nNode\.
  - Added type aliases \IAstNode\ and \INodeMetadata\.
- **\packages/transformer/src/decorators/types.ts\**:
  - Added \disabled\, \
otes\, and \
otesInFlow\ to \NodeDecoratorMetadata\.
  - Exported \NodeDecoratorOptions\ alias.
- **\packages/transformer/src/parser/json-to-ast.ts\**:
  - Preserved \disabled\, \
otes\, and \
otesInFlow\ in \parseNode\.
- **\packages/transformer/src/parser/ast-to-typescript.ts\**:
  - Formatted \disabled\, \
otes\ (properly escaped with \JSON.stringify\), and \
otesInFlow\ in \@node\ decorator generation.
  - Added \[disabled]\ flag in the workflow-map index.
- **\packages/transformer/src/compiler/typescript-parser.ts\**:
  - Parsed \disabled\, \
otes\, and \
otesInFlow\ from \@node\ decorator metadata into the AST representation.
- **\packages/transformer/src/compiler/workflow-builder.ts\**:
  - Assigned \disabled\, \
otes\, and \
otesInFlow\ when reconstructing n8n node JSON.
- **\packages/cli/src/core/assets/n8n-workflows.d.ts\**:
  - Updated \NodeDecoratorOptions\ interface with \disabled\, \
otes\, and \
otesInFlow\.

## Tests
- Added unit and round-trip tests in \packages/transformer/tests/json-to-typescript.test.ts\:
  - Verified JSON → AST → TypeScript preserves \disabled: true\, \
otes: 'important notes'\, and \
otesInFlow: true\.
  - Verified full round-trip (JSON → AST → TypeScript → AST → JSON) retains properties across nodes.
  - Verified \[disabled]\ flag emission in workflow-map header.
- Verified all vitest transformer test suites pass (77/77 passed).

Fixes #608, Fixes #612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workflow conversion now preserves node disabled states, notes, and note-display settings.
  - Disabled nodes are marked with a `[disabled]` indicator in workflow maps.
  - Node configuration types are publicly available for improved authoring and tooling support.

- **Bug Fixes**
  - Node metadata, including quoted text and backslashes in notes, remains intact through workflow import and export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->