### PR TITLE
fix(cli): exit non-zero when push refuses on conflict

### DIFF
--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -39,7 +39,7 @@ export class SyncCommand extends BaseCommand {
                 console.log(chalk.yellow(`To resolve the conflict you can either:`));
                 console.log(`  n8nac resolve ${workflowId} --mode keep-current`);
                 console.log(`  n8nac resolve ${workflowId} --mode keep-incoming`);
-                return;
+                process.exit(1);
             }
         }
 
@@ -88,7 +88,7 @@ export class SyncCommand extends BaseCommand {
                 console.log(chalk.yellow(`To resolve the conflict you can either:`));
                 console.log(`  n8nac resolve ${workflowId} --mode keep-current`);
                 console.log(`  n8nac resolve ${workflowId} --mode keep-incoming`);
-                return undefined;
+                process.exit(1);
             }
         }
 
@@ -117,8 +117,8 @@ export class SyncCommand extends BaseCommand {
                 if (workflowId) {
                     console.log(`  n8nac resolve ${workflowId} --mode keep-current`);
                     console.log(`  n8nac resolve ${workflowId} --mode keep-incoming`);
-                    return undefined;
                 }
+                process.exit(1);
             }
             if (e.message.includes('archived on n8n') || e.message.includes('isArchived')) {
                 spinner.stop();

--- a/packages/cli/tests/unit/sync-command.test.ts
+++ b/packages/cli/tests/unit/sync-command.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SyncCommand } from '../../src/commands/sync.js';
+import { SyncManager } from '../../src/core/services/sync-manager.js';
+import { WorkflowSyncStatus } from '../../src/core/types.js';
+import { installV4WorkspaceFixture } from '../helpers/v4-workspace-fixture.js';
+
+installV4WorkspaceFixture();
+
+// ── Mock ora (suppress spinner output) ────────────────────────────────────────
+vi.mock('ora', () => ({
+    default: () => ({
+        start: () => ({
+            stop: vi.fn(),
+            fail: vi.fn(),
+            succeed: vi.fn(),
+        }),
+    }),
+}));
+
+// ── Mock chalk (return plain strings so assertions are readable) ──────────────
+vi.mock('chalk', () => {
+    const identity = (s: string) => s;
+    const proxy: any = new Proxy(identity, {
+        get: (_target, prop) => {
+            if (prop === 'level') return 0;
+            return proxy;
+        },
+        apply: (_target, _this, args) => args[0],
+    });
+    return { default: proxy };
+});
+
+describe('SyncCommand exit codes on conflict', () => {
+    let cmd: SyncCommand;
+    let logSpy: ReturnType<typeof vi.spyOn>;
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+        errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+            throw new Error(`process.exit:${code ?? 0}`);
+        }) as never);
+
+        cmd = new SyncCommand();
+    });
+
+    describe('pushOne', () => {
+        it('exits 1 when conflict is detected before push', async () => {
+            vi.spyOn(SyncManager.prototype, 'refreshLocalState').mockResolvedValue(undefined as any);
+            vi.spyOn(SyncManager.prototype, 'resolvePushTarget').mockReturnValue({
+                filename: 'my-workflow.workflow.ts',
+                sourceDirectory: '/fake/dir',
+                resolvedPath: '/fake/dir/my-workflow.workflow.ts',
+            } as any);
+            vi.spyOn(SyncManager.prototype, 'getWorkflowIdForFilename').mockReturnValue('wf-123');
+            vi.spyOn(SyncManager.prototype, 'fetch').mockResolvedValue(true as any);
+            vi.spyOn(SyncManager.prototype, 'getSingleWorkflowDetailedStatus').mockResolvedValue({
+                status: WorkflowSyncStatus.CONFLICT,
+            } as any);
+            const recordPushRejectedSpy = vi.spyOn(SyncManager.prototype, 'recordWorkflowPushRejected').mockResolvedValue(undefined as any);
+
+            await expect(cmd.pushOne('workflows/dev/my-workflow.workflow.ts')).rejects.toThrow('process.exit:1');
+
+            expect(recordPushRejectedSpy).toHaveBeenCalledWith('my-workflow.workflow.ts', 'wf-123', 'Conflict detected before push');
+            expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Conflict detected for workflow wf-123'));
+        });
+
+        it('exits 1 when push throws "modified in the n8n UI" error', async () => {
+            vi.spyOn(SyncManager.prototype, 'refreshLocalState').mockResolvedValue(undefined as any);
+            vi.spyOn(SyncManager.prototype, 'resolvePushTarget').mockReturnValue({
+                filename: 'my-workflow.workflow.ts',
+                sourceDirectory: '/fake/dir',
+                resolvedPath: '/fake/dir/my-workflow.workflow.ts',
+            } as any);
+            vi.spyOn(SyncManager.prototype, 'getWorkflowIdForFilename').mockReturnValue('wf-123');
+            vi.spyOn(SyncManager.prototype, 'fetch').mockResolvedValue(true as any);
+            vi.spyOn(SyncManager.prototype, 'getSingleWorkflowDetailedStatus').mockResolvedValue({
+                status: WorkflowSyncStatus.MODIFIED_LOCALLY,
+            } as any);
+            vi.spyOn(SyncManager.prototype, 'push').mockRejectedValue(new Error('Workflow was modified in the n8n UI since last sync'));
+
+            await expect(cmd.pushOne('workflows/dev/my-workflow.workflow.ts')).rejects.toThrow('process.exit:1');
+            expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Conflict detected: Workflow was modified in the n8n UI since last sync'));
+        });
+
+        it('returns workflowId and does not exit on successful push', async () => {
+            vi.spyOn(SyncManager.prototype, 'refreshLocalState').mockResolvedValue(undefined as any);
+            vi.spyOn(SyncManager.prototype, 'resolvePushTarget').mockReturnValue({
+                filename: 'my-workflow.workflow.ts',
+                sourceDirectory: '/fake/dir',
+                resolvedPath: '/fake/dir/my-workflow.workflow.ts',
+            } as any);
+            vi.spyOn(SyncManager.prototype, 'getWorkflowIdForFilename').mockReturnValue('wf-123');
+            vi.spyOn(SyncManager.prototype, 'fetch').mockResolvedValue(true as any);
+            vi.spyOn(SyncManager.prototype, 'getSingleWorkflowDetailedStatus').mockResolvedValue({
+                status: WorkflowSyncStatus.MODIFIED_LOCALLY,
+            } as any);
+            vi.spyOn(SyncManager.prototype, 'push').mockResolvedValue('wf-123');
+
+            const result = await cmd.pushOne('workflows/dev/my-workflow.workflow.ts');
+            expect(result).toBe('wf-123');
+        });
+    });
+
+    describe('pullOne', () => {
+        it('exits 1 when conflict status is detected before pull', async () => {
+            vi.spyOn(SyncManager.prototype, 'refreshLocalState').mockResolvedValue(undefined as any);
+            vi.spyOn(SyncManager.prototype, 'fetch').mockResolvedValue(true as any);
+            vi.spyOn(SyncManager.prototype, 'getFilenameForId').mockReturnValue('my-workflow.workflow.ts');
+            vi.spyOn(SyncManager.prototype, 'getSingleWorkflowDetailedStatus').mockResolvedValue({
+                status: WorkflowSyncStatus.CONFLICT,
+            } as any);
+
+            await expect(cmd.pullOne('wf-123')).rejects.toThrow('process.exit:1');
+            expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Conflict detected for workflow wf-123'));
+        });
+
+        it('exits 1 when local changes conflict before pull', async () => {
+            vi.spyOn(SyncManager.prototype, 'refreshLocalState').mockResolvedValue(undefined as any);
+            vi.spyOn(SyncManager.prototype, 'fetch').mockResolvedValue(true as any);
+            vi.spyOn(SyncManager.prototype, 'getFilenameForId').mockReturnValue('my-workflow.workflow.ts');
+            vi.spyOn(SyncManager.prototype, 'getSingleWorkflowDetailedStatus').mockResolvedValue({
+                status: WorkflowSyncStatus.TRACKED,
+                localHash: 'hash-local',
+                lastSyncedHash: 'hash-synced',
+            } as any);
+
+            await expect(cmd.pullOne('wf-123')).rejects.toThrow('process.exit:1');
+            expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Conflict detected for workflow wf-123'));
+        });
+
+        it('pulls successfully without exiting when no conflict', async () => {
+            vi.spyOn(SyncManager.prototype, 'refreshLocalState').mockResolvedValue(undefined as any);
+            vi.spyOn(SyncManager.prototype, 'fetch').mockResolvedValue(true as any);
+            vi.spyOn(SyncManager.prototype, 'getFilenameForId').mockReturnValue('my-workflow.workflow.ts');
+            vi.spyOn(SyncManager.prototype, 'getSingleWorkflowDetailedStatus').mockResolvedValue({
+                status: WorkflowSyncStatus.TRACKED,
+                localHash: 'hash-same',
+                lastSyncedHash: 'hash-same',
+            } as any);
+            const pullSpy = vi.spyOn(SyncManager.prototype, 'pull').mockResolvedValue({} as any);
+
+            await cmd.pullOne('wf-123');
+            expect(pullSpy).toHaveBeenCalledWith('wf-123');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
Fixes #610

### Problem
When \
8nac push <path>\ encountered a conflict (either pre-push status check or during push with 'modified in the n8n UI'), the CLI printed conflict instructions but returned without exiting with a non-zero exit code. As a result, Node exited with code 0, causing CI/CD pipelines to report success even though nothing was pushed. Likewise, \
8nac pull\ returned without exiting non-zero on conflict or local changes.

### Solution
- In \packages/cli/src/commands/sync.ts\ (\pushOne\):
  - Call \process.exit(1)\ when \status.status === WorkflowSyncStatus.CONFLICT\.
  - Call \process.exit(1)\ in the catch handler when the error contains 'modified in the n8n UI'.
- In \packages/cli/src/commands/sync.ts\ (\pullOne\):
  - Call \process.exit(1)\ when \hasConflict || hasLocalChanges\ is detected.
- Added unit test suite in \packages/cli/tests/unit/sync-command.test.ts\ verifying \process.exit(1)\ for conflict conditions in \pushOne\ and \pullOne\.

### Testing
- Ran \
px vitest run packages/cli/tests/unit/sync-command.test.ts\ (6/6 tests passed)
- Ran \
px vitest run packages/cli/tests/unit/sync-manager.test.ts\ (11/11 tests passed)
- Ran \
px tsc --noEmit -p packages/cli/tsconfig.json\ (0 typecheck errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sync operations now terminate with an error status when workflow conflicts prevent pushing or pulling.
  * Conflict handling consistently reports failed syncs instead of continuing silently.

* **Tests**
  * Added coverage for push and pull conflict scenarios, successful pushes, and conflict-free pulls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->