### PR TITLE
fix(cli): update state filename on rename and prioritize disk scan

### DIFF
--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -36,6 +36,10 @@ const WINDOWS_RESERVED_FILENAMES = new Set([
 
 const EXPLICIT_WORKFLOW_ID_FIELD = '__n8nacExplicitWorkflowId';
 
+function workflowRelativePathToAbsolute(directory: string, filename: string): string {
+    return path.isAbsolute(filename) ? filename : path.join(directory, filename);
+}
+
 /**
  * Watcher - State Observation Component
  * 
@@ -185,6 +189,9 @@ export class WorkflowStateTracker extends EventEmitter {
             }
         }
 
+        const state = this.loadState();
+        let stateChanged = false;
+
         for (const [id, claimants] of idClaims) {
             // Remove the stale filename entry for this ID before setting the scan result
             const staleFilename = this.idToFileMap.get(id);
@@ -202,6 +209,15 @@ export class WorkflowStateTracker extends EventEmitter {
             }
             this.fileToIdMap.set(winner, id);
             this.idToFileMap.set(id, winner);
+
+            if (state.workflows[id] && state.workflows[id].filename !== winner) {
+                state.workflows[id].filename = winner;
+                stateChanged = true;
+            }
+        }
+
+        if (stateChanged) {
+            this.saveState(state);
         }
 
         // Explicit id: undefined/null means "create a new remote workflow". Do not
@@ -219,7 +235,7 @@ export class WorkflowStateTracker extends EventEmitter {
         // Recovery path: if a tracked file lost its decorator ID after a manual rewrite,
         // reconnect it using the last known filename hint from state.
         const claimedIds = new Set(idClaims.keys());
-        const state = this.loadState();
+
         for (const { filename, content } of fileContents) {
             if (content?.id) continue;
             if (content?.[EXPLICIT_WORKFLOW_ID_FIELD]) continue;
@@ -291,6 +307,7 @@ export class WorkflowStateTracker extends EventEmitter {
 
             const folderResolver = await this.createFolderResolver(remoteWorkflows);
             const state = this.loadState();
+            let stateChanged = false;
 
             // Build set of already-assigned filenames to prevent collisions
             const assignedFilenames = new Set<string>();
@@ -326,6 +343,10 @@ export class WorkflowStateTracker extends EventEmitter {
                             filename = undefined;
                         }
                     }
+                }
+
+                if (filename && !fs.existsSync(workflowRelativePathToAbsolute(this.directory, filename))) {
+                    filename = undefined;
                 }
 
                 // If no valid mapping, scan local files to discover/rediscover the workflow
@@ -372,9 +393,18 @@ export class WorkflowStateTracker extends EventEmitter {
                     this.fileToIdMap.set(filename, wf.id);
                 }
 
+                if (state.workflows[wf.id] && filename && state.workflows[wf.id].filename !== filename) {
+                    state.workflows[wf.id].filename = filename;
+                    stateChanged = true;
+                }
+
                 // In lightweight mode, we don't fetch full content or compute hashes here.
                 // We just broadcast that the workflow exists remotely.
                 this.broadcastStatus(filename, wf.id);
+            }
+
+            if (stateChanged) {
+                this.saveState(state);
             }
 
             // Prune remoteHashes and timestamps for deleted workflows
@@ -428,19 +458,19 @@ export class WorkflowStateTracker extends EventEmitter {
         let filename = this.idToFileMap.get(workflowId);
 
         // If workflow not tracked yet (first sync of local-only workflow),
-        // scan directory to find the file with this ID
-        if (!filename) {
-            const files = listWorkflowFilesRecursive(this.directory);
-            for (const file of files) {
-                const filePath = workflowRelativePathToAbsolute(this.directory, file);
-                const content = this.readJsonFile(filePath);
-                if (content?.id === workflowId) {
-                    filename = file;
-                    // Initialize tracking for this workflow
-                    this.fileToIdMap.set(filename, workflowId);
-                    this.idToFileMap.set(workflowId, filename);
-                    break;
+        // or if filename points to a file that does not exist on disk,
+        // scan directory to find the real file with this ID
+        if (!filename || !fs.existsSync(workflowRelativePathToAbsolute(this.directory, filename))) {
+            const staleFilename = filename;
+            filename = this.findFilenameByWorkflowId(workflowId);
+
+            if (filename) {
+                if (staleFilename && staleFilename !== filename) {
+                    this.fileToIdMap.delete(staleFilename);
+                    this.localHashes.delete(staleFilename);
                 }
+                this.fileToIdMap.set(filename, workflowId);
+                this.idToFileMap.set(workflowId, filename);
             }
 
             if (!filename) {

--- a/packages/cli/src/core/services/workflow-state-tracker.ts
+++ b/packages/cli/src/core/services/workflow-state-tracker.ts
@@ -36,10 +36,6 @@ const WINDOWS_RESERVED_FILENAMES = new Set([
 
 const EXPLICIT_WORKFLOW_ID_FIELD = '__n8nacExplicitWorkflowId';
 
-function workflowRelativePathToAbsolute(directory: string, filename: string): string {
-    return path.isAbsolute(filename) ? filename : path.join(directory, filename);
-}
-
 /**
  * Watcher - State Observation Component
  * 

--- a/packages/cli/tests/unit/workflow-state-tracker.test.ts
+++ b/packages/cli/tests/unit/workflow-state-tracker.test.ts
@@ -322,6 +322,172 @@ export class NestedWorkflow {
             parentFolderId: 'folder-file-processing',
         }));
     });
+
+    it('updates state filename on rename and prioritizes disk scan result in refreshLocalState', async () => {
+        const tracker = createTracker();
+        const workflowId = 'wf-rename-test';
+        const initialPath = path.join(tempDir!, 'initial.workflow.ts');
+        const renamedPath = path.join(tempDir!, 'renamed.workflow.ts');
+
+        fs.writeFileSync(
+            initialPath,
+            `import { workflow, node } from '@n8n-as-code/transformer';
+
+@workflow({
+  id: '${workflowId}',
+  name: 'Rename Test Workflow',
+  active: false
+})
+export class RenameTestWorkflow {
+  @node({
+    name: 'Webhook',
+    type: 'n8n-nodes-base.webhook',
+    version: 2.1,
+    position: [0, 0]
+  })
+  Webhook = { path: 'rename-test', httpMethod: 'POST' };
+}
+`,
+            'utf-8',
+        );
+
+        fs.writeFileSync(
+            path.join(tempDir!, '.n8n-state.json'),
+            JSON.stringify({
+                workflows: {
+                    [workflowId]: {
+                        lastSyncedHash: 'hash123',
+                        lastSyncedAt: '2026-03-30T12:00:00.000Z',
+                        filename: 'initial.workflow.ts',
+                    },
+                },
+            }),
+            'utf-8',
+        );
+
+        // Rename file on disk
+        fs.renameSync(initialPath, renamedPath);
+
+        await tracker.refreshLocalState();
+
+        expect(tracker.getFilenameForId(workflowId)).toBe('renamed.workflow.ts');
+        const state = JSON.parse(fs.readFileSync(path.join(tempDir!, '.n8n-state.json'), 'utf-8'));
+        expect(state.workflows[workflowId]?.filename).toBe('renamed.workflow.ts');
+    });
+
+    it('discovers renamed file during refreshRemoteState if persistedFilename is missing on disk', async () => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-tracker-'));
+        const workflowId = 'wf-remote-rename';
+        const mockApiClient = {
+            getAllWorkflows: vi.fn().mockResolvedValue([
+                { id: workflowId, name: 'Remote Rename Workflow', active: true } as IWorkflow,
+            ]),
+        } as any;
+
+        const tracker = new WorkflowStateTracker(mockApiClient, {
+            directory: tempDir,
+            syncInactive: false,
+            ignoredTags: [],
+            projectId: 'test-project',
+        });
+
+        fs.writeFileSync(
+            path.join(tempDir!, 'renamed.workflow.ts'),
+            `import { workflow, node } from '@n8n-as-code/transformer';
+
+@workflow({
+  id: '${workflowId}',
+  name: 'Remote Rename Workflow',
+  active: true
+})
+export class RemoteRenameWorkflow {
+  @node({
+    name: 'Webhook',
+    type: 'n8n-nodes-base.webhook',
+    version: 2.1,
+    position: [0, 0]
+  })
+  Webhook = { path: 'remote-rename', httpMethod: 'POST' };
+}
+`,
+            'utf-8',
+        );
+
+        fs.writeFileSync(
+            path.join(tempDir!, '.n8n-state.json'),
+            JSON.stringify({
+                workflows: {
+                    [workflowId]: {
+                        lastSyncedHash: 'hash123',
+                        lastSyncedAt: '2026-03-30T12:00:00.000Z',
+                        filename: 'initial.workflow.ts',
+                    },
+                },
+            }),
+            'utf-8',
+        );
+
+        await tracker.refreshRemoteState();
+
+        expect(tracker.getFilenameForId(workflowId)).toBe('renamed.workflow.ts');
+    });
+
+    it('re-scans to find the real file in finalizeSync if mapped filename was renamed on disk', async () => {
+        const tracker = createTracker();
+        const workflowId = 'wf-finalize-rename';
+        const initialPath = path.join(tempDir!, 'initial.workflow.ts');
+        const renamedPath = path.join(tempDir!, 'renamed.workflow.ts');
+
+        fs.writeFileSync(
+            initialPath,
+            `import { workflow, node } from '@n8n-as-code/transformer';
+
+@workflow({
+  id: '${workflowId}',
+  name: 'Finalize Rename Workflow',
+  active: false
+})
+export class FinalizeRenameWorkflow {
+  @node({
+    name: 'Webhook',
+    type: 'n8n-nodes-base.webhook',
+    version: 2.1,
+    position: [0, 0]
+  })
+  Webhook = { path: 'finalize-test', httpMethod: 'POST' };
+}
+`,
+            'utf-8',
+        );
+
+        fs.writeFileSync(
+            path.join(tempDir!, '.n8n-state.json'),
+            JSON.stringify({
+                workflows: {
+                    [workflowId]: {
+                        lastSyncedHash: 'hash-abc',
+                        lastSyncedAt: '2026-03-30T12:00:00.000Z',
+                        filename: 'initial.workflow.ts',
+                    },
+                },
+            }),
+            'utf-8',
+        );
+
+        // Populate initial tracker state
+        await tracker.refreshLocalState();
+        expect(tracker.getFilenameForId(workflowId)).toBe('initial.workflow.ts');
+
+        // Rename file on disk without calling refreshLocalState first
+        fs.renameSync(initialPath, renamedPath);
+
+        // finalizeSync should detect that initial.workflow.ts is gone and re-scan
+        await tracker.finalizeSync(workflowId);
+
+        expect(tracker.getFilenameForId(workflowId)).toBe('renamed.workflow.ts');
+        const state = JSON.parse(fs.readFileSync(path.join(tempDir!, '.n8n-state.json'), 'utf-8'));
+        expect(state.workflows[workflowId]?.filename).toBe('renamed.workflow.ts');
+    });
 });
 
 describe('WorkflowStateTracker drift detection', () => {
@@ -631,3 +797,4 @@ export class ${name}Workflow {
         expect(results[0].drift).toEqual({ local: false, remote: false });
     });
 });
+


### PR DESCRIPTION
## Problem
When a workflow file is renamed on disk, `.n8n-state.json` previously retained the old filename. This broke workflow resolution during sync operations, resulting in errors or stale mappings when pulling/pushing or refreshing remote state.

## Solution
1. **`refreshLocalState()`**:
   - Made disk scan result authoritative for workflow IDs discovered with decorators.
   - When a workflow's filename on disk differs from `state.workflows[id].filename`, update the state entry and batch save changes to `.n8n-state.json`.
2. **`refreshRemoteState()`**:
   - Check if `persistedFilename` exists on disk using `workflowRelativePathToAbsolute(this.directory, normalizedFilename)`. If the file no longer exists, do not treat it as a valid mapping and fall through to scan disk using `findFilenameByWorkflowId(wf.id)`.
3. **`finalizeSync()`**:
   - Re-scan to find the real file (`findFilenameByWorkflowId(workflowId)`) if `idToFileMap.get(workflowId)` points to a missing file on disk, cleaning up stale mapping references.

## Tests
- Added unit tests in `packages/cli/tests/unit/workflow-state-tracker.test.ts`:
  - `updates state filename on rename and prioritizes disk scan result in refreshLocalState`
  - `discovers renamed file during refreshRemoteState if persistedFilename is missing on disk`
  - `re-scans to find the real file in finalizeSync if mapped filename was renamed on disk`
- All unit tests in `packages/cli` pass (151 tests across 19 suites).
- TypeScript typecheck passed cleanly with no errors.

Fixes #611


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow synchronization when workflow files are renamed.
  * Updated stored workflow filenames after local or remote scans detect changes.
  * Automatically rediscovered workflows when their previously recorded files are missing.
  * Removed stale filename and hash mappings during synchronization.

* **Tests**
  * Added coverage for renamed, missing, and rediscovered workflow files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->