### PR TITLE
fix(skills): fix false-positive validation for multiOptions, versioned options and defaults

### DIFF
--- a/packages/skills/src/services/workflow-validator.ts
+++ b/packages/skills/src/services/workflow-validator.ts
@@ -266,6 +266,36 @@ export class WorkflowValidator {
       : rootParams[condParamName];
   }
 
+  private matchesVersionCondition(condition: any, nodeVersion: number): boolean {
+    if (Array.isArray(condition)) {
+      return condition.some((c) => this.evalVersionCondition(c, nodeVersion));
+    }
+    return this.evalVersionCondition(condition, nodeVersion);
+  }
+
+  private evalVersionCondition(cond: any, nodeVersion: number): boolean {
+    if (typeof cond === 'number') {
+      return nodeVersion === cond;
+    }
+    if (typeof cond === 'string') {
+      const num = Number(cond);
+      return !isNaN(num) ? nodeVersion === num : String(nodeVersion) === cond;
+    }
+    if (!cond || typeof cond !== 'object') {
+      return false;
+    }
+
+    const rule = (cond._cnd && typeof cond._cnd === 'object') ? cond._cnd : cond;
+
+    if (rule.eq !== undefined && !(nodeVersion === Number(rule.eq))) return false;
+    if (rule.lte !== undefined && !(nodeVersion <= Number(rule.lte))) return false;
+    if (rule.gte !== undefined && !(nodeVersion >= Number(rule.gte))) return false;
+    if (rule.lt !== undefined && !(nodeVersion < Number(rule.lt))) return false;
+    if (rule.gt !== undefined && !(nodeVersion > Number(rule.gt))) return false;
+
+    return true;
+  }
+
   /**
    * Check whether a schema property's displayOptions conditions are satisfied
    * by the current parameters. If no displayOptions defined -> always shown.
@@ -273,11 +303,19 @@ export class WorkflowValidator {
   private isPropertyDisplayed(
     prop: any,
     nodeParams: Record<string, any>,
-    rootParams: Record<string, any> = nodeParams
+    rootParams: Record<string, any> = nodeParams,
+    node?: any
   ): boolean {
+    const rawVersion = node?.typeVersion ?? node?.version ?? 1;
+    const nodeVersion = typeof rawVersion === 'number' ? rawVersion : (Number(rawVersion) || 1);
+
     const hide = prop.displayOptions?.hide;
     if (hide && typeof hide === 'object') {
       for (const [condParamName, hiddenValues] of Object.entries(hide)) {
+        if (condParamName === '@version') {
+          if (this.matchesVersionCondition(hiddenValues, nodeVersion)) return false;
+          continue;
+        }
         if (!Array.isArray(hiddenValues)) continue;
         const actualValue = this.getConditionParamValue(condParamName, nodeParams, rootParams);
         if (this.isExpressionValue(actualValue)) continue;
@@ -289,6 +327,10 @@ export class WorkflowValidator {
     if (!show || typeof show !== 'object') return true;
 
     for (const [condParamName, allowedValues] of Object.entries(show)) {
+      if (condParamName === '@version') {
+        if (!this.matchesVersionCondition(allowedValues, nodeVersion)) return false;
+        continue;
+      }
       if (!Array.isArray(allowedValues)) continue;
       const actualValue = this.getConditionParamValue(condParamName, nodeParams, rootParams);
       // Skip expression values — can't evaluate at static validation time
@@ -320,22 +362,24 @@ export class WorkflowValidator {
       typeof operationValue === 'string' && !operationValue.includes('{{')
     ) {
       const scopedOpProps = schemaProps.filter(
-        (p: any) => p.name === 'operation' && p.type === 'options' &&
+        (p: any) => p.name === 'operation' && (p.type === 'options' || p.type === 'multiOptions') &&
           Array.isArray(p.displayOptions?.show?.resource) &&
-          p.displayOptions.show.resource.includes(resourceValue)
+          p.displayOptions.show.resource.includes(resourceValue) &&
+          this.isPropertyDisplayed(p, node.parameters, node.parameters, node)
       );
       if (scopedOpProps.length > 0) {
         const scopedValues = new Set<string | number>(
           scopedOpProps.flatMap((p: any) => p.options?.map((o: any) => o.value) ?? [])
         );
-        if (!scopedValues.has(operationValue)) {
+        const opPath = `nodes[${node.name}].parameters.operation`;
+        if (!scopedValues.has(operationValue) && !errors.some(e => e.path === opPath)) {
           const validOps = [...scopedValues].join(', ');
           errors.push({
             type: 'error',
             nodeId: node.id,
             nodeName: node.name,
             message: `Operation "${operationValue}" is not valid for resource "${resourceValue}". n8n will show "Could not find property option". Valid operations for resource "${resourceValue}": [${validOps}].`,
-            path: `nodes[${node.name}].parameters.operation`,
+            path: opPath,
           });
         }
       }
@@ -353,16 +397,17 @@ export class WorkflowValidator {
     warnUnknownParameters: boolean
   ): void {
     // Only consider props whose display conditions are satisfied by the current params
-    const displayedProps = schemaProps.filter((p: any) => this.isPropertyDisplayed(p, params, rootParams));
-    const requiredProps = displayedProps.filter((p: any) => p.required === true);
+    const displayedProps = schemaProps.filter((p: any) => this.isPropertyDisplayed(p, params, rootParams, node));
+    const hasUsableDefault = (p: any): boolean => p.default !== undefined && p.default !== null && p.default !== '';
+    const requiredProps = displayedProps.filter((p: any) => p.required === true && !hasUsableDefault(p));
 
     // Check required parameters
     for (const prop of requiredProps) {
       if (!(prop.name in params)) {
         errors.push({
           type: 'error',
-          nodeId: node.id,
-          nodeName: node.name,
+          nodeId: node?.id,
+          nodeName: node?.name,
           message: `Missing required parameter: "${prop.name}"`,
           path: `${path}.${prop.name}`,
         });
@@ -378,8 +423,8 @@ export class WorkflowValidator {
         if (!knownParamNames.has(paramName)) {
           warnings.push({
             type: 'warning',
-            nodeId: node.id,
-            nodeName: node.name,
+            nodeId: node?.id,
+            nodeName: node?.name,
             message: `Unknown parameter: "${paramName}". This might be a typo or deprecated parameter.`,
             path: `${path}.${paramName}`,
           });
@@ -387,11 +432,11 @@ export class WorkflowValidator {
       }
     }
 
-    // Validate 'options' type parameter values
-    // Collect all valid values for each options-type property across all display conditions
+    // Validate 'options' and 'multiOptions' type parameter values
+    // Collect all valid values for each options-type property across displayed properties
     const optionValuesByPropName = new Map<string, Set<string | number>>();
-    for (const prop of schemaProps) {
-      if (prop.type === 'options' && Array.isArray(prop.options)) {
+    for (const prop of displayedProps) {
+      if ((prop.type === 'options' || prop.type === 'multiOptions') && Array.isArray(prop.options)) {
         if (!optionValuesByPropName.has(prop.name)) {
           optionValuesByPropName.set(prop.name, new Set());
         }
@@ -403,35 +448,56 @@ export class WorkflowValidator {
     }
 
     for (const [propName, validValues] of optionValuesByPropName) {
+      if (validValues.size === 0) continue;
       if (!(propName in params)) continue;
       const actualValue = params[propName];
       // Skip expressions
       if (this.isExpressionValue(actualValue)) continue;
-      if (!validValues.has(actualValue)) {
-        // Try to find which resource this operation belongs to, for a helpful hint
-        let hint = '';
-        if (propName === 'operation') {
-          const resourceValue = rootParams['resource'];
-          if (resourceValue) {
-            // Find operation props scoped to this resource
-            const scopedOps = schemaProps
-              .filter((p: any) => p.name === 'operation' && p.type === 'options' &&
-                Array.isArray(p.displayOptions?.show?.resource) &&
-                p.displayOptions.show.resource.includes(resourceValue))
-              .flatMap((p: any) => p.options?.map((o: any) => o.value) ?? []);
-            if (scopedOps.length > 0) {
-              hint = ` For resource "${resourceValue}", valid operations are: [${scopedOps.join(', ')}].`;
+      // Skip ResourceLocator values
+      if (actualValue && typeof actualValue === 'object' && actualValue.__rl === true) continue;
+
+      if (Array.isArray(actualValue)) {
+        const invalidValues = actualValue.filter(
+          (v: any) => !this.isExpressionValue(v) && !(v && typeof v === 'object' && v.__rl === true) && !validValues.has(v)
+        );
+        if (invalidValues.length > 0) {
+          const validList = [...validValues].slice(0, 20).join(', ') + (validValues.size > 20 ? ', ...' : '');
+          errors.push({
+            type: 'error',
+            nodeId: node?.id,
+            nodeName: node?.name,
+            message: `Invalid value(s) [${invalidValues.join(', ')}] for parameter "${propName}". n8n will reject this with "Could not find property option". All known values: [${validList}].`,
+            path: `${path}.${propName}`,
+          });
+        }
+      } else {
+        if (!validValues.has(actualValue)) {
+          // Try to find which resource this operation belongs to, for a helpful hint
+          let hint = '';
+          if (propName === 'operation') {
+            const resourceValue = rootParams['resource'];
+            if (resourceValue) {
+              // Find operation props scoped to this resource
+              const scopedOps = schemaProps
+                .filter((p: any) => p.name === 'operation' && (p.type === 'options' || p.type === 'multiOptions') &&
+                  Array.isArray(p.displayOptions?.show?.resource) &&
+                  p.displayOptions.show.resource.includes(resourceValue) &&
+                  this.isPropertyDisplayed(p, rootParams, rootParams, node))
+                .flatMap((p: any) => p.options?.map((o: any) => o.value) ?? []);
+              if (scopedOps.length > 0) {
+                hint = ` For resource "${resourceValue}", valid operations are: [${scopedOps.join(', ')}].`;
+              }
             }
           }
+          const validList = [...validValues].slice(0, 20).join(', ') + (validValues.size > 20 ? ', ...' : '');
+          errors.push({
+            type: 'error',
+            nodeId: node?.id,
+            nodeName: node?.name,
+            message: `Invalid value "${actualValue}" for parameter "${propName}". n8n will reject this with "Could not find property option".${hint} All known values: [${validList}].`,
+            path: `${path}.${propName}`,
+          });
         }
-        const validList = [...validValues].slice(0, 20).join(', ') + (validValues.size > 20 ? ', ...' : '');
-        errors.push({
-          type: 'error',
-          nodeId: node.id,
-          nodeName: node.name,
-          message: `Invalid value "${actualValue}" for parameter "${propName}". n8n will reject this with "Could not find property option".${hint} All known values: [${validList}].`,
-          path: `${path}.${propName}`,
-        });
       }
     }
 

--- a/packages/skills/tests/workflow-validator.test.ts
+++ b/packages/skills/tests/workflow-validator.test.ts
@@ -634,6 +634,335 @@ describe('WorkflowValidator - nested parameter validation', () => {
     });
 });
 
+describe('WorkflowValidator - Issue #609 false-positives', () => {
+    const createValidatorWithNodeSchema = (nodeSchema: any): WorkflowValidator => {
+        const indexPath = path.resolve(_dirname, 'fixtures/n8n-nodes-technical.json');
+        const validator = new WorkflowValidator(indexPath);
+        jest.spyOn(validator['provider'], 'getNodeSchema').mockReturnValue(nodeSchema);
+        return validator;
+    };
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe('multiOptions validation', () => {
+        const multiOptionsSchema = {
+            name: 'webhook',
+            type: 'n8n-nodes-base.webhook',
+            version: 1,
+            schema: {
+                properties: [
+                    {
+                        name: 'httpMethod',
+                        type: 'multiOptions',
+                        options: [
+                            { name: 'GET', value: 'GET' },
+                            { name: 'POST', value: 'POST' },
+                            { name: 'PUT', value: 'PUT' },
+                            { name: 'DELETE', value: 'DELETE' },
+                        ],
+                    },
+                ],
+            },
+        };
+
+        it('passes valid multiOptions array', async () => {
+            const validator = createValidatorWithNodeSchema(multiOptionsSchema);
+            const result = await validator.validateWorkflow({
+                nodes: [
+                    {
+                        id: '1',
+                        name: 'Webhook',
+                        type: 'n8n-nodes-base.webhook',
+                        typeVersion: 1,
+                        position: [0, 0],
+                        parameters: {
+                            httpMethod: ['GET', 'POST'],
+                        },
+                    },
+                ],
+                connections: {},
+            });
+
+            expect(result.valid).toBe(true);
+            expect(result.errors).toHaveLength(0);
+        });
+
+        it('rejects invalid array entries in multiOptions', async () => {
+            const validator = createValidatorWithNodeSchema(multiOptionsSchema);
+            const result = await validator.validateWorkflow({
+                nodes: [
+                    {
+                        id: '1',
+                        name: 'Webhook',
+                        type: 'n8n-nodes-base.webhook',
+                        typeVersion: 1,
+                        position: [0, 0],
+                        parameters: {
+                            httpMethod: ['POST', 'INVALID_METHOD'],
+                        },
+                    },
+                ],
+                connections: {},
+            });
+
+            expect(result.valid).toBe(false);
+            expect(result.errors.length).toBeGreaterThan(0);
+            expect(result.errors[0].message).toContain('Invalid value(s) [INVALID_METHOD] for parameter "httpMethod"');
+            expect(result.errors[0].path).toBe('nodes[Webhook].parameters.httpMethod');
+        });
+    });
+
+    describe('ResourceLocator values', () => {
+        it('skips ResourceLocator object without error', async () => {
+            const validator = createValidatorWithNodeSchema({
+                name: 'slack',
+                type: 'n8n-nodes-base.slack',
+                version: 1,
+                schema: {
+                    properties: [
+                        {
+                            name: 'channel',
+                            type: 'options',
+                            options: [
+                                { name: 'General', value: 'general' },
+                                { name: 'Random', value: 'random' },
+                            ],
+                        },
+                    ],
+                },
+            });
+
+            const result = await validator.validateWorkflow({
+                nodes: [
+                    {
+                        id: '1',
+                        name: 'Slack',
+                        type: 'n8n-nodes-base.slack',
+                        typeVersion: 1,
+                        position: [0, 0],
+                        parameters: {
+                            channel: {
+                                __rl: true,
+                                value: 'C01234567',
+                                mode: 'id',
+                            },
+                        },
+                    },
+                ],
+                connections: {},
+            });
+
+            expect(result.valid).toBe(true);
+            expect(result.errors).toHaveLength(0);
+        });
+    });
+
+    describe('@version-scoped properties', () => {
+        const versionedNodeSchema = {
+            name: 'myVersionedNode',
+            type: 'n8n-nodes-base.myVersionedNode',
+            version: [1, 1.1, 1.2, 2],
+            schema: {
+                properties: [
+                    {
+                        name: 'operation',
+                        type: 'options',
+                        displayOptions: {
+                            show: {
+                                '@version': [1, 1.1],
+                            },
+                        },
+                        options: [
+                            { name: 'Old Op', value: 'oldOp' },
+                        ],
+                    },
+                    {
+                        name: 'operation',
+                        type: 'options',
+                        displayOptions: {
+                            show: {
+                                '@version': [{ _cnd: { gte: 2 } }],
+                            },
+                        },
+                        options: [
+                            { name: 'New Op', value: 'newOp' },
+                        ],
+                    },
+                    {
+                        name: 'legacyField',
+                        type: 'string',
+                        required: true,
+                        displayOptions: {
+                            show: {
+                                '@version': { lte: 1.2 },
+                            },
+                        },
+                    },
+                ],
+            },
+        };
+
+        it('does not validate newer typeVersions against obsolete version options', async () => {
+            const validator = createValidatorWithNodeSchema(versionedNodeSchema);
+
+            // typeVersion 2 with newOp is valid
+            const validV2Result = await validator.validateWorkflow({
+                nodes: [
+                    {
+                        id: '1',
+                        name: 'MyNode',
+                        type: 'n8n-nodes-base.myVersionedNode',
+                        typeVersion: 2,
+                        position: [0, 0],
+                        parameters: {
+                            operation: 'newOp',
+                        },
+                    },
+                ],
+                connections: {},
+            });
+            expect(validV2Result.valid).toBe(true);
+            expect(validV2Result.errors).toHaveLength(0);
+
+            // typeVersion 2 with oldOp is invalid because oldOp is obsolete in v2
+            const invalidV2Result = await validator.validateWorkflow({
+                nodes: [
+                    {
+                        id: '1',
+                        name: 'MyNode',
+                        type: 'n8n-nodes-base.myVersionedNode',
+                        typeVersion: 2,
+                        position: [0, 0],
+                        parameters: {
+                            operation: 'oldOp',
+                        },
+                    },
+                ],
+                connections: {},
+            });
+            expect(invalidV2Result.valid).toBe(false);
+            expect(invalidV2Result.errors.some(e => e.message.includes('Invalid value "oldOp" for parameter "operation"'))).toBe(true);
+
+            // typeVersion 1 with oldOp is valid (and requires legacyField because v1 <= 1.2)
+            const validV1Result = await validator.validateWorkflow({
+                nodes: [
+                    {
+                        id: '1',
+                        name: 'MyNode',
+                        type: 'n8n-nodes-base.myVersionedNode',
+                        typeVersion: 1,
+                        position: [0, 0],
+                        parameters: {
+                            operation: 'oldOp',
+                            legacyField: 'legacy-val',
+                        },
+                    },
+                ],
+                connections: {},
+            });
+            expect(validV1Result.valid).toBe(true);
+            expect(validV1Result.errors).toHaveLength(0);
+
+            // typeVersion 2 does NOT require legacyField because it is scoped to { lte: 1.2 }
+            const legacyCheckResult = await validator.validateWorkflow({
+                nodes: [
+                    {
+                        id: '1',
+                        name: 'MyNode',
+                        type: 'n8n-nodes-base.myVersionedNode',
+                        typeVersion: 2,
+                        position: [0, 0],
+                        parameters: {
+                            operation: 'newOp',
+                        },
+                    },
+                ],
+                connections: {},
+            });
+            expect(legacyCheckResult.errors.some(e => e.message.includes('legacyField'))).toBe(false);
+        });
+    });
+
+    describe('required properties with defaults', () => {
+        it('does not report an error when required: true properties with a default are omitted', async () => {
+            const validator = createValidatorWithNodeSchema({
+                name: 'stickyNote',
+                type: 'n8n-nodes-base.stickyNote',
+                version: 1,
+                schema: {
+                    properties: [
+                        {
+                            name: 'height',
+                            type: 'number',
+                            required: true,
+                            default: 160,
+                        },
+                        {
+                            name: 'width',
+                            type: 'number',
+                            required: true,
+                            default: 240,
+                        },
+                        {
+                            name: 'color',
+                            type: 'number',
+                            required: true,
+                            default: 1,
+                        },
+                        {
+                            name: 'title',
+                            type: 'string',
+                            required: true,
+                            // no default
+                        },
+                    ],
+                },
+            });
+
+            // When title is provided, height/width/color have schema defaults and are omitted -> valid!
+            const validResult = await validator.validateWorkflow({
+                nodes: [
+                    {
+                        id: '1',
+                        name: 'Sticky Note',
+                        type: 'n8n-nodes-base.stickyNote',
+                        typeVersion: 1,
+                        position: [0, 0],
+                        parameters: {
+                            title: 'My Note',
+                        },
+                    },
+                ],
+                connections: {},
+            });
+
+            expect(validResult.valid).toBe(true);
+            expect(validResult.errors).toHaveLength(0);
+
+            // When title (which has no default) is omitted -> invalid!
+            const invalidResult = await validator.validateWorkflow({
+                nodes: [
+                    {
+                        id: '1',
+                        name: 'Sticky Note',
+                        type: 'n8n-nodes-base.stickyNote',
+                        typeVersion: 1,
+                        position: [0, 0],
+                        parameters: {},
+                    },
+                ],
+                connections: {},
+            });
+
+            expect(invalidResult.valid).toBe(false);
+            expect(invalidResult.errors).toHaveLength(1);
+            expect(invalidResult.errors[0].message).toBe('Missing required parameter: "title"');
+        });
+    });
+});
+
 describe('WorkflowValidator - fallback model', () => {
     const createValidator = (): WorkflowValidator => {
         const indexPath = path.resolve(_dirname, 'fixtures/n8n-nodes-technical.json');


### PR DESCRIPTION
## Problem
Issue #609: `skills validate` reported false-positive validation errors on valid workflows for:
1. `multiOptions` parameters (e.g. `['POST', 'GET']`) were validated as scalar values against valid options sets, triggering "Could not find property option" errors.
2. ResourceLocator objects (`{ __rl: true, mode: 'id', value: '...' }`) on options/resourceLocator parameters were treated as invalid option values.
3. `@version`-scoped properties were evaluated without node version awareness (as `@version` in `displayOptions.show` was looked up in node parameters rather than comparing against `node.typeVersion`), causing obsolete version options to be merged or valid version options to be excluded.
4. `required: true` properties that have schema defaults (e.g. `stickyNote`'s `height`, `width`, `color`) reported missing required parameter errors when omitted.

## Solution
1. **`@version` handling**: Updated `isPropertyDisplayed` to recognize `@version` in `displayOptions.show` and `hide`. Evaluates node version (`node?.typeVersion ?? node?.version ?? 1`) against version condition formats:
   - Array of numbers (e.g. `[1, 1.1]`)
   - Operator conditions (`lte`, `gte`, `lt`, `gt`, `eq`) and `_cnd` wrappers (e.g. `{ lte: 1.2 }`, `[{ _cnd: { gte: 2 } }]`).
2. **Options and `multiOptions` validation**:
   - Collect valid options from `displayedProps` (filtering out properties scoped to other versions or hidden display options).
   - Support `multiOptions` array values by verifying each element is contained in `validValues`, reporting invalid elements when present.
   - Skip ResourceLocator values (`actualValue?.__rl === true`).
3. **Required parameters with schema defaults**:
   - Filter `requiredProps` to exempt properties that have a usable schema default (`p.default !== undefined && p.default !== null && p.default !== ''`), avoiding false positives for nodes like `stickyNote` while still requiring truly required empty-default fields like `httpRequest.url`.

## Tests
- Added unit tests in `packages/skills/tests/workflow-validator.test.ts`:
  - `multiOptions` array values validation (accepting valid arrays, rejecting invalid entries).
  - ResourceLocator objects (`{ __rl: true, mode: 'id', value: '...' }`) skipped without error.
  - `@version`-scoped properties do not validate newer typeVersions against obsolete version options.
  - `required: true` properties with schema defaults do not report errors when omitted.
- Verified test suite passes: `cmd /c "set NODE_OPTIONS=--experimental-vm-modules && npx jest tests/workflow-validator.test.ts"`.
- Verified TypeScript typecheck passes: `npx tsc --noEmit -p packages/skills/tsconfig.json`.

Fixes #609


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow validation for version-specific options, preventing obsolete or unavailable settings from being incorrectly flagged.
  * Multi-option fields now correctly validate each selected value.
  * Resource locator values are handled without generating invalid validation errors.
  * Required fields with usable default values are no longer incorrectly reported as missing.
  * Validation errors now provide more relevant node details and avoid duplicate operation errors.
  * Required fields that remain unset and have no default continue to be reported clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->