### PR TITLE
docs(contributing): target main branch instead of next for pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,4 +2,4 @@
 
 **Related issue (if any):** #
 
-> ⚠️ All PRs must target the `next` branch as base.
+> ⚠️ All PRs must target the `main` branch as base.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
-    target-branch: next
+    target-branch: main
     schedule:
       interval: weekly
     open-pull-requests-limit: 10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,6 @@ This command rewrites matching workspace `package.json` files and refreshes the 
 - Keep PRs focused — one thing at a time
 - Write tests if you're adding new behavior
 - Don't worry too much about formatting, CI will catch style issues
-- All pull requests must target the `next` branch as base
+- All pull requests must target the `main` branch as base
 
 That's it. No CLA, no bureaucracy.

--- a/docs/docs/contribution/index.md
+++ b/docs/docs/contribution/index.md
@@ -160,11 +160,13 @@ If dependency alignment fails, run `npm run sync:deps`, review the manifest diff
 Let's say you fix a bug in the sync engine (embedded in `n8nac`):
 
 ```bash
-# 1. Push a conventional commit to next
+# 1. Create a feature branch from main, commit, and submit a PR targeting main
+git checkout -b fix/cli-sync-edge-case main
 git commit -m "fix(cli): handle sync edge case"
+gh pr create --base main
 
-# 2. Merge next into main
-# 3. Let the release PR bump versions automatically
+# 2. Maintainer merges PR into main
+# 3. Release workflow creates/updates release PR and publishes versions
 ```
 
 **Result:**
@@ -177,11 +179,9 @@ All packages that depend on `n8nac` will have their `package.json` updated to re
 ### Workflow Summary Diagram
 
 ```
-Developer pushes conventional commits to next
+Developer opens PR targeting main
        ↓
-CI publishes prereleases from next
-       ↓
-next is merged into main
+Maintainer merges PR into main
        ↓
 CI creates or updates a release PR
        ↓
@@ -218,7 +218,7 @@ CI automatically:
 1. Create a feature branch from `main`
 2. Make your changes with tests
 3. Ensure all tests pass
-4. Submit a pull request with clear description targeting `main`
+4. Submit a pull request with clear description targeting `main` (`next` is reserved for the automated prerelease release workflow; all contributor pull requests must target `main`)
 
 ### Documentation
 - Update relevant documentation when adding features

--- a/docs/docs/contribution/index.md
+++ b/docs/docs/contribution/index.md
@@ -215,10 +215,10 @@ CI automatically:
 - Write comprehensive tests for new features
 
 ### Pull Request Process
-1. Create a feature branch from `next`
+1. Create a feature branch from `main`
 2. Make your changes with tests
 3. Ensure all tests pass
-4. Submit a pull request with clear description targeting `next`
+4. Submit a pull request with clear description targeting `main`
 
 ### Documentation
 - Update relevant documentation when adding features


### PR DESCRIPTION
## Summary
Updates CONTRIBUTING.md and .github/PULL_REQUEST_TEMPLATE.md to instruct contributors to target the active \main\ branch as base instead of \
ext\.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines and pull request instructions to use `main` as the base and merge target.
  * Updated the pull request template to require `main` as the target branch.
  * Updated workflow examples and diagrams to reflect the `main`-based contribution process.
  * Clarified that `next` is reserved for the automated prerelease workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->