### PR TITLE
fix(vscode-extension): resolve SSO auth black screen, add open in browser and session token support

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -106,6 +106,16 @@
         "icon": "$(browser)"
       },
       {
+        "command": "n8n.openInBrowser",
+        "title": "Open in External Browser",
+        "icon": "$(link-external)"
+      },
+      {
+        "command": "n8n.setSessionCookie",
+        "title": "n8n: Set SSO Session Cookie",
+        "icon": "$(key)"
+      },
+      {
         "command": "n8n.openJson",
         "title": "Open File",
         "icon": "$(go-to-file)"
@@ -293,6 +303,11 @@
         {
           "command": "n8n.openAgentWorkbench",
           "group": "1_open@4",
+          "when": "viewItem =~ /^workflow-(tracked|tracked-archived|cloud-only)$/"
+        },
+        {
+          "command": "n8n.openInBrowser",
+          "group": "1_open@5",
           "when": "viewItem =~ /^workflow-(tracked|tracked-archived|cloud-only)$/"
         },
         {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -20,6 +20,7 @@ import { WorkflowWebview } from './ui/workflow-webview.js';
 import { AgentWorkbenchWebview } from './ui/agent-workbench-webview.js';
 import { ConfigurationWebview } from './ui/configuration-webview.js';
 import { WorkflowDecorationProvider } from './ui/workflow-decoration-provider.js';
+import { openExternalNavigation } from './utils/external-navigation.js';
 
 import { ProxyService } from './services/proxy-service.js';
 import { AgentRuntimeController } from './services/agent-runtime-controller.js';
@@ -952,7 +953,23 @@ async function openWorkflowInBrowser(workflow: IWorkflowStatus): Promise<void> {
     try {
         const url = await resolveWorkflowBrowserUrl(workflow);
         outputChannel.appendLine(`[n8n] Opening workflow ${workflow.id} in external browser: ${url}`);
-        await vscode.env.openExternal(vscode.Uri.parse(url));
+        const opened = await openExternalNavigation(
+            {
+                url,
+                reason: 'workflow-browser',
+                source: {
+                    workflowId: workflow.id,
+                    panelKind: 'workflow-tree',
+                },
+            },
+            {
+                outputChannel,
+                logPrefix: '[n8n]',
+            },
+        );
+        if (!opened) {
+            vscode.window.showWarningMessage(`Could not open workflow in external browser: ${url}`);
+        }
     } catch (e: any) {
         vscode.window.showErrorMessage(`Failed to open workflow in browser: ${e.message}`);
     }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -937,7 +937,7 @@ async function resolveWorkflowBrowserUrl(workflow: IWorkflowStatus): Promise<str
     }
 
     const base = n8nBaseUrl.endsWith('/') ? n8nBaseUrl : `${n8nBaseUrl}/`;
-    return new URL(`/workflow/${encodeURIComponent(workflow.id)}`, base).toString();
+    return new URL(`workflow/${encodeURIComponent(workflow.id)}`, base).toString();
 }
 
 async function openWorkflowInBrowser(workflow: IWorkflowStatus): Promise<void> {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -393,6 +393,38 @@ export async function activate(context: vscode.ExtensionContext) {
             await openWorkflowBoard(wf);
         }),
 
+        registerTelemetryCommand('n8n.openInBrowser', async (arg: any) => {
+            const wf = arg?.workflow ? arg.workflow : arg;
+            if (!wf) return;
+            telemetryClient?.track('vscode_workflow_view_opened', { mode: 'browser', workflow_state: 'unknown' });
+            await openWorkflowInBrowser(wf);
+        }),
+
+        registerTelemetryCommand('n8n.setSessionCookie', async () => {
+            const input = await vscode.window.showInputBox({
+                title: 'n8n: Set SSO Session Cookie',
+                prompt: 'Enter your "n8n-auth" cookie value (from browser DevTools > Application/Storage > Cookies > n8n-auth)',
+                placeHolder: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+                password: true,
+                ignoreFocusOut: true,
+            });
+            if (!input || !input.trim()) return;
+
+            let token = input.trim();
+            if (token.startsWith('n8n-auth=')) {
+                token = token.slice('n8n-auth='.length).trim();
+            }
+            if (token.includes(';')) {
+                token = token.split(';')[0].trim();
+            }
+            if (!token) return;
+
+            await proxyService.setSessionToken(token);
+            vscode.window.showInformationMessage('n8n SSO session cookie saved. Reloading workflow view...');
+
+            WorkflowWebview.reloadAll(outputChannel);
+        }),
+
         registerTelemetryCommand('n8n.openJson', async (arg: any) => {
             const wf = arg?.workflow ? arg.workflow : arg;
             if (!wf || !syncManager) return;
@@ -855,6 +887,71 @@ async function openWorkflowBoard(workflow: IWorkflowStatus, viewColumn?: vscode.
         registerClipboardHandler();
     } catch (e: any) {
         vscode.window.showErrorMessage(`Failed to open n8n workflow: ${e.message}`);
+    }
+}
+
+async function resolveWorkflowBrowserUrl(workflow: IWorkflowStatus): Promise<string> {
+    if (!workflow.id) {
+        throw new Error(`Workflow "${workflow.name}" does not have a remote ID.`);
+    }
+
+    const workspaceRoot = getWorkspaceRoot();
+    let n8nBaseUrl: string | undefined;
+
+    if (workspaceRoot) {
+        try {
+            const configService = new ConfigService(workspaceRoot);
+            const workspaceConfig = configService.getWorkspaceConfig();
+            if (workspaceConfig.version === 4) {
+                const environment = await configService.prepareEnvironment();
+                n8nBaseUrl = environment.host;
+            }
+        } catch {
+            // fallback
+        }
+    }
+
+    if (!n8nBaseUrl) {
+        try {
+            const facade = createN8nManagerFacade({ workspaceRoot });
+            const prepared = await facade.prepareEffectiveContext({
+                workspaceRoot,
+                syncFolderDefault: workspaceRoot ? 'workspace' : 'global',
+                consumer: 'vscode',
+                autoStart: false,
+            });
+            const effective = prepared.context;
+            n8nBaseUrl = effective.apiBaseUrl ?? effective.host;
+        } catch {
+            // fallback
+        }
+    }
+
+    if (!n8nBaseUrl) {
+        const credentials = getN8nConfig();
+        n8nBaseUrl = credentials.host;
+    }
+
+    if (!n8nBaseUrl) {
+        throw new Error('n8n instance host URL is not configured.');
+    }
+
+    const base = n8nBaseUrl.endsWith('/') ? n8nBaseUrl : `${n8nBaseUrl}/`;
+    return new URL(`/workflow/${encodeURIComponent(workflow.id)}`, base).toString();
+}
+
+async function openWorkflowInBrowser(workflow: IWorkflowStatus): Promise<void> {
+    if (!workflow.id) {
+        vscode.window.showWarningMessage(`Cannot open workflow "${workflow.name}": no remote ID is available.`);
+        return;
+    }
+
+    try {
+        const url = await resolveWorkflowBrowserUrl(workflow);
+        outputChannel.appendLine(`[n8n] Opening workflow ${workflow.id} in external browser: ${url}`);
+        await vscode.env.openExternal(vscode.Uri.parse(url));
+    } catch (e: any) {
+        vscode.window.showErrorMessage(`Failed to open workflow in browser: ${e.message}`);
     }
 }
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -419,10 +419,13 @@ export async function activate(context: vscode.ExtensionContext) {
             }
             if (!token) return;
 
-            await proxyService.setSessionToken(token);
-            vscode.window.showInformationMessage('n8n SSO session cookie saved. Reloading workflow view...');
-
-            WorkflowWebview.reloadAll(outputChannel);
+            try {
+                await proxyService.setSessionToken(token);
+                vscode.window.showInformationMessage('n8n SSO session cookie saved. Reloading workflow view...');
+                WorkflowWebview.reloadAll(outputChannel);
+            } catch (e: any) {
+                vscode.window.showErrorMessage(e.message || 'Failed to save SSO session cookie');
+            }
         }),
 
         registerTelemetryCommand('n8n.openJson', async (arg: any) => {

--- a/packages/vscode-extension/src/services/proxy-service.ts
+++ b/packages/vscode-extension/src/services/proxy-service.ts
@@ -1055,16 +1055,15 @@ export class ProxyService {
 
     if (typeof window.XMLHttpRequest === "function" && window.XMLHttpRequest.prototype) {
       var origXhrOpen = window.XMLHttpRequest.prototype.open;
-      var origXhrSend = window.XMLHttpRequest.prototype.send;
       window.XMLHttpRequest.prototype.open = function(method, url) {
-        this.__n8nacIsSso = isSsoInitUrl(url);
-        return origXhrOpen.apply(this, arguments);
-      };
-      window.XMLHttpRequest.prototype.send = function() {
-        if (this.__n8nacIsSso) {
+        var isSso = isSsoInitUrl(url);
+        this.__n8nacIsSso = isSso;
+        if (isSso) {
           var xhr = this;
-          xhr.addEventListener("load", function() {
-            if (xhr.status >= 200 && xhr.status < 300) {
+          var ssoHandled = false;
+          var onDone = function() {
+            if (!ssoHandled && xhr.status >= 200 && xhr.status < 300) {
+              ssoHandled = true;
               try {
                 var text = xhr.responseText;
                 handleSsoInitUrl(text);
@@ -1074,9 +1073,13 @@ export class ProxyService {
                 Object.defineProperty(xhr, "response", { value: "", configurable: true });
               } catch(e) {}
             }
+          };
+          xhr.addEventListener("readystatechange", function() {
+            if (xhr.readyState === 4) onDone();
           }, true);
+          xhr.addEventListener("load", onDone, true);
         }
-        return origXhrSend.apply(this, arguments);
+        return origXhrOpen.apply(this, arguments);
       };
     }
   }

--- a/packages/vscode-extension/src/services/proxy-service.ts
+++ b/packages/vscode-extension/src/services/proxy-service.ts
@@ -368,6 +368,23 @@ export class ProxyService {
         res.setHeader('access-control-allow-origin', '*');
         res.setHeader('access-control-allow-credentials', 'true');
 
+        // CWE-522: Strip n8n session cookies before forwarding requests to external IdP
+        if (req.headers['cookie']) {
+            const clientCookies = Array.isArray(req.headers['cookie'])
+                ? req.headers['cookie'].join('; ')
+                : req.headers['cookie'];
+            const filteredCookies = clientCookies
+                .split(';')
+                .map((c) => c.trim())
+                .filter((c) => !c.startsWith('n8n-auth='))
+                .join('; ');
+            if (filteredCookies) {
+                req.headers['cookie'] = filteredCookies;
+            } else {
+                delete req.headers['cookie'];
+            }
+        }
+
         this.proxy.web(req, res, {
             target: targetUrl.origin,
             changeOrigin: true,

--- a/packages/vscode-extension/src/services/proxy-service.ts
+++ b/packages/vscode-extension/src/services/proxy-service.ts
@@ -366,6 +366,13 @@ export class ProxyService {
         }
     }
 
+    public async setSessionToken(token: string): Promise<void> {
+        const cleanToken = token.trim();
+        this.cookieJar.set('n8n-auth', `n8n-auth=${cleanToken}`);
+        await this.saveCookies();
+        this.log(`[Proxy] Session token saved for ${this.target}`);
+    }
+
     private async loadCookies() {
         if (!this.secrets || !this.target) return;
         try {
@@ -376,6 +383,17 @@ export class ProxyService {
                     this.cookieJar.set(key, value);
                 }
                 this.log(`[Proxy] Loaded ${this.cookieJar.size} persisted cookies for ${this.target}`);
+            }
+            if (!this.cookieJar.has('n8n-auth') && process.env.N8NAC_FOLDER_LOGIN_TOKEN) {
+                let envToken = process.env.N8NAC_FOLDER_LOGIN_TOKEN.trim();
+                if (envToken.startsWith('n8n-auth=')) {
+                    envToken = envToken.slice('n8n-auth='.length).trim();
+                }
+                if (envToken.includes(';')) envToken = envToken.split(';')[0].trim();
+                if (envToken) {
+                    this.cookieJar.set('n8n-auth', `n8n-auth=${envToken}`);
+                    this.log(`[Proxy] Loaded n8n-auth session cookie from N8NAC_FOLDER_LOGIN_TOKEN`);
+                }
             }
         } catch (e: any) {
             this.log(`[Proxy] Error loading persisted cookies: ${e.message}`);
@@ -456,7 +474,7 @@ export class ProxyService {
                     const handoff = this.createExternalAuthHandoff(location, returnUrl);
                     if (handoff) {
                         const httpRes = res as http.ServerResponse;
-                        void this.openExternalUrl(handoff.authProxyUrl);
+                        void this.openExternalUrl(location);
                         proxyRes.resume();
                         httpRes.writeHead(200, {
                             'content-type': 'text/html; charset=utf-8',
@@ -987,6 +1005,83 @@ export class ProxyService {
   }
 
   installPopupBridge();
+
+  function isSsoInitUrl(url) {
+    if (!url) return false;
+    var s = String(url);
+    return s.indexOf('/sso/saml/initsso') !== -1
+      || s.indexOf('/sso/oidc/login') !== -1
+      || s.indexOf('/rest/sso/saml/initsso') !== -1
+      || s.indexOf('/rest/sso/oidc/login') !== -1;
+  }
+
+  function handleSsoInitUrl(rawUrl) {
+    if (!rawUrl || typeof rawUrl !== "string") return;
+    var target = rawUrl.trim();
+    if (target.startsWith('"') && target.endsWith('"')) {
+      try { target = JSON.parse(target); } catch(e) {}
+    }
+    if (!target || (!target.startsWith("http://") && !target.startsWith("https://"))) return;
+    window.parent.postMessage({
+      type: "n8n-sso-detected",
+      idpUrl: target,
+      workflowId: String(window.location.pathname)
+    }, "*");
+    postOpenExternal(target, "_blank", "oauth", "", "sso.initsso");
+  }
+
+  function installSsoBridge() {
+    if (typeof window.fetch === "function") {
+      var origFetch = window.fetch;
+      window.fetch = function(input, init) {
+        var url = typeof input === "string" ? input : (input && input.url ? input.url : "");
+        if (isSsoInitUrl(url)) {
+          return origFetch.apply(this, arguments).then(function(res) {
+            if (res.ok) {
+              try {
+                var clone = res.clone();
+                return clone.text().then(function(text) {
+                  handleSsoInitUrl(text);
+                  return new Response("", { status: 200, statusText: "OK", headers: res.headers });
+                });
+              } catch(e) {}
+            }
+            return res;
+          });
+        }
+        return origFetch.apply(this, arguments);
+      };
+    }
+
+    if (typeof window.XMLHttpRequest === "function" && window.XMLHttpRequest.prototype) {
+      var origXhrOpen = window.XMLHttpRequest.prototype.open;
+      var origXhrSend = window.XMLHttpRequest.prototype.send;
+      window.XMLHttpRequest.prototype.open = function(method, url) {
+        this.__n8nacIsSso = isSsoInitUrl(url);
+        return origXhrOpen.apply(this, arguments);
+      };
+      window.XMLHttpRequest.prototype.send = function() {
+        if (this.__n8nacIsSso) {
+          var xhr = this;
+          xhr.addEventListener("load", function() {
+            if (xhr.status >= 200 && xhr.status < 300) {
+              try {
+                var text = xhr.responseText;
+                handleSsoInitUrl(text);
+              } catch(e) {}
+              try {
+                Object.defineProperty(xhr, "responseText", { value: "", configurable: true });
+                Object.defineProperty(xhr, "response", { value: "", configurable: true });
+              } catch(e) {}
+            }
+          }, true);
+        }
+        return origXhrSend.apply(this, arguments);
+      };
+    }
+  }
+
+  installSsoBridge();
 
   function coerceNode(value) {
     var record = asRecord(value);

--- a/packages/vscode-extension/src/services/proxy-service.ts
+++ b/packages/vscode-extension/src/services/proxy-service.ts
@@ -18,6 +18,28 @@ type ExternalAuthSession = {
     expectedTargetUrl: string;
 };
 
+function isLoopbackTarget(targetUrl?: string): boolean {
+    if (!targetUrl) return false;
+    try {
+        const u = new URL(targetUrl);
+        const host = u.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+        return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '0.0.0.0';
+    } catch {
+        return false;
+    }
+}
+
+function shouldVerifyTargetTls(targetUrl?: string): boolean {
+    if (!targetUrl) return true;
+    try {
+        const u = new URL(targetUrl);
+        if (u.protocol !== 'https:') return false;
+        return !/^(0|false|no)$/i.test(process.env.NODE_TLS_REJECT_UNAUTHORIZED ?? '1');
+    } catch {
+        return true;
+    }
+}
+
 export class ProxyService {
     private server: http.Server | undefined;
     private proxy: HttpProxyServer | undefined;
@@ -349,10 +371,22 @@ export class ProxyService {
         this.proxy.web(req, res, {
             target: targetUrl.origin,
             changeOrigin: true,
-            secure: false,
+            secure: shouldVerifyTargetTls(targetUrl.origin),
             buffer: undefined,
         });
         return true;
+    }
+
+    private isTargetAllowedForCredentialForwarding(): boolean {
+        if (!this.target) return false;
+        try {
+            const u = new URL(this.target);
+            if (u.protocol === 'https:') return true;
+            if (u.protocol === 'http:' && isLoopbackTarget(this.target)) return true;
+            return false;
+        } catch {
+            return false;
+        }
     }
 
     private async saveCookies() {
@@ -367,6 +401,9 @@ export class ProxyService {
     }
 
     public async setSessionToken(token: string): Promise<void> {
+        if (this.target && !this.isTargetAllowedForCredentialForwarding()) {
+            throw new Error('Session tokens cannot be forwarded to unencrypted remote HTTP targets. Use HTTPS or a loopback address.');
+        }
         const cleanToken = token.trim();
         this.cookieJar.set('n8n-auth', `n8n-auth=${cleanToken}`);
         await this.saveCookies();
@@ -404,7 +441,12 @@ export class ProxyService {
         const finalCookies: string[] = clientCookies ? [clientCookies] : [];
 
         if (this.cookieJar.size > 0) {
+            const allowSensitiveCookies = this.isTargetAllowedForCredentialForwarding();
             for (const [key, value] of this.cookieJar) {
+                if (key === 'n8n-auth' && !allowSensitiveCookies) {
+                    this.log(`[Proxy] Suppressed sensitive n8n-auth cookie forwarding to unencrypted remote HTTP target: ${this.target}`);
+                    continue;
+                }
                 if (!clientCookies || !clientCookies.includes(key + '=')) {
                     finalCookies.push(value);
                 }
@@ -443,7 +485,7 @@ export class ProxyService {
         this.proxy = HttpProxy.createProxyServer({
             target: this.target,
             changeOrigin: true,
-            secure: false,
+            secure: shouldVerifyTargetTls(this.target),
             // Intercept HTML responses so we can inject the n8n UI bridge.
             selfHandleResponse: true,
             cookieDomainRewrite: "", // Rewrite all domains to match localhost
@@ -630,7 +672,7 @@ export class ProxyService {
                 res.setHeader('access-control-allow-headers', '*');
 
                 // CRITICAL for SSE: Disable buffering
-                this.proxy.web(req, res, { buffer: undefined, changeOrigin: true, secure: false });
+                this.proxy.web(req, res, { buffer: undefined, changeOrigin: true, secure: shouldVerifyTargetTls(this.target) });
             }
         });
 
@@ -694,7 +736,7 @@ export class ProxyService {
                     this.wsServer.handleUpgrade(req, socket, head, (clientWs) => {
                         const upstreamWs = new WebSocket(upstreamUrl, {
                             headers,
-                            rejectUnauthorized: false,
+                            rejectUnauthorized: shouldVerifyTargetTls(this.target),
                             perMessageDeflate: false,
                         });
 

--- a/packages/vscode-extension/src/services/workflow-webview-registry.ts
+++ b/packages/vscode-extension/src/services/workflow-webview-registry.ts
@@ -41,6 +41,16 @@ export class WorkflowWebviewRegistry {
         this.debugLogger?.(`[workflow-registry] reloadIfMatching result workflowId=${workflowId} reloaded=${reloaded}`);
         return reloaded;
     }
+
+    reloadAll(): boolean {
+        let reloaded = false;
+        this.debugLogger?.(`[workflow-registry] reloadAll targets=${this.targets.size}`);
+        for (const target of [...this.targets]) {
+            reloaded = true;
+            void Promise.resolve(target.reloadWorkflow()).catch(() => {});
+        }
+        return reloaded;
+    }
 }
 
 export const workflowWebviewRegistry = new WorkflowWebviewRegistry();

--- a/packages/vscode-extension/src/ui/tree-items/action-item.ts
+++ b/packages/vscode-extension/src/ui/tree-items/action-item.ts
@@ -13,6 +13,7 @@ export enum ActionItemType {
   
   // Standard workflow actions
   BOARD = 'board',     // Open workflow in n8n UI (requires remote id)
+  BROWSER = 'browser', // Open workflow in external browser (requires remote id)
   PULL = 'pull',       // Pull from remote to local (requires remote id)
   PUSH = 'push',       // Push from local to remote (requires local file)
   OPEN = 'open',       // Open local file in editor (requires local file)
@@ -48,6 +49,8 @@ export class ActionItem extends BaseTreeItem {
         return '⬇️ Keep Incoming (remote)';
       case ActionItemType.BOARD:
         return '🌐 Board';
+      case ActionItemType.BROWSER:
+        return '🔗 Browser';
       case ActionItemType.PULL:
         return '⬇️ Pull';
       case ActionItemType.PUSH:
@@ -71,6 +74,8 @@ export class ActionItem extends BaseTreeItem {
         return new vscode.ThemeIcon('cloud-download');
       case ActionItemType.BOARD:
         return new vscode.ThemeIcon('globe');
+      case ActionItemType.BROWSER:
+        return new vscode.ThemeIcon('link-external');
       case ActionItemType.OPEN:
         return new vscode.ThemeIcon('go-to-file');
       default:
@@ -102,6 +107,12 @@ export class ActionItem extends BaseTreeItem {
         return {
           command: 'n8n.openBoard',
           title: 'Open Board',
+          arguments: [workflow]
+        };
+      case ActionItemType.BROWSER:
+        return {
+          command: 'n8n.openInBrowser',
+          title: 'Open in Browser',
           arguments: [workflow]
         };
       case ActionItemType.PULL:
@@ -137,6 +148,8 @@ export class ActionItem extends BaseTreeItem {
         return 'Keep the incoming remote version — overwrite local file';
       case ActionItemType.BOARD:
         return 'Open workflow in n8n web UI';
+      case ActionItemType.BROWSER:
+        return 'Open workflow in external browser';
       case ActionItemType.PULL:
         return 'Pull latest from n8n to local file';
       case ActionItemType.PUSH:
@@ -150,8 +163,8 @@ export class ActionItem extends BaseTreeItem {
   
   // Enabled/disabled state for actions
   static isEnabledForArchived(actionType: ActionItemType): boolean {
-    // Only PULL and BOARD are allowed for archived workflows
-    return actionType === ActionItemType.PULL || actionType === ActionItemType.BOARD;
+    // PULL, BOARD, and BROWSER are allowed for archived workflows
+    return actionType === ActionItemType.PULL || actionType === ActionItemType.BOARD || actionType === ActionItemType.BROWSER;
   }
   
   static isLocalOnlyAction(actionType: ActionItemType): boolean {

--- a/packages/vscode-extension/src/ui/tree-items/workflow-item.ts
+++ b/packages/vscode-extension/src/ui/tree-items/workflow-item.ts
@@ -102,18 +102,18 @@ export class WorkflowItem extends BaseTreeItem {
 
       case WorkflowSyncStatus.EXIST_ONLY_REMOTELY:
         // Remote-only: no local file, so no OPEN or PUSH
-        // BOARD and PULL always available (archived or not)
-        return [ActionItemType.BOARD, ActionItemType.PULL];
+        // BOARD, BROWSER and PULL always available (archived or not)
+        return [ActionItemType.BOARD, ActionItemType.BROWSER, ActionItemType.PULL];
 
       case WorkflowSyncStatus.TRACKED:
         // Tracked: has both local and remote
         if (isArchived) {
           // Archived workflows are read-only on remote side
           // Local file exists but shouldn't be opened for editing since remote is archived
-          return [ActionItemType.BOARD, ActionItemType.PULL];
+          return [ActionItemType.BOARD, ActionItemType.BROWSER, ActionItemType.PULL];
         } else {
           // Normal tracked workflow: all actions available
-          return [ActionItemType.BOARD, ActionItemType.OPEN, ActionItemType.PULL, ActionItemType.PUSH];
+          return [ActionItemType.BOARD, ActionItemType.BROWSER, ActionItemType.OPEN, ActionItemType.PULL, ActionItemType.PUSH];
         }
 
       default:

--- a/packages/vscode-extension/src/ui/webview-html.ts
+++ b/packages/vscode-extension/src/ui/webview-html.ts
@@ -98,12 +98,112 @@ export function buildWebviewHtml(workflowId: string, url: string, endpointsOrFor
                     color: #666;
                     text-align: center;
                 }
+                .sso-overlay {
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                    width: 100%;
+                    height: 100%;
+                    background: rgba(0, 0, 0, 0.78);
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    z-index: 200;
+                }
+                .sso-modal {
+                    max-width: 440px;
+                    margin: 20px;
+                    padding: 24px;
+                    background: var(--vscode-editor-background, #1e1e1e);
+                    border: 1px solid var(--vscode-widget-border, #3c3c3c);
+                    border-radius: 8px;
+                    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+                    font-family: system-ui, -apple-system, sans-serif;
+                    color: var(--vscode-editor-foreground, #cccccc);
+                    text-align: center;
+                }
+                .sso-badge {
+                    display: inline-block;
+                    padding: 3px 9px;
+                    font-size: 11px;
+                    font-weight: 600;
+                    text-transform: uppercase;
+                    letter-spacing: 0.5px;
+                    background: var(--vscode-badge-background, #3a3d41);
+                    color: var(--vscode-badge-foreground, #ffffff);
+                    border-radius: 12px;
+                    margin-bottom: 12px;
+                }
+                .sso-modal h3 {
+                    margin: 0 0 10px;
+                    font-size: 17px;
+                    color: var(--vscode-editor-foreground, #ffffff);
+                    font-weight: 600;
+                }
+                .sso-modal p {
+                    font-size: 13px;
+                    line-height: 1.5;
+                    margin: 0 0 12px;
+                    color: var(--vscode-descriptionForeground, #999999);
+                }
+                .sso-hint {
+                    margin-bottom: 18px !important;
+                    font-weight: 500;
+                    color: var(--vscode-editor-foreground, #dddddd) !important;
+                }
+                .sso-buttons {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 8px;
+                }
+                .sso-btn {
+                    padding: 8px 16px;
+                    border-radius: 4px;
+                    font-size: 13px;
+                    font-weight: 500;
+                    cursor: pointer;
+                    border: none;
+                    transition: opacity 0.15s ease;
+                }
+                .sso-btn:hover {
+                    opacity: 0.9;
+                }
+                .sso-btn.primary {
+                    background: var(--vscode-button-background, #0e639c);
+                    color: var(--vscode-button-foreground, #ffffff);
+                }
+                .sso-btn.secondary {
+                    background: var(--vscode-button-secondaryBackground, #3a3d41);
+                    color: var(--vscode-button-secondaryForeground, #ffffff);
+                }
+                .sso-btn.text {
+                    background: transparent;
+                    color: var(--vscode-textLink-foreground, #3794ff);
+                    margin-top: 4px;
+                }
+                .sso-btn.text:hover {
+                    text-decoration: underline;
+                }
             </style>
         </head>
         <body>
             <div id="loading-overlay" class="loading-overlay">Refreshing n8n...</div>
             <div id="initial-loading" class="initial-loading">Loading n8n workflow...</div>
             
+            <div id="sso-overlay" class="sso-overlay" style="display: none;">
+                <div class="sso-modal">
+                    <div class="sso-badge">Single Sign-On</div>
+                    <h3>SSO Authentication Required</h3>
+                    <p>Enterprise identity providers (Microsoft Entra ID, Okta, etc.) prohibit iframe embedding for security.</p>
+                    <p class="sso-hint">Sign in opened in your browser. Choose how you would like to work:</p>
+                    <div class="sso-buttons">
+                        <button id="sso-btn-browser" class="sso-btn primary">Open Workflow in External Browser</button>
+                        <button id="sso-btn-cookie" class="sso-btn secondary">Enter Session Cookie (n8n-auth)</button>
+                        <button id="sso-btn-retry" class="sso-btn text">Retry Workflow</button>
+                    </div>
+                </div>
+            </div>
+
             <div class="iframe-container">
                 <iframe 
                     id="frame-1"
@@ -128,6 +228,34 @@ export function buildWebviewHtml(workflowId: string, url: string, endpointsOrFor
                 const workflowId = ${safeWorkflowIdJs};
                 const workflowEndpoints = ${workflowEndpointsJs};
                 const formTestUrl = ${formTestUrlJs};
+                const ssoOverlay = document.getElementById('sso-overlay');
+                const ssoBtnBrowser = document.getElementById('sso-btn-browser');
+                const ssoBtnCookie = document.getElementById('sso-btn-cookie');
+                const ssoBtnRetry = document.getElementById('sso-btn-retry');
+
+                if (ssoBtnBrowser) {
+                    ssoBtnBrowser.onclick = () => {
+                        vscode.postMessage({ type: 'open-workflow-in-browser' });
+                    };
+                }
+                if (ssoBtnCookie) {
+                    ssoBtnCookie.onclick = () => {
+                        vscode.postMessage({ type: 'prompt-session-cookie' });
+                    };
+                }
+                if (ssoBtnRetry) {
+                    ssoBtnRetry.onclick = () => {
+                        if (ssoOverlay) ssoOverlay.style.display = 'none';
+                        performSeamlessRefresh();
+                    };
+                }
+
+                function showSsoOverlay() {
+                    if (ssoOverlay) {
+                        ssoOverlay.style.display = 'flex';
+                        if (initialLoading) initialLoading.style.display = 'none';
+                    }
+                }
                 
                 function focusActiveFrame() {
                     try {
@@ -252,10 +380,16 @@ export function buildWebviewHtml(workflowId: string, url: string, endpointsOrFor
                     if (!message || typeof message !== 'object') return;
 
                     if (message.type === ${reloadMessageTypeJs}) {
+                        if (ssoOverlay) ssoOverlay.style.display = 'none';
                         const softRefreshWorked = attemptSoftRefresh();
                         if (!softRefreshWorked) {
                             performSeamlessRefresh();
                         }
+                        return;
+                    }
+
+                    if (message.type === 'n8n-sso-detected') {
+                        showSsoOverlay();
                         return;
                     }
 

--- a/packages/vscode-extension/src/ui/webview-html.ts
+++ b/packages/vscode-extension/src/ui/webview-html.ts
@@ -190,10 +190,10 @@ export function buildWebviewHtml(workflowId: string, url: string, endpointsOrFor
             <div id="loading-overlay" class="loading-overlay">Refreshing n8n...</div>
             <div id="initial-loading" class="initial-loading">Loading n8n workflow...</div>
             
-            <div id="sso-overlay" class="sso-overlay" style="display: none;">
+            <div id="sso-overlay" class="sso-overlay" role="dialog" aria-modal="true" aria-labelledby="sso-title" style="display: none;">
                 <div class="sso-modal">
                     <div class="sso-badge">Single Sign-On</div>
-                    <h3>SSO Authentication Required</h3>
+                    <h3 id="sso-title">SSO Authentication Required</h3>
                     <p>Enterprise identity providers (Microsoft Entra ID, Okta, etc.) prohibit iframe embedding for security.</p>
                     <p class="sso-hint">Sign in opened in your browser. Choose how you would like to work:</p>
                     <div class="sso-buttons">
@@ -232,6 +232,7 @@ export function buildWebviewHtml(workflowId: string, url: string, endpointsOrFor
                 const ssoBtnBrowser = document.getElementById('sso-btn-browser');
                 const ssoBtnCookie = document.getElementById('sso-btn-cookie');
                 const ssoBtnRetry = document.getElementById('sso-btn-retry');
+                let previousFocusedElement = null;
 
                 if (ssoBtnBrowser) {
                     ssoBtnBrowser.onclick = () => {
@@ -245,15 +246,27 @@ export function buildWebviewHtml(workflowId: string, url: string, endpointsOrFor
                 }
                 if (ssoBtnRetry) {
                     ssoBtnRetry.onclick = () => {
-                        if (ssoOverlay) ssoOverlay.style.display = 'none';
+                        hideSsoOverlay();
                         performSeamlessRefresh();
                     };
                 }
 
                 function showSsoOverlay() {
                     if (ssoOverlay) {
+                        previousFocusedElement = document.activeElement;
                         ssoOverlay.style.display = 'flex';
                         if (initialLoading) initialLoading.style.display = 'none';
+                        if (ssoBtnBrowser) ssoBtnBrowser.focus();
+                    }
+                }
+
+                function hideSsoOverlay() {
+                    if (ssoOverlay && ssoOverlay.style.display !== 'none') {
+                        ssoOverlay.style.display = 'none';
+                        if (previousFocusedElement && typeof previousFocusedElement.focus === 'function') {
+                            try { previousFocusedElement.focus(); } catch (e) {}
+                        }
+                        previousFocusedElement = null;
                     }
                 }
                 
@@ -380,7 +393,7 @@ export function buildWebviewHtml(workflowId: string, url: string, endpointsOrFor
                     if (!message || typeof message !== 'object') return;
 
                     if (message.type === ${reloadMessageTypeJs}) {
-                        if (ssoOverlay) ssoOverlay.style.display = 'none';
+                        hideSsoOverlay();
                         const softRefreshWorked = attemptSoftRefresh();
                         if (!softRefreshWorked) {
                             performSeamlessRefresh();

--- a/packages/vscode-extension/src/ui/workflow-webview.ts
+++ b/packages/vscode-extension/src/ui/workflow-webview.ts
@@ -56,6 +56,14 @@ export class WorkflowWebview {
                     features: typeof message.features === 'string' ? message.features : undefined,
                 });
             }
+            if (message.type === 'open-workflow-in-browser') {
+                void vscode.commands.executeCommand('n8n.openInBrowser', {
+                    workflow: { id: this._workflowId, name: this._workflowName },
+                });
+            }
+            if (message.type === 'prompt-session-cookie') {
+                void vscode.commands.executeCommand('n8n.setSessionCookie');
+            }
         }, null, this._disposables);
     }
 
@@ -102,6 +110,13 @@ export class WorkflowWebview {
      */
     public static reloadIfMatching(workflowId: string, _outputChannel?: vscode.OutputChannel) {
         return workflowWebviewRegistry.reloadIfMatching(workflowId);
+    }
+
+    /**
+     * Trigger a reload of all active workflow webviews.
+     */
+    public static reloadAll(_outputChannel?: vscode.OutputChannel) {
+        return workflowWebviewRegistry.reloadAll();
     }
 
     public update(workflow: IWorkflowStatus, url: string, endpoints?: WorkflowWebviewEndpoints) {

--- a/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
+++ b/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
@@ -535,6 +535,44 @@ test('ProxyService: loadCookies automatically picks up N8NAC_FOLDER_LOGIN_TOKEN'
     }
 });
 
+test('ProxyService: setSessionToken rejects unencrypted remote HTTP targets', async () => {
+    const { ProxyService } = require('../../src/services/proxy-service.js');
+    const service = new ProxyService();
+    (service as any).target = 'http://n8n.example.test:5678';
+    (service as any).secrets = {
+        store: async () => {},
+        get: async () => null,
+    };
+
+    await assert.rejects(
+        async () => {
+            await service.setSessionToken('jwt-session-token-123');
+        },
+        /cannot be forwarded to unencrypted remote HTTP targets/,
+    );
+});
+
+test('ProxyService: buildMergedCookieHeader suppresses sensitive n8n-auth on remote HTTP targets', async () => {
+    const { ProxyService } = require('../../src/services/proxy-service.js');
+    const service = new ProxyService();
+    (service as any).target = 'http://n8n.example.test:5678';
+    (service as any).cookieJar.set('n8n-auth', 'n8n-auth=sensitive-token');
+    (service as any).cookieJar.set('regular-cookie', 'regular-cookie=safe-value');
+
+    const header = (service as any).buildMergedCookieHeader();
+    assert.equal(header, 'regular-cookie=safe-value');
+});
+
+test('ProxyService: allows credentials on localhost loopback HTTP targets', async () => {
+    const { ProxyService } = require('../../src/services/proxy-service.js');
+    const service = new ProxyService();
+    (service as any).target = 'http://localhost:5678';
+    (service as any).cookieJar.set('n8n-auth', 'n8n-auth=local-token');
+
+    const header = (service as any).buildMergedCookieHeader();
+    assert.equal(header, 'n8n-auth=local-token');
+});
+
 test('Bridge script: includes SSO endpoint interception', () => {
     const { ProxyService } = require('../../src/services/proxy-service.js');
     const script = ProxyService.buildBridgeScript();

--- a/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
+++ b/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
@@ -542,6 +542,10 @@ test('Bridge script: includes SSO endpoint interception', () => {
     assert.ok(script.includes('/sso/saml/initsso'), 'Bridge script must monitor saml initsso endpoint');
     assert.ok(script.includes('/sso/oidc/login'), 'Bridge script must monitor oidc login endpoint');
     assert.ok(script.includes('n8n-sso-detected'), 'Bridge script must notify parent webview on SSO detection');
+    assert.ok(
+        script.includes('origXhrOpen') && script.includes('readystatechange') && script.includes('ssoHandled'),
+        'Bridge script must set up XHR interception at open() time before caller listeners attach',
+    );
 });
 
 test('Parent webview HTML: renders SSO overlay modal and action buttons', () => {
@@ -549,8 +553,12 @@ test('Parent webview HTML: renders SSO overlay modal and action buttons', () => 
     const html: string = buildWebviewHtml('wf-1', 'http://localhost:5678/workflow/wf-1');
 
     assert.ok(html.includes('id="sso-overlay"'), 'Parent webview must contain SSO overlay');
+    assert.ok(html.includes('role="dialog"'), 'Parent webview must include dialog role for accessibility');
+    assert.ok(html.includes('aria-modal="true"'), 'Parent webview must declare modal dialog');
     assert.ok(html.includes('id="sso-btn-browser"'), 'Parent webview must contain open browser button');
     assert.ok(html.includes('id="sso-btn-cookie"'), 'Parent webview must contain enter session cookie button');
+    assert.ok(html.includes('ssoBtnBrowser.focus()'), 'Parent webview must focus primary action on open');
+    assert.ok(html.includes('hideSsoOverlay()'), 'Parent webview must restore focus on close');
     assert.ok(html.includes('open-workflow-in-browser'), 'Parent webview script must wire up open in browser message');
     assert.ok(html.includes('prompt-session-cookie'), 'Parent webview script must wire up prompt session cookie message');
     assert.ok(html.includes('n8n-sso-detected'), 'Parent webview must listen for n8n-sso-detected message');

--- a/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
+++ b/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
@@ -601,3 +601,30 @@ test('Parent webview HTML: renders SSO overlay modal and action buttons', () => 
     assert.ok(html.includes('prompt-session-cookie'), 'Parent webview script must wire up prompt session cookie message');
     assert.ok(html.includes('n8n-sso-detected'), 'Parent webview must listen for n8n-sso-detected message');
 });
+
+test('ProxyService: handleExternalAuthProxyRequest strips n8n-auth from forwarded cookies to IdP', () => {
+    const { ProxyService } = require('../../src/services/proxy-service.js');
+    const service = new ProxyService();
+    (service as any).proxy = {
+        web: () => {},
+    };
+    const req: any = {
+        url: '/_auth/external/token-123',
+        headers: {
+            host: 'localhost:5678',
+            cookie: 'n8n-auth=sensitive-secret; other-cookie=safe-idp-val',
+        },
+    };
+    const res: any = {
+        setHeader: () => {},
+    };
+    (service as any).parseExternalAuthProxyRequest = () => ({
+        token: 'token-123',
+        targetUrl: 'https://login.microsoftonline.com/oauth/authorize?foo=bar',
+    });
+
+    const handled = (service as any).handleExternalAuthProxyRequest(req, res);
+    assert.strictEqual(handled, true);
+    assert.strictEqual(req.headers.cookie, 'other-cookie=safe-idp-val');
+    assert.ok(!req.headers.cookie.includes('n8n-auth'));
+});

--- a/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
+++ b/packages/vscode-extension/tests/unit/clipboard-bridge.test.ts
@@ -494,3 +494,64 @@ test('registerClipboardHandler: guard skips registration on non-darwin platforms
         'Must return false on non-macOS platforms — handler must not be registered'
     );
 });
+
+// ── 5 : SSO Authentication & Session Token Support ────────────────────────────
+
+test('ProxyService: setSessionToken sets n8n-auth cookie and merged header', async () => {
+    const { ProxyService } = require('../../src/services/proxy-service.js');
+    const service = new ProxyService();
+    (service as any).target = 'https://n8n.example.test';
+    (service as any).secrets = {
+        store: async () => {},
+        get: async () => null,
+    };
+
+    await service.setSessionToken('jwt-session-token-123');
+    const cookieHeader = (service as any).buildMergedCookieHeader();
+    assert.equal(cookieHeader, 'n8n-auth=jwt-session-token-123');
+});
+
+test('ProxyService: loadCookies automatically picks up N8NAC_FOLDER_LOGIN_TOKEN', async () => {
+    const { ProxyService } = require('../../src/services/proxy-service.js');
+    const service = new ProxyService();
+    (service as any).target = 'https://n8n.example.test';
+    (service as any).secrets = {
+        store: async () => {},
+        get: async () => null,
+    };
+
+    const prevEnv = process.env.N8NAC_FOLDER_LOGIN_TOKEN;
+    try {
+        process.env.N8NAC_FOLDER_LOGIN_TOKEN = 'n8n-auth=jwt-from-env; Path=/; HttpOnly';
+        await (service as any).loadCookies();
+        const cookieHeader = (service as any).buildMergedCookieHeader();
+        assert.equal(cookieHeader, 'n8n-auth=jwt-from-env');
+    } finally {
+        if (prevEnv !== undefined) {
+            process.env.N8NAC_FOLDER_LOGIN_TOKEN = prevEnv;
+        } else {
+            delete process.env.N8NAC_FOLDER_LOGIN_TOKEN;
+        }
+    }
+});
+
+test('Bridge script: includes SSO endpoint interception', () => {
+    const { ProxyService } = require('../../src/services/proxy-service.js');
+    const script = ProxyService.buildBridgeScript();
+
+    assert.ok(script.includes('/sso/saml/initsso'), 'Bridge script must monitor saml initsso endpoint');
+    assert.ok(script.includes('/sso/oidc/login'), 'Bridge script must monitor oidc login endpoint');
+    assert.ok(script.includes('n8n-sso-detected'), 'Bridge script must notify parent webview on SSO detection');
+});
+
+test('Parent webview HTML: renders SSO overlay modal and action buttons', () => {
+    const { buildWebviewHtml } = require('../../src/ui/webview-html.js');
+    const html: string = buildWebviewHtml('wf-1', 'http://localhost:5678/workflow/wf-1');
+
+    assert.ok(html.includes('id="sso-overlay"'), 'Parent webview must contain SSO overlay');
+    assert.ok(html.includes('id="sso-btn-browser"'), 'Parent webview must contain open browser button');
+    assert.ok(html.includes('id="sso-btn-cookie"'), 'Parent webview must contain enter session cookie button');
+    assert.ok(html.includes('open-workflow-in-browser'), 'Parent webview script must wire up open in browser message');
+    assert.ok(html.includes('prompt-session-cookie'), 'Parent webview script must wire up prompt session cookie message');
+    assert.ok(html.includes('n8n-sso-detected'), 'Parent webview must listen for n8n-sso-detected message');
+});


### PR DESCRIPTION
## What does this PR do?

Resolves issue #465 where instances configured with enterprise SSO (Microsoft Entra ID / SAML / OIDC) encounter a black screen when clicking "Continue with SSO" in the embedded VS Code webview.

### Root Cause
- When clicking "Continue with SSO", n8n's frontend (`SSOLogin.vue`) calls `GET /sso/saml/initsso` which returns `200 OK` with the IdP URL (e.g. `https://login.microsoftonline.com/...`) in the body.
- The frontend immediately executes `window.location.href = redirectUrl` inside the iframe.
- Identity Providers (Microsoft Entra ID, Okta, etc.) enforce strict clickjacking protection via `X-Frame-Options: DENY` and `Content-Security-Policy: frame-ancestors 'none'`.
- Chromium/Electron blocks the frame from loading, rendering a completely blank/black frame against VS Code's dark background.
- SAML POST assertions target the registered n8n public ACS URL, making direct iframe proxying of enterprise IdPs impossible.

### Key Changes
1. **Direct "Open in External Browser" Action (`n8n.openInBrowser`)**:
   - Added `n8n.openInBrowser` command (`$(link-external)`) and context menu action (`1_open@5`).
   - Added `🔗 Browser` action item under remote and archived workflows in the tree explorer.
   - Opens the workflow directly in the system's default browser (`vscode.env.openExternal`) where corporate SSO sessions are already authenticated.
2. **SSO Interception & Black Screen Elimination**:
   - Injected `installSsoBridge()` into the iframe bridge script to intercept `window.fetch` and `XMLHttpRequest` calls to `/sso/saml/initsso` and `/sso/oidc/login`.
   - Neutralizes client-side navigation (`window.location.href`) toward the IdP, preventing iframe blocking and eliminating the black screen.
   - Automatically relays the IdP login URL to the system browser.
   - Added an integrated `#sso-overlay` in `webview-html.ts` styled after VS Code theme variables, giving users immediate options:
     - **Open Workflow in External Browser**
     - **Enter Session Cookie (n8n-auth)**
     - **Retry Workflow**
3. **Session Token Support (`n8n.setSessionCookie`)**:
   - Added `n8n.setSessionCookie` command allowing users who wish to use the embedded VS Code canvas to paste their `n8n-auth` cookie.
   - Persisted securely in VS Code `SecretStorage` and injected on outgoing proxy requests via `buildMergedCookieHeader`.
   - Automatically imports `N8NAC_FOLDER_LOGIN_TOKEN` if present in the environment (matching existing CLI support).
   - Automatically reloads active webviews via `workflowWebviewRegistry.reloadAll()`.
4. **Unit Tests**:
   - Added unit tests in `clipboard-bridge.test.ts` covering session token setting, environment token loading, bridge SSO endpoint interception, and webview SSO overlay rendering. All 156 unit tests pass.

**Related issue (if any):** Fixes #465


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Open workflows directly in an external browser from workflow menus, including archived and cloud-only workflows.
  - Set an SSO session cookie from the extension to authenticate workflow views.
  - Added an SSO sign-in overlay with browser, session-cookie, and retry options.
  - Workflow views now refresh after authentication credentials are updated.
- **Bug Fixes**
  - Improved workflow links and authentication redirects while preserving configured paths.
  - Strengthened credential forwarding and certificate verification for safer connections.
- **Tests**
  - Added coverage for SSO authentication, session tokens, secure forwarding, and webview interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->