### PR TITLE
fix(transformer): persist continueOnFail and pass through unmodelled node properties

### DIFF
--- a/packages/cli/src/core/assets/n8n-workflows.d.ts
+++ b/packages/cli/src/core/assets/n8n-workflows.d.ts
@@ -122,6 +122,10 @@ declare module '@n8n-as-code/transformer' {
         notes?: string;
         /** Display notes directly on the workflow canvas */
         notesInFlow?: boolean;
+        /** Continue workflow execution even if this node fails (legacy onError equivalent) */
+        continueOnFail?: boolean;
+        /** Passthrough for unmodelled node properties */
+        [key: string]: any;
     }
 
     // =========================================================================

--- a/packages/transformer/src/compiler/typescript-parser.ts
+++ b/packages/transformer/src/compiler/typescript-parser.ts
@@ -6,7 +6,7 @@
  */
 
 import { Project, SourceFile, SyntaxKind, ClassDeclaration, PropertyDeclaration, MethodDeclaration, Node } from 'ts-morph';
-import { WorkflowAST, NodeAST, ConnectionAST, WorkflowMetadata, AI_ARRAY_ROLES } from '../types.js';
+import { WorkflowAST, NodeAST, ConnectionAST, WorkflowMetadata, AI_ARRAY_ROLES, KNOWN_NODE_METADATA_KEYS } from '../types.js';
 
 /**
  * Parse TypeScript workflow file
@@ -165,6 +165,16 @@ export class TypeScriptParser {
             const initializer = prop.getInitializer();
             const parameters = initializer ? this.extractValueFromASTNode(initializer) : {};
             
+            const handledMetadataKeys = new Set<string>(KNOWN_NODE_METADATA_KEYS);
+            const extraMetadata: Record<string, any> = {};
+            if (metadata && typeof metadata === 'object') {
+                for (const [key, value] of Object.entries(metadata)) {
+                    if (!handledMetadataKeys.has(key) && value !== undefined) {
+                        extraMetadata[key] = value;
+                    }
+                }
+            }
+
             nodes.push({
                 propertyName,
                 ...(metadata.id && { id: metadata.id }),
@@ -183,6 +193,8 @@ export class TypeScriptParser {
                 ...(metadata.disabled !== undefined && { disabled: metadata.disabled }),
                 ...(metadata.notes !== undefined && { notes: metadata.notes }),
                 ...(metadata.notesInFlow !== undefined && { notesInFlow: metadata.notesInFlow }),
+                ...(metadata.continueOnFail !== undefined && { continueOnFail: metadata.continueOnFail }),
+                ...extraMetadata,
                 parameters
                 // aiDependencies will be added by extractAIDependencies()
             });

--- a/packages/transformer/src/compiler/workflow-builder.ts
+++ b/packages/transformer/src/compiler/workflow-builder.ts
@@ -4,7 +4,7 @@
  * Builds n8n workflow JSON from extracted TypeScript metadata
  */
 
-import { WorkflowAST, N8nWorkflow, N8nNode, N8nConnections, NodeAST, ConnectionAST, AI_ARRAY_ROLES, AI_SINGLE_ROLES } from '../types.js';
+import { WorkflowAST, N8nWorkflow, N8nNode, N8nConnections, NodeAST, ConnectionAST, AI_ARRAY_ROLES, AI_SINGLE_ROLES, KNOWN_NODE_METADATA_KEYS, INTERNAL_AST_NODE_KEYS } from '../types.js';
 import { randomUUID } from 'crypto';
 import { createHash } from 'crypto';
 
@@ -111,6 +111,20 @@ export class WorkflowBuilder {
             }
             if (node.notesInFlow !== undefined) {
                 n8nNode.notesInFlow = node.notesInFlow;
+            }
+            if (node.continueOnFail !== undefined) {
+                n8nNode.continueOnFail = node.continueOnFail;
+            }
+
+            const handledKeys = new Set<string>([
+                ...KNOWN_NODE_METADATA_KEYS,
+                ...INTERNAL_AST_NODE_KEYS
+            ]);
+
+            for (const [key, value] of Object.entries(node)) {
+                if (!handledKeys.has(key) && value !== undefined) {
+                    (n8nNode as any)[key] = value;
+                }
             }
             
             return n8nNode;

--- a/packages/transformer/src/decorators/types.ts
+++ b/packages/transformer/src/decorators/types.ts
@@ -80,6 +80,12 @@ export interface NodeDecoratorMetadata {
 
     /** Display notes directly on the workflow canvas */
     notesInFlow?: boolean;
+
+    /** Continue workflow execution even if this node fails (legacy onError equivalent) */
+    continueOnFail?: boolean;
+
+    /** Passthrough for unmodelled node properties */
+    [key: string]: any;
 }
 
 export type NodeDecoratorOptions = NodeDecoratorMetadata;

--- a/packages/transformer/src/index.ts
+++ b/packages/transformer/src/index.ts
@@ -45,6 +45,11 @@ export type {
     ValidationWarning
 } from './types.js';
 
+export {
+    KNOWN_NODE_METADATA_KEYS,
+    INTERNAL_AST_NODE_KEYS
+} from './types.js';
+
 // Utilities
 export {
     generatePropertyName,

--- a/packages/transformer/src/parser/ast-to-typescript.ts
+++ b/packages/transformer/src/parser/ast-to-typescript.ts
@@ -4,7 +4,7 @@
  * Generates TypeScript code from AST representation
  */
 
-import { WorkflowAST, NodeAST, ConnectionAST, JsonToTypeScriptOptions, AI_ARRAY_ROLES, AI_SINGLE_ROLES } from '../types.js';
+import { WorkflowAST, NodeAST, ConnectionAST, JsonToTypeScriptOptions, AI_ARRAY_ROLES, AI_SINGLE_ROLES, KNOWN_NODE_METADATA_KEYS, INTERNAL_AST_NODE_KEYS } from '../types.js';
 import {
     formatTypeScript,
     generateSectionComment,
@@ -110,6 +110,7 @@ export class AstToTypeScriptGenerator {
             if (n.executeOnce) flags.push('[executeOnce]');
             if (n.retryOnFail) flags.push('[retry]');
             if (n.disabled) flags.push('[disabled]');
+            if (n.continueOnFail) flags.push('[continueOnFail]');
             for (const role of subNodeRoles.get(n.propertyName) ?? []) flags.push(`[${role}]`);
             lines.push(`// ${prop} ${t} ${flags.join(' ')}`);
         }
@@ -361,6 +362,20 @@ export class AstToTypeScriptGenerator {
         }
         if (node.notesInFlow !== undefined) {
             parts.push(`notesInFlow: ${node.notesInFlow}`);
+        }
+        if (node.continueOnFail !== undefined) {
+            parts.push(`continueOnFail: ${node.continueOnFail}`);
+        }
+
+        const handledKeys = new Set<string>([
+            ...KNOWN_NODE_METADATA_KEYS,
+            ...INTERNAL_AST_NODE_KEYS
+        ]);
+
+        for (const [key, value] of Object.entries(node)) {
+            if (!handledKeys.has(key) && value !== undefined) {
+                parts.push(`${this.formatPropertyKey(key)}: ${this.formatValue(value, 2)}`);
+            }
         }
         
         return `{\n        ${parts.join(',\n        ')}\n    }`;

--- a/packages/transformer/src/parser/json-to-ast.ts
+++ b/packages/transformer/src/parser/json-to-ast.ts
@@ -4,7 +4,7 @@
  * Converts n8n workflow JSON to intermediate AST representation
  */
 
-import { N8nWorkflow, WorkflowAST, NodeAST, ConnectionAST, PropertyNameContext, AI_ARRAY_ROLES, AI_SINGLE_ROLES } from '../types.js';
+import { N8nWorkflow, WorkflowAST, NodeAST, ConnectionAST, PropertyNameContext, AI_ARRAY_ROLES, AI_SINGLE_ROLES, KNOWN_NODE_METADATA_KEYS } from '../types.js';
 import { createPropertyNameContext, generatePropertyName } from '../utils/naming.js';
 
 // AI connection types are handled separately by extractAIDependencies()
@@ -80,6 +80,16 @@ export class JsonToAstParser {
      * Parse single node
      */
     private parseNode(node: any, propertyName: string): NodeAST {
+        const handledKeys = new Set<string>(KNOWN_NODE_METADATA_KEYS);
+        handledKeys.add('parameters');
+
+        const extraProps: Record<string, any> = {};
+        for (const [key, value] of Object.entries(node)) {
+            if (!handledKeys.has(key) && value !== undefined) {
+                extraProps[key] = value;
+            }
+        }
+
         return {
             propertyName,
             ...(node.id && { id: node.id }),
@@ -99,6 +109,8 @@ export class JsonToAstParser {
             ...(node.disabled !== undefined && { disabled: node.disabled }),
             ...(node.notes !== undefined && { notes: node.notes }),
             ...(node.notesInFlow !== undefined && { notesInFlow: node.notesInFlow }),
+            ...(node.continueOnFail !== undefined && { continueOnFail: node.continueOnFail }),
+            ...extraProps,
         };
     }
     

--- a/packages/transformer/src/types.ts
+++ b/packages/transformer/src/types.ts
@@ -87,12 +87,18 @@ export interface NodeAST {
     disabled?: boolean;
     notes?: string;
     notesInFlow?: boolean;
+
+    // Legacy error handling
+    continueOnFail?: boolean;
     
     // Node parameters (property value in TypeScript)
     parameters: Record<string, any>;
     
     // AI node dependencies (from .uses() calls)
     aiDependencies?: AIDependencies;
+
+    // Passthrough for unmodelled node properties
+    [key: string]: any;
 }
 
 /**
@@ -217,7 +223,50 @@ export interface N8nNode {
     disabled?: boolean;
     notes?: string;
     notesInFlow?: boolean;
+
+    // Legacy error handling
+    continueOnFail?: boolean;
+
+    // Passthrough for unmodelled node properties
+    [key: string]: any;
 }
+
+/**
+ * Known node-level metadata properties in n8n / @node decorator.
+ */
+export const KNOWN_NODE_METADATA_KEYS = [
+    'id',
+    'webhookId',
+    'name',
+    'type',
+    'version',
+    'typeVersion',
+    'position',
+    'credentials',
+    'onError',
+    'alwaysOutputData',
+    'executeOnce',
+    'retryOnFail',
+    'maxTries',
+    'waitBetweenTries',
+    'disabled',
+    'notes',
+    'notesInFlow',
+    'continueOnFail',
+] as const;
+
+/**
+ * Internal NodeAST properties that should not be emitted into @node decorators
+ * or serialized back as extra n8n node properties.
+ */
+export const INTERNAL_AST_NODE_KEYS = [
+    'propertyName',
+    'displayName',
+    'version',
+    'typeVersion',
+    'parameters',
+    'aiDependencies',
+] as const;
 
 /**
  * Type aliases for AST / Metadata nodes

--- a/packages/transformer/tests/json-to-typescript.test.ts
+++ b/packages/transformer/tests/json-to-typescript.test.ts
@@ -573,4 +573,189 @@ export class AiTestWorkflow {
 
         expect(tsCode).toMatch(/InactiveNode\s+set\s+.*\[disabled\]/);
     });
+
+    it('should preserve continueOnFail through full pull→push roundtrip', async () => {
+        const workflowJson = {
+            id: 'wf-roundtrip-continue-on-fail',
+            name: 'Roundtrip continueOnFail Workflow',
+            active: false,
+            nodes: [
+                {
+                    id: 'node-cof-1',
+                    name: 'Lenient Node',
+                    type: 'n8n-nodes-base.set',
+                    typeVersion: 3,
+                    position: [100, 200],
+                    parameters: { mode: 'manual' },
+                    continueOnFail: true,
+                },
+                {
+                    id: 'node-cof-2',
+                    name: 'Strict Node',
+                    type: 'n8n-nodes-base.set',
+                    typeVersion: 3,
+                    position: [300, 200],
+                    parameters: { mode: 'manual' },
+                    continueOnFail: false,
+                },
+            ],
+            connections: {},
+            settings: {},
+        };
+
+        // JSON → AST → TypeScript
+        const jsonParser = new JsonToAstParser();
+        const ast1 = jsonParser.parse(workflowJson as any);
+        const generator = new AstToTypeScriptGenerator();
+        const tsCode = await generator.generate(ast1, { format: false, commentStyle: 'minimal' });
+
+        expect(tsCode).toContain('continueOnFail: true');
+        expect(tsCode).toContain('continueOnFail: false');
+
+        // TypeScript → AST → JSON
+        const tsParser = new TypeScriptParser();
+        const ast2 = await tsParser.parseCode(tsCode);
+
+        expect(ast2.nodes[0].continueOnFail).toBe(true);
+        expect(ast2.nodes[1].continueOnFail).toBe(false);
+
+        const builder = new WorkflowBuilder();
+        const rebuilt = builder.build(ast2);
+
+        expect(rebuilt.nodes[0].continueOnFail).toBe(true);
+        expect(rebuilt.nodes[1].continueOnFail).toBe(false);
+    });
+
+    it('should emit [continueOnFail] flag in workflow-map for continueOnFail nodes', async () => {
+        const workflowJson = {
+            id: 'wf-flags-continue-on-fail',
+            name: 'ContinueOnFail Flags Workflow',
+            active: false,
+            nodes: [
+                {
+                    id: 'node-cof-flag-1',
+                    name: 'Tolerant Node',
+                    type: 'n8n-nodes-base.set',
+                    typeVersion: 3,
+                    position: [0, 0],
+                    parameters: {},
+                    continueOnFail: true,
+                },
+            ],
+            connections: {},
+            settings: {},
+        };
+
+        const parser = new JsonToAstParser();
+        const ast = parser.parse(workflowJson as any);
+        const generator = new AstToTypeScriptGenerator();
+        const tsCode = await generator.generate(ast, { format: false });
+
+        expect(tsCode).toMatch(/TolerantNode\s+set\s+.*\[continueOnFail\]/);
+    });
+
+    it('should preserve unmodelled node properties through full pull→push roundtrip', async () => {
+        const workflowJson = {
+            id: 'wf-roundtrip-unmodelled',
+            name: 'Roundtrip Unmodelled Properties Workflow',
+            active: false,
+            nodes: [
+                {
+                    id: 'node-unmodelled-1',
+                    name: 'Custom Node',
+                    type: 'n8n-nodes-base.set',
+                    typeVersion: 3,
+                    position: [100, 200],
+                    parameters: { value: 123 },
+                    customFlag: true,
+                    customScore: 42,
+                    customLabel: 'production-critical',
+                    customTags: ['tag1', 'tag2'],
+                    customMeta: {
+                        tier: 'gold',
+                        retriesAllowed: 5,
+                    },
+                },
+            ],
+            connections: {},
+            settings: {},
+        };
+
+        // JSON → AST
+        const jsonParser = new JsonToAstParser();
+        const ast1 = jsonParser.parse(workflowJson as any);
+
+        expect(ast1.nodes[0].customFlag).toBe(true);
+        expect(ast1.nodes[0].customScore).toBe(42);
+        expect(ast1.nodes[0].customLabel).toBe('production-critical');
+        expect(ast1.nodes[0].customTags).toEqual(['tag1', 'tag2']);
+        expect(ast1.nodes[0].customMeta).toEqual({ tier: 'gold', retriesAllowed: 5 });
+
+        // AST → TypeScript
+        const generator = new AstToTypeScriptGenerator();
+        const tsCode = await generator.generate(ast1, { format: false, commentStyle: 'minimal' });
+
+        expect(tsCode).toContain('customFlag: true');
+        expect(tsCode).toContain('customScore: 42');
+        expect(tsCode).toContain('customLabel: "production-critical"');
+        expect(tsCode).toContain('tier: "gold"');
+
+        // TypeScript → AST
+        const tsParser = new TypeScriptParser();
+        const ast2 = await tsParser.parseCode(tsCode);
+
+        expect(ast2.nodes[0].customFlag).toBe(true);
+        expect(ast2.nodes[0].customScore).toBe(42);
+        expect(ast2.nodes[0].customLabel).toBe('production-critical');
+        expect(ast2.nodes[0].customTags).toEqual(['tag1', 'tag2']);
+        expect(ast2.nodes[0].customMeta).toEqual({ tier: 'gold', retriesAllowed: 5 });
+
+        // AST → JSON
+        const builder = new WorkflowBuilder();
+        const rebuilt = builder.build(ast2);
+
+        const rebuiltNode = rebuilt.nodes[0];
+        expect(rebuiltNode.customFlag).toBe(true);
+        expect(rebuiltNode.customScore).toBe(42);
+        expect(rebuiltNode.customLabel).toBe('production-critical');
+        expect(rebuiltNode.customTags).toEqual(['tag1', 'tag2']);
+        expect(rebuiltNode.customMeta).toEqual({ tier: 'gold', retriesAllowed: 5 });
+    });
+
+    it('should support authoring unmodelled properties directly in TypeScript @node decorator', async () => {
+        const tsWorkflow = `
+import { workflow, node, links } from '@n8n-as-code/core';
+
+@workflow({ name: 'Direct TS Unmodelled', active: false })
+export class DirectTsWorkflow {
+    @node({
+        name: 'Authored Node',
+        type: 'n8n-nodes-base.set',
+        version: 1,
+        position: [0, 0],
+        customFutureSetting: 'preserved-value',
+        nestedFutureConfig: {
+            mode: 'experimental',
+            count: 3
+        }
+    })
+    AuthoredNode = { message: 'hello' };
+
+    @links()
+    defineRouting() {}
+}
+`;
+
+        const tsParser = new TypeScriptParser();
+        const ast = await tsParser.parseCode(tsWorkflow);
+
+        expect(ast.nodes[0].customFutureSetting).toBe('preserved-value');
+        expect(ast.nodes[0].nestedFutureConfig).toEqual({ mode: 'experimental', count: 3 });
+
+        const builder = new WorkflowBuilder();
+        const rebuilt = builder.build(ast);
+
+        expect(rebuilt.nodes[0].customFutureSetting).toBe('preserved-value');
+        expect(rebuilt.nodes[0].nestedFutureConfig).toEqual({ mode: 'experimental', count: 3 });
+    });
 });

--- a/packages/vscode-extension/src/utils/external-navigation.ts
+++ b/packages/vscode-extension/src/utils/external-navigation.ts
@@ -14,7 +14,7 @@ export type ExternalNavigationReason =
     | 'unknown';
 
 export interface ExternalNavigationSource {
-    panelKind?: 'workflow-board' | 'agent-workbench' | 'proxy' | 'unknown';
+    panelKind?: 'workflow-board' | 'agent-workbench' | 'workflow-tree' | 'proxy' | 'unknown';
     workflowId?: string;
     workflowName?: string;
     sessionId?: string;


### PR DESCRIPTION
## Problem
As reported in #608 (specifically [comment #5533609408](https://github.com/EtienneLescot/n8n-as-code/issues/608#issuecomment-5533609408)), while #615 resolved the round-trip loss of \disabled\, \
otes\, and \
otesInFlow\, the property whitelist still silently dropped \continueOnFail\ on pull→push round-trips.

In n8n, \continueOnFail: true\ is the legacy predecessor to \onError: 'continueRegularOutput'\, still present across many existing production workflows. When pulled and pushed via n8nac, \continueOnFail\ was silently stripped, causing nodes to revert to failing the entire execution on error.

Furthermore, a hardcoded property whitelist means that whenever n8n introduces or users utilize unmodelled node-level properties, they are silently deleted on roundtrip.

## Solution
1. **Explicit \continueOnFail\ support**:
   - Added \continueOnFail?: boolean;\ to \NodeAST\, \N8nNode\, \NodeDecoratorMetadata\, and \NodeDecoratorOptions\.
   - Mapped \continueOnFail\ through \JsonToAstParser\, \AstToTypeScriptGenerator\, \TypeScriptParser\, and \WorkflowBuilder\.
   - Added \[continueOnFail]\ flag in workflow map header comment index.

2. **Generic passthrough for unmodelled node properties**:
   - Added index signature \[key: string]: any;\ to \NodeAST\, \N8nNode\, \NodeDecoratorMetadata\, and \NodeDecoratorOptions\.
   - Exported \KNOWN_NODE_METADATA_KEYS\ and \INTERNAL_AST_NODE_KEYS\ in \@n8n-as-code/transformer\.
   - Captured and preserved unmodelled properties across the full bidirectional pipeline (\JSON\ ↔ \AST\ ↔ \TS @node\ ↔ \AST\ ↔ \JSON\).

## Tests
- Added unit and round-trip tests in \packages/transformer/tests/json-to-typescript.test.ts\:
  - Verified \continueOnFail\ (both \	rue\ and \alse\) round-trips through JSON → AST → TypeScript → AST → JSON.
  - Verified \[continueOnFail]\ flag emission in workflow map.
  - Verified unmodelled properties (primitives, nested objects, arrays) survive full pull→push round-trip.
  - Verified authoring unmodelled properties directly in TypeScript \@node\ decorator survives build to JSON.
- Verified all transformer (87/87) and CLI (403/403) vitest tests pass.

Ref #608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for preserving legacy `continueOnFail` settings when converting workflows between JSON and TypeScript.
  * Unrecognized node properties are now retained during workflow conversion.
  * Custom node properties can be authored in TypeScript decorators and restored when rebuilding workflows.
  * Workflow maps now reflect nodes configured with `continueOnFail`.
* **Bug Fixes**
  * Improved round-trip conversion to maintain additional node configuration and custom metadata.
  * Added support for workflow-tree sources in external navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->