### PR TITLE
fix(vscode-extension): coalesce running operation stream events to unfreeze workbench chat

### DIFF
--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -1575,6 +1575,7 @@ export class AgentRuntimeController implements vscode.Disposable {
             const pending = [...pendingOperationEvents.values()];
             pendingOperationEvents = new Map();
             for (const pendingEvent of pending) {
+                if (signal.aborted) break;
                 await emitStreamEventNow(pendingEvent);
             }
         };
@@ -3905,6 +3906,9 @@ export class AgentRuntimeController implements vscode.Disposable {
             const existingEntry = existingIndex >= 0 && next[existingIndex]?.kind === 'operation'
                 ? next[existingIndex] as Extract<AgentTimelineEntry, { kind: 'operation' }>
                 : undefined;
+            if (event.status === 'running' && existingEntry?.status && existingEntry.status !== 'running') {
+                return next;
+            }
             const shouldPreserveOperationSummary = ['shell', 'file-read', 'file-write', 'todo'].includes(event.category);
             const operationEntry: AgentTimelineEntry = {
                 kind: 'operation',

--- a/packages/vscode-extension/src/services/agent-runtime-controller.ts
+++ b/packages/vscode-extension/src/services/agent-runtime-controller.ts
@@ -31,6 +31,7 @@ const NON_FINAL_ASSISTANT_PHASE_RECOVERY_MARKER = 'N8N_NON_FINAL_ASSISTANT_PHASE
 const NON_FINAL_ASSISTANT_PHASE_MAX_RECOVERY_ATTEMPTS = 12;
 const STREAM_TEXT_FLUSH_INTERVAL_MS = 33;
 const STREAM_TEXT_FLUSH_CHAR_THRESHOLD = 512;
+const STREAM_OPERATION_FLUSH_INTERVAL_MS = 250;
 
 type ActiveWorktreePathsBySession = Record<string, string | null>;
 
@@ -1517,6 +1518,8 @@ export class AgentRuntimeController implements vscode.Disposable {
         let pendingTextDelta = '';
         let pendingTextFlushTimer: NodeJS.Timeout | undefined;
         let textFlushChain = Promise.resolve();
+        let pendingOperationEvents = new Map<string, AgentStreamEvent>();
+        let pendingOperationFlushTimer: NodeJS.Timeout | undefined;
         let streamClosed = false;
         this.outputChannel.appendLine(`[n8n-agent-debug] deepagents.v3.run started sessionId=${input.sessionId || 'none'} workflowId=${input.workflowId || 'none'}`);
         const syncEntries = () => {
@@ -1563,6 +1566,29 @@ export class AgentRuntimeController implements vscode.Disposable {
                 });
             }, STREAM_TEXT_FLUSH_INTERVAL_MS);
         };
+        const flushPendingOperationsNow = async () => {
+            if (pendingOperationFlushTimer) {
+                clearTimeout(pendingOperationFlushTimer);
+                pendingOperationFlushTimer = undefined;
+            }
+            if (!pendingOperationEvents.size) return;
+            const pending = [...pendingOperationEvents.values()];
+            pendingOperationEvents = new Map();
+            for (const pendingEvent of pending) {
+                await emitStreamEventNow(pendingEvent);
+            }
+        };
+        const scheduleOperationFlush = () => {
+            if (streamClosed) return;
+            if (pendingOperationFlushTimer) return;
+            pendingOperationFlushTimer = setTimeout(() => {
+                pendingOperationFlushTimer = undefined;
+                if (streamClosed) return;
+                void flushPendingOperationsNow().catch((error: any) => {
+                    this.outputChannel.appendLine(`[n8n-agent] Stream operation flush failed: ${error?.message || String(error)}`);
+                });
+            }, STREAM_OPERATION_FLUSH_INTERVAL_MS);
+        };
         const emitStreamEvent = async (streamEvent: AgentStreamEvent) => {
             if (streamEvent.type === 'text-delta') {
                 pendingTextDelta += streamEvent.delta;
@@ -1573,13 +1599,21 @@ export class AgentRuntimeController implements vscode.Disposable {
                 }
                 return;
             }
+            if (streamEvent.type === 'operation' && streamEvent.status === 'running') {
+                // ponytail: one postMessage per operation per 250ms; per-token thinking/tool deltas otherwise saturate the webview.
+                pendingOperationEvents.set(streamEvent.operationId || `${streamEvent.category}:${streamEvent.label}`, streamEvent);
+                scheduleOperationFlush();
+                return;
+            }
             await flushPendingTextDelta();
+            await flushPendingOperationsNow();
             await emitStreamEventNow(streamEvent);
         };
         const emitFinalEvent = async (response: string, finalState: string) => {
             if (authoritativeFinalEmitted) return;
             authoritativeFinalEmitted = true;
             await flushPendingTextDelta();
+            await flushPendingOperationsNow();
             const activeRun = input.sessionId ? this.activeRuns.get(input.sessionId) : undefined;
             if (activeRun && activeRun.sessionId === input.sessionId) {
                 activeRun.visibleDone = true;
@@ -1671,12 +1705,20 @@ export class AgentRuntimeController implements vscode.Disposable {
                 clearTimeout(pendingTextFlushTimer);
                 pendingTextFlushTimer = undefined;
             }
+            if (pendingOperationFlushTimer) {
+                clearTimeout(pendingOperationFlushTimer);
+                pendingOperationFlushTimer = undefined;
+            }
             if (signal.aborted) {
                 pendingTextDelta = '';
+                pendingOperationEvents = new Map();
                 await textFlushChain.catch(() => undefined);
             } else {
                 await flushPendingTextDelta().catch((error: any) => {
                     this.outputChannel.appendLine(`[n8n-agent] Stream text flush failed during cleanup: ${error?.message || String(error)}`);
+                });
+                await flushPendingOperationsNow().catch((error: any) => {
+                    this.outputChannel.appendLine(`[n8n-agent] Stream operation flush failed during cleanup: ${error?.message || String(error)}`);
                 });
             }
         }

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -3084,8 +3084,9 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                     startedAt: event.startedAt,
                     endedAt: event.endedAt,
                 };
-                if (idx >= 0) entries[idx] = opEntry;
-                else insertBeforeFinalAssistant(entries, opEntry);
+                const isStaleRunning = event.status === 'running' && existing && existing.status && existing.status !== 'running';
+                if (!isStaleRunning && idx >= 0) entries[idx] = opEntry;
+                else if (!isStaleRunning) insertBeforeFinalAssistant(entries, opEntry);
                 if (opEntry.status === 'running') deferRender = true;
             } else if (event.type === 'progress') {
                 const idx = findMatchingPendingOperationIndex(entries, '', event.title, event.phase || 'phase');

--- a/packages/vscode-extension/src/ui/agent-workbench-html.ts
+++ b/packages/vscode-extension/src/ui/agent-workbench-html.ts
@@ -3086,6 +3086,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 };
                 if (idx >= 0) entries[idx] = opEntry;
                 else insertBeforeFinalAssistant(entries, opEntry);
+                if (opEntry.status === 'running') deferRender = true;
             } else if (event.type === 'progress') {
                 const idx = findMatchingPendingOperationIndex(entries, '', event.title, event.phase || 'phase');
                 const progressEntry = {
@@ -3099,6 +3100,7 @@ export function buildAgentWorkbenchHtml(input: AgentWorkbenchHtmlInput): string 
                 };
                 if (idx >= 0) entries[idx] = progressEntry;
                 else insertBeforeFinalAssistant(entries, progressEntry);
+                if (progressEntry.status === 'running') deferRender = true;
             } else if (event.type === 'compaction') {
                 const compactionEntry = { kind: 'compaction', id: crypto.randomUUID(), timestamp: Date.now(), event: event };
                 entries.push(compactionEntry);

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -714,3 +714,30 @@ test('Agent Workbench HTML: handles panel.visibility to unload/reload iframe', (
     assert.ok(html.includes("frame.src = 'about:blank'"), 'Must set frame.src to about:blank when hidden');
     assert.ok(html.includes("frame.src = workflowUrl"), 'Must restore original workflowUrl when visible');
 });
+
+test('Agent runtime: running operation deltas are coalesced before reaching the webview', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const source = fs.readFileSync(path.join(__dirname, '../../src/services/agent-runtime-controller.ts'), 'utf8');
+
+    assert.ok(source.includes('STREAM_OPERATION_FLUSH_INTERVAL_MS'), 'Runtime should define a bounded operation flush interval');
+    assert.ok(source.includes('pendingOperationEvents'), 'Runtime should coalesce running operation events per operation');
+    assert.ok(source.includes("streamEvent.type === 'operation' && streamEvent.status === 'running'"), 'Only running operations should be deferred; terminal states stay immediate');
+    assert.ok(source.includes('scheduleOperationFlush()'), 'Deferred operations should flush on a timer');
+    const flushCount = (source.match(/await flushPendingOperationsNow\(\);/g) || []).length;
+    assert.ok(flushCount >= 2, 'Terminal events and the final response must flush deferred operations first');
+    assert.ok(source.includes('pendingOperationEvents = new Map();'), 'Aborted runs should drop buffered operations');
+});
+
+test('Agent Workbench HTML: running operations defer full feed rendering', () => {
+    const { buildAgentWorkbenchHtml } = require('../../src/ui/agent-workbench-html.js');
+    const html: string = buildAgentWorkbenchHtml({
+        workflowId: 'wf-1',
+        workflowName: 'Workflow 1',
+        workflowUrl: 'http://localhost:5678/workflow/wf-1',
+        providerModelLabel: 'openai / gpt-5.4',
+    });
+
+    assert.ok(html.includes("if (opEntry.status === 'running') deferRender = true;"), 'Running operation updates must defer full feed rendering');
+    assert.ok(html.includes("if (progressEntry.status === 'running') deferRender = true;"), 'Running progress updates must defer full feed rendering');
+});

--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -741,3 +741,20 @@ test('Agent Workbench HTML: running operations defer full feed rendering', () =>
     assert.ok(html.includes("if (opEntry.status === 'running') deferRender = true;"), 'Running operation updates must defer full feed rendering');
     assert.ok(html.includes("if (progressEntry.status === 'running') deferRender = true;"), 'Running progress updates must defer full feed rendering');
 });
+
+test('Agent runtime: stale running events cannot reopen terminal operations', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const controller = fs.readFileSync(path.join(__dirname, '../../src/services/agent-runtime-controller.ts'), 'utf8');
+    const { buildAgentWorkbenchHtml } = require('../../src/ui/agent-workbench-html.js');
+    const html: string = buildAgentWorkbenchHtml({
+        workflowId: 'wf-1',
+        workflowName: 'Workflow 1',
+        workflowUrl: 'http://localhost:5678/workflow/wf-1',
+        providerModelLabel: 'openai / gpt-5.4',
+    });
+
+    assert.ok(controller.includes('if (signal.aborted) break;'), 'Aborted runs should drop buffered operations instead of emitting them');
+    assert.ok(controller.includes("existingEntry.status !== 'running'"), 'Host entries must reject running updates for terminal operations');
+    assert.ok(html.includes('isStaleRunning'), 'Webview must reject running updates for terminal operations');
+});


### PR DESCRIPTION
Symptom: during a long run (e.g. workflow creation), the workbench chat turns flaky (details cannot be expanded, answer missing) and the machine slows down. After restarting VS Code, the finished answer displays correctly.

Cause: every reasoning token and every tool-output delta emitted a running operation event carrying the full cumulative body, each triggering a postMessage plus a full feed rebuild. Message storm, saturated webview thread, lost clicks, final answer drowned out.

Fix:
- runtime-controller: running events coalesced per operation, flushed at most once per 250 ms; terminal states and the final response always flush first.
- workbench html: running updates go through requestAnimationFrame instead of synchronous re-render.

Verification: tsc clean, extension unit suite 162/162 (including 2 new tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved operation and progress updates in the Agent Workbench by batching rapid activity and deferring feed refreshes for smoother display.
  * Prevented delayed activity updates from overwriting or restoring operations that have already completed or failed.
  * Discarded pending operation updates when a run is aborted, keeping the activity feed accurate.

* **Tests**
  * Added coverage for update batching, rendering behavior, abort handling, and terminal operation states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->