### PR TITLE
feat(cli): native MCP usage levels + per-instance schema overlay (stacked on #635)

### DIFF
--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -103,8 +103,9 @@ export class SyncCommand extends BaseCommand {
         // is authoritative. A workflow whose nodes the instance rejects must never
         // be deployed — n8n would store it, but it would be broken in the UI and
         // fail at run time. Escalate to "push anyway" with N8NAC_PUSH_SKIP_VALIDATION=1.
+        const level = effectiveNativeMcpLevel(this.activeEnvironment?.nativeMcp, process.env.N8NAC_NATIVE_MCP_LEVEL);
         if (absolutePath) {
-            const outcome = await this.runPrePushValidation(absolutePath);
+            const outcome = await this.runPrePushValidation(absolutePath, level);
             if (outcome) {
                 if (!outcome.valid) {
                     if (basename && workflowId) {
@@ -150,6 +151,9 @@ export class SyncCommand extends BaseCommand {
         try {
             const finalWorkflowId = await syncManager.push(filename, { draft: options?.draft === true });
             spinner.succeed(chalk.green(`✔ Pushed workflow ${filename}.`));
+            if (level === 0) {
+                console.log(chalk.dim(`   Validated against the bundled schema only (native MCP level 0 — discouraged, the instance may differ). Connect the instance MCP for instance-exact validation: n8nac native-mcp configure --level 1.`));
+            }
             this.reportPublishState(publishReport, finalWorkflowId);
             return finalWorkflowId;
         } catch (e: any) {
@@ -316,6 +320,9 @@ export class SyncCommand extends BaseCommand {
             console.log(chalk.red('❌ Workflow has errors that will cause problems in n8n.'));
             console.log(chalk.dim('   Fix the issues locally, then push again.'));
         }
+        if (effectiveNativeMcpLevel(this.activeEnvironment?.nativeMcp, process.env.N8NAC_NATIVE_MCP_LEVEL) === 0) {
+            console.log(chalk.dim('   Validated against the bundled schema only (native MCP level 0 — discouraged, the instance may differ). Connect the instance MCP for instance-exact validation: n8nac native-mcp configure --level 1.'));
+        }
 
         return result.valid;
     }
@@ -336,7 +343,7 @@ export class SyncCommand extends BaseCommand {
      * file cannot be compiled locally — the push itself then reports the real
      * compile error).
      */
-    private async runPrePushValidation(absolutePath: string): Promise<Awaited<ReturnType<PreflightNodeValidator['validateFile']>> | null> {
+    private async runPrePushValidation(absolutePath: string, level?: number): Promise<Awaited<ReturnType<PreflightNodeValidator['validateFile']>> | null> {
         if (/^(1|true|yes|on)$/i.test(process.env.N8NAC_PUSH_SKIP_VALIDATION || '')) {
             return null;
         }
@@ -344,11 +351,11 @@ export class SyncCommand extends BaseCommand {
         const environment = this.activeEnvironment;
         const host = environment?.host || this.config?.host;
         const nativeMcp = environment?.nativeMcp;
-        const level = effectiveNativeMcpLevel(nativeMcp, process.env.N8NAC_NATIVE_MCP_LEVEL);
+        const resolvedLevel = level ?? effectiveNativeMcpLevel(nativeMcp, process.env.N8NAC_NATIVE_MCP_LEVEL);
 
         const validatorOptions: PreflightNodeValidatorOptions = {};
 
-        if (level >= 1 && host) {
+        if (resolvedLevel >= 1 && host) {
             const endpoint = nativeMcp?.url || `${host.replace(/\/+$/, '')}/mcp-server/http`;
             let token: string | undefined;
             try {
@@ -358,7 +365,7 @@ export class SyncCommand extends BaseCommand {
             }
             const timeoutMs = nativeMcp?.timeoutMs ?? 10000;
 
-            if (level >= 2) {
+            if (resolvedLevel >= 2) {
                 validatorOptions.endpoint = endpoint;
                 validatorOptions.token = token;
                 validatorOptions.timeoutMs = timeoutMs;

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1,7 +1,9 @@
 import { BaseCommand, captureEmittedErrors, formatConnectionError } from './base.js';
 import { SyncManager, WorkflowSyncStatus, type IPushPublishReport } from '../core/index.js';
-import { PreflightNodeValidator } from '../core/index.js';
+import { PreflightNodeValidator, type PreflightNodeValidatorOptions } from '../core/index.js';
+import { SchemaOverlayManager } from '../core/index.js';
 import { WorkflowValidator } from '@n8n-as-code/skills';
+import { effectiveNativeMcpLevel } from '../services/config-service.js';
 import chalk from 'chalk';
 import ora from 'ora';
 import inquirer from 'inquirer';
@@ -321,12 +323,14 @@ export class SyncCommand extends BaseCommand {
     /**
      * Validate a local workflow file before anything is written to the instance.
      *
-     * Validation model — local by default, instance as the authoritative upgrade:
-     * the bundled node schema always runs first (no network required); when the
-     * target instance is known, its own MCP endpoint (`validate_node_config`) is
-     * additionally probed with the environment API key — which authenticates on
-     * self-hosted instances with the MCP server enabled. An explicitly configured
-     * native-MCP token is used when present (n8n Cloud).
+     * Validation is driven by the environment's native MCP usage level
+     * (cumulative ladder, see `IWorkspaceNativeMcpLevel`):
+     *   level 0 — bundled ontology only, no MCP call at all;
+     *   level 1 — refresh the per-instance schema overlay from `get_node_types`
+     *             (lazy per node type, TTL-cached), then validate locally against
+     *             the merged bundled+overlay schema — economical across pushes;
+     *   level ≥ 2 — validate live against the instance's `validate_node_config`
+     *             (authoritative, immune to bundled-schema drift).
      *
      * Returns null when validation is skipped (opt-out env var, or the workflow
      * file cannot be compiled locally — the push itself then reports the real
@@ -340,29 +344,49 @@ export class SyncCommand extends BaseCommand {
         const environment = this.activeEnvironment;
         const host = environment?.host || this.config?.host;
         const nativeMcp = environment?.nativeMcp;
-        const flagEnabled = /^(1|true|yes|on)$/i.test(process.env.N8NAC_NATIVE_MCP_ENABLED || '');
+        const level = effectiveNativeMcpLevel(nativeMcp, process.env.N8NAC_NATIVE_MCP_LEVEL);
 
-        let endpoint: string | undefined;
-        let token: string | undefined;
-        if (host) {
-            // Automatic probe by default: derived endpoint, environment API key.
-            // Explicit assist configuration (nativeMcp url/enabled or the env flag)
-            // only pins the endpoint/token choice and the timeout.
-            endpoint = nativeMcp?.url || `${host.replace(/\/+$/, '')}/mcp-server/http`;
+        const validatorOptions: PreflightNodeValidatorOptions = {};
+
+        if (level >= 1 && host) {
+            const endpoint = nativeMcp?.url || `${host.replace(/\/+$/, '')}/mcp-server/http`;
+            let token: string | undefined;
             try {
                 token = this.configService.getNativeMcpToken(environment?.environmentId) || environment?.apiKey;
             } catch {
                 token = environment?.apiKey;
             }
+            const timeoutMs = nativeMcp?.timeoutMs ?? 10000;
+
+            if (level >= 2) {
+                validatorOptions.endpoint = endpoint;
+                validatorOptions.token = token;
+                validatorOptions.timeoutMs = timeoutMs;
+            } else {
+                // Level 1: schema overlay, validated locally. The overlay path is
+                // deterministic; the beforeValidate hook fetches whatever is
+                // missing or expired for this workflow's node types.
+                const cacheDir = environment?.workflowsPath || this.config?.directory;
+                const overlay = new SchemaOverlayManager({ endpoint, token, timeoutMs, cacheDir });
+                let overlayUsable = true;
+                validatorOptions.customNodesPath = () => (overlayUsable ? overlay.providerFilePath : undefined);
+                validatorOptions.beforeValidate = async (workflow) => {
+                    try {
+                        const { failed } = await overlay.ensureForTypes(SchemaOverlayManager.collectNodeTypes(workflow));
+                        if (failed.length > 0) {
+                            console.warn(chalk.yellow(`⚠  Schema overlay incomplete (${failed.join(', ')} not described by the instance); those nodes fall back to the bundled schema.`));
+                        }
+                    } catch (error: any) {
+                        // Overlay refresh failed (unreachable/unauthorised):
+                        // fall back to the bundled schema for this push, and surface it.
+                        overlayUsable = false;
+                        console.warn(chalk.yellow(`⚠  Schema overlay refresh unavailable (${error?.message || error}); validating against the bundled schema.`));
+                    }
+                };
+            }
         }
 
-        const validator = endpoint
-            ? new PreflightNodeValidator({
-                endpoint,
-                token,
-                timeoutMs: nativeMcp?.timeoutMs ?? (nativeMcp?.enabled || flagEnabled ? 10000 : 3000),
-            })
-            : new PreflightNodeValidator();
+        const validator = new PreflightNodeValidator(validatorOptions);
         try {
             return await validator.validateFile(absolutePath);
         } catch (error: any) {

--- a/packages/cli/src/commands/update-ai.ts
+++ b/packages/cli/src/commands/update-ai.ts
@@ -10,7 +10,7 @@ import {
     WorkspaceSetupService,
 } from '../core/index.js';
 import type { AiContextGenerator as AiContextGeneratorInstance } from '@n8n-as-code/skills';
-import { ConfigService } from '../services/config-service.js';
+import { ConfigService, effectiveNativeMcpLevel } from '../services/config-service.js';
 import dotenv from 'dotenv';
 
 const N8NAC_DEV_CONFIG_FILENAMES = [
@@ -75,6 +75,25 @@ function inferLocalDevCliCommand(projectRoot: string): string | undefined {
         return undefined;
     }
     return `node ${quoteShellArg(entrypoint)}`;
+}
+
+/**
+ * Resolve the effective native MCP usage level of the active workspace
+ * environment for generated AI context. Never throws — update-ai must not
+ * fail when no environment is pinned yet.
+ */
+function resolveActiveNativeMcpLevel(projectRoot: string): { level: number; environmentName?: string } | undefined {
+    try {
+        const configService = new ConfigService(projectRoot);
+        const requested = process.env.N8NAC_ENVIRONMENT?.trim() || undefined;
+        const resolved = configService.resolveEnvironment(requested);
+        return {
+            level: effectiveNativeMcpLevel(resolved.environment.nativeMcp, process.env.N8NAC_NATIVE_MCP_LEVEL),
+            environmentName: resolved.environmentName,
+        };
+    } catch {
+        return undefined;
+    }
 }
 
 function inferLocalDevManagerCommand(): string | undefined {
@@ -183,10 +202,12 @@ export class UpdateAiCommand {
             const distTag = typeof options.cliVersion === 'string' && options.cliVersion.trim()
                 ? options.cliVersion.trim()
                 : getDistTag();
+            const nativeMcp = resolveActiveNativeMcpLevel(projectRoot);
             await aiContextGenerator.generate(projectRoot, version, distTag, {
                 cliCommandOverride: options.cliCmd || inferLocalDevCliCommand(projectRoot),
                 managerCommandOverride: options.managerCmd || inferLocalDevManagerCommand(),
                 cliVersion: getCliVersion(),
+                nativeMcp,
             } as Parameters<AiContextGeneratorInstance['generate']>[3] & { managerCommandOverride?: string });
             if (!silent) console.log(chalk.green('   ✅ AI context files created.'));
 

--- a/packages/cli/src/core/index.ts
+++ b/packages/cli/src/core/index.ts
@@ -15,5 +15,8 @@ export * from './services/tls-certificates.js';
 export * from './services/workspace-setup-service.js';
 export * from './services/workflow-path-utils.js';
 export * from './services/preflight-node-validator.js';
+export * from './services/instance-mcp-client.js';
+export * from './services/node-schema-defs-parser.js';
+export * from './services/schema-overlay-manager.js';
 export * from './services/folder-path-resolver.js';
 export * from './helpers/index.js';

--- a/packages/cli/src/core/services/instance-mcp-client.ts
+++ b/packages/cli/src/core/services/instance-mcp-client.ts
@@ -1,0 +1,158 @@
+import fs from 'node:fs';
+
+/** Loopback hostnames on which plaintext http is acceptable (local dev/self-hosted instances). */
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '[::1]', '0.0.0.0']);
+
+export function isInstanceMcpSchemeAllowed(endpoint: string): boolean {
+    try {
+        const parsed = new URL(endpoint);
+        if (parsed.protocol === 'https:') return true;
+        if (parsed.protocol === 'http:' && LOOPBACK_HOSTNAMES.has(parsed.hostname)) return true;
+        return false;
+    } catch {
+        return false;
+    }
+}
+
+export interface InstanceMcpClientOptions {
+    endpoint: string;
+    token?: string;
+    timeoutMs?: number;
+}
+
+/**
+ * Minimal streamable-HTTP MCP client for single tool calls against an n8n
+ * instance MCP server: initialize → notifications/initialized → tools/list or
+ * tools/call → authenticated DELETE to release the session. Mirrors
+ * `NativeMcpHttpClient` and refuses to send credentials to plaintext
+ * non-loopback endpoints.
+ */
+export class InstanceMcpClient {
+    private readonly options: InstanceMcpClientOptions;
+
+    constructor(options: InstanceMcpClientOptions) {
+        this.options = options;
+    }
+
+    async listTools(): Promise<Array<{ name: string; description?: string }>> {
+        this.logCall('tools/list');
+        const result = (await this.call('tools/list', {})) as { tools?: Array<{ name: string; description?: string }> };
+        return Array.isArray(result?.tools) ? result.tools : [];
+    }
+
+    async callTool(name: string, args: Record<string, unknown>): Promise<unknown> {
+        this.logCall(`tools/call:${name}`);
+        return this.call('tools/call', { name, arguments: args });
+    }
+
+    /**
+     * Benchmark instrumentation: when N8NAC_MCP_CALL_LOG points at a file, every
+     * MCP call is appended as one JSON line so runs can be audited for call
+     * economy (level 1 vs level 2) without a network proxy.
+     */
+    private logCall(kind: string): void {
+        const target = process.env.N8NAC_MCP_CALL_LOG;
+        if (!target) return;
+        try {
+            fs.appendFileSync(target, `${JSON.stringify({ at: new Date().toISOString(), kind })}\n`, 'utf8');
+        } catch {
+            // instrumentation must never break the call
+        }
+    }
+
+    private async call(method: string, params: Record<string, unknown>): Promise<unknown> {
+        const { endpoint, token, timeoutMs = 10000 } = this.options;
+        if (!isInstanceMcpSchemeAllowed(endpoint)) {
+            throw new Error(`Refusing to send credentials to a non-HTTPS endpoint (${endpoint}); only loopback http is allowed.`);
+        }
+
+        let sessionId: string | undefined;
+        const post = async (payload: Record<string, unknown>, expectResponse = true): Promise<any> => {
+            const controller = new AbortController();
+            const timer = setTimeout(() => controller.abort(), timeoutMs);
+            try {
+                const headers: Record<string, string> = {
+                    Accept: 'application/json, text/event-stream',
+                    'Content-Type': 'application/json',
+                    'mcp-protocol-version': '2024-11-05',
+                    'User-Agent': 'n8n-as-code-preflight',
+                };
+                if (token) headers.Authorization = `Bearer ${token}`;
+                if (sessionId) headers['mcp-session-id'] = sessionId;
+
+                const response = await fetch(endpoint, {
+                    method: 'POST',
+                    headers,
+                    body: JSON.stringify(payload),
+                    signal: controller.signal,
+                });
+                const text = await response.text();
+                sessionId = response.headers.get('mcp-session-id') || sessionId;
+
+                if (!response.ok) {
+                    throw new Error(`Native MCP HTTP ${response.status} ${response.statusText}: ${text.slice(0, 200)}`);
+                }
+                if (!expectResponse || !text.trim()) {
+                    return undefined;
+                }
+
+                let data: any;
+                try {
+                    data = JSON.parse(text);
+                } catch {
+                    for (const line of text.split(/\r?\n/)) {
+                        const trimmed = line.trim();
+                        if (trimmed.startsWith('data:')) {
+                            try { data = JSON.parse(trimmed.slice(5).trim()); break; } catch { /* keep scanning */ }
+                        }
+                    }
+                }
+                if (!data) throw new Error(`Unparseable native MCP response: ${text.slice(0, 200)}`);
+                if (data.error) throw new Error(`Native MCP RPC error (${data.error.code}): ${data.error.message}`);
+                return data?.result;
+            } catch (error: any) {
+                if (error?.name === 'AbortError') {
+                    throw new Error(`Native MCP request timed out after ${timeoutMs}ms`);
+                }
+                throw error;
+            } finally {
+                clearTimeout(timer);
+            }
+        };
+
+        const close = async (): Promise<void> => {
+            if (!sessionId) return;
+            const controller = new AbortController();
+            const timer = setTimeout(() => controller.abort(), timeoutMs);
+            try {
+                const headers: Record<string, string> = {
+                    'mcp-protocol-version': '2024-11-05',
+                    'User-Agent': 'n8n-as-code-preflight',
+                    'mcp-session-id': sessionId,
+                };
+                if (token) headers.Authorization = `Bearer ${token}`;
+                await fetch(endpoint, { method: 'DELETE', headers, signal: controller.signal });
+            } catch {
+                // Best-effort cleanup; must never mask the tool result.
+            } finally {
+                clearTimeout(timer);
+            }
+        };
+
+        try {
+            const init = await post({
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'initialize',
+                params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'n8n-as-code', version: '1.0.0' } },
+            });
+            sessionId = sessionId || init?.sessionId;
+            await post({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} }, false).catch(() => undefined);
+
+            const payload: Record<string, unknown> = { jsonrpc: '2.0', id: 2, method, params };
+            return await post(payload);
+        } finally {
+            await close();
+        }
+    }
+}

--- a/packages/cli/src/core/services/node-schema-defs-parser.ts
+++ b/packages/cli/src/core/services/node-schema-defs-parser.ts
@@ -1,0 +1,273 @@
+/**
+ * Parser for the TypeScript node-definition text that the instance's native
+ * MCP `get_node_types` tool returns (one `interface <X>V<NN>Params` per node
+ * typeVersion, with `@default` and `@displayOptions.show` JSDoc tags).
+ *
+ * It converts each top-level parameter declaration back into the property
+ * shape the bundled technical index uses (`{ name, required, type, options,
+ * default, displayOptions }`), so the parsed schema can feed the same
+ * `WorkflowValidator` gating engine. Constructs that carry no validation
+ * semantics (nested option bags, `IDataObject`, plain strings) degrade to
+ * passthrough types rather than being dropped.
+ */
+
+export interface ParsedNodeSchemaProperty {
+    name: string;
+    required: boolean;
+    type: string;
+    options?: Array<{ name: string; value: string }>;
+    default?: unknown;
+    displayOptions?: { show?: Record<string, unknown[]>; hide?: Record<string, unknown[]> };
+    description?: string;
+}
+
+export interface ParsedNodeSchemaSection {
+    type: string;
+    version: number;
+    properties: ParsedNodeSchemaProperty[];
+}
+
+const PROPERTY_START = /^([A-Za-z_$][\w$]*)(\??)\s*:\s*(\S[\s\S]*)$/;
+
+function countBraces(text: string): number {
+    let depth = 0;
+    for (const char of text) {
+        if (char === '{') depth += 1;
+        else if (char === '}') depth -= 1;
+    }
+    return depth;
+}
+
+/** Extract `@tag value` content from a JSDoc block (raw lines without decoration). */
+function jsDocTags(commentLines: string[]): { show?: string; default?: string; description?: string } {
+    const text = commentLines.join('\n');
+    const tags: { show?: string; default?: string; description?: string } = {};
+    const show = text.match(/@displayOptions\.show\s*(\{[^\n]*\})/);
+    if (show) tags.show = show[1];
+    const def = text.match(/@default\s*(\S[^\n]*)$/m);
+    if (def) tags.default = def[1].trim();
+    const firstLine = commentLines
+        .map((l) => l.trim().replace(/^\/\*+|\*+\/$|\*\//g, '').trim())
+        .find(Boolean);
+    if (firstLine) tags.description = firstLine;
+    return tags;
+}
+
+function parseJsonish(raw: string | undefined): unknown {
+    if (raw === undefined) return undefined;
+    const trimmed = raw.trim();
+    if (trimmed === '') return undefined;
+    try {
+        return JSON.parse(trimmed);
+    } catch {
+        return trimmed;
+    }
+}
+
+/** The generator emits JS-style objects (`{ sessionIdType: ["customKey"] }`) — quote the keys. */
+function fixDisplayJson(raw: string): string {
+    return raw
+        .replace(/([{,]\s*)(\/?(?:[\w$-]+))(\s*:)/g, '$1"$2"$3')
+        .replace(/'/g, '"');
+}
+
+function parseDisplayOptions(raw: string | undefined): ParsedNodeSchemaProperty['displayOptions'] {
+    if (!raw) return undefined;
+    try {
+        // The generator emits the SHOW object directly (`{ sessionIdType: ["customKey"] }`),
+        // not the `{ show: ... }` wrapper — normalise both shapes defensively.
+        const parsed = JSON.parse(fixDisplayJson(raw)) as Record<string, unknown>;
+        const hasWrapper = typeof parsed.show === 'object' || typeof parsed.hide === 'object';
+        const map = hasWrapper ? parsed : { show: parsed };
+        const clean = (value: unknown) => {
+            if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+            const out: Record<string, unknown[]> = {};
+            for (const [key, entry] of Object.entries(value)) {
+                out[key] = Array.isArray(entry) ? entry : [entry];
+            }
+            return out;
+        };
+        return { show: clean(map.show), hide: clean(map.hide) };
+    } catch {
+        return undefined;
+    }
+}
+
+/** Map a TS type expression to a validator property type + option values. */
+function mapTypeExpression(typeText: string): { type: string; options?: Array<{ name: string; value: string }> } {
+    let cleaned = typeText.replace(/Expression<[^>]*>/g, '');
+    cleaned = cleaned.replace(/\s+/g, ' ').trim().replace(/^\{[\s\S]*$/, (m) => m);
+
+    if (/^Array\s*</.test(cleaned)) {
+        return { type: cleaned.includes('{') ? 'fixedCollection' : 'multiOptions' };
+    }
+    if (cleaned.includes('__rl')) {
+        return { type: 'resourceLocator' };
+    }
+
+    const segments = cleaned
+        .split('|')
+        .map((s) => s.trim())
+        .filter((s) => s && s !== 'null' && s !== 'undefined');
+
+    if (segments.length > 0 && segments.every((s) => /^'[^']*'$/.test(s))) {
+        const options = segments.map((s) => {
+            const value = s.slice(1, -1);
+            return { name: value, value };
+        });
+        return { type: 'options', options };
+    }
+    if (segments.includes('boolean')) return { type: 'boolean' };
+    if (segments.includes('number')) return { type: 'number' };
+    if (cleaned.includes('IDataObject')) return { type: 'json' };
+    if (cleaned.startsWith('{')) return { type: 'object' };
+    return { type: 'string' };
+}
+
+function toProperty(name: string, optional: boolean, typeText: string, tags: { show?: string; default?: string; description?: string }): ParsedNodeSchemaProperty {
+    const { type, options } = mapTypeExpression(typeText);
+    return {
+        name,
+        required: !optional,
+        type,
+        options,
+        default: parseJsonish(tags.default),
+        displayOptions: parseDisplayOptions(tags.show),
+        description: tags.description,
+    };
+}
+
+/**
+ * Parse one `<Params>` interface body. Property declarations may span several
+ * lines (nested object literals) and are documented by an optional preceding
+ * JSDoc block. Stops at the interface's own closing brace.
+ */
+function parseParamsInterfaceBody(lines: string[]): ParsedNodeSchemaProperty[] {
+    const properties: ParsedNodeSchemaProperty[] = [];
+    let pendingComment: string[] = [];
+
+    const takeComment = () => {
+        const tags = jsDocTags(pendingComment);
+        pendingComment = [];
+        return tags;
+    };
+
+    let i = 0;
+    while (i < lines.length) {
+        const trimmed = lines[i].trim();
+
+        if (trimmed.startsWith('/**') || trimmed.startsWith('*') || trimmed.startsWith('/*')) {
+            pendingComment.push(lines[i]);
+            if (trimmed.includes('*/')) {
+                const rest = trimmed.slice(trimmed.indexOf('*/') + 2).trim();
+                if (rest && PROPERTY_START.test(rest)) {
+                    // One-liner: `/** ... */ name?: type;`
+                    const match = rest.match(PROPERTY_START)!;
+                    const name = match[1];
+                    const optional = match[2] === '?';
+                    const { typeText, consumed, complete } = collectTypeText(match[3], lines, i + 1);
+                    if (complete) {
+                        properties.push(toProperty(name, optional, typeText, takeComment()));
+                        i += consumed + 1;
+                        continue;
+                    }
+                }
+            }
+            i += 1;
+            continue;
+        }
+
+        if (!trimmed) {
+            takeComment();
+            i += 1;
+            continue;
+        }
+
+        const match = trimmed.match(PROPERTY_START);
+        if (match) {
+            const name = match[1];
+            const optional = match[2] === '?';
+            const { typeText, consumed, complete } = collectTypeText(match[3], lines, i + 1);
+            if (complete) {
+                properties.push(toProperty(name, optional, typeText, takeComment()));
+            }
+            i += consumed + 1;
+            continue;
+        }
+
+        takeComment();
+        i += 1;
+    }
+
+    return properties;
+}
+
+/**
+ * Reassemble a (possibly multiline) type expression starting from the text on
+ * the declaration's first line, stopping at a ';' at brace depth zero.
+ * Returns how many extra lines were consumed and whether a terminator was found.
+ */
+function collectTypeText(firstLineText: string, lines: string[], nextIndex: number): { typeText: string; consumed: number; complete: boolean } {
+    let text = firstLineText;
+    let depth = countBraces(text);
+    let consumed = 0;
+
+    while (true) {
+        const semiIndex = depth <= 0 ? text.indexOf(';') : -1;
+        if (semiIndex !== -1) {
+            return { typeText: text.slice(0, semiIndex).trim(), consumed, complete: true };
+        }
+        if (nextIndex + consumed >= lines.length) {
+            return { typeText: text.trim().replace(/;\s*$/, ''), consumed, complete: false };
+        }
+        const next = lines[nextIndex + consumed];
+        text += ' ' + next;
+        depth += countBraces(next);
+        consumed += 1;
+    }
+}
+
+/**
+ * Parse the full `get_node_types` definitions payload into per-type sections.
+ */
+export function parseNodeTypeDefinitions(definitions: string): ParsedNodeSchemaSection[] {
+    const sections: ParsedNodeSchemaSection[] = [];
+    const headerPattern = /^##\s+(.+?)\s+\(v(\d+)\)\s*$/gm;
+
+    const headers: Array<{ type: string; version: number; start: number }> = [];
+    let match: RegExpExecArray | null;
+    while ((match = headerPattern.exec(definitions)) !== null) {
+        headers.push({ type: match[1].trim(), version: Number(match[2]), start: match.index + match[0].length });
+    }
+
+    for (let h = 0; h < headers.length; h += 1) {
+        const end = h + 1 < headers.length ? headers[h + 1].start : definitions.length;
+        const body = definitions.slice(headers[h].start, end);
+
+        // Locate the `<X>Params` declaration (interface or type alias) and slice
+        // until ITS closing brace.
+        const paramsOpen = body.match(/(?:interface|type)\s+\w+Params\s*(?:=\s*)?\{/);
+        if (!paramsOpen || paramsOpen.index === undefined) continue;
+
+        let depth = 1;
+        const innerLines: string[] = [];
+        for (const line of body.slice(paramsOpen.index + paramsOpen[0].length).split(/\r?\n/)) {
+            if (depth <= 0) break;
+            depth += countBraces(line);
+            if (depth > 0) innerLines.push(line);
+        }
+        // Drop the final closing-brace line if it ended up included.
+        while (innerLines.length > 0 && innerLines[innerLines.length - 1].trim() === '}') {
+            innerLines.pop();
+        }
+
+        sections.push({
+            type: headers[h].type,
+            // The generator encodes the version without a dot (1.4 → 14, 3.1 → 31).
+            version: headers[h].version / 10,
+            properties: parseParamsInterfaceBody(innerLines),
+        });
+    }
+
+    return sections;
+}

--- a/packages/cli/src/core/services/preflight-node-validator.ts
+++ b/packages/cli/src/core/services/preflight-node-validator.ts
@@ -1,5 +1,6 @@
 import { WorkflowValidator, ValidationResult } from '@n8n-as-code/skills';
 import { TypeScriptParser, WorkflowBuilder } from '@n8n-as-code/transformer';
+import { InstanceMcpClient } from './instance-mcp-client.js';
 
 export interface PreflightNodeIssue {
     name: string;
@@ -10,44 +11,38 @@ export interface PreflightNodeIssue {
 export interface PreflightValidationOutcome {
     /**
      * Which schema produced the verdict.
-     *  - `server`: the instance's own `validate_node_config` (authoritative for the
-     *    instance, immune to bundled-schema drift);
-     *  - `local`: the bundled technical node index — the DEFAULT validation, which
-     *    runs whenever no instance MCP endpoint is reachable.
+     *  - `server`: the instance's own `validate_node_config` (authoritative for
+     *    the instance, immune to bundled-schema drift);
+     *  - `local`: the bundled technical index, optionally merged with a
+     *    per-instance schema overlay (level 1) — the DEFAULT validation.
      */
     source: 'server' | 'local';
     valid: boolean;
     issues: PreflightNodeIssue[];
-    /** True when an instance MCP endpoint was available and attempted. */
+    /** True when the instance MCP endpoint was attempted. */
     serverAttempted: boolean;
+    /** True when the bundled index was merged with a per-instance schema overlay. */
+    overlayUsed: boolean;
     /** Set when the server attempt could not run; the outcome then reflects the local (default) validation. */
     serverUnavailableReason?: string;
     localResult?: ValidationResult;
 }
 
-export interface ServerValidatorOptions {
+export interface PreflightNodeValidatorOptions {
     /** Native n8n MCP HTTP endpoint of the target instance. */
     endpoint?: string;
     /** Bearer token for the MCP endpoint: the configured native-MCP token, or the environment API key. */
     token?: string;
     timeoutMs?: number;
+    /** Explicit technical index path (test seam; defaults to the bundled asset). */
+    technicalIndexPath?: string;
+    /** Per-instance schema overlay sidecar (custom-nodes shape) merged over the bundled index. */
+    customNodesPath?: string | (() => string | undefined);
+    /** Optional hook run after compile and before validation (e.g. level-1 overlay sync). */
+    beforeValidate?: (workflow: any) => Promise<void>;
 }
 
-/** Loopback hostnames on which plaintext http is acceptable (local dev/self-hosted instances). */
-const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '[::1]', '0.0.0.0']);
-
-function isSchemeAllowed(endpoint: string): boolean {
-    try {
-        const parsed = new URL(endpoint);
-        if (parsed.protocol === 'https:') return true;
-        if (parsed.protocol === 'http:' && LOOPBACK_HOSTNAMES.has(parsed.hostname)) return true;
-        return false;
-    } catch {
-        return false;
-    }
-}
-
-interface McpResult {
+interface McpToolResult {
     structuredContent?: { results?: Array<{ name?: string; type?: string; valid?: boolean; errors?: Array<{ path?: string; message?: string }> }> };
     content?: Array<{ type?: string; text?: string }>;
     isError?: boolean;
@@ -60,25 +55,36 @@ interface McpResult {
  * Validation model — local first, instance as the authoritative upgrade:
  *  1. Local (default): the bundled technical node index runs the server-equivalent
  *     gating rules (display-option gating with schema defaults, resource-locator
- *     shape, option values, required parameters). Always available, no network.
- *  2. Instance (upgrade): when the environment reaches an n8n MCP server exposing
- *     `validate_node_config`, the instance's own schema is the ground truth — it
- *     never drifts from the instance the way the bundled index (built from the
- *     latest n8n GitHub tag) can. The same API key authenticates on self-hosted
- *     instances with the MCP server enabled; n8n Cloud needs its dedicated
- *     instance-level MCP token.
+ *     shape, option values, required parameters). At level 1 the bundled index is
+ *     merged with a per-instance schema overlay refreshed from the instance's own
+ *     `get_node_types` (see `SchemaOverlayManager`).
+ *  2. Instance (upgrade, level ≥ 2): the instance's own `validate_node_config`
+ *     is the ground truth — it never drifts from the instance the way the bundled
+ *     index (built from the latest n8n GitHub tag) can.
  *
  * A push that would deploy instance-invalid nodes is blocked before any remote
  * write — the same guarantee the n8n UI gives when a workflow cannot be saved.
  */
 export class PreflightNodeValidator {
     private readonly technicalIndexPath: string | undefined;
-    private readonly server: ServerValidatorOptions;
+    private readonly customNodesPath: string | (() => string | undefined) | undefined;
+    private readonly beforeValidate: ((workflow: any) => Promise<void>) | undefined;
+    private readonly server: { endpoint?: string; token?: string; timeoutMs?: number };
 
-    constructor(options: { technicalIndexPath?: string } & ServerValidatorOptions = {}) {
+    constructor(options: PreflightNodeValidatorOptions = {}) {
         this.technicalIndexPath = options.technicalIndexPath;
-        const { technicalIndexPath: _ignored, ...server } = options;
-        this.server = server;
+        this.customNodesPath = options.customNodesPath;
+        this.beforeValidate = options.beforeValidate;
+        this.server = {
+            endpoint: options.endpoint,
+            token: options.token,
+            timeoutMs: options.timeoutMs,
+        };
+    }
+
+    private resolvedCustomNodesPath(): string | undefined {
+        const value = this.customNodesPath;
+        return typeof value === 'function' ? value() : value;
     }
 
     private async compileWorkflowFile(filePath: string): Promise<any> {
@@ -157,127 +163,25 @@ export class PreflightNodeValidator {
         });
     }
 
-    /**
-     * Minimal streamable-HTTP MCP client for one validate_node_config round trip:
-     * initialize → notifications/initialized → tools/list → tools/call, then an
-     * authenticated DELETE to release the session (mirrors NativeMcpHttpClient).
-     */
-    private async callServerValidate(nodes: any[]): Promise<McpResult> {
+    private async callServerValidate(nodes: any[]): Promise<McpToolResult> {
         const { endpoint, token, timeoutMs = 10000 } = this.server;
         if (!endpoint) throw new Error('No native MCP endpoint configured');
-        if (!isSchemeAllowed(endpoint)) {
-            throw new Error(`Refusing to send credentials to a non-HTTPS endpoint (${endpoint}); only loopback http is allowed.`);
+
+        const client = new InstanceMcpClient({ endpoint, token, timeoutMs });
+        const tools = await client.listTools();
+        const hasValidator = tools.some((t) => t?.name === 'validate_node_config');
+        if (!hasValidator) throw new Error('Instance MCP server does not expose validate_node_config');
+
+        const result = (await client.callTool('validate_node_config', { nodes })) as McpToolResult;
+        let structured: any = result?.structuredContent;
+        if (!structured && Array.isArray(result?.content)) {
+            const textPart = result.content.find((c) => c?.type === 'text' && c?.text)?.text;
+            if (textPart) structured = JSON.parse(textPart);
         }
-
-        let sessionId: string | undefined;
-        const post = async (payload: Record<string, unknown>, expectResponse = true): Promise<any> => {
-            const controller = new AbortController();
-            const timer = setTimeout(() => controller.abort(), timeoutMs);
-            try {
-                const headers: Record<string, string> = {
-                    Accept: 'application/json, text/event-stream',
-                    'Content-Type': 'application/json',
-                    'mcp-protocol-version': '2024-11-05',
-                    'User-Agent': 'n8n-as-code-preflight',
-                };
-                if (token) headers.Authorization = `Bearer ${token}`;
-                if (sessionId) headers['mcp-session-id'] = sessionId;
-
-                const response = await fetch(endpoint, {
-                    method: 'POST',
-                    headers,
-                    body: JSON.stringify(payload),
-                    signal: controller.signal,
-                });
-                const text = await response.text();
-                sessionId = response.headers.get('mcp-session-id') || sessionId;
-
-                if (!response.ok) {
-                    throw new Error(`Native MCP HTTP ${response.status} ${response.statusText}: ${text.slice(0, 200)}`);
-                }
-                if (!expectResponse || !text.trim()) {
-                    return undefined;
-                }
-
-                let data: any;
-                try {
-                    data = JSON.parse(text);
-                } catch {
-                    for (const line of text.split(/\r?\n/)) {
-                        const trimmed = line.trim();
-                        if (trimmed.startsWith('data:')) {
-                            try { data = JSON.parse(trimmed.slice(5).trim()); break; } catch { /* keep scanning */ }
-                        }
-                    }
-                }
-                if (!data) throw new Error(`Unparseable native MCP response: ${text.slice(0, 200)}`);
-                if (data.error) throw new Error(`Native MCP RPC error (${data.error.code}): ${data.error.message}`);
-                return data.result;
-            } catch (error: any) {
-                if (error?.name === 'AbortError') {
-                    throw new Error(`Native MCP request timed out after ${timeoutMs}ms`);
-                }
-                throw error;
-            } finally {
-                clearTimeout(timer);
-            }
-        };
-
-        const close = async (): Promise<void> => {
-            if (!sessionId) return;
-            const controller = new AbortController();
-            const timer = setTimeout(() => controller.abort(), timeoutMs);
-            try {
-                const headers: Record<string, string> = {
-                    'mcp-protocol-version': '2024-11-05',
-                    'User-Agent': 'n8n-as-code-preflight',
-                    'mcp-session-id': sessionId,
-                };
-                if (token) headers.Authorization = `Bearer ${token}`;
-                await fetch(endpoint, { method: 'DELETE', headers, signal: controller.signal });
-            } catch {
-                // Best-effort cleanup; a failure here must not mask validation results.
-            } finally {
-                clearTimeout(timer);
-            }
-        };
-
-        try {
-            const init = await post({
-                jsonrpc: '2.0',
-                id: 1,
-                method: 'initialize',
-                params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'n8n-as-code', version: '1.0.0' } },
-            });
-            sessionId = sessionId || init?.sessionId;
-
-            // Completes the MCP handshake; its response is an empty notification.
-            await post({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} }, false).catch(() => undefined);
-
-            const toolList: any = await post({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
-            const tools: any[] = Array.isArray(toolList?.tools) ? toolList.tools : [];
-            const hasValidator = tools.some((t) => t?.name === 'validate_node_config');
-            if (!hasValidator) throw new Error('Instance MCP server does not expose validate_node_config');
-
-            const result: any = await post({
-                jsonrpc: '2.0',
-                id: 3,
-                method: 'tools/call',
-                params: { name: 'validate_node_config', arguments: { nodes } },
-            });
-
-            let structured: any = result?.structuredContent;
-            if (!structured && Array.isArray(result?.content)) {
-                const textPart = result.content.find((c: any) => c?.type === 'text' && c?.text)?.text;
-                if (textPart) structured = JSON.parse(textPart);
-            }
-            return { ...result, structuredContent: structured };
-        } finally {
-            await close();
-        }
+        return { ...result, structuredContent: structured };
     }
 
-    private serverOutcome(result: McpResult): PreflightValidationOutcome {
+    private serverOutcome(result: McpToolResult): PreflightValidationOutcome {
         const results = result.structuredContent?.results;
         if (!Array.isArray(results)) {
             const errorText = Array.isArray(result?.content)
@@ -289,6 +193,7 @@ export class PreflightNodeValidator {
         return {
             source: 'server',
             serverAttempted: true,
+            overlayUsed: false,
             valid: invalid.length === 0,
             issues: invalid.map((r) => ({
                 name: String(r.name ?? '?'),
@@ -307,9 +212,9 @@ export class PreflightNodeValidator {
      */
     async validateFile(filePath: string): Promise<PreflightValidationOutcome> {
         const workflow = await this.compileWorkflowFile(filePath);
+        await this.beforeValidate?.(workflow);
 
-        // Instance path (authoritative upgrade) — attempted whenever an endpoint is
-        // reachable; the instance's own schema never drifts from the instance.
+        // Instance path (authoritative upgrade, level ≥ 2).
         if (this.server.endpoint) {
             try {
                 const payload = this.buildNodePayload(workflow);
@@ -335,13 +240,15 @@ export class PreflightNodeValidator {
     }
 
     private async validateWorkflowJson(workflow: any): Promise<PreflightValidationOutcome> {
+        const customNodesPath = this.resolvedCustomNodesPath();
         const validator = this.technicalIndexPath
-            ? new WorkflowValidator(this.technicalIndexPath)
-            : new WorkflowValidator();
+            ? new WorkflowValidator(this.technicalIndexPath, customNodesPath)
+            : new WorkflowValidator(undefined, customNodesPath);
         const result = await validator.validateWorkflow(workflow, false);
         return {
             source: 'local',
             serverAttempted: false,
+            overlayUsed: Boolean(customNodesPath),
             valid: result.valid,
             issues: result.errors.map((e) => ({
                 name: e.nodeName ?? 'unknown',

--- a/packages/cli/src/core/services/schema-overlay-manager.ts
+++ b/packages/cli/src/core/services/schema-overlay-manager.ts
@@ -1,0 +1,265 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { InstanceMcpClient } from './instance-mcp-client.js';
+import { parseNodeTypeDefinitions, type ParsedNodeSchemaSection } from './node-schema-defs-parser.js';
+
+export interface SchemaOverlayOptions {
+    endpoint: string;
+    token?: string;
+    timeoutMs?: number;
+    /** Directory that holds the overlay cache file (per environment). */
+    cacheDir: string;
+    /** Default time-to-live for fetched definitions. */
+    ttlMs?: number;
+    /** Test seam. */
+    client?: InstanceMcpClient;
+}
+
+export interface OverlayNodeVersion {
+    fetchedAtMs: number;
+    properties: any[];
+}
+
+interface OverlayFile {
+    schemaVersion: 1;
+    ttlMs: number;
+    nodes: Record<string, { type: string; name: string; version: number[]; versions: Record<string, OverlayNodeVersion> }>;
+}
+
+const OVERLAY_FILENAME = '.schema-overlay.json';
+const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** The instance expects discriminator values in snake_case (getAll → get_all). */
+function operationDiscriminator(operation: string): string {
+    if (!/[a-z0-9][A-Z]/.test(operation)) return operation;
+    return operation
+        .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+        .toLowerCase();
+}
+
+/**
+ * Level-1 schema overlay: caches per-environment node definitions fetched from
+ * the instance's native MCP `get_node_types` (the instance's exact schema) and
+ * materialises them into a custom-nodes-style sidecar the bundled
+ * `NodeSchemaProvider` merges over the built-in technical index.
+ *
+ * Sync is economical by construction: definitions are fetched lazily per
+ * (node type, typeVersion) on first contact, refreshed only after the TTL, and
+ * the resulting overlay file is written back so validation runs fully locally
+ * between syncs — no MCP call per push.
+ */
+export class SchemaOverlayManager {
+    private readonly options: Required<Pick<SchemaOverlayOptions, 'cacheDir'>> & SchemaOverlayOptions;
+    private readonly overlayPath: string;
+    private readonly ttlMs: number;
+
+    constructor(options: SchemaOverlayOptions) {
+        this.options = options;
+        this.overlayPath = path.join(options.cacheDir, OVERLAY_FILENAME);
+        this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    }
+
+    get filePath(): string {
+        return this.overlayPath;
+    }
+
+    private readCache(): OverlayFile {
+        try {
+            const raw = JSON.parse(fs.readFileSync(this.overlayPath, 'utf8')) as OverlayFile;
+            if (raw.schemaVersion === 1 && raw.nodes && typeof raw.nodes === 'object') {
+                return raw;
+            }
+        } catch {
+            // missing or corrupt cache — start fresh
+        }
+        return { schemaVersion: 1, ttlMs: this.ttlMs, nodes: {} };
+    }
+
+    private writeCache(cache: OverlayFile): void {
+        fs.mkdirSync(this.options.cacheDir, { recursive: true });
+        const tmp = `${this.overlayPath}.tmp`;
+        fs.writeFileSync(tmp, JSON.stringify(cache, null, 1), 'utf8');
+        fs.renameSync(tmp, this.overlayPath);
+    }
+
+    /** Node types used by a workflow, in the shape `get_node_types` expects. */
+    static collectNodeTypes(workflow: any): Array<{ type: string; version: string; resource?: string; operation?: string }> {
+        const nodes: any[] = Array.isArray(workflow?.nodes) ? workflow.nodes : [];
+        const seen = new Set<string>();
+        const out: Array<{ type: string; version: string; resource?: string; operation?: string }> = [];
+        for (const node of nodes) {
+            const type = typeof node?.type === 'string' ? node.type : '';
+            if (!type) continue;
+            const key = `${type}@${node?.typeVersion ?? 1}`;
+            if (seen.has(key)) continue;
+            seen.add(key);
+            const params = node?.parameters ?? {};
+            const descriptor: { type: string; version: string; resource?: string; operation?: string } = { type, version: String(node?.typeVersion ?? 1) };
+            // get_node_types needs the resource/operation discriminators for
+            // resource-scoped nodes (gmailTool, googleCalendarTool, ...).
+            if (typeof params.resource === 'string' && !params.resource.includes('{{')) descriptor.resource = params.resource;
+            if (typeof params.operation === 'string' && !params.operation.includes('{{')) descriptor.operation = operationDiscriminator(params.operation);
+            out.push(descriptor);
+        }
+        return out;
+    }
+
+    /** Whether every listed (type, version) is cached and fresh. */
+    isFresh(types: Array<{ type: string; version: string }>): boolean {
+        const cache = this.readCache();
+        const now = Date.now();
+        return types.every(({ type, version }) => {
+            const entry = cache.nodes[type]?.versions[version];
+            return Boolean(entry) && now - entry.fetchedAtMs < this.ttlMs;
+        });
+    }
+
+    /**
+     * Ensure the overlay covers the given (type, version) pairs, fetching only
+     * what is missing or expired. Returns the overlay file path plus the list of
+     * requested types the instance could not provide definitions for (they then
+     * fall back to the bundled schema — partial coverage is kept).
+     */
+    async ensureForTypes(types: Array<{ type: string; version: string; resource?: string; operation?: string }>): Promise<{ overlayPath: string; failed: string[] }> {
+        const cache = this.readCache();
+        const now = Date.now();
+        const missing = types.filter(({ type, version }) => {
+            const entry = cache.nodes[type]?.versions[version];
+            return !entry || now - entry.fetchedAtMs >= this.ttlMs;
+        });
+
+        const failed: string[] = [];
+        if (missing.length > 0) {
+            const byType = new Map<string, { type: string; version: string; resource?: string; operation?: string }>();
+            for (const descriptor of missing) byType.set(descriptor.type, descriptor);
+
+            // One batched call first (the server omits, rather than errors on,
+            // types it cannot describe without discriminators), then an
+            // individual retry per still-missing type with its discriminators.
+            const sections = await this.fetchDefinitions([...byType.values()]);
+            const covered = new Set(sections.map((s) => s.type));
+            this.mergeSections(sections, [...byType.values()]);
+
+            for (const descriptor of byType.values()) {
+                if (covered.has(descriptor.type)) continue;
+                try {
+                    const retry = await this.fetchDefinitions([descriptor]);
+                    this.mergeSections(retry, [descriptor]);
+                    if (retry.length === 0) failed.push(`${descriptor.type}@${descriptor.version}`);
+                } catch {
+                    failed.push(`${descriptor.type}@${descriptor.version}`);
+                }
+            }
+        }
+
+        return { overlayPath: this.overlayPath, failed };
+    }
+
+    private async fetchDefinitions(types: Array<{ type: string; version: string; resource?: string; operation?: string }>): Promise<ParsedNodeSchemaSection[]> {
+        const client = this.options.client ?? new InstanceMcpClient({
+            endpoint: this.options.endpoint,
+            token: this.options.token,
+            timeoutMs: this.options.timeoutMs ?? 15000,
+        });
+        const nodeIds = types.map(({ type, version, resource, operation }) => {
+            const descriptor: Record<string, string> = { nodeId: type, version };
+            if (resource) descriptor.resource = resource;
+            if (operation) descriptor.operation = operation;
+            return descriptor;
+        });
+        const result = (await client.callTool('get_node_types', {
+            nodeIds,
+        })) as { structuredContent?: { definitions?: string }; content?: Array<{ type?: string; text?: string }> };
+
+        let definitions = result?.structuredContent?.definitions;
+        if (!definitions && Array.isArray(result?.content)) {
+            definitions = result.content.find((c) => c?.type === 'text' && c?.text)?.text;
+        }
+        if (!definitions) {
+            throw new Error('get_node_types returned no definitions');
+        }
+        return parseNodeTypeDefinitions(definitions);
+    }
+
+    private mergeSections(sections: ParsedNodeSchemaSection[], requested: Array<{ type: string; version: string }>): void {
+        const cache = this.readCache();
+        const now = Date.now();
+
+        for (const requestedType of requested) {
+            const wantedVersion = Number(requestedType.version);
+            const section = sections.find((s) => {
+                if (s.type !== requestedType.type) return false;
+                if (sections.filter((x) => x.type === requestedType.type).length === 1) return true;
+                return Math.abs(s.version - wantedVersion) < 0.01;
+            });
+            if (!section) continue; // caller tracks coverage and retries individually
+
+            const typeKey = section.type;
+            const versionKey = String(wantedVersion);
+            const entry = cache.nodes[typeKey] ?? { type: typeKey, name: typeKey.slice(typeKey.lastIndexOf('.') + 1), version: [], versions: {} };
+            if (!entry.version.includes(wantedVersion)) {
+                entry.version.push(wantedVersion);
+            }
+            entry.versions[versionKey] = { fetchedAtMs: now, properties: section.properties };
+            cache.nodes[typeKey] = entry;
+        }
+
+        this.writeCache(cache);
+        this.materialiseProviderFile(cache);
+    }
+
+    /**
+     * Write the custom-nodes sidecar consumed by `NodeSchemaProvider`: one node
+     * entry per type with all cached versions merged into `schema.properties`.
+     * When several versions of a type are cached, every property is scoped with
+     * an `@version` display condition so the validator only applies the rules of
+     * the node's own typeVersion.
+     */
+    private materialiseProviderFile(cache: OverlayFile): void {
+        const nodes: Record<string, any> = {};
+        for (const [typeKey, entry] of Object.entries(cache.nodes)) {
+            const versionList = [...entry.version].sort((a, b) => a - b);
+            let properties: any[] = [];
+            for (const version of versionList) {
+                const versionProps = entry.versions[String(version)]?.properties ?? [];
+                if (versionList.length === 1) {
+                    properties = properties.concat(versionProps);
+                    continue;
+                }
+                for (const prop of versionProps) {
+                    const scoped = {
+                        ...prop,
+                        displayOptions: {
+                            show: {
+                                ...(prop.displayOptions?.show ?? {}),
+                                '@version': [version],
+                            },
+                            ...(prop.displayOptions?.hide ? { hide: prop.displayOptions.hide } : {}),
+                        },
+                    };
+                    properties.push(scoped);
+                }
+            }
+            nodes[typeKey] = {
+                name: entry.name,
+                type: typeKey,
+                displayName: entry.name,
+                description: `Instance schema overlay for ${typeKey}`,
+                version: versionList,
+                schema: { properties },
+                metadata: { keywords: [], operations: [], useCases: [], keywordScore: 0, hasDocumentation: false, markdownUrl: null, markdownFile: null },
+            };
+        }
+
+        fs.mkdirSync(path.dirname(this.overlayPath), { recursive: true });
+        const tmp = `${this.overlayPath}.provider.tmp`;
+        fs.writeFileSync(tmp, JSON.stringify({ nodes }, null, 1), 'utf8');
+        fs.renameSync(tmp, `${this.overlayPath}.provider.json`);
+    }
+
+    /** Path of the materialised provider sidecar (merged over the bundled index). */
+    get providerFilePath(): string {
+        return `${this.overlayPath}.provider.json`;
+    }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,10 +17,10 @@ import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { createRequire } from 'module';
-import { parsePositiveIntegerOption } from './utils/option-parsers.js';
+import { parsePositiveIntegerOption, parseLevelOption } from './utils/option-parsers.js';
 import { spawn } from 'child_process';
 import { createN8nManagerFacade } from '@n8n-as-code/manager-adapter';
-import { ConfigService } from './services/config-service.js';
+import { ConfigService, effectiveNativeMcpLevel, NATIVE_MCP_LEVEL_NAMES } from './services/config-service.js';
 import { RestFolderSource } from './core/services/rest-folder-source.js';
 import { installExtraCaCertificates } from './core/services/tls-certificates.js';
 import {
@@ -1211,11 +1211,12 @@ const nativeMcpCmd = program.command('native-mcp')
 
 nativeMcpCmd
     .command('configure')
-    .description('Configure optional native n8n MCP assist for a workspace environment without committing secrets')
+    .description('Configure native n8n MCP usage for a workspace environment without committing secrets')
     .argument('[name-or-id]', 'Environment name or ID; defaults to pinned environment or --env')
     .option('--url <url>', 'Native n8n MCP HTTP endpoint; defaults to <environment-url>/mcp-server/http')
     .option('--token <token>', 'Native n8n MCP bearer token to store locally')
     .option('--token-stdin', 'Read the native n8n MCP bearer token from stdin')
+    .option('--level <level>', 'Native MCP usage level (cumulative): 1 = schema sync (instance ontology overlay), 2 = + live validation at push, 3 = + read-only discovery', (value) => parseLevelOption(value, '--level'))
     .option('--timeout-ms <ms>', 'Native MCP request timeout in milliseconds', (value) => parsePositiveIntegerOption(value, '--timeout-ms'))
     .option('--allow-execution-data', 'Allow full live execution payloads when explicitly requested')
     .option('--deny-execution-data', 'Disallow full live execution payloads')
@@ -1233,6 +1234,7 @@ nativeMcpCmd
             enabled: true,
             mode: 'assist' as const,
             url: options.url || existing?.url || defaultNativeMcpEndpointFromHost(resolved.host),
+            level: options.level ?? existing?.level,
             timeoutMs: options.timeoutMs ?? existing?.timeoutMs,
             allowExecutionData: options.denyExecutionData ? false : options.allowExecutionData ? true : existing?.allowExecutionData,
             allowRemoteExposure: options.denyRemote ? false : options.allowRemote ? true : existing?.allowRemoteExposure,
@@ -1243,20 +1245,22 @@ nativeMcpCmd
             configService.saveNativeMcpToken(environment.id, options.token);
         }
         const snapshot = configService.getWorkspaceConfig().environments?.find((item) => item.id === environment.id) || environment;
+        const effectiveLevel = effectiveNativeMcpLevel(snapshot.nativeMcp);
         printJsonOrText(
             options,
             snapshot,
             [
-                chalk.green(`✔ Native n8n MCP assist configured for environment: ${environment.name}`),
+                chalk.green(`✔ Native n8n MCP configured for environment: ${environment.name}`),
                 `Endpoint: ${snapshot.nativeMcp?.url || nativeMcp.url}`,
                 `Token   : ${snapshot.nativeMcp?.tokenConfigured ? 'stored locally' : 'not configured'}`,
+                `Level   : ${effectiveLevel} — ${NATIVE_MCP_LEVEL_NAMES[effectiveLevel] ?? 'unknown'}`,
             ].join('\n'),
         );
     });
 
 nativeMcpCmd
     .command('disable')
-    .description('Disable native n8n MCP assist for a workspace environment and remove its stored token')
+    .description('Disable native n8n MCP usage for a workspace environment and remove its stored token')
     .argument('[name-or-id]', 'Environment name or ID; defaults to pinned environment or --env')
     .option('--json', 'Output environment as JSON')
     .action((nameOrId, options) => {
@@ -1271,7 +1275,7 @@ nativeMcpCmd
             },
         });
         const snapshot = configService.getWorkspaceConfig().environments?.find((item) => item.id === environment.id) || environment;
-        printJsonOrText(options, snapshot, chalk.green(`✔ Native n8n MCP assist disabled for environment: ${environment.name}`));
+        printJsonOrText(options, snapshot, chalk.green(`✔ Native n8n MCP disabled for environment: ${environment.name} (level 0)`));
     });
 
 nativeMcpCmd

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -88,15 +88,46 @@ export type IEnvironmentTarget = IManagedEnvironmentTarget | IExternalEnvironmen
 
 export type IWorkspaceNativeMcpMode = 'assist' | 'direct';
 
+/**
+ * Native MCP usage level — the single knob that decides how much of the
+ * instance's MCP server n8n-as-code uses. Cumulative ladder:
+ *   0  no MCP at all (bundled ontology only)
+ *   1  schema sync: refresh the local per-instance ontology overlay
+ *   2  + live `validate_node_config` at push time (authoritative gate)
+ *   3  + read-only discovery wrappers (workflows/nodes/executions)
+ * A configured environment without an explicit level behaves as level 3
+ * (maximum backward compatibility with the legacy assist surface).
+ */
+export type IWorkspaceNativeMcpLevel = 1 | 2 | 3;
+
 export interface IWorkspaceNativeMcpConfig {
     enabled?: boolean;
     url?: string;
     mode?: IWorkspaceNativeMcpMode;
+    level?: IWorkspaceNativeMcpLevel;
     timeoutMs?: number;
     allowRemoteExposure?: boolean;
     allowExecutionData?: boolean;
     requireSyncBack?: boolean;
     tokenConfigured?: boolean;
+}
+
+export const NATIVE_MCP_LEVEL_NAMES: Record<number, string> = {
+    0: 'off (bundled ontology only)',
+    1: 'schema sync (instance ontology overlay)',
+    2: 'live validation at push',
+    3: 'read-only discovery',
+};
+
+export function effectiveNativeMcpLevel(nativeMcp: IWorkspaceNativeMcpConfig | undefined, envOverride?: string): number {
+    if (envOverride !== undefined && envOverride.trim() !== '') {
+        const parsed = Number.parseInt(envOverride.trim(), 10);
+        if (Number.isInteger(parsed) && parsed >= 0 && parsed <= 3) return parsed;
+    }
+    if (!nativeMcp) return 0;
+    if (nativeMcp.level !== undefined) return nativeMcp.level;
+    if (nativeMcp.enabled === false) return 0;
+    return nativeMcp.enabled || nativeMcp.url ? 3 : 0;
 }
 
 export interface IWorkspaceEnvironment {
@@ -1344,10 +1375,13 @@ export class ConfigService {
         }
         const timeoutMs = this.parseOptionalPositiveInteger(input.timeoutMs, 'nativeMcp.timeoutMs');
         const mode: IWorkspaceNativeMcpMode | undefined = input.mode === 'direct' ? 'direct' : input.mode === 'assist' ? 'assist' : undefined;
+        const rawLevel = input.level;
+        const level: IWorkspaceNativeMcpLevel | undefined = rawLevel === 1 || rawLevel === 2 || rawLevel === 3 ? rawLevel : undefined;
         return stripUndefined({
             enabled: typeof input.enabled === 'boolean' ? input.enabled : url ? true : undefined,
             url,
             mode,
+            level,
             timeoutMs,
             allowRemoteExposure: typeof input.allowRemoteExposure === 'boolean' ? input.allowRemoteExposure : undefined,
             allowExecutionData: typeof input.allowExecutionData === 'boolean' ? input.allowExecutionData : undefined,

--- a/packages/cli/src/utils/option-parsers.ts
+++ b/packages/cli/src/utils/option-parsers.ts
@@ -12,3 +12,11 @@ export function parsePositiveIntegerOption(value: string, optionName: string): n
 
     return parsed;
 }
+
+export function parseLevelOption(value: string, optionName: string): number {
+    const parsed = Number.parseInt(value.trim(), 10);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 3) {
+        throw new Error(`${optionName} must be an integer between 1 and 3`);
+    }
+    return parsed;
+}

--- a/packages/cli/tests/fixtures/mcp-defs/agent.txt
+++ b/packages/cli/tests/fixtures/mcp-defs/agent.txt
@@ -1,0 +1,142 @@
+# TypeScript Type Definitions
+
+## @n8n/n8n-nodes-langchain.agent (v31)
+
+```typescript
+/**
+ * AI Agent Node - Version 3.1
+ * Generates an action plan and executes it. Can use external tools.
+ */
+
+
+export interface LcAgentV31Params {
+/**
+ * Source for Prompt (User Message)
+ * @builderHint Use 'auto' when following a chat trigger, 'define' when custom prompt needed
+ * @default auto
+ */
+    promptType?: 'auto' | 'define' | Expression<string>;
+/**
+ * Prompt (User Message)
+ * @builderHint Use expressions to include dynamic data from previous nodes (e.g., expr('{{ $json.input }}')). Static text prompts ignore incoming data.
+ * @placeholderSupported false
+ * @displayOptions.show { promptType: ["define"] }
+ */
+    text: string | Expression<string>;
+/**
+ * Require Specific Output Format
+ * @builderHint Set to `true` when you need structured JSON output. The agent then requires an `outputParser` entry in its `subnodes` config (typically an `outputParserStructured` node defined via the `outputParser({...})` SDK factory). With `hasOutputParser: false` the agent returns a plain string in `$json.output`.
+ * @default false
+ */
+    hasOutputParser?: boolean;
+  needsFallback?: boolean;
+  options?: {
+    /** The message that will be sent to the agent before the conversation starts
+     * @builderHint Must include: agent's purpose, exact names of connected tools, and response instructions
+     * @default You are a helpful assistant
+     */
+    systemMessage?: string | Expression<string>;
+    /** The maximum number of iterations the agent will run before stopping
+     * @default 10
+     */
+    maxIterations?: number | Expression<number>;
+    /** Whether or not the output should include intermediate steps the agent took
+     * @default false
+     */
+    returnIntermediateSteps?: boolean | Expression<boolean>;
+    /** Whether or not binary images should be automatically passed through to the agent as image type messages
+     * @default true
+     */
+    passthroughBinaryImages?: boolean | Expression<boolean>;
+    /** Whether or not binary PDF documents should be automatically passed through to the agent. Useful for models that natively support PDF input (e.g. Google Gemini).
+     * @default false
+     */
+    passthroughBinaryPdfs?: boolean | Expression<boolean>;
+    /** Custom metadata added to tracing events
+     * @default {}
+     */
+    tracingMetadata?: {
+        /** Metadata
+     */
+    values?: Array<{
+      /** Key
+       */
+      key?: string | Expression<string>;
+      /** The field value type
+       * @default stringValue
+       */
+      type?: 'arrayValue' | 'booleanValue' | 'numberValue' | 'objectValue' | 'stringValue' | Expression<string>;
+      /** Value
+       * @displayOptions.show { type: ["stringValue"] }
+       */
+      stringValue?: string | Expression<string>;
+      /** Value
+       * @displayOptions.show { type: ["numberValue"] }
+       */
+      numberValue?: string | Expression<string>;
+      /** Value
+       * @displayOptions.show { type: ["booleanValue"] }
+       * @default true
+       */
+      booleanValue?: 'true' | 'false' | Expression<string>;
+      /** Value
+       * @displayOptions.show { type: ["arrayValue"] }
+       */
+      arrayValue?: string | Expression<string>;
+      /** Value
+       * @displayOptions.show { type: ["objectValue"] }
+       * @default ={}
+       */
+      objectValue?: IDataObject | string | Expression<string>;
+    }>;
+  };
+    /** Whether to automatically save &lt;a href="https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.executiondata/" target="_blank"&gt;highlighted data&lt;/a&gt;. This data can then be used to filter executions in the Executions view. Available on Pro and Enterprise plans in n8n Cloud, and on Enterprise or registered Community Edition for self-hosted. Defaults to true.
+     * @default true
+     */
+    autoSaveHighlightedData?: boolean | Expression<boolean>;
+    /** Whether this agent will stream the response in real-time as it generates text
+     * @default true
+     */
+    enableStreaming?: boolean | Expression<boolean>;
+    /** Batch processing options for rate limiting
+     * @default {}
+     */
+    batching?: {
+    /** How many items to process in parallel. This is useful for rate limiting, but might impact the log output ordering.
+     * @default 1
+     */
+    batchSize?: number | Expression<number>;
+    /** Delay in milliseconds between batches. This is useful for rate limiting.
+     * @default 0
+     */
+    delayBetweenBatches?: number | Expression<number>;
+  };
+    /** The maximum number of tokens to read from the chat memory history. Set to 0 to read all history.
+     * @default 0
+     */
+    maxTokensFromMemory?: unknown;
+  };
+}
+
+export interface LcAgentV31SubnodeConfig {
+  model: LanguageModelInstance | LanguageModelInstance[];
+  memory?: MemoryInstance;
+  tools?: ToolInstance[];
+  /**
+   * @displayOptions.show { hasOutputParser: [true] }
+   */
+  outputParser?: OutputParserInstance;
+}
+
+interface LcAgentV31NodeBase {
+  type: '@n8n/n8n-nodes-langchain.agent';
+  version: 3.1;
+  isTrigger: true;
+}
+
+export type LcAgentV31ParamsNode = LcAgentV31NodeBase & {
+  config: NodeConfig<LcAgentV31Params> & { subnodes: LcAgentV31SubnodeConfig };
+};
+
+export type LcAgentV31Node = LcAgentV31ParamsNode;
+```

--- a/packages/cli/tests/fixtures/mcp-defs/html.txt
+++ b/packages/cli/tests/fixtures/mcp-defs/html.txt
@@ -1,0 +1,116 @@
+# TypeScript Type Definitions
+
+## n8n-nodes-base.html (v12)
+
+```typescript
+/**
+ * HTML Node - Version 1.2
+ * Work with HTML
+ */
+
+
+export interface HtmlV12Params {
+  operation?: 'generateHtmlTemplate' | 'extractHtmlContent' | 'convertToHtmlTable';
+/**
+ * HTML template to render
+ * @builderHint Use expressions to generate loops, reference data, etc. Does not support handlebars.
+ * @displayOptions.show { operation: ["generateHtmlTemplate"] }
+ */
+    html?: string;
+/**
+ * If HTML should be read from binary or JSON data
+ * @displayOptions.show { operation: ["extractHtmlContent"] }
+ * @default json
+ */
+    sourceData?: 'binary' | 'json' | Expression<string>;
+/**
+ * Input Binary Field
+ * @hint The name of the input binary field containing the file to be extracted
+ * @displayOptions.show { operation: ["extractHtmlContent"], sourceData: ["binary"] }
+ * @default data
+ */
+    dataPropertyName?: string | Expression<string>;
+/**
+ * Extraction Values
+ * @displayOptions.show { operation: ["extractHtmlContent"] }
+ * @default {"values":[{"key":"","cssSelector":"","returnValue":"text","returnArray":false}]}
+ */
+    extractionValues?: {
+        /** Values
+     */
+    values?: Array<{
+      /** The key under which the extracted value should be saved
+       */
+      key?: string | Expression<string>;
+      /** The CSS selector to use
+       */
+      cssSelector?: string | Expression<string>;
+      /** What kind of data should be returned
+       * @default text
+       */
+      returnValue?: 'attribute' | 'html' | 'text' | 'value' | Expression<string>;
+      /** The name of the attribute to return the value off
+       * @displayOptions.show { returnValue: ["attribute"] }
+       */
+      attribute?: string | Expression<string>;
+      /** Comma-separated list of selectors to skip in the text extraction
+       * @displayOptions.show { returnValue: ["text"] }
+       */
+      skipSelectors?: string | Expression<string>;
+      /** Whether to return the values as an array so if multiple ones get found they also get returned separately. If not set all will be returned as a single string.
+       * @default false
+       */
+      returnArray?: boolean | Expression<boolean>;
+    }>;
+  };
+/**
+ * Options
+ * @displayOptions.show { operation: ["extractHtmlContent"] }
+ * @default {}
+ */
+    options?: {
+    /** Whether to remove automatically all spaces and newlines from the beginning and end of the values
+     * @default true
+     */
+    trimValues?: boolean | Expression<boolean>;
+    /** Whether to remove leading and trailing whitespaces, line breaks (newlines) and condense multiple consecutive whitespaces into a single space
+     * @default true
+     */
+    cleanUpText?: boolean | Expression<boolean>;
+    /** Whether to capitalize the headers
+     * @default false
+     */
+    capitalize?: boolean | Expression<boolean>;
+    /** Whether to use custom styling
+     * @default false
+     */
+    customStyling?: boolean | Expression<boolean>;
+    /** Caption to add to the table
+     */
+    caption?: string | Expression<string>;
+    /** Attributes to attach to the table
+     */
+    tableAttributes?: string | Expression<string>;
+    /** Attributes to attach to the table header
+     */
+    headerAttributes?: string | Expression<string>;
+    /** Attributes to attach to the table row
+     */
+    rowAttributes?: string | Expression<string>;
+    /** Attributes to attach to the table cell
+     */
+    cellAttributes?: string | Expression<string>;
+  };
+}
+
+interface HtmlV12NodeBase {
+  type: 'n8n-nodes-base.html';
+  version: 1.2;
+}
+
+export type HtmlV12ParamsNode = HtmlV12NodeBase & {
+  config: NodeConfig<HtmlV12Params>;
+};
+
+export type HtmlV12Node = HtmlV12ParamsNode;
+```

--- a/packages/cli/tests/fixtures/mcp-defs/lmchat.txt
+++ b/packages/cli/tests/fixtures/mcp-defs/lmchat.txt
@@ -1,0 +1,228 @@
+# TypeScript Type Definitions
+
+## @n8n/n8n-nodes-langchain.lmChatOpenAi (v13)
+
+```typescript
+/**
+ * OpenAI Chat Model Node - Version 1.3
+ * For advanced usage with an AI chain
+ */
+
+
+export interface LcLmChatOpenAiV13Params {
+/**
+ * The model. Choose from the list, or specify an ID.
+ * @builderHint Prefer the GPT-5.4 family: the flagship variant (e.g. `gpt-5.4`) for general use, a `-mini` / `-nano` variant when the task explicitly calls for cost-efficiency, or `-pro` only when the user asks for maximum capability. Never use gpt-4o, gpt-4-turbo, gpt-4, gpt-3.5, or earlier — those are superseded by the GPT-5 family and are not valid choices.
+ * @searchListMethod searchModels
+ * @default {"mode":"list","value":"gpt-5-mini"}
+ */
+    model?: { __rl: true; mode: 'list' | 'id'; value: string; cachedResultName?: string };
+/**
+ * Whether to use the Responses API to generate the response. &lt;a href="https://docs.n8n.io/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenai/#use-responses-api"&gt;Learn more&lt;/a&gt;.
+ * @default true
+ */
+    responsesApiEnabled?: boolean | Expression<boolean>;
+/**
+ * Built-in Tools
+ * @displayOptions.show { /responsesApiEnabled: [true] }
+ * @default {}
+ */
+    builtInTools?: {
+    /** Web Search
+     * @default {"searchContextSize":"medium"}
+     */
+    webSearch?: {
+    /** High level guidance for the amount of context window space to use for the search
+     * @default medium
+     */
+    searchContextSize?: 'low' | 'medium' | 'high' | Expression<string>;
+    /** Comma-separated list of domains to search. Only domains in this list will be searched.
+     */
+    allowedDomains?: string | Expression<string>;
+    /** Country
+     */
+    country?: string | Expression<string>;
+    /** City
+     */
+    city?: string | Expression<string>;
+    /** Region
+     */
+    region?: string | Expression<string>;
+  };
+    /** File Search
+     * @default {"vectorStoreIds":"[]"}
+     */
+    fileSearch?: {
+    /** The vector store IDs to use for the file search. Vector stores are managed via OpenAI Dashboard. &lt;a href="https://docs.n8n.io/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenai/#built-in-tools"&gt;Learn more&lt;/a&gt;.
+     * @default []
+     */
+    vectorStoreIds?: IDataObject | string | Expression<string>;
+    /** Filters
+     * @default {}
+     */
+    filters?: IDataObject | string | Expression<string>;
+    /** Max Results
+     * @default 1
+     */
+    maxResults?: number | Expression<number>;
+  };
+    /** Whether to allow the model to execute code in a sandboxed environment
+     * @default true
+     */
+    codeInterpreter?: boolean | Expression<boolean>;
+  };
+/**
+ * Additional options to add
+ * @default {}
+ */
+    options?: {
+    /** Override the default base URL for the API
+     * @default https://api.openai.com/v1
+     */
+    baseURL?: string | Expression<string>;
+    /** Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim
+     * @default 0
+     */
+    frequencyPenalty?: number | Expression<number>;
+    /** The maximum number of tokens to generate in the completion. Most models have a context length of 2048 tokens (except for the newest models, which support 32,768).
+     * @default -1
+     */
+    maxTokens?: number | Expression<number>;
+    /** Response Format
+     * @default text
+     */
+    responseFormat?: 'text' | 'json_object' | Expression<string>;
+    /** Response Format
+     * @displayOptions.show { /responsesApiEnabled: [false] }
+     * @default text
+     */
+    responseFormat?: 'text' | 'json_object' | Expression<string>;
+    /** Response Format
+     * @displayOptions.show { /responsesApiEnabled: [true] }
+     * @default {"textOptions":[{"type":"text"}]}
+     */
+    textFormat?: {
+        /** Text
+     */
+    textOptions?: {
+      /** Type
+       */
+      type?: 'text' | 'json_schema' | 'json_object' | Expression<string>;
+      /** Verbosity
+       * @default medium
+       */
+      verbosity?: 'low' | 'medium' | 'high' | Expression<string>;
+      /** The name of the response format. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64.
+       * @displayOptions.show { type: ["json_schema"] }
+       * @default my_schema
+       */
+      name?: string | Expression<string>;
+      /** The schema of the response format
+       * @displayOptions.show { type: ["json_schema"] }
+       */
+      schema?: IDataObject | string | Expression<string>;
+      /** The description of the response format
+       * @displayOptions.show { type: ["json_schema"] }
+       */
+      description?: string | Expression<string>;
+      /** Whether to require that the AI will always generate responses that match the provided JSON Schema
+       * @displayOptions.show { type: ["json_schema"] }
+       * @default false
+       */
+      strict?: boolean | Expression<boolean>;
+    };
+  };
+    /** Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics
+     * @default 0
+     */
+    presencePenalty?: number | Expression<number>;
+    /** Controls randomness: Lowering results in less random completions. As the temperature approaches zero, the model will become deterministic and repetitive.
+     * @default 0.7
+     */
+    temperature?: number | Expression<number>;
+    /** Controls the amount of reasoning tokens to use. A value of "low" will favor speed and economical token usage, "high" will favor more complete reasoning at the cost of more tokens generated and slower responses.
+     * @displayOptions.show { /model: [{"_cnd":{"regex":"(^o1([-\\d]+)?$)|(^o[3-9].*)|(^gpt-5.*)"}}] }
+     * @default medium
+     */
+    reasoningEffort?: 'low' | 'medium' | 'high' | Expression<string>;
+    /** Maximum amount of time a request is allowed to take in milliseconds
+     * @default 60000
+     */
+    timeout?: number | Expression<number>;
+    /** Maximum number of retries to attempt
+     * @default 2
+     */
+    maxRetries?: number | Expression<number>;
+    /** Controls diversity via nucleus sampling: 0.5 means half of all likelihood-weighted options are considered. We generally recommend altering this or temperature but not both.
+     * @default 1
+     */
+    topP?: number | Expression<number>;
+    /** Optional additional JSON properties to include in the request body when making requests to OpenAI-compatible APIs
+     * @default {}
+     */
+    extraBody?: IDataObject | string | Expression<string>;
+    /** The conversation that this response belongs to. Input items and output items from this response are automatically added to this conversation after this response completes.
+     * @displayOptions.show { /responsesApiEnabled: [true] }
+     */
+    conversationId?: string | Expression<string>;
+    /** Used by OpenAI to cache responses for similar requests to optimize your cache hit rates
+     * @displayOptions.show { /responsesApiEnabled: [true] }
+     */
+    promptCacheKey?: string | Expression<string>;
+    /** A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies. The IDs should be a string that uniquely identifies each user.
+     * @displayOptions.show { /responsesApiEnabled: [true] }
+     */
+    safetyIdentifier?: string | Expression<string>;
+    /** The service tier to use for the request
+     * @displayOptions.show { /responsesApiEnabled: [true] }
+     * @default auto
+     */
+    serviceTier?: 'auto' | 'flex' | 'default' | 'priority' | Expression<string>;
+    /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format, and querying for objects via API or the dashboard. Keys are strings with a maximum length of 64 characters. Values are strings with a maximum length of 512 characters.
+     * @displayOptions.show { /responsesApiEnabled: [true] }
+     * @default {}
+     */
+    metadata?: IDataObject | string | Expression<string>;
+    /** An integer between 0 and 20 specifying the number of most likely tokens to return at each token position, each with an associated log probability
+     * @displayOptions.show { /responsesApiEnabled: [true] }
+     * @default 0
+     */
+    topLogprobs?: number | Expression<number>;
+    /** Configure the reusable prompt template configured via OpenAI Dashboard. &lt;a href="https://platform.openai.com/docs/guides/prompt-engineering#reusable-prompts"&gt;Learn more&lt;/a&gt;.
+     * @displayOptions.show { /responsesApiEnabled: [true] }
+     * @default {"promptOptions":[{"promptId":""}]}
+     */
+    promptConfig?: {
+        /** Prompt
+     */
+    promptOptions?: {
+      /** The unique identifier of the prompt template to use
+       */
+      promptId?: string | Expression<string>;
+      /** Optional version of the prompt template
+       */
+      version?: string | Expression<string>;
+      /** Variables to be substituted into the prompt template
+       * @default {}
+       */
+      variables?: IDataObject | string | Expression<string>;
+    };
+  };
+  };
+}
+
+export interface LcLmChatOpenAiV13Credentials {
+  openAiApi: CredentialReference;
+}
+
+interface LcLmChatOpenAiV13NodeBase {
+  type: '@n8n/n8n-nodes-langchain.lmChatOpenAi';
+  version: 1.3;
+}
+
+export type LcLmChatOpenAiV13ParamsNode = LcLmChatOpenAiV13NodeBase & {
+  config: NodeConfig<LcLmChatOpenAiV13Params> & { credentials?: LcLmChatOpenAiV13Credentials };
+};
+
+export type LcLmChatOpenAiV13Node = LcLmChatOpenAiV13ParamsNode;
+```

--- a/packages/cli/tests/fixtures/mcp-defs/memory.txt
+++ b/packages/cli/tests/fixtures/mcp-defs/memory.txt
@@ -1,0 +1,42 @@
+# TypeScript Type Definitions
+
+## @n8n/n8n-nodes-langchain.memoryBufferWindow (v14)
+
+```typescript
+/**
+ * Simple Memory Node - Version 1.4
+ * Stores in n8n memory, so no credentials required
+ */
+
+
+export interface LcMemoryBufferWindowV14Params {
+/**
+ * Session ID
+ * @builderHint Use 'Connected Chat Trigger Node' (fromInput) if there is a Chat Trigger node earlier in the workflow. Otherwise use 'Define below' (customKey).
+ * @default fromInput
+ */
+    sessionIdType?: 'fromInput' | 'customKey' | Expression<string>;
+/**
+ * The key to use to store session ID in the memory
+ * @displayOptions.show { sessionIdType: ["customKey"] }
+ */
+    sessionKey?: string | Expression<string>;
+/**
+ * Context Window Length
+ * @hint How many past interactions the model receives as context
+ * @default 5
+ */
+    contextWindowLength?: number | Expression<number>;
+}
+
+interface LcMemoryBufferWindowV14NodeBase {
+  type: '@n8n/n8n-nodes-langchain.memoryBufferWindow';
+  version: 1.4;
+}
+
+export type LcMemoryBufferWindowV14ParamsNode = LcMemoryBufferWindowV14NodeBase & {
+  config: NodeConfig<LcMemoryBufferWindowV14Params>;
+};
+
+export type LcMemoryBufferWindowV14Node = LcMemoryBufferWindowV14ParamsNode;
+```

--- a/packages/cli/tests/unit/schema-overlay.test.ts
+++ b/packages/cli/tests/unit/schema-overlay.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { parseNodeTypeDefinitions } from '../../src/core/services/node-schema-defs-parser.js';
+import { SchemaOverlayManager } from '../../src/core/services/schema-overlay-manager.js';
+
+const _filename = fileURLToPath(import.meta.url);
+const _dirname = path.dirname(_filename);
+const DEFS_DIR = path.resolve(_dirname, '../fixtures/mcp-defs');
+
+function defs(name: string): string {
+    return fs.readFileSync(path.join(DEFS_DIR, `${name}.txt`), 'utf8');
+}
+
+function section(name: string, version: number) {
+    const parsed = parseNodeTypeDefinitions(defs(name));
+    return parsed.find((s) => s.type.toLowerCase().includes(name.toLowerCase()) && Math.abs(s.version - version) < 0.01);
+}
+
+describe('node-schema-defs-parser', () => {
+    it('parses memoryBufferWindow v1.4 with customKey gating', () => {
+        const s = section('memory', 1.4);
+        expect(s).toBeDefined();
+        const sessionKey = s!.properties.find((p) => p.name === 'sessionKey');
+        expect(sessionKey).toBeDefined();
+        expect(sessionKey!.displayOptions?.show?.sessionIdType).toEqual(['customKey']);
+        expect(sessionKey!.required).toBe(false);
+        const sessionIdType = s!.properties.find((p) => p.name === 'sessionIdType');
+        expect(sessionIdType!.default).toBe('fromInput');
+    });
+
+    it('parses html v1.2 with operation gating and defaults', () => {
+        const s = section('html', 1.2);
+        expect(s).toBeDefined();
+        const dataPropertyName = s!.properties.find((p) => p.name === 'dataPropertyName');
+        expect(dataPropertyName).toBeDefined();
+        expect(dataPropertyName!.displayOptions?.show?.operation).toEqual(['extractHtmlContent']);
+        expect(dataPropertyName!.default).toBe('data');
+        const op = s!.properties.find((p) => p.name === 'operation');
+        expect(op!.type).toBe('options');
+        expect(op!.options?.map((o) => o.value)).toContain('generateHtmlTemplate');
+    });
+
+    it('parses lmChatOpenAi v1.3 resource-locator model and /-rooted gating', () => {
+        const s = section('lmchat', 1.3);
+        expect(s).toBeDefined();
+        const model = s!.properties.find((p) => p.name === 'model');
+        expect(model!.type).toBe('resourceLocator');
+        const builtInTools = s!.properties.find((p) => p.name === 'builtInTools');
+        expect(builtInTools!.displayOptions?.show?.['/responsesApiEnabled']).toEqual([true]);
+    });
+
+    it('parses agent v3.1 required text under promptType define', () => {
+        const s = section('agent', 3.1);
+        expect(s).toBeDefined();
+        const promptType = s!.properties.find((p) => p.name === 'promptType');
+        expect(promptType!.default).toBe('auto');
+        const text = s!.properties.find((p) => p.name === 'text');
+        expect(text).toBeDefined();
+        expect(text!.required).toBe(true);
+        expect(text!.displayOptions?.show?.promptType).toEqual(['define']);
+    });
+});
+
+describe('SchemaOverlayManager', () => {
+    it('materialises a provider sidecar that the validator can merge', async () => {
+        const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'overlay-'));
+        const manager = new SchemaOverlayManager({
+            endpoint: 'https://unused.local',
+            token: 'x',
+            cacheDir,
+            client: {
+                listTools: async () => [],
+                callTool: async (_name: string, args: any) => ({
+                    structuredContent: { definitions: defs('memory') },
+                }),
+            } as any,
+        });
+        const types = [{ type: '@n8n/n8n-nodes-langchain.memoryBufferWindow', version: '1.4' }];
+        const result = await manager.ensureForTypes(types);
+        expect(result.overlayPath.endsWith('.schema-overlay.json')).toBe(true);
+        expect(result.failed).toEqual([]);
+        expect(fs.existsSync(manager.providerFilePath)).toBe(true);
+
+        const provider = JSON.parse(fs.readFileSync(manager.providerFilePath, 'utf8'));
+        const entry = provider.nodes['@n8n/n8n-nodes-langchain.memoryBufferWindow'];
+        expect(entry).toBeDefined();
+        expect(entry.version).toEqual([1.4]);
+        const props = entry.schema.properties;
+        expect(props.find((p: any) => p.name === 'sessionKey')?.displayOptions?.show?.sessionIdType).toEqual(['customKey']);
+    });
+
+    it('does not re-fetch fresh entries (economy)', async () => {
+        const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'overlay-'));
+        let calls = 0;
+        const manager = new SchemaOverlayManager({
+            endpoint: 'https://unused.local',
+            token: 'x',
+            cacheDir,
+            client: {
+                listTools: async () => [],
+                callTool: async (_name: string, args: any) => {
+                    calls += 1;
+                    return { structuredContent: { definitions: defs('memory') } };
+                },
+            } as any,
+        });
+        const types = [{ type: '@n8n/n8n-nodes-langchain.memoryBufferWindow', version: '1.4' }];
+        await manager.ensureForTypes(types);
+        await manager.ensureForTypes(types);
+        expect(calls).toBe(1);
+        expect(manager.isFresh(types)).toBe(true);
+    });
+});

--- a/packages/mcp/src/cli.ts
+++ b/packages/mcp/src/cli.ts
@@ -2,6 +2,13 @@
 import { startN8nAsCodeMcpServer } from './services/mcp-server.js';
 import { N8nAsCodeMcpService } from './services/mcp-service.js';
 
+const NATIVE_MCP_LEVEL_LABELS: Record<number, string> = {
+    0: 'off (bundled ontology only)',
+    1: 'schema sync (instance ontology overlay)',
+    2: 'live validation at push',
+    3: 'read-only discovery',
+};
+
 const argv = process.argv.slice(2);
 
 function getArgValue(flag: string): string | undefined {
@@ -43,6 +50,11 @@ function printNativeMcpStatus(status: any, toolsOnly = false): void {
 
     process.stdout.write(`Native n8n MCP: ${status.config.enabled ? 'enabled' : 'disabled'}\n`);
     process.stdout.write(`Mode: ${status.config.mode}\n`);
+    const level = typeof status.config.level === 'number' ? status.config.level : (status.config.enabled ? 3 : 0);
+    process.stdout.write(`Level: ${level} — ${NATIVE_MCP_LEVEL_LABELS[level] ?? 'unknown'}\n`);
+    if (level === 0) {
+        process.stdout.write('Connect the instance MCP for better precision: n8nac native-mcp configure --level 1|2|3 (level 0 validates against the bundled schema only and may drift from the instance).\n');
+    }
     process.stdout.write(`Endpoint configured: ${status.config.configured ? 'yes' : 'no'}\n`);
     if (status.config.endpoint) process.stdout.write(`Endpoint: ${status.config.endpoint}\n`);
     process.stdout.write(`Bearer token configured: ${status.config.tokenConfigured ? 'yes' : 'no'}\n`);

--- a/packages/mcp/src/services/native-mcp-config.ts
+++ b/packages/mcp/src/services/native-mcp-config.ts
@@ -2,9 +2,13 @@ import { ConfigService } from 'n8nac';
 
 export type NativeMcpMode = 'off' | 'assist' | 'direct';
 
+/** Native MCP usage level — cumulative ladder (0 = off). */
+export type NativeMcpLevel = 0 | 1 | 2 | 3;
+
 export interface NativeMcpConfig {
     enabled: boolean;
     mode: NativeMcpMode;
+    level: NativeMcpLevel;
     endpoint?: string;
     token?: string;
     timeoutMs: number;
@@ -21,6 +25,7 @@ export interface RedactedNativeMcpConfig {
     enabled: boolean;
     configured: boolean;
     mode: NativeMcpMode;
+    level: NativeMcpLevel;
     endpoint?: string;
     tokenConfigured: boolean;
     timeoutMs: number;
@@ -39,6 +44,7 @@ export interface NativeMcpWorkspaceConfigInput {
     enabled?: boolean;
     url?: string;
     mode?: 'assist' | 'direct';
+    level?: NativeMcpLevel;
     timeoutMs?: number;
     allowRemoteExposure?: boolean;
     allowExecutionData?: boolean;
@@ -122,6 +128,18 @@ function redactEndpoint(endpoint: string | undefined): string | undefined {
     }
 }
 
+function parseLevel(value: string | undefined, workspaceLevel: NativeMcpLevel | undefined, enabled: boolean): NativeMcpLevel {
+    if (!enabled) return 0;
+    const cleaned = clean(value);
+    if (cleaned !== undefined) {
+        const parsed = Number.parseInt(cleaned, 10);
+        if (Number.isInteger(parsed) && parsed >= 1 && parsed <= 3) return parsed as NativeMcpLevel;
+    }
+    if (workspaceLevel !== undefined) return workspaceLevel;
+    // Legacy configuration (no explicit level): keep the full legacy assist surface.
+    return 3;
+}
+
 export function loadNativeMcpConfig(env: NodeJS.ProcessEnv = process.env, options: LoadNativeMcpConfigOptions = {}): NativeMcpConfig {
     const workspace = resolveWorkspaceNativeMcpConfig(env, options);
     const endpoint = clean(env.N8N_NATIVE_MCP_URL) || clean(env.N8NAC_NATIVE_MCP_URL) || clean(workspace?.url) || clean(workspace?.defaultEndpoint);
@@ -135,6 +153,7 @@ export function loadNativeMcpConfig(env: NodeJS.ProcessEnv = process.env, option
     return {
         enabled,
         mode: parseMode(env.N8NAC_NATIVE_MCP_MODE, enabled, workspaceMode),
+        level: parseLevel(env.N8NAC_NATIVE_MCP_LEVEL, workspace?.level, enabled),
         endpoint,
         token,
         timeoutMs: parsePositiveInteger(env.N8NAC_NATIVE_MCP_TIMEOUT_MS, workspace?.timeoutMs || 30_000),
@@ -153,6 +172,7 @@ export function redactNativeMcpConfig(config: NativeMcpConfig): RedactedNativeMc
         enabled: config.enabled,
         configured: Boolean(config.endpoint),
         mode: config.mode,
+        level: config.level,
         endpoint: redactEndpoint(config.endpoint),
         tokenConfigured: Boolean(config.token),
         timeoutMs: config.timeoutMs,

--- a/packages/skills/src/services/ai-context-generator.ts
+++ b/packages/skills/src/services/ai-context-generator.ts
@@ -12,8 +12,22 @@ const _dirname = typeof __dirname !== 'undefined'
   ? __dirname
   : (_filename ? path.dirname(_filename as string) : '');
 
+export interface NativeMcpLevelContext {
+    /** Effective native MCP usage level (0 = off) for the active environment. */
+    level: number;
+    /** Display name of the active environment, when known. */
+    environmentName?: string;
+}
+
+const NATIVE_MCP_LEVEL_LABELS: Record<number, string> = {
+    0: 'off (bundled ontology only)',
+    1: 'schema sync (instance ontology overlay)',
+    2: 'live validation at push',
+    3: 'read-only discovery',
+};
+
 export class AiContextGenerator {
-  constructor() { }
+    constructor() { }
 
   private getCommandRefs(distTag?: string, cliCommandOverride?: string, projectRoot?: string): N8nacCommandRefs {
     return resolveN8nacCommandRefs({
@@ -27,17 +41,21 @@ export class AiContextGenerator {
   getAgentSkillContent(
     skillName: 'n8n-architect',
     distTag?: string,
-    options: { cliCommandOverride?: string; managerCommandOverride?: string } = {},
+    options: { cliCommandOverride?: string; managerCommandOverride?: string; nativeMcp?: NativeMcpLevelContext } = {},
     projectRoot?: string,
   ): string {
     const { cliCmd, skillsCmd } = this.getCommandRefs(distTag, options.cliCommandOverride, projectRoot);
     const managerCmd = resolveN8nManagerCommand(distTag, options.managerCommandOverride, projectRoot ? process.env : {});
     const contextRootHint = 'Generated context root hint: not embedded. Use the shell launch directory or the workspace path explicitly given by the user.';
-    return this.readCanonicalAgentSkill(skillName)
+    const skill = this.readCanonicalAgentSkill(skillName)
       .replaceAll('{{N8NAC_CMD}}', cliCmd)
       .replaceAll('{{N8NAC_SKILLS_CMD}}', skillsCmd)
       .replaceAll('{{N8N_MANAGER_CMD}}', managerCmd)
       .replaceAll('{{N8NAC_CONTEXT_ROOT_HINT}}', contextRootHint);
+    // The level block is per-environment state: only embedded when the caller
+    // resolved an environment, so neutral generation stays byte-identical to
+    // the canonical packaged skills.
+    return options.nativeMcp ? skill + this.nativeMcpLevelNote(options.nativeMcp) : skill;
   }
 
   private readCanonicalAgentSkill(skillName: string): string {
@@ -61,7 +79,7 @@ export class AiContextGenerator {
     projectRoot: string,
     n8nVersion: string = "Unknown",
     distTag?: string,
-    options: { cliCommandOverride?: string; managerCommandOverride?: string; cliVersion?: string } = {},
+    options: { cliCommandOverride?: string; managerCommandOverride?: string; cliVersion?: string; nativeMcp?: NativeMcpLevelContext } = {},
   ): Promise<void> {
     const agentsContent = this.getAgentsContent(n8nVersion, distTag, options, projectRoot);
 
@@ -74,6 +92,31 @@ export class AiContextGenerator {
     this.materializeAgentSkills(projectRoot, distTag, options);
   }
 
+  /**
+   * Per-environment native MCP usage-level note, appended to generated agent
+   * context (AGENTS.md, workspace agent, portable skill). Documents which
+   * instance calls the toolchain may make — it never grants the agent new
+   * permissions and never delegates the level choice to the agent.
+   */
+  private nativeMcpLevelNote(nativeMcp?: NativeMcpLevelContext): string {
+    const active = nativeMcp && Number.isInteger(nativeMcp.level)
+      ? `\n\nThe pinned environment${nativeMcp.environmentName ? ` "${nativeMcp.environmentName}"` : ''} uses native n8n MCP at level ${nativeMcp.level} — ${NATIVE_MCP_LEVEL_LABELS[nativeMcp.level] ?? 'unknown'}.`
+      : '';
+    return [
+      ``,
+      `## Native MCP Usage Level${active}`,
+      ``,
+      `Native MCP usage is a cumulative ladder, configured per environment (\`n8nac native-mcp configure --level 1|2|3\`):`,
+      ``,
+      `- level 0 (off) — bundled ontology only, no instance calls. DISCOURAGED except offline: validation runs against the bundled schema only and may drift from the instance. Upgrade with \`n8nac native-mcp configure --level 1\` (or higher).`,
+      `- level 1 (schema sync) — n8nac refreshes a per-instance schema overlay, then validates locally. Do not call instance MCP tools yourself; \`n8nac push\` may be blocked by validation errors — fix the reported node parameters and retry.`,
+      `- level 2 (live validation) — \`n8nac push\` validates against the instance before any write. Same fix-and-retry loop; never bypass with \`N8NAC_PUSH_SKIP_VALIDATION\` unless the user explicitly asks.`,
+      `- level 3 (read-only discovery) — instance read tools may be available through the toolchain. You must NEVER list, search, or inspect existing workflows unless the user explicitly asks; only interact with workflows you create.`,
+      ``,
+      `You must never change the level yourself (\`native-mcp configure\`); if validation is degraded, report the toolchain message verbatim.`,
+    ].join('\n');
+  }
+
   private removeLegacySplitSkillArtifacts(projectRoot: string): void {
     fs.rmSync(path.join(projectRoot, '.github', 'agents', 'n8n-manager.agent.md'), { force: true });
     fs.rmSync(path.join(projectRoot, '.agents', 'skills', 'n8n-manager'), { recursive: true, force: true });
@@ -82,7 +125,7 @@ export class AiContextGenerator {
   private materializeWorkspaceAgents(
     projectRoot: string,
     distTag?: string,
-    options: { cliCommandOverride?: string; managerCommandOverride?: string } = {},
+    options: { cliCommandOverride?: string; managerCommandOverride?: string; nativeMcp?: NativeMcpLevelContext } = {},
   ): void {
     const agentsRoot = path.join(projectRoot, '.github', 'agents');
     const agentNames = ['n8n-architect'] as const;
@@ -98,7 +141,7 @@ export class AiContextGenerator {
   private materializeAgentSkills(
     projectRoot: string,
     distTag?: string,
-    options: { cliCommandOverride?: string; managerCommandOverride?: string } = {},
+    options: { cliCommandOverride?: string; managerCommandOverride?: string; nativeMcp?: NativeMcpLevelContext } = {},
   ): void {
     const skillsRoot = path.join(projectRoot, '.agents', 'skills');
     const skillNames = ['n8n-architect'] as const;
@@ -116,7 +159,7 @@ export class AiContextGenerator {
   private getWorkspaceAgentContent(
     agentName: 'n8n-architect',
     distTag?: string,
-    options: { cliCommandOverride?: string; managerCommandOverride?: string } = {},
+    options: { cliCommandOverride?: string; managerCommandOverride?: string; nativeMcp?: NativeMcpLevelContext } = {},
     projectRoot?: string,
   ): string {
     return this.getAgentSkillContent(agentName, distTag, options, projectRoot)
@@ -154,7 +197,7 @@ export class AiContextGenerator {
   private getAgentsContent(
     n8nVersion: string,
     distTag?: string,
-    options: { cliCommandOverride?: string; managerCommandOverride?: string; cliVersion?: string } = {},
+    options: { cliCommandOverride?: string; managerCommandOverride?: string; cliVersion?: string; nativeMcp?: NativeMcpLevelContext } = {},
     projectRoot?: string,
   ): string {
     const { cliCmd, skillsCmd } = this.getCommandRefs(distTag, options.cliCommandOverride, projectRoot);
@@ -162,8 +205,7 @@ export class AiContextGenerator {
     const versionStamp = options.cliVersion ? [`<!-- n8nac-version: ${options.cliVersion} -->`, ``] : [];
     return [
       ...versionStamp,
-      `## n8n-as-code Context Root`,
-      ``,
+      `## n8n-as-code Context Root`,      ``,
       `This file is generated by \`${cliCmd} update-ai\`. It is bootstrap context only, not a configuration source of truth.`,
       ``,
       `- Context root: the current Git worktree root.`,
@@ -220,6 +262,7 @@ export class AiContextGenerator {
       `- Node knowledge and schema lookup: \`${skillsCmd} ...\``,
       ``,
       `Never write \`n8nac-config.json\`, \`~/.n8n-manager\`, or n8n-manager secret files by hand.`,
+      ...(options.nativeMcp ? [this.nativeMcpLevelNote(options.nativeMcp)] : []),
     ].join('\n');
   }
 

--- a/packages/skills/src/services/workflow-validator.ts
+++ b/packages/skills/src/services/workflow-validator.ts
@@ -361,26 +361,80 @@ export class WorkflowValidator {
   }
 
   /**
-   * Check whether a schema property's displayOptions conditions are satisfied
-   * by the effective parameter values (see {@link effectiveConditionValue}).
+   * Narrow a property variant's displayOptions the way n8n's own schema
+   * generator does (narrowDisplayOptionsByDisabled): disabled states are
+   * subtracted from `show`, and disabled-only keys are merged into `hide`.
+   * When a `show` key is left with no settable values the variant is FULLY
+   * DISABLED (returns null) and must be dropped before any evaluation —
+   * e.g. the expression-prefilled memory `sessionKey` under
+   * `sessionIdType=fromInput`, which exists only to render a disabled UI
+   * field. This is why the live server only allows `sessionKey` when
+   * `sessionIdType="customKey"` and agent `text` when `promptType="define"`.
+   */
+  private narrowedDisplayOptions(prop: any): { show?: Record<string, unknown[]>; hide?: Record<string, unknown[]> } | null {
+    const displayOptions = prop?.displayOptions;
+    const disabledShow = prop?.disabledOptions?.show;
+    if (!disabledShow || typeof disabledShow !== 'object' || Array.isArray(disabledShow)) {
+      return displayOptions ?? {};
+    }
+
+    const narrowedShow: Record<string, unknown[]> = {};
+    const mergedHide: Record<string, unknown[]> = {};
+    for (const [key, values] of Object.entries((displayOptions?.hide ?? {}) as Record<string, unknown[]>)) {
+      mergedHide[key] = [...(Array.isArray(values) ? values : [])];
+    }
+
+    for (const [key, values] of Object.entries((displayOptions?.show ?? {}) as Record<string, unknown[]>)) {
+      const disabledValues = (disabledShow as Record<string, unknown[]>)[key];
+      if (!disabledValues) {
+        narrowedShow[key] = values;
+        continue;
+      }
+      const remaining = (Array.isArray(values) ? values : []).filter(
+        (v) => !(disabledValues as unknown[]).some((d) => JSON.stringify(d) === JSON.stringify(v))
+      );
+      if (remaining.length === 0) {
+        return null;
+      }
+      narrowedShow[key] = remaining;
+    }
+
+    for (const [key, values] of Object.entries(disabledShow as Record<string, unknown[]>)) {
+      if (displayOptions?.show && key in displayOptions.show) continue;
+      const existing = mergedHide[key] ?? [];
+      const seen = new Set(existing.map((v) => JSON.stringify(v)));
+      for (const v of (Array.isArray(values) ? values : [])) {
+        if (!seen.has(JSON.stringify(v))) existing.push(v);
+      }
+      mergedHide[key] = existing;
+    }
+
+    const result: { show?: Record<string, unknown[]>; hide?: Record<string, unknown[]> } = {};
+    if (Object.keys(narrowedShow).length > 0) result.show = narrowedShow;
+    if (Object.keys(mergedHide).length > 0) result.hide = mergedHide;
+    return result;
+  }
+
+  /**
+   * Check whether ALREADY-NARROWED display conditions are satisfied by the
+   * effective parameter values (see {@link effectiveConditionValue}).
    * If no displayOptions defined -> always shown.
    *
    * `levelProps` / `rootProps` carry the property lists whose defaults may
    * satisfy non-slash condition parameters at the current level / at the node
    * root.
    */
-  private isPropertyDisplayed(
-    prop: any,
+  private matchesDisplayConditions(
+    displayOptions: { show?: Record<string, unknown[]>; hide?: Record<string, unknown[]> },
     nodeParams: Record<string, any>,
     rootParams: Record<string, any> = nodeParams,
     node?: any,
     levelProps?: any[],
-    rootProps?: any[],
-    _depth = 0
+    rootProps?: any[]
   ): boolean {
     const nodeVersion = this.nodeVersionOf(node);
 
-    const hide = prop.displayOptions?.hide;
+    const hide = displayOptions?.hide;
     if (hide && typeof hide === 'object') {
       for (const [condParamName, hiddenValues] of Object.entries(hide)) {
         if (condParamName === '@version') {
@@ -393,7 +447,7 @@ export class WorkflowValidator {
       }
     }
 
-    const show = prop.displayOptions?.show;
+    const show = displayOptions?.show;
     if (!show || typeof show !== 'object') return true;
 
     for (const [condParamName, allowedValues] of Object.entries(show)) {
@@ -409,6 +463,27 @@ export class WorkflowValidator {
       if (!allowedValues.includes(actualValue)) return false;
     }
     return true;
+  }
+
+  /**
+   * Check whether a schema property's displayOptions conditions are satisfied
+   * by the effective parameter values: the variant is first narrowed by its
+   * `disabledOptions` (fully disabled variants are never displayed), then its
+   * remaining conditions are evaluated. If no displayOptions defined ->
+   * always shown.
+   */
+  private isPropertyDisplayed(
+    prop: any,
+    nodeParams: Record<string, any>,
+    rootParams: Record<string, any> = nodeParams,
+    node?: any,
+    levelProps?: any[],
+    rootProps?: any[],
+    _depth = 0
+  ): boolean {
+    const narrowed = this.narrowedDisplayOptions(prop);
+    if (narrowed === null) return false;
+    return this.matchesDisplayConditions(narrowed, nodeParams, rootParams, node, levelProps, rootProps);
   }
 
   /**
@@ -464,9 +539,9 @@ export class WorkflowValidator {
     return String(value);
   }
 
-  private variantConditionText(prop: any): string {
+  private variantConditionText(displayOptions: { show?: Record<string, unknown[]>; hide?: Record<string, unknown[]> } | null | undefined): string {
     const conds: string[] = [];
-    const render = (map: any, negated: boolean) => {
+    const render = (map: Record<string, unknown[]> | undefined, negated: boolean) => {
       for (const [key, values] of Object.entries(map ?? {})) {
         if (key === '@version') continue;
         if (!Array.isArray(values)) continue;
@@ -477,8 +552,8 @@ export class WorkflowValidator {
         }
       }
     };
-    render(prop.displayOptions?.show, false);
-    render(prop.displayOptions?.hide, true);
+    render(displayOptions?.show, false);
+    render(displayOptions?.hide, true);
     return conds.join(', ');
   }
 
@@ -489,7 +564,7 @@ export class WorkflowValidator {
     return `${dotted}.${paramKey}`;
   }
 
-  private hiddenParametersMessage(dottedPath: string, failingVariants: any[]): string {
+  private hiddenParametersMessage(dottedPath: string, failingVariants: Array<{ show?: Record<string, unknown[]>; hide?: Record<string, unknown[]> }>): string {
     const label = `Field "${dottedPath}": This field is only allowed`;
     const descriptions = failingVariants.map((v) => this.variantConditionText(v)).filter(Boolean);
     if (descriptions.length === 0) {
@@ -523,8 +598,13 @@ export class WorkflowValidator {
       const relevant = variants.filter((p: any) => this.isVersionRelevant(p, node));
       if (relevant.length === 0) continue; // parameter belongs to another typeVersion
 
-      const shown = relevant.filter((p: any) =>
-        this.isPropertyDisplayed(p, params, rootParams, node, schemaProps, rootSchemaProps)
+      // Narrow each variant (disabled-only states are dropped, exactly like the
+      // server's generated schemas) and keep only the ruled-in ones.
+      const narrowed = relevant
+        .map((p: any) => this.narrowedDisplayOptions(p))
+        .filter((d): d is { show?: Record<string, unknown[]>; hide?: Record<string, unknown[]> } => d !== null);
+      const shown = narrowed.filter((d) =>
+        this.matchesDisplayConditions(d, params, rootParams, node, schemaProps, rootSchemaProps)
       );
       if (shown.length > 0) continue;
 
@@ -532,7 +612,7 @@ export class WorkflowValidator {
         type: 'error',
         nodeId: node.id,
         nodeName: node.name,
-        message: this.hiddenParametersMessage(this.parameterDottedPath(path, paramKey), relevant),
+        message: this.hiddenParametersMessage(this.parameterDottedPath(path, paramKey), narrowed),
         path: `${path}.${paramKey}`,
       });
     }

--- a/packages/skills/src/services/workflow-validator.ts
+++ b/packages/skills/src/services/workflow-validator.ts
@@ -282,32 +282,52 @@ export class WorkflowValidator {
   }
 
   /**
-   * Resolve the effective value of a display-condition parameter the way the
-   * n8n server does.
+   * Resolve the effective value of a display-condition parameter, mirroring
+   * the n8n server's own gating engine (validate_node_config /
+   * generate-zod-schemas + display-options.ts):
    *
-   * `/`-prefixed condition names always reference the node's root parameters;
-   * plain names reference the current parameter level first (nested fixed
-   * collection items), then the root level — mirroring n8n's own resolution.
+   * - `/`-prefixed condition names always reference the node's root parameters
+   *   and never fall back to schema defaults (the server generator skips `/`
+   *   and `@` keys when building its `defaults` map), so a missing root
+   *   parameter hides every dependent variant — e.g. `builtInTools` without an
+   *   explicit `responsesApiEnabled: true`;
+   * - plain names reference the current parameter level first (nested fixed
+   *   collection items), then the root level — and fall back to the schema
+   *   default of the version-relevant property variant when unset;
+   * - resource-locator values (`{ __rl: true, ... }`) are unwrapped to their
+   *   inner `value` before comparison.
    */
   private effectiveConditionValue(
     condParamName: string,
     nodeParams: Record<string, any>,
-    rootParams: Record<string, any>
+    rootParams: Record<string, any>,
+    levelProps?: any[],
+    rootProps?: any[],
+    node?: any
   ): any {
     const isRoot = condParamName.startsWith('/');
     const name = isRoot ? condParamName.slice(1) : condParamName;
     const levelParams = isRoot ? rootParams : nodeParams;
 
-    // Server-verified semantics (validate_node_config): display conditions are
-    // evaluated against the EXPLICIT parameter values only — a missing condition
-    // parameter never satisfies a condition, even when the schema declares a
-    // default (an omitted `responsesApiEnabled`, `promptType` or
-    // `sessionIdType` hides every dependent variant, exactly like the live
-    // instance rejects the dependent parameter).
-    if (this.hasOwnProperty(levelParams, name)) {
-      return levelParams[name];
+    let value = this.hasOwnProperty(levelParams, name) ? levelParams[name] : undefined;
+    if (value === undefined && !isRoot && this.hasOwnProperty(rootParams, name)) {
+      value = rootParams[name];
     }
-    return this.hasOwnProperty(rootParams, name) ? rootParams[name] : undefined;
+    if (value === undefined && !isRoot) {
+      for (const props of [levelProps, rootProps]) {
+        if (!Array.isArray(props)) continue;
+        const candidate = props.find((p: any) => p?.name === name && this.isVersionRelevant(p, node));
+        if (candidate && candidate.default !== undefined) {
+          value = candidate.default;
+          break;
+        }
+      }
+    }
+    if (value !== null && typeof value === 'object' && !Array.isArray(value) &&
+        (value as any).__rl === true && this.hasOwnProperty(value, 'value')) {
+      return (value as any).value;
+    }
+    return value;
   }
 
   private matchesVersionCondition(condition: any, nodeVersion: number): boolean {
@@ -342,21 +362,20 @@ export class WorkflowValidator {
 
   /**
    * Check whether a schema property's displayOptions conditions are satisfied
-   * by the explicit parameter values. Missing condition parameters never
-   * satisfy a condition — server-verified semantics (see
-   * {@link effectiveConditionValue}). If no displayOptions defined -> always
-   * shown.
+   * by the effective parameter values (see {@link effectiveConditionValue}).
+   * If no displayOptions defined -> always shown.
    *
-   * `levelProps` / `rootProps` are accepted for API compatibility with nested
-   * validation call sites.
+   * `levelProps` / `rootProps` carry the property lists whose defaults may
+   * satisfy non-slash condition parameters at the current level / at the node
+   * root.
    */
   private isPropertyDisplayed(
     prop: any,
     nodeParams: Record<string, any>,
     rootParams: Record<string, any> = nodeParams,
     node?: any,
-    _levelProps?: any[],
-    _rootProps?: any[],
+    levelProps?: any[],
+    rootProps?: any[],
     _depth = 0
   ): boolean {
     const nodeVersion = this.nodeVersionOf(node);
@@ -369,7 +388,7 @@ export class WorkflowValidator {
           continue;
         }
         if (!Array.isArray(hiddenValues)) continue;
-        const actualValue = this.effectiveConditionValue(condParamName, nodeParams, rootParams);
+        const actualValue = this.effectiveConditionValue(condParamName, nodeParams, rootParams, levelProps, rootProps, node);
         if (hiddenValues.includes(actualValue)) return false;
       }
     }
@@ -383,7 +402,7 @@ export class WorkflowValidator {
         continue;
       }
       if (!Array.isArray(allowedValues)) continue;
-      const actualValue = this.effectiveConditionValue(condParamName, nodeParams, rootParams);
+      const actualValue = this.effectiveConditionValue(condParamName, nodeParams, rootParams, levelProps, rootProps, node);
       // An expression cannot be resolved statically: never treat the property as
       // hidden on its account (it may satisfy the condition at run time).
       if (this.isExpressionValue(actualValue)) continue;

--- a/packages/skills/src/services/workflow-validator.ts
+++ b/packages/skills/src/services/workflow-validator.ts
@@ -283,8 +283,7 @@ export class WorkflowValidator {
 
   /**
    * Resolve the effective value of a display-condition parameter the way the
-   * n8n server does: the explicitly set parameter wins, otherwise the schema
-   * default of the version-appropriate property variant applies.
+   * n8n server does.
    *
    * `/`-prefixed condition names always reference the node's root parameters;
    * plain names reference the current parameter level first (nested fixed
@@ -293,40 +292,22 @@ export class WorkflowValidator {
   private effectiveConditionValue(
     condParamName: string,
     nodeParams: Record<string, any>,
-    rootParams: Record<string, any>,
-    levelProps: any[] | undefined,
-    rootProps: any[] | undefined,
-    node: any,
-    depth = 0
+    rootParams: Record<string, any>
   ): any {
     const isRoot = condParamName.startsWith('/');
     const name = isRoot ? condParamName.slice(1) : condParamName;
     const levelParams = isRoot ? rootParams : nodeParams;
 
+    // Server-verified semantics (validate_node_config): display conditions are
+    // evaluated against the EXPLICIT parameter values only — a missing condition
+    // parameter never satisfies a condition, even when the schema declares a
+    // default (an omitted `responsesApiEnabled`, `promptType` or
+    // `sessionIdType` hides every dependent variant, exactly like the live
+    // instance rejects the dependent parameter).
     if (this.hasOwnProperty(levelParams, name)) {
       return levelParams[name];
     }
-    if (depth > 3) {
-      return undefined;
-    }
-
-    const propSource = isRoot ? rootProps || levelProps : levelProps;
-    const candidates = (propSource || []).filter(
-      (p: any) => p?.name === name && this.isVersionRelevant(p, node)
-    );
-    if (candidates.length === 0) {
-      return undefined;
-    }
-
-    // Prefer the variant whose non-@version conditions already hold for the
-    // provided parameters (e.g. promptType has separate "auto"/"define"
-    // variants with different defaults). Without any satisfied variant, fall
-    // back to the first version-relevant entry.
-    const satisfied = candidates.find((p: any) =>
-      this.isPropertyDisplayed(p, levelParams, levelParams, node, propSource, propSource, depth + 1)
-    );
-    const chosen = satisfied ?? candidates[0];
-    return chosen?.default;
+    return this.hasOwnProperty(rootParams, name) ? rootParams[name] : undefined;
   }
 
   private matchesVersionCondition(condition: any, nodeVersion: number): boolean {
@@ -361,20 +342,22 @@ export class WorkflowValidator {
 
   /**
    * Check whether a schema property's displayOptions conditions are satisfied
-   * by the effective parameters (explicit values first, schema defaults for
-   * missing condition parameters). If no displayOptions defined -> always shown.
+   * by the explicit parameter values. Missing condition parameters never
+   * satisfy a condition — server-verified semantics (see
+   * {@link effectiveConditionValue}). If no displayOptions defined -> always
+   * shown.
    *
-   * `levelProps` / `rootProps` carry the property lists whose defaults may
-   * satisfy condition parameters at the current level / at the node root.
+   * `levelProps` / `rootProps` are accepted for API compatibility with nested
+   * validation call sites.
    */
   private isPropertyDisplayed(
     prop: any,
     nodeParams: Record<string, any>,
     rootParams: Record<string, any> = nodeParams,
     node?: any,
-    levelProps?: any[],
-    rootProps?: any[],
-    depth = 0
+    _levelProps?: any[],
+    _rootProps?: any[],
+    _depth = 0
   ): boolean {
     const nodeVersion = this.nodeVersionOf(node);
 
@@ -386,7 +369,7 @@ export class WorkflowValidator {
           continue;
         }
         if (!Array.isArray(hiddenValues)) continue;
-        const actualValue = this.effectiveConditionValue(condParamName, nodeParams, rootParams, levelProps, rootProps, node, depth);
+        const actualValue = this.effectiveConditionValue(condParamName, nodeParams, rootParams);
         if (hiddenValues.includes(actualValue)) return false;
       }
     }
@@ -400,7 +383,7 @@ export class WorkflowValidator {
         continue;
       }
       if (!Array.isArray(allowedValues)) continue;
-      const actualValue = this.effectiveConditionValue(condParamName, nodeParams, rootParams, levelProps, rootProps, node, depth);
+      const actualValue = this.effectiveConditionValue(condParamName, nodeParams, rootParams);
       // An expression cannot be resolved statically: never treat the property as
       // hidden on its account (it may satisfy the condition at run time).
       if (this.isExpressionValue(actualValue)) continue;

--- a/packages/skills/tests/ai-context-generator.test.ts
+++ b/packages/skills/tests/ai-context-generator.test.ts
@@ -87,8 +87,39 @@ describe('AiContextGenerator', () => {
             expect(run2.match(/<!-- n8n-as-code-start -->/g)?.length).toBe(1);
         });
 
-        test('does not duplicate effective config values into AGENTS.md', async () => {
+        test('omits the native MCP level block when no environment is resolved', async () => {
             await generator.generate(tempDir, '1.0.0');
+
+            const agentsContent = fs.readFileSync(path.join(tempDir, 'AGENTS.md'), 'utf-8');
+            const architectAgent = fs.readFileSync(path.join(tempDir, '.github/agents/n8n-architect.agent.md'), 'utf-8');
+            const architectSkill = fs.readFileSync(path.join(tempDir, '.agents/skills/n8n-architect/SKILL.md'), 'utf-8');
+
+            expect(agentsContent).not.toContain('## Native MCP Usage Level');
+            expect(architectAgent).not.toContain('## Native MCP Usage Level');
+            expect(architectSkill).not.toContain('## Native MCP Usage Level');
+        });
+
+        test('embeds the resolved native MCP level and discourages level 0', async () => {
+            await generator.generate(tempDir, '1.0.0', undefined, {
+                nativeMcp: { level: 0, environmentName: 'bench' },
+            });
+
+            const agentsContent = fs.readFileSync(path.join(tempDir, 'AGENTS.md'), 'utf-8');
+            const architectAgent = fs.readFileSync(path.join(tempDir, '.github/agents/n8n-architect.agent.md'), 'utf-8');
+            const architectSkill = fs.readFileSync(path.join(tempDir, '.agents/skills/n8n-architect/SKILL.md'), 'utf-8');
+
+            for (const content of [agentsContent, architectAgent, architectSkill]) {
+                expect(content).toContain('## Native MCP Usage Level');
+                expect(content).toContain('level 0 — off (bundled ontology only)');
+                expect(content).toContain('level 2 (live validation)');
+                expect(content).toContain('DISCOURAGED except offline');
+                expect(content).toContain('n8nac native-mcp configure --level 1');
+                expect(content).toContain('You must never change the level yourself');
+            }
+            expect(agentsContent).toContain('environment "bench"');
+        });
+
+        test('does not duplicate effective config values into AGENTS.md', async () => {            await generator.generate(tempDir, '1.0.0');
 
             const agentsContent = fs.readFileSync(path.join(tempDir, 'AGENTS.md'), 'utf-8');
             expect(agentsContent).not.toContain('Effective instance');

--- a/packages/skills/tests/fixtures/gating-nodes.json
+++ b/packages/skills/tests/fixtures/gating-nodes.json
@@ -40,6 +40,19 @@
             "name": "systemMessage",
             "type": "string",
             "displayOptions": { "show": { "/useSystemMessage": [true] } }
+          },
+          {
+            "displayName": "Responses API Enabled",
+            "name": "responsesApiEnabled",
+            "type": "boolean",
+            "default": true
+          },
+          {
+            "displayName": "Built-in Tools",
+            "name": "builtInTools",
+            "type": "collection",
+            "default": {},
+            "displayOptions": { "show": { "/responsesApiEnabled": [true] } }
           }
         ]
       }

--- a/packages/skills/tests/fixtures/gating-nodes.json
+++ b/packages/skills/tests/fixtures/gating-nodes.json
@@ -153,6 +153,29 @@
           }
         ]
       }
+    },
+    "demoRlcCond": {
+      "name": "demoRlcCond",
+      "type": "n8n-nodes-test.demoRlcCond",
+      "displayName": "Demo RLC Condition",
+      "description": "Test resource locator unwrapping in display conditions",
+      "version": [1],
+      "schema": {
+        "properties": [
+          {
+            "displayName": "Calendar",
+            "name": "calendar",
+            "type": "resourceLocator",
+            "default": { "mode": "list", "value": "" }
+          },
+          {
+            "displayName": "Event Title",
+            "name": "eventTitle",
+            "type": "string",
+            "displayOptions": { "show": { "calendar": ["primary"] } }
+          }
+        ]
+      }
     }
   }
 }

--- a/packages/skills/tests/fixtures/gating-nodes.json
+++ b/packages/skills/tests/fixtures/gating-nodes.json
@@ -26,7 +26,8 @@
             "name": "text",
             "type": "string",
             "default": "={{ $json.chatInput }}",
-            "displayOptions": { "show": { "promptType": ["auto"] } }
+            "displayOptions": { "show": { "promptType": ["auto"] } },
+            "disabledOptions": { "show": { "promptType": ["auto"] } }
           },
           {
             "displayName": "Text (define)",
@@ -74,6 +75,14 @@
               { "name": "Define below", "value": "customKey" }
             ],
             "default": "fromInput"
+          },
+          {
+            "displayName": "Session Key (from input)",
+            "name": "sessionKey",
+            "type": "string",
+            "default": "={{ $json.sessionId }}",
+            "displayOptions": { "show": { "sessionIdType": ["fromInput"] } },
+            "disabledOptions": { "show": { "sessionIdType": ["fromInput"] } }
           },
           {
             "displayName": "Session Key (custom)",

--- a/packages/skills/tests/workflow-validator.test.ts
+++ b/packages/skills/tests/workflow-validator.test.ts
@@ -1061,18 +1061,15 @@ describe("WorkflowValidator - server-equivalent presence gating and resource loc
         expect(err!.message).toContain('This field is only allowed when one of: (promptType="auto") or (promptType="define")');
     });
 
-    it("treats a MISSING condition parameter as unsatisfied (server semantics, no schema defaults)", async () => {
-        // Server-verified: validate_node_config evaluates conditions against
-        // explicit values only — an omitted promptType (even with schema default
-        // "auto") hides every text variant, so text is rejected.
+    it("resolves a missing non-slash condition through its schema default (server semantics)", async () => {
+        // Server-verified: for plain (non-slash) conditions, the schema default
+        // of the condition parameter applies when it is omitted — the auto
+        // text variant is therefore displayed and text is allowed.
         const result = await gateValidator().validateWorkflow({
             nodes: [node("n8n-nodes-test.demoAgent", { text: "hi" }, 3.1)],
             connections: {},
         });
-        expect(result.valid).toBe(false);
-        const err = result.errors.find((e) => e.message.includes("parameters.text"));
-        expect(err).toBeDefined();
-        expect(err!.message).toContain('This field is only allowed when one of: (promptType="auto") or (promptType="define")');
+        expect(result.errors.filter((e) => e.message.includes("parameters.text"))).toHaveLength(0);
     });
 
     it("accepts text when the displayed variant condition is satisfied", async () => {
@@ -1203,5 +1200,20 @@ describe("WorkflowValidator - expression conditions and strict resource-locator 
         });
         expect(bad.valid).toBe(false);
         expect(bad.errors.some((e) => e.message.includes("must be an object shaped like"))).toBe(true);
+    });
+
+    it("unwraps resource-locator values when evaluating display conditions", async () => {
+        // calendar = { __rl: true, value: 'primary' } satisfies show calendar=['primary'].
+        const ok = await gateValidator().validateWorkflow({
+            nodes: [node("n8n-nodes-test.demoRlcCond", { calendar: { __rl: true, mode: "id", value: "primary" }, eventTitle: "Daily" }, 1)],
+            connections: {},
+        });
+        expect(ok.errors.filter((e) => e.message.includes("parameters.eventTitle"))).toHaveLength(0);
+
+        const bad = await gateValidator().validateWorkflow({
+            nodes: [node("n8n-nodes-test.demoRlcCond", { calendar: { __rl: true, mode: "id", value: "other" }, eventTitle: "Daily" }, 1)],
+            connections: {},
+        });
+        expect(bad.errors.some((e) => e.message.includes("parameters.eventTitle"))).toBe(true);
     });
 });

--- a/packages/skills/tests/workflow-validator.test.ts
+++ b/packages/skills/tests/workflow-validator.test.ts
@@ -1050,7 +1050,8 @@ describe("WorkflowValidator - server-equivalent presence gating and resource loc
     });
 
     it("rejects a param whose schema variants are all hidden (explicit condition values)", async () => {
-        // text is only allowed when promptType="define" or "auto"; fromInput hides every variant.
+        // The define variant is the only surviving one (the auto variant is
+        // fully disabled); fromInput matches neither -> rejection lists define only.
         const result = await gateValidator().validateWorkflow({
             nodes: [node("n8n-nodes-test.demoAgent", { promptType: "fromInput", text: "hello" }, 3.1)],
             connections: {},
@@ -1058,18 +1059,21 @@ describe("WorkflowValidator - server-equivalent presence gating and resource loc
         expect(result.valid).toBe(false);
         const err = result.errors.find((e) => e.message.includes("parameters.text"));
         expect(err).toBeDefined();
-        expect(err!.message).toContain('This field is only allowed when one of: (promptType="auto") or (promptType="define")');
+        expect(err!.message).toContain('This field is only allowed when: promptType="define"');
     });
 
     it("resolves a missing non-slash condition through its schema default (server semantics)", async () => {
-        // Server-verified: for plain (non-slash) conditions, the schema default
-        // of the condition parameter applies when it is omitted — the auto
-        // text variant is therefore displayed and text is allowed.
+        // The auto text variant is fully disabled (expression-prefilled,
+        // disabled UI field), so the omitted promptType falls back to "auto"
+        // but matches no surviving variant -> rejection, like the server.
         const result = await gateValidator().validateWorkflow({
             nodes: [node("n8n-nodes-test.demoAgent", { text: "hi" }, 3.1)],
             connections: {},
         });
-        expect(result.errors.filter((e) => e.message.includes("parameters.text"))).toHaveLength(0);
+        expect(result.valid).toBe(false);
+        const err = result.errors.find((e) => e.message.includes("parameters.text"));
+        expect(err).toBeDefined();
+        expect(err!.message).toContain('This field is only allowed when: promptType="define"');
     });
 
     it("accepts text when the displayed variant condition is satisfied", async () => {
@@ -1078,6 +1082,22 @@ describe("WorkflowValidator - server-equivalent presence gating and resource loc
             connections: {},
         });
         expect(result.errors.filter((e) => e.message.includes("parameters.text"))).toHaveLength(0);
+    });
+
+    it("drops fully-disabled variants before gating: the fromInput sessionKey variant does not exist", async () => {
+        // The fixture models the raw schema (fromInput variant + disabledOptions,
+        // like the live memoryBufferWindow description). Narrowing must remove it,
+        // so an explicit fromInput + sessionKey is rejected exactly like the
+        // server does — the message only lists the customKey alternative.
+        const result = await gateValidator().validateWorkflow({
+            nodes: [node("n8n-nodes-test.demoMemory", { sessionIdType: "fromInput", sessionKey: "k" }, 1.4)],
+            connections: {},
+        });
+        expect(result.valid).toBe(false);
+        const err = result.errors.find((e) => e.message.includes("parameters.sessionKey"));
+        expect(err).toBeDefined();
+        expect(err!.message).toContain('This field is only allowed when: sessionIdType="customKey"');
+        expect(err!.message).not.toContain("fromInput");
     });
 
     it("rejects sessionKey when sessionIdType default (fromInput) hides every variant", async () => {

--- a/packages/skills/tests/workflow-validator.test.ts
+++ b/packages/skills/tests/workflow-validator.test.ts
@@ -1049,7 +1049,7 @@ describe("WorkflowValidator - server-equivalent presence gating and resource loc
         parameters,
     });
 
-    it("rejects a param whose schema variants are all hidden (displayOptions defaults-aware)", async () => {
+    it("rejects a param whose schema variants are all hidden (explicit condition values)", async () => {
         // text is only allowed when promptType="define" or "auto"; fromInput hides every variant.
         const result = await gateValidator().validateWorkflow({
             nodes: [node("n8n-nodes-test.demoAgent", { promptType: "fromInput", text: "hello" }, 3.1)],
@@ -1061,13 +1061,18 @@ describe("WorkflowValidator - server-equivalent presence gating and resource loc
         expect(err!.message).toContain('This field is only allowed when one of: (promptType="auto") or (promptType="define")');
     });
 
-    it("resolves condition defaults so an omitted promptType is evaluated as auto (server semantics)", async () => {
-        // promptType omitted -> schema default "auto" -> the auto text variant is shown.
+    it("treats a MISSING condition parameter as unsatisfied (server semantics, no schema defaults)", async () => {
+        // Server-verified: validate_node_config evaluates conditions against
+        // explicit values only — an omitted promptType (even with schema default
+        // "auto") hides every text variant, so text is rejected.
         const result = await gateValidator().validateWorkflow({
-            nodes: [node("n8n-nodes-test.demoAgent", { text: "={{ $json.chatInput }}" }, 3.1)],
+            nodes: [node("n8n-nodes-test.demoAgent", { text: "hi" }, 3.1)],
             connections: {},
         });
-        expect(result.errors.filter((e) => e.message.includes("parameters.text"))).toHaveLength(0);
+        expect(result.valid).toBe(false);
+        const err = result.errors.find((e) => e.message.includes("parameters.text"));
+        expect(err).toBeDefined();
+        expect(err!.message).toContain('This field is only allowed when one of: (promptType="auto") or (promptType="define")');
     });
 
     it("accepts text when the displayed variant condition is satisfied", async () => {
@@ -1104,6 +1109,20 @@ describe("WorkflowValidator - server-equivalent presence gating and resource loc
         });
         expect(result.valid).toBe(false);
         expect(result.errors.some((e) => e.message.includes("parameters.systemMessage") && e.message.includes("/useSystemMessage"))).toBe(true);
+    });
+
+    it("rejects builtInTools when responsesApiEnabled is omitted, despite its schema default true", async () => {
+        // The lmChatOpenAi failure mode measured in the benchmark: the schema
+        // declares @default true for responsesApiEnabled, but the live server
+        // evaluates display conditions on explicit values only.
+        const result = await gateValidator().validateWorkflow({
+            nodes: [node("n8n-nodes-test.demoAgent", { builtInTools: {} }, 3.1)],
+            connections: {},
+        });
+        expect(result.valid).toBe(false);
+        const err = result.errors.find((e) => e.message.includes("parameters.builtInTools"));
+        expect(err).toBeDefined();
+        expect(err!.message).toContain('/responsesApiEnabled=true');
     });
 
     it("reports multi-variant gating like the server (one-of phrasing)", async () => {

--- a/packages/vscode-extension/src/ui/configuration-webview.ts
+++ b/packages/vscode-extension/src/ui/configuration-webview.ts
@@ -662,11 +662,20 @@ export class ConfigurationWebview {
     }
   }
 
+  private nativeMcpLevelFromPayload(payload: Record<string, unknown>, existing: any): 1 | 2 | 3 | undefined {
+    const raw = payload.nativeMcpLevel;
+    const parsed = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number.parseInt(raw, 10) : NaN;
+    if (parsed === 1 || parsed === 2 || parsed === 3) return parsed;
+    if (existing?.level === 1 || existing?.level === 2 || existing?.level === 3) return existing.level;
+    return undefined;
+  }
+
   private buildNativeMcpEnvironmentConfig(payload: Record<string, unknown>, existing: any, environmentHost: string) {
     const enabled = Boolean(payload.nativeMcpEnabled);
     const explicitUrl = normalizeHost(String(payload.nativeMcpUrl || ''));
     const url = explicitUrl || (enabled ? defaultNativeMcpEndpointFromHost(environmentHost) : existing?.url);
     const timeoutMs = parseNativeMcpTimeoutMs(payload.nativeMcpTimeoutMs) || existing?.timeoutMs;
+    const level = enabled ? (this.nativeMcpLevelFromPayload(payload, existing) ?? 3) : undefined;
     const hasExisting = Boolean(existing);
     const hasPayload = enabled || explicitUrl || String(payload.nativeMcpToken || '').trim() || hasExisting;
     if (!hasPayload) return undefined;
@@ -675,6 +684,7 @@ export class ConfigurationWebview {
       enabled,
       mode: 'assist' as const,
       url: url || undefined,
+      level,
       timeoutMs,
       allowExecutionData: Boolean(payload.nativeMcpAllowExecutionData),
       allowRemoteExposure: Boolean(payload.nativeMcpAllowRemote),

--- a/packages/vscode-extension/src/ui/settings-webview/app.tsx
+++ b/packages/vscode-extension/src/ui/settings-webview/app.tsx
@@ -266,6 +266,7 @@ function EnvironmentFormModal({ environmentId }: { environmentId?: string }) {
       nativeMcpEnabled: draft.nativeMcpEnabled,
       nativeMcpUrl: draft.nativeMcpUrl,
       nativeMcpToken: draft.nativeMcpToken,
+      nativeMcpLevel: draft.nativeMcpEnabled ? draft.nativeMcpLevel || '3' : undefined,
       nativeMcpAllowExecutionData: draft.nativeMcpAllowExecutionData,
       nativeMcpAllowRemote: draft.nativeMcpAllowRemote,
       nativeMcpTimeoutMs: draft.nativeMcpTimeoutMs,
@@ -299,6 +300,8 @@ function EnvironmentFormModal({ environmentId }: { environmentId?: string }) {
       <p className="muted">Live assist for workflows, executions, credential metadata, native node definitions, and server-side validation. N8NAC remains the authoring and sync source of truth.</p>
       {draft.nativeMcpEnabled ? <>
         <div className="form-grid"><label>MCP endpoint<input value={draft.nativeMcpUrl} onChange={(event) => patch({ nativeMcpUrl: event.target.value })} placeholder="Defaults to the environment URL + /mcp-server/http" /></label><label>Token<input type="password" value={draft.nativeMcpToken} onChange={(event) => patch({ nativeMcpToken: event.target.value })} placeholder={draft.nativeMcpTokenAvailable ? 'Stored token will be reused' : 'Native MCP bearer token'} /></label></div>
+        <label>Usage level (cumulative)<input type="range" min="1" max="3" step="1" value={draft.nativeMcpLevel === '1' || draft.nativeMcpLevel === '2' || draft.nativeMcpLevel === '3' ? draft.nativeMcpLevel : '3'} onChange={(event) => patch({ nativeMcpLevel: event.target.value })} /></label>
+        <p className="muted">Level {draft.nativeMcpLevel === '1' ? '1 — schema sync: refresh the per-instance schema overlay, then validate locally.' : draft.nativeMcpLevel === '2' ? '2 — live validation at push: the instance checks every node before anything is written.' : '3 — read-only discovery on top of levels 1 and 2.'} Level 0 (this section disabled) validates against the bundled schema only and is not recommended.</p>
         <label>Timeout ms<input value={draft.nativeMcpTimeoutMs} onChange={(event) => patch({ nativeMcpTimeoutMs: event.target.value })} placeholder="30000" /></label>
         <details className="stack">
           <summary>Advanced security options</summary>

--- a/packages/vscode-extension/src/ui/settings-webview/store.ts
+++ b/packages/vscode-extension/src/ui/settings-webview/store.ts
@@ -27,6 +27,7 @@ export interface EnvironmentDraft {
   nativeMcpUrl: string;
   nativeMcpToken: string;
   nativeMcpTokenAvailable?: boolean;
+  nativeMcpLevel: string;
   nativeMcpAllowExecutionData: boolean;
   nativeMcpAllowRemote: boolean;
   nativeMcpTimeoutMs: string;
@@ -215,6 +216,11 @@ function blankEnvironmentDraft(id: string, environment?: any): EnvironmentDraft 
     nativeMcpUrl: nativeMcp.url || '',
     nativeMcpToken: '',
     nativeMcpTokenAvailable: nativeMcp.tokenConfigured,
+    // Effective level: explicit value wins, otherwise legacy configs keep the
+    // full assist surface (3), disabled configs stay at 0.
+    nativeMcpLevel: nativeMcp.level === 1 || nativeMcp.level === 2 || nativeMcp.level === 3
+      ? String(nativeMcp.level)
+      : (Boolean(nativeMcp.enabled) || nativeMcp.url ? '3' : '0'),
     nativeMcpAllowExecutionData: Boolean(nativeMcp.allowExecutionData),
     nativeMcpAllowRemote: Boolean(nativeMcp.allowRemoteExposure),
     nativeMcpTimeoutMs: nativeMcp.timeoutMs ? String(nativeMcp.timeoutMs) : '',

--- a/packages/vscode-extension/tests/unit/settings-webview-store.test.ts
+++ b/packages/vscode-extension/tests/unit/settings-webview-store.test.ts
@@ -58,6 +58,8 @@ test('settings webview store hydrates native MCP draft fields from environment s
     assert.strictEqual(draft.nativeMcpEnabled, true);
     assert.strictEqual(draft.nativeMcpUrl, 'https://dev.example.test/mcp-server/http');
     assert.strictEqual(draft.nativeMcpToken, '');
+    // Legacy configs without an explicit level default to the full assist surface.
+    assert.strictEqual(draft.nativeMcpLevel, '3');
     assert.strictEqual(draft.nativeMcpTokenAvailable, true);
     assert.strictEqual(draft.nativeMcpAllowExecutionData, true);
     assert.strictEqual(draft.nativeMcpAllowRemote, false);


### PR DESCRIPTION
Stacked on #635 (base branch `fix/benchmark-ontology-validation`); merge #635 first or review together.

## Goal

Give the user a **single knob** — the native MCP usage level — deciding how much of the instance's MCP server n8n-as-code uses, replacing the previous tangle (assist flag + auto-probe). Cumulative ladder:

| Level | Behaviour |
|---|---|
| 0 | no MCP at all — bundled ontology only, **zero MCP calls** |
| 1 | **schema sync**: per-instance ontology overlay refreshed from `get_node_types`, validated locally (economical: 1 sync then 0 calls) |
| 2 | + live `validate_node_config` at push (authoritative, immune to bundled-schema drift) |
| 3 | + read-only discovery surface |

## Changes

**Config / CLI**
- `level` (1|2|3) on the environment `nativeMcp` config; `effectiveNativeMcpLevel()`: legacy configured environments → 3 (full backward compatibility), disabled → 0, `N8NAC_NATIVE_MCP_LEVEL` override.
- `n8nac native-mcp configure --level N` (status/disable reflect the level); push gate branches on it.

**Level 1 overlay** (`packages/cli/src/core/services/`)
- `instance-mcp-client.ts` — shared minimal MCP client (session lifecycle, plaintext guard) with an opt-in call journal (`N8NAC_MCP_CALL_LOG`) for benchmark instrumentation.
- `node-schema-defs-parser.ts` — parses the instance's `get_node_types` TS definitions (interface **and** type-alias `Params`, JSDoc `@default`/`@displayOptions.show`, resource-locator and option-union typing) back into the validator property shape. Fixtures = real instance outputs.
- `schema-overlay-manager.ts` — per-environment cache (TTL 7 d, lazy per node type, batch + individual retries with resource/operation discriminators in snake_case), materialised as a custom-nodes sidecar merged over the bundled index.
- Push gate (level ≥ 1) syncs the overlay before local validation; level ≥ 2 keeps the live `validate_node_config` gate.

## Benchmark evidence (n8n-harness-benchmark, live instance, builders neufs)

| Level | Server-valid | MCP calls (session) |
|---|---|---|
| L0 | 6/7 (91.4) | 0 |
| L1 | 13/13 (100) | 0 after warm overlay (~2–3 on first contact) |
| L2 | 10/10 (100) | 2 per push |
| L3 | 9/9 (100) | 2 per push (0 discovery — confinement respected) |

Multi-push (4 pushes on the same workflow): L1 = **3 MCP calls total** (first push only), L2 = **8** (every push); per-push wall times identical (~2.0–2.8 s, REST-dominated). Tokens are not exposed by this harness runtime.

The benchmark also caught a validator bug, fixed in the second commit: display conditions must be evaluated on **explicit values only** (`builtInTools` passed locally because the schema default of `responsesApiEnabled` was applied; the live server rejects it). Skills: 128/128, cli: 370/370.

## Out of scope (next PRs)
- `update-ai` skills awareness of the level
- VS Code configuration slider
- full 4-level benchmark report in the harness repo