### PR TITLE
test(vscode-extension): point the skills-assets guard at the shared resolver

### DIFF
--- a/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
+++ b/packages/vscode-extension/tests/unit/agent-workbench-html.test.ts
@@ -485,6 +485,10 @@ test('CLI skills assets: extension bundles only runtime-required agent assets', 
     const ensureExtensionAssetsSource = fs.readFileSync(path.join(__dirname, '../../../../scripts/ensure-extension-skills-assets.cjs'), 'utf8');
     const cliSource = fs.readFileSync(path.join(__dirname, '../../../cli/src/index.ts'), 'utf8');
     const skillsCliSource = fs.readFileSync(path.join(__dirname, '../../../skills/src/cli.ts'), 'utf8');
+    // The skills CLI delegates asset resolution to a shared module so the MCP server and the
+    // extension resolve assets identically. Assert on that module, and on the delegation, so
+    // this guard follows the logic instead of pinning it to one file.
+    const skillsAssetsSource = fs.readFileSync(path.join(__dirname, '../../../skills/src/services/assets-dir.ts'), 'utf8');
 
     assert.ok(rootPackage.scripts['build:extension'].includes('ensure-extension-skills-assets.cjs'), 'Extension build must verify agent skills before bundling');
     assert.ok(ensureExtensionAssetsSource.includes('hasRequiredAgentSkills'), 'Extension build preflight must verify agent skills before bundling');
@@ -500,8 +504,9 @@ test('CLI skills assets: extension bundles only runtime-required agent assets', 
     assert.ok(!extensionBuildSource.includes('skills assets not found; run `npm run build:extension`'), 'Extension bundler must not fail on missing generated skills JSON assets');
     assert.ok(cliSource.includes('hasRequiredAssets'), 'CLI must verify skills asset directories before selecting them');
     assert.ok(cliSource.includes("'vscode-extension', 'assets'"), 'CLI dev fallback should find extension-bundled assets');
-    assert.ok(skillsCliSource.includes('hasRequiredAssets'), 'Direct skills CLI must verify skills asset directories before selecting them');
-    assert.ok(skillsCliSource.includes('vscode-extension/assets'), 'Direct skills CLI dev fallback should find extension-bundled assets');
+    assert.ok(skillsCliSource.includes('resolveSkillsAssetsDir'), 'Direct skills CLI must resolve assets through the shared resolver');
+    assert.ok(skillsAssetsSource.includes('hasRequiredAssets'), 'Shared skills asset resolver must verify asset directories before selecting them');
+    assert.ok(skillsAssetsSource.includes('vscode-extension/assets'), 'Shared skills asset resolver dev fallback should find extension-bundled assets');
 });
 
 test('Agent Workbench state delivery: runtime states are lightweight and ordered', () => {


### PR DESCRIPTION
Fixes the red `build-and-test` job on `main` (`cdfe16bc`): 162 of 163 extension unit tests passed, and the one failure was a stale source grep.

## What broke

`CLI skills assets: extension bundles only runtime-required agent assets` asserts that the skills CLI verifies an asset directory before selecting it, by grepping `packages/skills/src/cli.ts` for `hasRequiredAssets`.

That check moved. `cli.ts` now delegates to `resolveSkillsAssetsDir` in `services/assets-dir.ts`, so the unified CLI, the MCP server and the extension resolve assets through one implementation instead of three copies of the same walk.

## Why it is a test fix and not a code fix

The behaviour the guard protects is intact — both `hasRequiredAssets` and the `vscode-extension/assets` dev fallback live in the resolver, and `cli.ts` calls it. Nothing stopped verifying anything; the grep just pointed at the file the logic had left.

## The fix

Assert on the resolver for the verification and the dev fallback, and separately on `cli.ts` for the delegation. The guard now follows the logic instead of pinning it to one path, so moving the implementation again fails only if the delegation actually breaks.

Verified locally: the previously failing test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated validation coverage for CLI skills assets to reflect centralized asset resolution.
  * Added checks that the shared resolver performs required asset verification and supports the development fallback path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->