### PR TITLE
chore-release-stamp-n8nVersion-2.38.5

### DIFF
--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -49,5 +49,5 @@
     "publishConfig": {
         "access": "public"
     },
-    "n8nVersion": "2.37.11"
+    "n8nVersion": "2.38.5"
 }


### PR DESCRIPTION
Unblocks the RC cut. The `rc` run [34399239776](https://github.com/EtienneLescot/n8n-as-code/actions/runs/34399239776) failed at **Verify release build is reproducible**, before publishing anything:

```
❌ Release build modified tracked files other than the lockfile.
 M packages/skills/package.json
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Cause

`packages/skills` runs `stamp-n8n-version.cjs` in `prebuild`, which writes the resolved upstream n8n version into `n8nVersion`. The same run logged:

```
✅ Stamped n8nVersion=2.38.5 in packages/skills/package.json
```

`main` carries `2.37.11`, stamped manually in 89547a93 on 7 September. n8n has published 2.38.5 since, so every release build now rewrites the file and trips the reproducibility gate. Nothing in `release.yml` refreshes the stamp — it only verifies that it does not drift.

## Scope

One line. The generated knowledge assets are gitignored and rebuilt on every build, so the stamp is the only tracked artefact that moves with the upstream version; that is why the gate flagged this file and nothing else.

Same shape as the precedent it follows: 89547a93 changed exactly `packages/skills/package.json | 2 +-`.

Unrelated to the benchmark work merged in #638/#639/#644 — this would have blocked any RC cut taken today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the supported n8n version to 2.38.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->