### PR TITLE
fix(ci): stamp n8nVersion before the release commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,14 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve and stamp the n8n stable tag
+        id: n8n-tag
+        run: |
+          TAG=$(node scripts/ensure-n8n-cache.cjs --print-tag)
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "N8N_VERSION=$TAG" >> "$GITHUB_ENV"
+          N8N_VERSION="$TAG" node scripts/stamp-n8n-version.cjs
+
       - name: Commit RC versions
         run: |
           git config user.name 'github-actions[bot]'
@@ -160,10 +168,6 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-
-      - name: Resolve n8n stable tag
-        id: n8n-tag
-        run: echo "tag=$(node scripts/ensure-n8n-cache.cjs --print-tag)" >> "$GITHUB_OUTPUT"
 
       - name: Cache n8n repository
         uses: actions/cache@v4
@@ -408,6 +412,14 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve and stamp the n8n stable tag
+        id: n8n-tag
+        run: |
+          TAG=$(node scripts/ensure-n8n-cache.cjs --print-tag)
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "N8N_VERSION=$TAG" >> "$GITHUB_ENV"
+          N8N_VERSION="$TAG" node scripts/stamp-n8n-version.cjs
+
       - name: Commit final versions
         run: |
           git config user.name 'github-actions[bot]'
@@ -433,10 +445,6 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-
-      - name: Resolve n8n stable tag
-        id: n8n-tag
-        run: echo "tag=$(node scripts/ensure-n8n-cache.cjs --print-tag)" >> "$GITHUB_OUTPUT"
 
       - name: Cache n8n repository
         uses: actions/cache@v4


### PR DESCRIPTION
## Problème

La coupe RC échoue à l'étape « Verify release build is reproducible » dès que n8n publie une nouvelle version stable.

Le prebuild de `@n8n-as-code/skills` lance `stamp-n8n-version.cjs`, qui réécrit `n8nVersion` dans `packages/skills/package.json`. Cette écriture arrive après le commit de version, donc le garde-fou voit un fichier suivi modifié et arrête le job.

Quatre commits manuels `chore-release-stamp-n8nVersion-*` existent déjà dans l'historique pour contourner ça, un par run bloqué. n8n est passé à 2.38.6, le prochain run échouerait à l'identique.

## Correctif

Sur les deux jobs `cut-rc` et `promote` :

- L'étape de résolution du tag n8n remonte avant le commit de version et estampille dans la foulée. Le `git add -A` existant l'embarque, la branche de release enregistre donc la version n8n utilisée.
- Le tag résolu est épinglé en `N8N_VERSION` pour le reste du job, donc la clé de cache et l'estampillage du prebuild voient la même valeur, même si n8n publie pendant le run.
- L'estampillage du prebuild devient un no-op et la vérification de reproductibilité passe, sans être affaiblie pour les autres fichiers.

Aucune étape ajoutée. `ensure-n8n-cache.cjs --print-tag` n'utilise que des modules natifs et sort avant tout clone, il peut donc tourner avant `npm install`.

## Vérification

Résolveur exécuté localement, renvoie `n8n@2.38.6`. L'estampillage écrit bien la valeur. Ordre des étapes contrôlé après parsing YAML des deux jobs : estampillage avant commit, commit avant cache, cache avant vérification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow version handling to resolve and stamp the n8n stable version earlier during release candidate and promotion processes.
  * Preserved n8n cache setup using the resolved stable tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->