### PR TITLE
fix(skills): stop pinning @next on release branches by name

### DIFF
--- a/packages/skills/scripts/build-skill-adapters.js
+++ b/packages/skills/scripts/build-skill-adapters.js
@@ -117,8 +117,13 @@ function resolveAdapterDistTag() {
     return 'next';
   }
 
+  // The -rc/-next check above is the real prerelease signal. A release branch still
+  // carries stable versions until its RC bump lands, and its committed mirrors are
+  // main's stable payload, so pinning @next on the branch name alone made every push
+  // to release/** fail the committed-skills guard. Use build:adapters:branch when you
+  // explicitly want the next-channel payload.
   const branch = process.env.GITHUB_REF_NAME || process.env.BRANCH_NAME || readGitBranch();
-  return (branch === 'next' || branch?.startsWith('release/')) ? 'next' : undefined;
+  return branch === 'next' ? 'next' : undefined;
 }
 
 function readPackageVersion(packagePath) {

--- a/packages/skills/tests/ai-context-generator.test.ts
+++ b/packages/skills/tests/ai-context-generator.test.ts
@@ -376,7 +376,9 @@ function resolveAdapterDistTag(repoRoot: string): string | undefined {
         path.join(repoRoot, 'packages/skills/package.json'),
     ].map((packagePath) => JSON.parse(fs.readFileSync(packagePath, 'utf8')).version as string);
 
-    if (versions.some((version) => version.includes('-next'))) {
+    // ponytail: hand-copied from resolveAdapterDistTag in scripts/build-skill-adapters.js.
+    // It has already drifted twice; share one module if it drifts again.
+    if (versions.some((version) => version.includes('-next') || version.includes('-rc'))) {
         return 'next';
     }
 


### PR DESCRIPTION
## Problème

Toutes les CI poussées sur `release/**` échouent à l'étape « Verify committed generated skills are up to date », et ce depuis au moins le 6 septembre. Le même arbre passe sur `main`.

Exemple : le commit `971bca09` réussit sur `main` ([run 34490185703](https://github.com/EtienneLescot/n8n-as-code/actions/runs/34490185703)) et échoue sur `release/v2.6.0` ([run 34491364003](https://github.com/EtienneLescot/n8n-as-code/actions/runs/34491364003)), contenu identique.

## Cause

`resolveAdapterDistTag()` dans `packages/skills/scripts/build-skill-adapters.js` épinglait le dist-tag depuis le nom de branche : tout ce qui commence par `release/` générait des skills pointant sur `npx --yes n8nac@next`.

Or les fichiers de skills committés portent la commande stable, générée depuis `main`. La garde CI compare donc une sortie `@next` à des fichiers stables. L'échec est structurel, pas accidentel.

Le garde-fou déjà présent au-dessus, sur `GITHUB_BASE_REF === 'main'`, ne couvrait que les pull requests. Les push sur une branche de release passaient à travers.

## Correctif

Suppression de la clause sur le nom de branche. Le test sur les versions `-rc` et `-next`, juste au-dessus, est le vrai signal de préversion : une branche de release porte des versions stables jusqu'à son commit de bump RC, et à partir de là le test de version épingle `@next` tout seul.

`build:adapters:branch` reste disponible pour qui veut explicitement la charge utile du canal next.

## Vérification

Génération lancée en local pour chaque contexte, en comptant les fichiers suivis modifiés :

| Contexte | Avant | Après |
|---|---|---|
| `release/v2.6.0`, versions stables | 4 | 0 |
| `main` | 0 | 0 |
| `next` | 4 | 4, comportement voulu |
| `release/v2.6.0`, versions `-rc` | pin `@next` | pin `@next` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release branches now use the stable package channel by default.
  * Prerelease versions, including next and release-candidate versions, use the appropriate prerelease channel.
  * Explicitly named `next` branches retain their existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->