### PR TITLE
perf(skills,docs): name a local n8nac install instead of routing every agent call through npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,12 @@ If your agent asks for an explicit skill path, use `skills/n8n-architect`.
 
 ### CLI
 
+Install first. `update-ai` then writes agent instructions that name the local binary directly; without an install they fall back to `npx`, which pays npm's own startup on every one of the tens of calls an agent makes per task.
+
 Create a workspace environment for an existing n8n URL:
 
 ```bash
+npm install n8nac
 npx --yes n8nac env add Dev --base-url https://n8n.example.com --workflows-path workflows/dev
 printf '%s' "$N8N_API_KEY" | npx --yes n8nac env auth set Dev --api-key-stdin
 npx --yes n8nac env use Dev
@@ -107,9 +110,11 @@ npx --yes n8nac update-ai
 Or attach a local managed instance:
 
 ```bash
+npm install n8nac
 n8n-manager instance list
 npx --yes n8nac env add Local --managed-instance <id> --workflows-path workflows/local
 npx --yes n8nac env use Local
+npx --yes n8nac update-ai
 ```
 
 Then sync workflows explicitly:

--- a/docs/docs/contribution/local-dev-workspace.md
+++ b/docs/docs/contribution/local-dev-workspace.md
@@ -6,7 +6,7 @@ description: Test n8n-as-code facades against local n8nac and n8n-manager builds
 
 # Local Dev Workspace
 
-Published agent instructions intentionally use `npx --yes n8nac` by default. This is required for VS Code, Cursor, MCP clients, and agent environments where the `n8nac` binary is not installed globally.
+Generated agent instructions name whatever `n8nac` the workspace already has, and fall back to `npx --yes n8nac` only when it has none. That fallback matters for VS Code, Cursor, MCP clients and agent shells, which are handed no `node_modules/.bin` on their `PATH`. Everywhere else npx is pure overhead: it pays npm's own startup on every call, and an agent makes tens of calls per task.
 
 Local end-to-end development uses an explicit override instead of changing that default.
 
@@ -33,12 +33,17 @@ N8N_MANAGER_STATE_PATH="/home/etienne/repos/n8n-ecosystem-dev/.dev-state/n8n-man
 
 ## Command Resolution SSOT
 
-Generated `AGENTS.md` and skill prompts resolve the `n8nac` command in this order:
+`resolveN8nacCommandRefs` in `packages/skills/src/services/cli-command-resolver.ts` is the only place that decides the command. Generated `AGENTS.md` and skill prompts resolve it in this order:
 
-1. `--cli-cmd`
+1. `--cli-cmd`, or the command `update-ai` infers for itself when that flag is absent: the monorepo entry point in a dev checkout, then a global install found on `PATH`
 2. `N8NAC_COMMAND`
 3. `.n8nac-dev.json` in the target workspace
-4. published fallback: `npx --yes n8nac`
+4. a local install at `node_modules/n8nac/dist/index.js`, named by a relative path
+5. published fallback: `npx --yes n8nac`
+
+Rung 4 emits a relative path deliberately. Generated context is committed in user projects, so an absolute path would name a directory that exists on one machine only; and a path without spaces needs no shell quoting, which is what keeps it working under `cmd.exe`.
+
+Rungs 3 and 4 both require a project root. Passing none is how the packaged skill mirrors stay machine-independent: they are pre-rendered at build time and diff-gated in CI.
 
 This keeps production and extension behavior safe while making local dev reproducible.
 

--- a/docs/docs/getting-started/index.md
+++ b/docs/docs/getting-started/index.md
@@ -39,9 +39,12 @@ After that, use the sidebar to pull workflows or create a local workflow file, t
 
 ## CLI Setup
 
+Install first. `update-ai` then writes agent instructions that name the installed binary directly; without an install they fall back to `npx`, which pays npm's own startup on every one of the tens of calls an agent makes per task.
+
 ### Remote n8n environment
 
 ```bash
+npm install -g n8nac
 n8nac env add Dev --base-url https://n8n.example.com --workflows-path workflows/dev
 n8nac env auth set Dev --api-key-stdin
 n8nac env use Dev
@@ -51,6 +54,7 @@ n8nac update-ai
 ### Local managed instance
 
 ```bash
+npm install -g n8nac
 n8n-manager instance list
 n8nac env add Local --managed-instance <id> --workflows-path workflows/local
 n8nac env use Local

--- a/docs/docs/home/index.md
+++ b/docs/docs/home/index.md
@@ -45,6 +45,7 @@ Install the extension, open the `n8n` view, run `n8n: Configure`, and create an 
 ### CLI
 
 ```bash
+npm install -g n8nac
 n8nac env add Dev --base-url https://n8n.example.com --workflows-path workflows/dev
 n8nac env auth set Dev --api-key-stdin
 n8nac env use Dev

--- a/docs/docs/usage/cli.md
+++ b/docs/docs/usage/cli.md
@@ -18,11 +18,13 @@ Install once. `update-ai` then writes agent instructions that name the binary di
 npm install -g n8nac
 ```
 
-A project-local install works too, and pins the version for everyone who clones the repo. Run it through `npx n8nac <command>`, which finds it without downloading anything.
+A project-local install works too. It adds n8nac to the project dependencies, so anyone who clones the repo gets it from `npm install`. Run it through `npx n8nac <command>`, which finds it without downloading anything.
 
 ```bash
 npm install n8nac
 ```
+
+That records a semver range, not a fixed version. For everyone to run the same build, add `--save-exact` and commit your lockfile.
 
 Without any install, every documented command still runs:
 

--- a/docs/docs/usage/cli.md
+++ b/docs/docs/usage/cli.md
@@ -12,20 +12,40 @@ Local managed instances, Docker lifecycle, and tunnels belong to `n8n-manager`.
 
 ## Install
 
-```bash
-npx --yes n8nac <command>
-```
-
-Optional global install:
+Install once. `update-ai` then writes agent instructions that name the binary directly, instead of routing every call through npx.
 
 ```bash
 npm install -g n8nac
 ```
 
+A project-local install works too, and pins the version for everyone who clones the repo. Run it through `npx n8nac <command>`, which finds it without downloading anything.
+
+```bash
+npm install n8nac
+```
+
+Without any install, every documented command still runs:
+
+```bash
+npx --yes n8nac <command>
+```
+
+That form re-resolves the package from the registry on every call and pays npm's own startup each time. It is the right choice for a one-off or a CI step, and the wrong one for an agent that makes tens of calls per task.
+
+## Update
+
+Nothing updates the CLI on its own. Use the same command you installed with:
+
+```bash
+npm install -g n8nac@latest
+```
+
+Then rerun `n8nac update-ai`, so the generated agent context matches the version you now have.
+
 For prerelease work, keep the CLI and manager on matching tags:
 
 ```bash
-npx --yes n8nac@next <command>
+npm install -g n8nac@next
 npx --yes @n8n-as-code/n8n-manager@next <command>
 ```
 

--- a/packages/skills/src/agent-skills/n8n-architect/SKILL.md
+++ b/packages/skills/src/agent-skills/n8n-architect/SKILL.md
@@ -265,7 +265,7 @@ Otherwise, use these commands instead of guessing:
 ```
 
 - Prefer `--compact` on `search`, `node-info`, and `node-schema`: same schemas, bounded output (required params + snippet + gating flags).
-- Prefer one `batch --compact` over N separate lookups: one process parses the ontology once. Pass `--calls '<json>'`, `--calls-file <path>` (file avoids shell-quoting), or pipe JSON via stdin. `--compact` applies to `search`, `node-info`, `node-schema`; `examples-search` and `examples-info` always return full workflow data. Example: `npx --yes n8nac skills batch --compact --calls '[{"cmd":"search","query":"gmail"},{"cmd":"node-info","name":"gmailTool"}]'`.
+- Prefer one `batch --compact` over N separate lookups: one process parses the ontology once. Pass `--calls '<json>'`, `--calls-file <path>` (file avoids shell-quoting), or pipe JSON via stdin. `--compact` applies to `search`, `node-info`, `node-schema`; `examples-search` and `examples-info` always return full workflow data. Example: `{{N8NAC_SKILLS_CMD}} batch --compact --calls '[{"cmd":"search","query":"gmail"},{"cmd":"node-info","name":"gmailTool"}]'`.
 - For several nodes at once, `node-info` and `node-schema` also take multiple names directly: `{{N8NAC_SKILLS_CMD}} node-info <node1> <node2> ... --compact`.
 - Start with `examples search` when the user asks for a common automation pattern.
 - Fetch community examples only when you do not know how to wire something, when the workflow is unusually complex, or when the user explicitly asks. Each download costs a full roundtrip: for routine tasks, local knowledge (`search`, `node-info`, `batch`) is faster and authoritative. Skip examples otherwise.

--- a/packages/skills/src/services/ai-context-generator.ts
+++ b/packages/skills/src/services/ai-context-generator.ts
@@ -226,6 +226,20 @@ export class AiContextGenerator {
         '> ```',
       ]
       : [];
+    // A local install is pinned: nothing refreshes it the way a dist tag refreshed the npx
+    // form, so the file has to say how. Only shown when we actually resolved one.
+    const updateNote = source === 'local-install'
+      ? [
+        ``,
+        `> The command above names the n8nac installed in this workspace, which is why it is not`,
+        `> an \`npx\` call and does not pay npm's startup. Nothing updates it on its own:`,
+        `>`,
+        '> ```bash',
+        `> npm i n8nac${distTag ? `@${distTag}` : '@latest'}`,
+        `> ${cliCmd} update-ai   # picks up the new version and rewrites this file`,
+        '> ```',
+      ]
+      : [];
     const versionStamp = options.cliVersion ? [`<!-- n8nac-version: ${options.cliVersion} -->`, ``] : [];
     const levelStamp = options.nativeMcp && Number.isInteger(options.nativeMcp.level)
       ? [`<!-- n8nac-mcp-level: ${options.nativeMcp.level} -->`, ``]
@@ -242,6 +256,7 @@ export class AiContextGenerator {
       `- n8n-manager command: \`${managerCmd}\``,
       `- n8n knowledge command: \`${skillsCmd}\``,
       ...installOnce,
+      ...updateNote,
       ``,
       `Run workspace commands from the current Git worktree root. Do not \`cd\` into the n8n-as-code source repository, n8n-manager source repository, plugin directory, or package directory to run \`${cliCmd} workspace ...\`, \`${cliCmd} list\`, \`${cliCmd} pull\`, \`${cliCmd} push\`, or \`${cliCmd} update-ai\`.`,
       ``,

--- a/packages/skills/src/services/cli-command-resolver.ts
+++ b/packages/skills/src/services/cli-command-resolver.ts
@@ -4,7 +4,7 @@ import path from 'path';
 export interface N8nacCommandRefs {
   cliCmd: string;
   skillsCmd: string;
-  source: 'override' | 'env' | 'workspace-config' | 'published';
+  source: 'override' | 'env' | 'workspace-config' | 'local-install' | 'published';
 }
 
 export interface ResolveN8nacCommandOptions {
@@ -26,6 +26,12 @@ const DEV_CONFIG_FILENAMES = [
   '.n8n-as-code-dev.json',
 ];
 
+/**
+ * Entry point of a locally installed n8nac, relative to the project root.
+ * Kept as segments so the filesystem probe and the emitted command cannot drift apart.
+ */
+const LOCAL_ENTRYPOINT_SEGMENTS = ['node_modules', 'n8nac', 'dist', 'index.js'];
+
 export function resolveN8nacCommandRefs(options: ResolveN8nacCommandOptions = {}): N8nacCommandRefs {
   const env = options.env ?? process.env;
   const override = cleanCommand(options.override);
@@ -36,6 +42,9 @@ export function resolveN8nacCommandRefs(options: ResolveN8nacCommandOptions = {}
 
   const workspaceCommand = cleanCommand(readWorkspaceCommand(options.projectRoot));
   if (workspaceCommand) return buildRefs(workspaceCommand, 'workspace-config');
+
+  const localCommand = readLocalInstallCommand(options.projectRoot);
+  if (localCommand) return buildRefs(localCommand, 'local-install');
 
   const published = options.distTag ? `npx --yes n8nac@${options.distTag}` : 'npx --yes n8nac';
   return buildRefs(published, 'published');
@@ -74,4 +83,30 @@ function readWorkspaceCommand(projectRoot: string | undefined): string | undefin
   }
 
   return undefined;
+}
+
+/**
+ * A locally installed n8nac, named directly instead of through npx. npx pays npm's own
+ * startup on every invocation; naming the entry point does not, and an agent makes tens of
+ * calls per task.
+ *
+ * The emitted path is relative, and deliberately so on three counts:
+ * - the generated context is committed in user projects, so an absolute path would name a
+ *   directory that exists on one machine and breaks for every teammate and in CI;
+ * - a relative path carries no spaces, so it needs no shell quoting and survives cmd.exe,
+ *   which does not strip the POSIX single quotes the CLI's own quoting helper emits;
+ * - the generated context already requires workspace commands to run from the worktree
+ *   root, which is the only precondition a relative path has.
+ *
+ * Returns undefined without a projectRoot. That guard is load-bearing: the packaged skill
+ * mirrors are pre-rendered with no project root and diff-gated in CI, so anything
+ * machine-specific leaking into them turns the build red.
+ */
+function readLocalInstallCommand(projectRoot: string | undefined): string | undefined {
+  if (!projectRoot) return undefined;
+
+  const entrypoint = path.join(projectRoot, ...LOCAL_ENTRYPOINT_SEGMENTS);
+  return fs.existsSync(entrypoint)
+    ? `node ${LOCAL_ENTRYPOINT_SEGMENTS.join('/')}`
+    : undefined;
 }

--- a/packages/skills/tests/cli-command-resolver.test.ts
+++ b/packages/skills/tests/cli-command-resolver.test.ts
@@ -1,0 +1,117 @@
+import { resolveN8nacCommandRefs } from '../src/services/cli-command-resolver.js';
+import { AiContextGenerator } from '../src/services/ai-context-generator.js';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+/** Written this way so the literal cannot be mangled by an editor or a shell heredoc. */
+const BACKSLASH = String.fromCharCode(92);
+
+/** A project root holding a locally installed n8nac, as `npm install n8nac` leaves it. */
+function withLocalInstall(root: string): string {
+    fs.mkdirSync(path.join(root, 'node_modules', 'n8nac', 'dist'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'node_modules', 'n8nac', 'dist', 'index.js'), '', 'utf8');
+    return root;
+}
+
+describe('resolveN8nacCommandRefs', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'n8nac-resolver-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    describe('local install', () => {
+        test('names the locally installed entry point instead of paying npx startup', () => {
+            const refs = resolveN8nacCommandRefs({ projectRoot: withLocalInstall(tempDir), env: {} });
+
+            expect(refs.source).toBe('local-install');
+            expect(refs.cliCmd).toBe('node node_modules/n8nac/dist/index.js');
+            expect(refs.skillsCmd).toBe('node node_modules/n8nac/dist/index.js skills');
+        });
+
+        test('falls back to the published npx form when nothing is installed locally', () => {
+            const refs = resolveN8nacCommandRefs({ projectRoot: tempDir, distTag: 'next', env: {} });
+
+            expect(refs.source).toBe('published');
+            expect(refs.cliCmd).toBe('npx --yes n8nac@next');
+        });
+
+        test('ignores a local install when no project root is given', () => {
+            // The packaged skill mirrors are pre-rendered with no project root and diff-gated in
+            // CI. If this guard ever goes, the build bakes a machine-specific path into them.
+            const cwd = process.cwd();
+            try {
+                process.chdir(withLocalInstall(tempDir));
+                const refs = resolveN8nacCommandRefs({ env: {} });
+
+                expect(refs.source).toBe('published');
+                expect(refs.cliCmd).toBe('npx --yes n8nac');
+            } finally {
+                process.chdir(cwd);
+            }
+        });
+
+        test('emits a relative, unquoted path so it survives cmd.exe and a committed AGENTS.md', () => {
+            const refs = resolveN8nacCommandRefs({ projectRoot: withLocalInstall(tempDir), env: {} });
+
+            expect(refs.cliCmd).not.toContain(tempDir);
+            expect(refs.cliCmd).not.toMatch(/['"]/);
+            expect(refs.cliCmd).not.toContain(BACKSLASH);
+            expect(path.isAbsolute(refs.cliCmd.replace(/^node /, ''))).toBe(false);
+        });
+    });
+
+    describe('precedence', () => {
+        test('an explicit override wins over a local install', () => {
+            const refs = resolveN8nacCommandRefs({
+                projectRoot: withLocalInstall(tempDir),
+                override: 'node /dev/cli.js',
+                env: {},
+            });
+
+            expect(refs.source).toBe('override');
+            expect(refs.cliCmd).toBe('node /dev/cli.js');
+        });
+
+        test('N8NAC_COMMAND wins over a local install', () => {
+            const refs = resolveN8nacCommandRefs({
+                projectRoot: withLocalInstall(tempDir),
+                env: { N8NAC_COMMAND: 'n8nac-dev' },
+            });
+
+            expect(refs.source).toBe('env');
+            expect(refs.cliCmd).toBe('n8nac-dev');
+        });
+
+        test('a workspace dev config wins over a local install', () => {
+            withLocalInstall(tempDir);
+            fs.writeFileSync(
+                path.join(tempDir, '.n8nac-dev.json'),
+                JSON.stringify({ commands: { n8nac: 'node ../cli/dist/index.js' } }),
+                'utf8',
+            );
+
+            const refs = resolveN8nacCommandRefs({ projectRoot: tempDir, env: {} });
+
+            expect(refs.source).toBe('workspace-config');
+            expect(refs.cliCmd).toBe('node ../cli/dist/index.js');
+        });
+    });
+
+    describe('generated AGENTS.md', () => {
+        test('swaps the install-once nudge for an update note once a local install resolves', async () => {
+            await new AiContextGenerator().generate(withLocalInstall(tempDir), '1.0.0');
+            const agents = fs.readFileSync(path.join(tempDir, 'AGENTS.md'), 'utf-8');
+
+            expect(agents).toContain('- n8nac command: `node node_modules/n8nac/dist/index.js`');
+            expect(agents).not.toContain('Installing once removes it');
+            expect(agents).toContain('Nothing updates it on its own');
+            expect(agents).toContain('npm i n8nac@latest');
+        });
+    });
+});


### PR DESCRIPTION
Generated agent context routes every CLI call through `npx --yes n8nac@<tag>`, even when the workspace already has n8nac installed. npx pays npm's own startup on each invocation, and an agent makes tens of calls per task.

Measured on Windows, node 24.14.0 / npm 11.1.0, in a workspace with a local install:

| form | per call |
|---|---|
| `npx --yes n8nac@next` | 1280 ms warm, 2600 ms cold |
| `npx --no-install n8nac` | 1140 ms |
| `node node_modules/n8nac/dist/index.js` | 150 ms |

That matches what the harness benchmark measured end to end: a 110 s median build-time gap over roughly 45 calls, about 2.4 s per call.

## The change

One new rung in `resolveN8nacCommandRefs`, between the workspace dev config and the published npx fallback: when `<projectRoot>/node_modules/n8nac/dist/index.js` exists, name it instead.

```
1. --cli-cmd, or what update-ai infers for itself: dev-checkout entry point, then a global install on PATH
2. N8NAC_COMMAND
3. .n8nac-dev.json
4. a local install -> node node_modules/n8nac/dist/index.js   <- new
5. npx --yes n8nac
```

`--no-install` was considered and rejected. It resolves by exactly the same rules as `--yes` (npx rewrites it to `--yes=false` and reads the flag only after the search has already failed), so it buys 10% and adds a failure mode with an opaque error.

### Why the resolver and not the CLI

`resolveN8nacCommandRefs` is the only producer of the command string, and it already receives `projectRoot`. Putting the rung there covers the VS Code extension too, which calls the generator directly with the workspace root. Putting it in `update-ai` would not: the extension's own override returns undefined outside development mode, and it silently regenerates `AGENTS.md` on a version-stamp mismatch, so it would have overwritten the fast command back to npx.

### Why a relative path

- Generated context is committed in user projects. An absolute path names a directory that exists on one machine and breaks for every teammate and in CI.
- It carries no spaces, so it needs no shell quoting. `quoteShellArg` emits POSIX single quotes, which `cmd.exe` does not strip; a relative path sidesteps that entirely. Verified under both `cmd.exe` and PowerShell.
- The generated context already requires workspace commands to run from the worktree root, which is the only precondition a relative path has.

`isN8nacOnShellPath` still excludes `node_modules/.bin`, and deliberately: those entries are injected by our own npx invocation and will not exist in the agent's later shell. The new rung tests the filesystem instead.

## Regressions checked

- **Packaged skill mirrors unchanged.** `build-skill-adapters.js` renders with no project root, so the rung cannot fire there. The `projectRoot` guard is what keeps a machine-specific path out of the five committed files the CI diff gate gates. Covered by a test.
- **VS Code extension** never spawns the CLI; it imports n8nac as a pinned dependency and its only `child_process` use is git. It does hand `AGENTS.md` to an embedded agent whose shell gets no `node_modules/.bin`, which is exactly why npx must stay as rung 5.
- **MCP** is untouched. Nothing in this repo generates an MCP client config, and the committed ones launch a different package.
- **Plugins, skills CLI, CI** consume the rendered mirrors, which do not change.
- `npm test`, `npm run check:adapters` and `npm run docs:build` all pass.

## Also in here

`agent-skills/n8n-architect/SKILL.md` had one hardcoded `npx --yes n8nac skills batch` among 80 templated placeholders. It happened to match the rendered stable output, which is why no mirror changes, but it was wrong on the prerelease channel, where every other command carries `@next` and that one did not.

## Docs

- The three quick-starts installed nothing, so `update-ai` had nothing to find and fell through to npx forever. Each now installs first. The README installs project-locally and drives commands through npx; the doc site installs globally, matching the bare `n8nac` it uses throughout.
- `usage/cli.md` gains an **Update** section. There was no user-facing line anywhere that updated the CLI, because `npx @next` was doing it invisibly on every call.
- `contribution/local-dev-workspace.md` documented a four-rung precedence that had already been stale before this PR, and described npx as the intended default. Both corrected.

The other npx mentions in the docs are left alone. They are valid no-install invocations for a human running a command or two.

## Deliberately not in this PR

- `quoteShellArg` emits POSIX single quotes that break under `cmd.exe`. Pre-existing, reachable only from the dev-checkout rung, and it needs its own tests.
- The landing page CTA installs `@n8n-as-code/cli`, the package the docs elsewhere tell users to uninstall, and runs `n8nac init`, which is not a registered command.
- No version-drift check exists anywhere in the CLI. Pinning to a local install makes that more visible, which is why the Update section is here, but a real staleness warning is a feature of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Generated agent instructions now use an available project-local `n8nac` installation when present.
  - Generated guidance explains how to update a locally installed CLI and regenerate instructions.
  - Added project-local CLI support with `npx n8nac` as a fallback.

- **Documentation**
  - Updated quick-start and setup guides to recommend installing `n8nac` globally.
  - Clarified global, local, and fallback command options, update commands, and command resolution behavior.
  - Updated skill examples to use portable command placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->