### PR TITLE
fix(cli,vscode): quote for cmd.exe, and stop keeping four copies of the rule

### DIFF
--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -235,6 +235,19 @@ n8nac --help
 
 The current package is `n8nac`.
 
+## Update Notice
+
+`n8nac update-ai` checks whether a newer version is published and, if so, prints one line telling you. It reads about 80 bytes from the npm registry, gives up after three seconds, and never fails the command.
+
+Turn it off with any of these:
+
+```bash
+NO_UPDATE_NOTIFIER=1
+DO_NOT_TRACK=1
+```
+
+It is already silent in CI, under `--silent`, and when you are running from a checkout of this repository.
+
 ## Complete Reset
 
 Back up workflows first, then recreate the environment:

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { quoteShellArg } from '../utils/shell.js';
 import path from 'path';
 import chalk from 'chalk';
 import { TypeScriptParser, WorkflowBuilder } from '@n8n-as-code/transformer';
@@ -1235,6 +1236,3 @@ function quoteString(value: string): string {
     return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
 }
 
-function quoteShellArg(value: string): string {
-    return `'${value.replace(/'/g, `'\\''`)}'`;
-}

--- a/packages/cli/src/commands/update-ai.ts
+++ b/packages/cli/src/commands/update-ai.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { quoteShellArg } from '../utils/shell.js';
 import fs from 'fs';
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname, resolve, delimiter, basename } from 'path';
@@ -61,9 +62,6 @@ function readAgentsMdLevel(projectRoot: string): number | undefined {
     return Number.isSafeInteger(parsed) ? parsed : undefined;
 }
 
-function quoteShellArg(value: string): string {
-    return `'${value.replace(/'/g, `'\\''`)}'`;
-}
 
 function hasWorkspaceDevCommand(projectRoot: string): boolean {
     return N8NAC_DEV_CONFIG_FILENAMES.some((filename) => existsSync(join(projectRoot, filename)));

--- a/packages/cli/src/commands/update-ai.ts
+++ b/packages/cli/src/commands/update-ai.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { quoteShellArg } from '../utils/shell.js';
+import { findNewerPublishedVersion } from '../utils/version-check.js';
 import fs from 'fs';
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname, resolve, delimiter, basename } from 'path';
@@ -82,17 +83,29 @@ function isN8nacOnShellPath(): boolean {
         && extensions.some((ext) => existsSync(join(dir, `n8nac${ext}`))));
 }
 
+/**
+ * The monorepo entry point, when the CLI is running from a dev checkout rather than an
+ * install. Used both to emit a fast command and to stay quiet about version drift: a
+ * maintainer on a locally bumped version should not be told to update.
+ */
+function devCheckoutEntrypoint(): string | undefined {
+    const entrypoint = process.argv[1] ? resolve(process.argv[1]) : '';
+    return entrypoint
+        && !entrypoint.includes(`${join('node_modules', '')}`)
+        && entrypoint.endsWith(join('packages', 'cli', 'dist', 'index.js'))
+        && existsSync(entrypoint)
+        ? entrypoint
+        : undefined;
+}
+
 function inferFastCliCommand(projectRoot: string): string | undefined {
     if (process.env.N8NAC_COMMAND || hasWorkspaceDevCommand(projectRoot)) {
         return undefined;
     }
 
-    const entrypoint = process.argv[1] ? resolve(process.argv[1]) : '';
-    if (entrypoint
-        && !entrypoint.includes(`${join('node_modules', '')}`)
-        && entrypoint.endsWith(join('packages', 'cli', 'dist', 'index.js'))
-        && existsSync(entrypoint)) {
-        return `node ${quoteShellArg(entrypoint)}`;
+    const devEntrypoint = devCheckoutEntrypoint();
+    if (devEntrypoint) {
+        return `node ${quoteShellArg(devEntrypoint)}`;
     }
 
     // Prefer the installed binary: npx pays npm's own startup on every invocation.
@@ -147,6 +160,33 @@ async function createAiContextGenerator(): Promise<AiContextGeneratorInstance> {
 
     const mod = await import('@n8n-as-code/skills');
     return new mod.AiContextGenerator();
+}
+
+/**
+ * One dim line when a newer version is published. Runs only after update-ai has already
+ * succeeded, and swallows everything: a version check has no business failing a command.
+ * Written to stderr, like the refresh notice, so machine-readable stdout stays clean.
+ *
+ * Built by concatenation rather than a template literal so the backticks in the message
+ * are plainly literal.
+ */
+async function noticeIfOutdated(): Promise<void> {
+    try {
+        if (devCheckoutEntrypoint()) return;
+
+        const current = getCliVersion();
+        const distTag = getDistTag();
+        const published = await findNewerPublishedVersion(current, distTag);
+        if (!published) return;
+
+        console.error(chalk.dim(
+            'ℹ  n8nac: ' + published + ' is published, this is ' + current + '. '
+            + 'Update with `npm i n8nac@' + (distTag ?? 'latest') + '`, adding `-g` if you installed '
+            + 'globally, then rerun `update-ai`.',
+        ));
+    } catch {
+        // Never surface a version check to the user as a failure.
+    }
 }
 
 export class UpdateAiCommand {
@@ -261,6 +301,8 @@ export class UpdateAiCommand {
                 console.log(chalk.gray('   ✔ .agents/skills: Portable n8n-architect skill fallback'));
                 console.log(chalk.gray('   ✔ n8n-workflows.d.ts: TypeScript stubs (per environment)'));
                 console.log(chalk.gray('   ✔ Source of truth: n8n-nodes-technical.json (via @n8n-as-code/skills)\n'));
+
+                await noticeIfOutdated();
             } else if (updatedCount > 0 || existsSync(join(projectRoot, 'AGENTS.md'))) {
                 // Single dim notice so the user knows a refresh happened — written to stderr
                 // to avoid corrupting machine-readable stdout output (e.g. `n8nac list --raw`)

--- a/packages/cli/src/core/services/sync-manager.ts
+++ b/packages/cli/src/core/services/sync-manager.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { quoteShellArg } from '../../utils/shell.js';
 import path from 'path';
 import EventEmitter from 'events';
 import { N8nApiClient } from './n8n-api-client.js';
@@ -395,7 +396,7 @@ export class SyncManager extends EventEmitter {
             const suggestedPath = scopeRelativeToCwd === '' ? `./${trimmed}` : path.join(scopeRelativeToCwd, trimmed);
             throw new Error(
                 `Cannot push "${trimmed}": use the full relative path to the workflow file, not a bare filename.\n` +
-                `Example: n8nac push ${this.quoteShellArg(suggestedPath)}`
+                `Example: n8nac push ${quoteShellArg(suggestedPath)}`
             );
         }
 
@@ -424,7 +425,7 @@ export class SyncManager extends EventEmitter {
                 `Cannot push "${trimmed}": path is not within the active sync scope.\n` +
                 `Active sync scope : ${scopeLabel}\n` +
                 `Expected path form: ${suggestedPath}\n` +
-                `Run               : n8nac push ${this.quoteShellArg(suggestedPath)}\n\n` +
+                `Run               : n8nac push ${quoteShellArg(suggestedPath)}\n\n` +
                 `Tip: run \`n8nac workspace status --json\` and read \`workflowsPath\` to ` +
                 `get the exact relative path where workflow files must be created and pushed from.`
             );
@@ -447,9 +448,6 @@ export class SyncManager extends EventEmitter {
         }
     }
 
-    private quoteShellArg(value: string): string {
-        return `'${value.replace(/'/g, `'\\''`)}'`;
-    }
 
     public async resolveConflict(workflowId: string, filename: string, resolution: 'local' | 'remote'): Promise<void> {
         await this.ensureInitialized();

--- a/packages/cli/src/utils/shell.ts
+++ b/packages/cli/src/utils/shell.ts
@@ -1,0 +1,24 @@
+/**
+ * Quote a path or argument for a shell we do not control.
+ *
+ * Nothing here is executed by us. The result is written into generated agent context
+ * and into CLI hints, for a person or an agent to paste into whatever shell they have.
+ * On Windows that is often `cmd.exe`, which does not strip POSIX single quotes: it hands
+ * them to the program verbatim, so a single-quoted path fails the moment it contains a
+ * space. Double quotes are understood by `cmd.exe`, PowerShell and bash alike, which
+ * makes them the only portable choice there. Windows forbids `"` in a path, so nothing
+ * needs escaping.
+ *
+ * POSIX keeps single quotes, which suppress every expansion; double quotes do not.
+ *
+ * Known ceiling: on Windows a value containing `$` or a backtick still expands under
+ * PowerShell and bash. Both are legal in Windows filenames, and no escaping satisfies
+ * cmd.exe, PowerShell and bash at once. Emit a relative path where you can.
+ *
+ * `platform` is injectable so the Windows branch is testable from any host.
+ */
+export function quoteShellArg(value: string, platform: NodeJS.Platform = process.platform): string {
+    return platform === 'win32'
+        ? `"${value}"`
+        : `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/packages/cli/src/utils/shell.ts
+++ b/packages/cli/src/utils/shell.ts
@@ -1,19 +1,28 @@
 /**
  * Quote a path or argument for a shell we do not control.
  *
- * Nothing here is executed by us. The result is written into generated agent context
- * and into CLI hints, for a person or an agent to paste into whatever shell they have.
- * On Windows that is often `cmd.exe`, which does not strip POSIX single quotes: it hands
- * them to the program verbatim, so a single-quoted path fails the moment it contains a
- * space. Double quotes are understood by `cmd.exe`, PowerShell and bash alike, which
- * makes them the only portable choice there. Windows forbids `"` in a path, so nothing
- * needs escaping.
+ * Nothing here is executed by us. The result is written into generated agent context and
+ * into CLI hints, for a person or an agent to paste into whatever shell they have. On
+ * Windows that is often `cmd.exe`, which does not strip POSIX single quotes: it hands them
+ * to the program verbatim, so a single-quoted path fails the moment it contains a space.
+ * Double quotes are understood by `cmd.exe`, PowerShell and bash alike, which makes them
+ * the only portable choice there.
  *
- * POSIX keeps single quotes, which suppress every expansion; double quotes do not.
+ * POSIX keeps single quotes, which suppress every expansion. That branch is airtight.
  *
- * Known ceiling: on Windows a value containing `$` or a backtick still expands under
- * PowerShell and bash. Both are legal in Windows filenames, and no escaping satisfies
- * cmd.exe, PowerShell and bash at once. Emit a relative path where you can.
+ * What this promises, and what it does not: it groups a value into a single argument. On
+ * Windows it does not suppress expansion, and cannot. Measured on cmd.exe:
+ *
+ *     "C:\dir\%VAR%\b.js"   ->  %VAR% expands, with or without the quotes
+ *     "C:\dir\!VAR!\b.js"   ->  expands too, when delayed expansion is on
+ *
+ * No escaping fixes that. `%%` is batch-file syntax a prompt takes literally, `^` is inert
+ * inside quotes, and either would corrupt the same string under PowerShell and bash, where
+ * `$` and a backtick expand instead. One string cannot be safe in three shells at once.
+ *
+ * So the rule for callers is to prefer a relative path in generated text wherever one will
+ * do. `%`, `!`, `$` and a backtick are all legal in Windows filenames, and a value carrying
+ * one reaches the program changed.
  *
  * `platform` is injectable so the Windows branch is testable from any host.
  */

--- a/packages/cli/src/utils/version-check.ts
+++ b/packages/cli/src/utils/version-check.ts
@@ -1,0 +1,66 @@
+/**
+ * Tell the user when the installed CLI is behind what is published.
+ *
+ * This exists because of what it replaced. Generated agent instructions used to run
+ * `npx --yes n8nac@<tag>`, which re-resolved the dist tag from the registry on every
+ * single call, so an agent silently ran the newest publish and nobody had to think
+ * about versions. Naming a local install is far faster but pins it, so the invisible
+ * update is gone and something has to say so out loud.
+ *
+ * Everything here is best-effort: it must never fail a command, never block for long,
+ * and never reach the network when the user has said not to.
+ */
+
+/** The whole document is about 80 bytes, so there is no packument to download. */
+const DIST_TAGS_URL = 'https://registry.npmjs.org/-/package/n8nac/dist-tags';
+const TIMEOUT_MS = 3000;
+
+/**
+ * Reuses the vocabulary the telemetry package already established rather than inventing
+ * a variable, plus `NO_UPDATE_NOTIFIER`, the de-facto standard name for this one check.
+ */
+function optedOut(env: NodeJS.ProcessEnv): boolean {
+    return env.CI === 'true'
+        || env.DO_NOT_TRACK === '1'
+        || Boolean(env.NO_UPDATE_NOTIFIER);
+}
+
+/**
+ * The version published under `distTag`, when it differs from what is running.
+ * Undefined for every other outcome, including every failure.
+ */
+export async function findNewerPublishedVersion(
+    currentVersion: string | undefined,
+    distTag: string | undefined,
+    env: NodeJS.ProcessEnv = process.env,
+    fetchImpl: typeof fetch = fetch,
+): Promise<string | undefined> {
+    if (!currentVersion || optedOut(env)) return undefined;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+    try {
+        const response = await fetchImpl(DIST_TAGS_URL, {
+            headers: { 'User-Agent': 'n8n-as-code' },
+            signal: controller.signal,
+            redirect: 'error',
+        });
+        if (!response.ok) return undefined;
+
+        const tags = await response.json() as Record<string, unknown>;
+        const published = tags?.[distTag ?? 'latest'];
+
+        // Plain inequality, not a semver comparison. The caller skips dev checkouts, which
+        // is the only case where the running version can legitimately be ahead of the tag,
+        // and a dependency for one string compare would not earn its place.
+        return typeof published === 'string' && published !== currentVersion
+            ? published
+            : undefined;
+    } catch {
+        // Offline, slow, rate-limited, or a response shaped differently than expected.
+        // None of that is the user's problem in the middle of an update-ai.
+        return undefined;
+    } finally {
+        clearTimeout(timer);
+    }
+}

--- a/packages/cli/tests/unit/shell.test.ts
+++ b/packages/cli/tests/unit/shell.test.ts
@@ -5,6 +5,7 @@ import { quoteShellArg } from '../../src/utils/shell.js';
 // what these tests are about, so a literal that a tool or an editor can quietly reshape
 // would let the test agree with a broken implementation.
 const BACKSLASH = String.fromCharCode(92);
+const DOLLAR = String.fromCharCode(36);
 
 describe('quoteShellArg', () => {
     it('double-quotes on Windows, because cmd.exe does not strip single quotes', () => {
@@ -28,5 +29,20 @@ describe('quoteShellArg', () => {
     it('quotes a plain value on both, so callers never concatenate bare', () => {
         expect(quoteShellArg('n8nac', 'win32')).toBe('"n8nac"');
         expect(quoteShellArg('n8nac', 'linux')).toBe("'n8nac'");
+    });
+
+    it('groups a Windows value without suppressing expansion, which no escaping can fix', () => {
+        // Measured on cmd.exe: %VAR% expands inside double quotes, and !VAR! expands when
+        // delayed expansion is on. The value passes through unchanged on purpose. %% is
+        // batch-file syntax a prompt takes literally, ^ is inert inside quotes, and either
+        // would corrupt the same string under PowerShell and bash. Callers avoid this by
+        // preferring a relative path, not by escaping.
+        const p = 'C:' + BACKSLASH + 'dir' + BACKSLASH + '%VAR%' + BACKSLASH + '!VAR!.js';
+
+        expect(quoteShellArg(p, 'win32')).toBe('"' + p + '"');
+    });
+
+    it('does suppress expansion on POSIX, where single quotes can', () => {
+        expect(quoteShellArg('/home/u/' + DOLLAR + 'VAR/e.js', 'linux')).toBe("'/home/u/" + DOLLAR + "VAR/e.js'");
     });
 });

--- a/packages/cli/tests/unit/shell.test.ts
+++ b/packages/cli/tests/unit/shell.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { quoteShellArg } from '../../src/utils/shell.js';
+
+// Written with an explicit BACKSLASH constant rather than source escapes. The escaping is
+// what these tests are about, so a literal that a tool or an editor can quietly reshape
+// would let the test agree with a broken implementation.
+const BACKSLASH = String.fromCharCode(92);
+
+describe('quoteShellArg', () => {
+    it('double-quotes on Windows, because cmd.exe does not strip single quotes', () => {
+        // Measured: `node '<path with a space>'` fails under cmd.exe with MODULE_NOT_FOUND,
+        // the quotes reaching node as part of the path. Double quotes work in cmd.exe,
+        // PowerShell and bash alike.
+        const p = 'C:' + BACKSLASH + 'dir with space' + BACKSLASH + 'e.js';
+
+        expect(quoteShellArg(p, 'win32')).toBe('"' + p + '"');
+    });
+
+    it('single-quotes on POSIX, where they suppress every expansion', () => {
+        expect(quoteShellArg('/home/u/my dir/e.js', 'linux')).toBe("'/home/u/my dir/e.js'");
+    });
+
+    it('closes, escapes and reopens around an embedded single quote on POSIX', () => {
+        expect(quoteShellArg("/home/u/it's/e.js", 'darwin'))
+            .toBe("'/home/u/it'" + BACKSLASH + "''s/e.js'");
+    });
+
+    it('quotes a plain value on both, so callers never concatenate bare', () => {
+        expect(quoteShellArg('n8nac', 'win32')).toBe('"n8nac"');
+        expect(quoteShellArg('n8nac', 'linux')).toBe("'n8nac'");
+    });
+});

--- a/packages/cli/tests/unit/sync-manager.test.ts
+++ b/packages/cli/tests/unit/sync-manager.test.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { quoteShellArg } from '../../src/utils/shell.js';
 import os from 'os';
 import path from 'path';
 import { describe, it, expect, vi } from 'vitest';
@@ -74,7 +75,7 @@ describe('SyncManager push filename contract', () => {
         const outsidePath = path.join(TMP, 'outside-workflow.workflow.ts');
         expect(() => manager.resolvePushTarget(outsidePath)).toThrowError(
             expect.objectContaining({
-                message: expect.stringContaining("Run               : n8nac push '")
+                message: expect.stringContaining('Run               : n8nac push ')
             })
         );
     });
@@ -109,7 +110,7 @@ describe('SyncManager push filename contract', () => {
         );
         expect(() => manager.resolvePushTarget(path.join(TMP, 'outside workflow.workflow.ts'))).toThrowError(
             expect.objectContaining({
-                message: expect.stringContaining("Run               : n8nac push './outside workflow.workflow.ts'")
+                message: expect.stringContaining(`Run               : n8nac push ${quoteShellArg('./outside workflow.workflow.ts')}`)
             })
         );
 

--- a/packages/cli/tests/unit/version-check.test.ts
+++ b/packages/cli/tests/unit/version-check.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { findNewerPublishedVersion } from '../../src/utils/version-check.js';
+
+const TAGS = { latest: '2.7.0', next: '2.7.1-rc.1' };
+
+/** A fetch that answers with a dist-tags document, and records how it was called. */
+function tagsFetch(body: unknown = TAGS, ok = true) {
+    return vi.fn(async () => ({ ok, json: async () => body })) as unknown as typeof fetch;
+}
+
+describe('findNewerPublishedVersion', () => {
+    it('reports the published version for the running dist tag', async () => {
+        await expect(findNewerPublishedVersion('2.6.0', undefined, {}, tagsFetch())).resolves.toBe('2.7.0');
+        await expect(findNewerPublishedVersion('2.6.0-rc.9', 'next', {}, tagsFetch())).resolves.toBe('2.7.1-rc.1');
+    });
+
+    it('stays quiet when the running version is already the published one', async () => {
+        await expect(findNewerPublishedVersion('2.7.0', undefined, {}, tagsFetch())).resolves.toBeUndefined();
+    });
+
+    it('never reaches the network when the environment has opted out', async () => {
+        for (const env of [{ CI: 'true' }, { DO_NOT_TRACK: '1' }, { NO_UPDATE_NOTIFIER: '1' }]) {
+            const fetchImpl = tagsFetch();
+            await expect(findNewerPublishedVersion('2.6.0', undefined, env, fetchImpl)).resolves.toBeUndefined();
+            expect(fetchImpl).not.toHaveBeenCalled();
+        }
+    });
+
+    it('stays quiet without a version to compare against', async () => {
+        const fetchImpl = tagsFetch();
+        await expect(findNewerPublishedVersion(undefined, undefined, {}, fetchImpl)).resolves.toBeUndefined();
+        expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it('swallows a refused, malformed or unreachable registry', async () => {
+        const rejects = vi.fn(async () => { throw new Error('ENOTFOUND'); }) as unknown as typeof fetch;
+
+        await expect(findNewerPublishedVersion('2.6.0', undefined, {}, rejects)).resolves.toBeUndefined();
+        await expect(findNewerPublishedVersion('2.6.0', undefined, {}, tagsFetch(TAGS, false))).resolves.toBeUndefined();
+        await expect(findNewerPublishedVersion('2.6.0', undefined, {}, tagsFetch(null))).resolves.toBeUndefined();
+        await expect(findNewerPublishedVersion('2.6.0', undefined, {}, tagsFetch({ latest: 42 }))).resolves.toBeUndefined();
+    });
+
+    it('stays quiet when the running dist tag is absent from the document', async () => {
+        await expect(findNewerPublishedVersion('2.6.0', 'canary', {}, tagsFetch())).resolves.toBeUndefined();
+    });
+
+    it('sends an abort signal, so a hanging registry cannot hold the command open', async () => {
+        const fetchImpl = tagsFetch();
+        await findNewerPublishedVersion('2.6.0', undefined, {}, fetchImpl);
+
+        const init = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1];
+        expect(init.signal).toBeInstanceOf(AbortSignal);
+    });
+});

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -2444,8 +2444,15 @@ function resolveAiContextManagerCommandOverride(context: vscode.ExtensionContext
     return `node ${quoteShellArg(siblingManagerCliPath)}`;
 }
 
+// Mirrors packages/cli/src/utils/shell.ts. Duplicated on purpose: a three-line pure
+// function is not worth widening the n8nac public type surface across a package boundary.
+// cmd.exe does not strip POSIX single quotes, so a single-quoted path reaches the program
+// with the quotes still attached and fails on the first space. Double quotes are understood
+// by cmd.exe, PowerShell and bash alike, and Windows forbids `"` in a path.
 function quoteShellArg(value: string): string {
-    return `'${value.replace(/'/g, `'\\''`)}'`;
+    return process.platform === 'win32'
+        ? `"${value}"`
+        : `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 async function updateAiContextAfterSyncInitialization(

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -2446,9 +2446,15 @@ function resolveAiContextManagerCommandOverride(context: vscode.ExtensionContext
 
 // Mirrors packages/cli/src/utils/shell.ts. Duplicated on purpose: a three-line pure
 // function is not worth widening the n8nac public type surface across a package boundary.
+//
 // cmd.exe does not strip POSIX single quotes, so a single-quoted path reaches the program
 // with the quotes still attached and fails on the first space. Double quotes are understood
-// by cmd.exe, PowerShell and bash alike, and Windows forbids `"` in a path.
+// by cmd.exe, PowerShell and bash alike.
+//
+// This groups a value into one argument; on Windows it does not suppress expansion and
+// cannot. %VAR% expands in cmd.exe with or without quotes, !VAR! expands under delayed
+// expansion, and $ and a backtick expand under PowerShell and bash. See the canonical file
+// for why no escaping satisfies all three shells.
 function quoteShellArg(value: string): string {
     return process.platform === 'win32'
         ? `"${value}"`


### PR DESCRIPTION
Closes #658.

`quoteShellArg` wrapped paths in POSIX single quotes. `cmd.exe` does not strip them, so the program receives the quotes as part of the path and fails the moment it contains a space.

Measured on Windows 11, node 24.14.0:

| shell | single quotes | double quotes |
|---|---|---|
| `cmd.exe` | **fails** | works |
| PowerShell | works | works |
| bash (Git Bash) | works | works |

```
node 'C:\...\dir with space\e.js'
Error: Cannot find module 'C:\...\'C:\...\dir with space\e.js''
```

Nothing here is executed by us. The quoted string is written into generated agent context and into CLI hints, for a person or an agent to paste into whatever shell they have. On Windows that is often `cmd.exe`.

## Four copies, one rule

The same three-line function was defined four times, byte-identical and wrong the same way, which is why it reached `update-ai`, `promote`, `sync-manager` and the extension at once. The three inside `packages/cli` now call `packages/cli/src/utils/shell.ts`.

The extension keeps its own copy, fixed identically. A three-line pure function is not worth widening the `n8nac` public type surface across a package boundary, and the comment there says so and points at the canonical one.

## Tests

Four new cases in `packages/cli/tests/unit/shell.test.ts`, covering both branches and the embedded-quote escape.

They are written with an explicit `BACKSLASH` constant rather than source escapes. That is deliberate, and it is not stylistic: while writing this change a tool silently ate one backslash from both the implementation and the test at the same time, so the test agreed with a broken implementation and passed. A literal that cannot be reshaped removes that failure mode.

The two `sync-manager` tests that pinned the single-quoted form now build their expectation from the helper instead of restating it, so the quoting style stays the helper's business.

## Known ceiling

Written into the helper rather than pretended away: on Windows a value containing `$` or a backtick still expands under PowerShell and bash. Both are legal in Windows filenames, and no escaping satisfies `cmd.exe`, PowerShell and bash at once. Emit a relative path where you can.

## Checks

`packages/cli`: 450 tests pass, typecheck clean. The extension package does not compile in my worktree for unrelated reasons, a stale `n8nac` link; error count is identical before and after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a best-effort update notice when a newer CLI version is available.
  * Notices remain silent in CI, silent mode, development checkouts, and when opted out.

* **Bug Fixes**
  * Improved shell command argument quoting across Windows and POSIX platforms.
  * Updated command output and error messages to display paths safely and consistently.
  * Clarified platform-specific handling of environment-variable and special-character expansion.

* **Documentation**
  * Added troubleshooting guidance for update notices and opt-out settings.

* **Tests**
  * Added coverage for update checks and platform-specific quoting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->