### PR TITLE
feat(cli): say so when the installed n8nac is behind what is published

### DIFF
--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -235,6 +235,19 @@ n8nac --help
 
 The current package is `n8nac`.
 
+## Update Notice
+
+`n8nac update-ai` checks whether a newer version is published and, if so, prints one line telling you. It reads about 80 bytes from the npm registry, gives up after three seconds, and never fails the command.
+
+Turn it off with any of these:
+
+```bash
+NO_UPDATE_NOTIFIER=1
+DO_NOT_TRACK=1
+```
+
+It is already silent in CI, under `--silent`, and when you are running from a checkout of this repository.
+
 ## Complete Reset
 
 Back up workflows first, then recreate the environment:

--- a/packages/cli/src/commands/update-ai.ts
+++ b/packages/cli/src/commands/update-ai.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { quoteShellArg } from '../utils/shell.js';
+import { findNewerPublishedVersion } from '../utils/version-check.js';
 import fs from 'fs';
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname, resolve, delimiter, basename } from 'path';
@@ -82,17 +83,29 @@ function isN8nacOnShellPath(): boolean {
         && extensions.some((ext) => existsSync(join(dir, `n8nac${ext}`))));
 }
 
+/**
+ * The monorepo entry point, when the CLI is running from a dev checkout rather than an
+ * install. Used both to emit a fast command and to stay quiet about version drift: a
+ * maintainer on a locally bumped version should not be told to update.
+ */
+function devCheckoutEntrypoint(): string | undefined {
+    const entrypoint = process.argv[1] ? resolve(process.argv[1]) : '';
+    return entrypoint
+        && !entrypoint.includes(`${join('node_modules', '')}`)
+        && entrypoint.endsWith(join('packages', 'cli', 'dist', 'index.js'))
+        && existsSync(entrypoint)
+        ? entrypoint
+        : undefined;
+}
+
 function inferFastCliCommand(projectRoot: string): string | undefined {
     if (process.env.N8NAC_COMMAND || hasWorkspaceDevCommand(projectRoot)) {
         return undefined;
     }
 
-    const entrypoint = process.argv[1] ? resolve(process.argv[1]) : '';
-    if (entrypoint
-        && !entrypoint.includes(`${join('node_modules', '')}`)
-        && entrypoint.endsWith(join('packages', 'cli', 'dist', 'index.js'))
-        && existsSync(entrypoint)) {
-        return `node ${quoteShellArg(entrypoint)}`;
+    const devEntrypoint = devCheckoutEntrypoint();
+    if (devEntrypoint) {
+        return `node ${quoteShellArg(devEntrypoint)}`;
     }
 
     // Prefer the installed binary: npx pays npm's own startup on every invocation.
@@ -147,6 +160,33 @@ async function createAiContextGenerator(): Promise<AiContextGeneratorInstance> {
 
     const mod = await import('@n8n-as-code/skills');
     return new mod.AiContextGenerator();
+}
+
+/**
+ * One dim line when a newer version is published. Runs only after update-ai has already
+ * succeeded, and swallows everything: a version check has no business failing a command.
+ * Written to stderr, like the refresh notice, so machine-readable stdout stays clean.
+ *
+ * Built by concatenation rather than a template literal so the backticks in the message
+ * are plainly literal.
+ */
+async function noticeIfOutdated(): Promise<void> {
+    try {
+        if (devCheckoutEntrypoint()) return;
+
+        const current = getCliVersion();
+        const distTag = getDistTag();
+        const published = await findNewerPublishedVersion(current, distTag);
+        if (!published) return;
+
+        console.error(chalk.dim(
+            'ℹ  n8nac: ' + published + ' is published, this is ' + current + '. '
+            + 'Update with `npm i n8nac@' + (distTag ?? 'latest') + '`, adding `-g` if you installed '
+            + 'globally, then rerun `update-ai`.',
+        ));
+    } catch {
+        // Never surface a version check to the user as a failure.
+    }
 }
 
 export class UpdateAiCommand {
@@ -261,6 +301,8 @@ export class UpdateAiCommand {
                 console.log(chalk.gray('   ✔ .agents/skills: Portable n8n-architect skill fallback'));
                 console.log(chalk.gray('   ✔ n8n-workflows.d.ts: TypeScript stubs (per environment)'));
                 console.log(chalk.gray('   ✔ Source of truth: n8n-nodes-technical.json (via @n8n-as-code/skills)\n'));
+
+                await noticeIfOutdated();
             } else if (updatedCount > 0 || existsSync(join(projectRoot, 'AGENTS.md'))) {
                 // Single dim notice so the user knows a refresh happened — written to stderr
                 // to avoid corrupting machine-readable stdout output (e.g. `n8nac list --raw`)

--- a/packages/cli/src/utils/version-check.ts
+++ b/packages/cli/src/utils/version-check.ts
@@ -1,0 +1,66 @@
+/**
+ * Tell the user when the installed CLI is behind what is published.
+ *
+ * This exists because of what it replaced. Generated agent instructions used to run
+ * `npx --yes n8nac@<tag>`, which re-resolved the dist tag from the registry on every
+ * single call, so an agent silently ran the newest publish and nobody had to think
+ * about versions. Naming a local install is far faster but pins it, so the invisible
+ * update is gone and something has to say so out loud.
+ *
+ * Everything here is best-effort: it must never fail a command, never block for long,
+ * and never reach the network when the user has said not to.
+ */
+
+/** The whole document is about 80 bytes, so there is no packument to download. */
+const DIST_TAGS_URL = 'https://registry.npmjs.org/-/package/n8nac/dist-tags';
+const TIMEOUT_MS = 3000;
+
+/**
+ * Reuses the vocabulary the telemetry package already established rather than inventing
+ * a variable, plus `NO_UPDATE_NOTIFIER`, the de-facto standard name for this one check.
+ */
+function optedOut(env: NodeJS.ProcessEnv): boolean {
+    return env.CI === 'true'
+        || env.DO_NOT_TRACK === '1'
+        || Boolean(env.NO_UPDATE_NOTIFIER);
+}
+
+/**
+ * The version published under `distTag`, when it differs from what is running.
+ * Undefined for every other outcome, including every failure.
+ */
+export async function findNewerPublishedVersion(
+    currentVersion: string | undefined,
+    distTag: string | undefined,
+    env: NodeJS.ProcessEnv = process.env,
+    fetchImpl: typeof fetch = fetch,
+): Promise<string | undefined> {
+    if (!currentVersion || optedOut(env)) return undefined;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+    try {
+        const response = await fetchImpl(DIST_TAGS_URL, {
+            headers: { 'User-Agent': 'n8n-as-code' },
+            signal: controller.signal,
+            redirect: 'error',
+        });
+        if (!response.ok) return undefined;
+
+        const tags = await response.json() as Record<string, unknown>;
+        const published = tags?.[distTag ?? 'latest'];
+
+        // Plain inequality, not a semver comparison. The caller skips dev checkouts, which
+        // is the only case where the running version can legitimately be ahead of the tag,
+        // and a dependency for one string compare would not earn its place.
+        return typeof published === 'string' && published !== currentVersion
+            ? published
+            : undefined;
+    } catch {
+        // Offline, slow, rate-limited, or a response shaped differently than expected.
+        // None of that is the user's problem in the middle of an update-ai.
+        return undefined;
+    } finally {
+        clearTimeout(timer);
+    }
+}

--- a/packages/cli/tests/unit/version-check.test.ts
+++ b/packages/cli/tests/unit/version-check.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { findNewerPublishedVersion } from '../../src/utils/version-check.js';
+
+const TAGS = { latest: '2.7.0', next: '2.7.1-rc.1' };
+
+/** A fetch that answers with a dist-tags document, and records how it was called. */
+function tagsFetch(body: unknown = TAGS, ok = true) {
+    return vi.fn(async () => ({ ok, json: async () => body })) as unknown as typeof fetch;
+}
+
+describe('findNewerPublishedVersion', () => {
+    it('reports the published version for the running dist tag', async () => {
+        await expect(findNewerPublishedVersion('2.6.0', undefined, {}, tagsFetch())).resolves.toBe('2.7.0');
+        await expect(findNewerPublishedVersion('2.6.0-rc.9', 'next', {}, tagsFetch())).resolves.toBe('2.7.1-rc.1');
+    });
+
+    it('stays quiet when the running version is already the published one', async () => {
+        await expect(findNewerPublishedVersion('2.7.0', undefined, {}, tagsFetch())).resolves.toBeUndefined();
+    });
+
+    it('never reaches the network when the environment has opted out', async () => {
+        for (const env of [{ CI: 'true' }, { DO_NOT_TRACK: '1' }, { NO_UPDATE_NOTIFIER: '1' }]) {
+            const fetchImpl = tagsFetch();
+            await expect(findNewerPublishedVersion('2.6.0', undefined, env, fetchImpl)).resolves.toBeUndefined();
+            expect(fetchImpl).not.toHaveBeenCalled();
+        }
+    });
+
+    it('stays quiet without a version to compare against', async () => {
+        const fetchImpl = tagsFetch();
+        await expect(findNewerPublishedVersion(undefined, undefined, {}, fetchImpl)).resolves.toBeUndefined();
+        expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it('swallows a refused, malformed or unreachable registry', async () => {
+        const rejects = vi.fn(async () => { throw new Error('ENOTFOUND'); }) as unknown as typeof fetch;
+
+        await expect(findNewerPublishedVersion('2.6.0', undefined, {}, rejects)).resolves.toBeUndefined();
+        await expect(findNewerPublishedVersion('2.6.0', undefined, {}, tagsFetch(TAGS, false))).resolves.toBeUndefined();
+        await expect(findNewerPublishedVersion('2.6.0', undefined, {}, tagsFetch(null))).resolves.toBeUndefined();
+        await expect(findNewerPublishedVersion('2.6.0', undefined, {}, tagsFetch({ latest: 42 }))).resolves.toBeUndefined();
+    });
+
+    it('stays quiet when the running dist tag is absent from the document', async () => {
+        await expect(findNewerPublishedVersion('2.6.0', 'canary', {}, tagsFetch())).resolves.toBeUndefined();
+    });
+
+    it('sends an abort signal, so a hanging registry cannot hold the command open', async () => {
+        const fetchImpl = tagsFetch();
+        await findNewerPublishedVersion('2.6.0', undefined, {}, fetchImpl);
+
+        const init = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1];
+        expect(init.signal).toBeInstanceOf(AbortSignal);
+    });
+});


### PR DESCRIPTION
Closes #660. **Stacked on #661**, because both touch `update-ai.ts`. Review or merge that one first; the diff here is the last commit only.

Nothing in this repo ever compared the installed CLI against the registry. No `update-notifier`, no query, no warning.

That was survivable while generated agent instructions ran `npx --yes n8nac@<tag>`: npx re-resolved the dist tag on every single call, so an agent silently ran the newest publish and nobody had to think about versions. #657 makes the generated context name a locally installed n8nac, which is roughly eight times faster per call but pins the version. The invisible update is gone, so something has to say so out loud.

## What it does

One dim line on stderr at the end of a successful `update-ai`:

```
ℹ  n8nac: 2.7.0 is published, this is 2.6.0. Update with `npm i n8nac@latest`, adding `-g` if you installed globally, then rerun `update-ai`.
```

`update-ai` is the right place: it runs rarely, it is exactly when the agent context is regenerated, and it already knows both the version and the dist tag.

## Why it cannot hurt

- Reads the registry's **dist-tags** document, about 80 bytes. No packument.
- Three-second abort signal, and a catch that swallows offline, refused, malformed and unexpected alike.
- Runs only after the command has already succeeded. `update-ai` is documented as never throwing and that stays true.
- stderr, never stdout. The reason is written down at `update-ai.ts:267-269`: around forty commands take `--json`.
- Silent under `--silent`, and silent in a dev checkout, where a maintainer on a locally bumped version should not be told to update.

## Opt-outs

Reuses what already exists rather than inventing a variable. `CI=true` and `DO_NOT_TRACK=1` are both already read by `packages/telemetry`. Added `NO_UPDATE_NOTIFIER`, the de-facto standard name for this one check.

**These want a doc line.** The natural home is the Update section #657 adds to `docs/docs/usage/cli.md`, which does not exist on this branch. I will add it there rather than write a conflicting version here.

## No semver dependency

A plain inequality against the dist tag is enough for a hint, and skipping dev checkouts removes the only case where it could read backwards. `semver` is not a direct dependency of `packages/cli` and one string compare does not earn it.

## Checks

Seven new unit tests covering the opt-outs, the missing-version case, a refused response, a rejected fetch, a malformed document, an absent dist tag, and the abort signal being sent. Fetch is injected, matching the global-swap pattern already used in `preflight-node-validator.test.ts`.

`packages/cli`: 457 tests pass, typecheck clean. Also exercised against the live registry: `latest` and `next` both resolve, an up-to-date version reports nothing, and `CI=true` never opens a socket.

## Adjacent, not fixed here

`checkAndRefreshIfStale` has no production caller. Outside `dist` and `node_modules`, the only references are its own definition and two tests, so only the explicit `update-ai` path runs today. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
